### PR TITLE
feat(publishing): preserve abbreviations

### DIFF
--- a/packages/dendron-cli/src/commands/__tests__/__snapshots__/build-site.spec.ts.snap
+++ b/packages/dendron-cli/src/commands/__tests__/__snapshots__/build-site.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`buildSite basic: bond 1`] = `
 "- [lbl](refactor.one)
+
 "
 `;
 
@@ -9,16 +10,19 @@ exports[`buildSite ids are converted: converted 1`] = `
 "Build site home
 
 - [build-site.one](notes/id.build-site.one)
+
 "
 `;
 
 exports[`buildSite image prefix and no copy assets: sample.image-link.md 1`] = `
 "![link-alt](fake-s3.com/link-path.jpg)
+
 "
 `;
 
 exports[`buildSite image prefix: sample.image-link.md 1`] = `
 "![link-alt](fake-s3.com/link-path.jpg)
+
 "
 `;
 
@@ -26,11 +30,13 @@ exports[`buildSite multiple roots: build-site.md 1`] = `
 "Build site home
 
 - [build-site.one](id.build-site.one)
+
 "
 `;
 
 exports[`buildSite multiple roots: foo.md 1`] = `
 "- [lbl](notes/refactor.one)
+
 "
 `;
 
@@ -72,8 +78,10 @@ exports[`note refs note refs 1`] = `
  [foo](notes/id.foo)
 
 
+
 </div>    
 </div>
+
 "
 `;
 
@@ -83,11 +91,14 @@ exports[`note refs note refs, disable pretty 1`] = `
 # Bar Content # I am bar
 
  [foo](notes/id.foo)
+
+
 "
 `;
 
 exports[`wiki link case sensitive link 1`] = `
 "[foo.Mixed_case](id.foo.mixed-case)
+
 "
 `;
 
@@ -95,6 +106,7 @@ exports[`wiki link missing link 1`] = `
 "# Foo Content
 
 # Bar Content [missing-link](/404.html)
+
 "
 `;
 

--- a/packages/dendron-cli/src/commands/__tests__/__snapshots__/build-site.v2.spec.ts.snap
+++ b/packages/dendron-cli/src/commands/__tests__/__snapshots__/build-site.v2.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`buildSite basic: bond 1`] = `
 "- [lbl](refactor.one)
+
 "
 `;
 
@@ -9,11 +10,13 @@ exports[`buildSite ids are converted: converted 1`] = `
 "Build site home
 
 - [build-site.one](notes/id.build-site.one)
+
 "
 `;
 
 exports[`buildSite image prefix: sample.image-link.md 1`] = `
 "![link-alt](fake-s3.com/link-path.jpg)
+
 "
 `;
 
@@ -21,11 +24,13 @@ exports[`buildSite multiple roots: build-site.md 1`] = `
 "Build site home
 
 - [build-site.one](id.build-site.one)
+
 "
 `;
 
 exports[`buildSite multiple roots: foo.md 1`] = `
 "- [lbl](notes/refactor.one)
+
 "
 `;
 
@@ -65,6 +70,7 @@ hpath: foo
 permalink: /
 ---
 foo body
+
 "
 `;
 
@@ -93,6 +99,7 @@ permalink: /
 ## Header 1.1
 
 ## Header 2
+
 "
 `;
 
@@ -117,8 +124,10 @@ exports[`note refs note refs 1`] = `
  [foo](notes/id.foo)
 
 
+
 </div>    
 </div>
+
 "
 `;
 
@@ -128,6 +137,8 @@ exports[`note refs note refs, disable pretty 1`] = `
 # Bar Content # I am bar
 
  [foo](notes/id.foo)
+
+
 "
 `;
 
@@ -166,8 +177,10 @@ exports[`note refs note refs, recursive 1`] = `
 </div>
 
 
+
 </div>    
 </div>
+
 "
 `;
 
@@ -196,6 +209,7 @@ permalink: /
 ## Header 1.1
 
 ## Header 2
+
 "
 `;
 
@@ -220,11 +234,13 @@ permalink: /
 ## Header 1.1
 
 ## Header 2
+
 "
 `;
 
 exports[`wiki link case sensitive link 1`] = `
 "[foo.Mixed_case](id.foo.mixed-case)
+
 "
 `;
 
@@ -232,6 +248,7 @@ exports[`wiki link missing link 1`] = `
 "# Foo Content
 
 # Bar Content [missing-link](/404.html)
+
 "
 `;
 

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -65,6 +65,7 @@
     "mdast-util-compact": "^2.0.1",
     "mdast-util-inject": "^1.1.0",
     "remark": "^12.0.1",
+    "remark-abbr": "^1.4.0",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.3",
     "remark-toc": "^7.0.0",

--- a/packages/engine-server/src/__tests__/__snapshots__/enginev2.spec.ts.snap
+++ b/packages/engine-server/src/__tests__/__snapshots__/enginev2.spec.ts.snap
@@ -245,6 +245,7 @@ Object {
     Object {
       "note": Object {
         "body": "[[baz]]
+
 ",
         "children": Array [],
         "created": "1",

--- a/packages/engine-server/src/topics/markdown/__snapshots__/markdown.spec.ts.snap
+++ b/packages/engine-server/src/topics/markdown/__snapshots__/markdown.spec.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Markdown extensions abbreviations are preserved 1`] = `
+"HTML, JS and CSS are the fundamental building blocks of the web.
+
+    
+
+*[HTML]: HyperText Markup Language
+*[JS]: JavaScript
+*[CSS]: Cascading Style Sheets"
+`;
+
 exports[`replaceRefs wiki2Md and swap id: raw 1`] = `
 "Replace-refs Text
 
@@ -7,6 +17,7 @@ exports[`replaceRefs wiki2Md and swap id: raw 1`] = `
 - [lbl](234)
 - [engine-server.replace-refs.one.md](234)
 - [lbl](234)
+
 "
 `;
 
@@ -354,5 +365,6 @@ exports[`replaceRefs wiki2Md: raw 1`] = `
 - [label](foo-wiki-link)
 - [label](foo-wiki-link)#foobar
     
+
 "
 `;

--- a/packages/engine-server/src/topics/markdown/__tests__/__snapshots__/utilsv2.spec.ts.snap
+++ b/packages/engine-server/src/topics/markdown/__tests__/__snapshots__/utilsv2.spec.ts.snap
@@ -28,36 +28,43 @@ exports[`ParserUtilsV2 replaceLinks fenced code 1`] = `
 "\`\`\`
 [[bond]]
 \`\`\`
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks inline code 1`] = `
 "\`[[bond]]\`
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks multiple 1`] = `
 "[[bar]]
 [[bar]]
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks one 1`] = `
 "[[bar]]
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks ref 1`] = `
 "((ref: [[bar]]))
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks with alias 1`] = `
 "[[hero|bar]]
+
 "
 `;
 
 exports[`ParserUtilsV2 replaceLinks with offset  1`] = `
 "   [[bar]]
+
 "
 `;

--- a/packages/engine-server/src/topics/markdown/markdown.spec.ts
+++ b/packages/engine-server/src/topics/markdown/markdown.spec.ts
@@ -38,6 +38,10 @@ code fence
 - [[foo-wiki-link]]
 - [[label|foo-wiki-link]]
 - [[label|foo-wiki-link]]#foobar
+
+HTML
+
+*[HTML]: HyperText Markup Language
 `;
 
 describe("replaceRefs", () => {
@@ -97,5 +101,20 @@ describe("replaceRefs", () => {
     const out = proc.processSync(note.body);
 
     expect(out.toString()).toMatchSnapshot("raw");
+  });
+});
+
+describe("Markdown extensions", () => {
+  test("abbreviations are preserved", async () => {
+    const abbr = `
+HTML, JS and CSS are the fundamental building blocks of the web.
+
+*[CSS]: Cascading Style Sheets
+*[HTML]: HyperText Markup Language
+*[JS]: JavaScript
+    `;
+    const proc = getProcessor();
+    const out = await proc.process(abbr);
+    expect(out.toString()).toMatchSnapshot();
   });
 });

--- a/packages/engine-server/src/topics/markdown/plugins/__tests__/__snapshots__/dendronRefsPlugin.spec.ts.snap
+++ b/packages/engine-server/src/topics/markdown/plugins/__tests__/__snapshots__/dendronRefsPlugin.spec.ts.snap
@@ -368,6 +368,8 @@ exports[`basic stingify basic 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -378,6 +380,8 @@ exports[`basic stingify basic block 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -388,6 +392,8 @@ exports[`basic stingify basic block with fm 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -397,6 +403,8 @@ exports[`basic stingify basic block with header and start  1`] = `
 ## Header2
 
 task2
+
+
 "
 `;
 
@@ -405,6 +413,8 @@ exports[`basic stingify basic block with header and start, offset  1`] = `
 
 
 task2
+
+
 "
 `;
 
@@ -414,6 +424,8 @@ exports[`basic stingify basic block with header and start, start invalid  1`] = 
 ### Note Ref Error
 
 start anchor badheader not found  
+
+
 "
 `;
 
@@ -423,6 +435,8 @@ exports[`basic stingify basic block with header, start and end  1`] = `
 ## Header1
 
 task1
+
+
 "
 `;
 
@@ -432,6 +446,8 @@ exports[`basic stingify basic block with header, start and end, end invalid  1`]
 ### Note Ref Error
 
 end anchor badheader not found  
+
+
 "
 `;
 
@@ -440,6 +456,8 @@ exports[`basic stingify basic block with header, start and end, offset  1`] = `
 
 
 task1
+
+
 "
 `;
 
@@ -450,6 +468,8 @@ exports[`basic stingify basic block with wildcard as 1st elem  1`] = `
 ## Header1
 
 task1
+
+
 "
 `;
 
@@ -458,6 +478,8 @@ exports[`basic stingify basic block with wildcard as 2nd elem  1`] = `
 
 
 task1
+
+
 "
 `;
 
@@ -482,7 +504,9 @@ exports[`basic stingify renderWithOutline 1`] = `
 task1
 
 
+
 </div>    
 </div>
+
 "
 `;

--- a/packages/engine-server/src/topics/markdown/plugins/__tests__/__snapshots__/denronNoteRefPlugin.spec.ts.snap
+++ b/packages/engine-server/src/topics/markdown/plugins/__tests__/__snapshots__/denronNoteRefPlugin.spec.ts.snap
@@ -371,6 +371,8 @@ exports[`basic stingify 2 lvl recursion 1`] = `
 # Foo.Two
 
 blah
+
+
 "
 `;
 
@@ -382,6 +384,8 @@ exports[`basic stingify 3 levels of recursion 1`] = `
 # Foo.Two
 
 ERROR: Too many nested note references
+
+
 "
 `;
 
@@ -390,6 +394,8 @@ exports[`basic stingify basic 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -400,6 +406,8 @@ exports[`basic stingify basic block 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -410,6 +418,8 @@ exports[`basic stingify basic block with fm 1`] = `
 
 task1
 task2
+
+
 "
 `;
 
@@ -419,6 +429,8 @@ exports[`basic stingify basic block with header and start  1`] = `
 ## Header2
 
 task2
+
+
 "
 `;
 
@@ -427,6 +439,8 @@ exports[`basic stingify basic block with header and start, offset  1`] = `
 
 
 task2
+
+
 "
 `;
 
@@ -436,6 +450,8 @@ exports[`basic stingify basic block with header and start, start invalid  1`] = 
 ### Note Ref Error
 
 start anchor badheader not found  
+
+
 "
 `;
 
@@ -445,6 +461,8 @@ exports[`basic stingify basic block with header, start and end  1`] = `
 ## Header1
 
 task1
+
+
 "
 `;
 
@@ -454,6 +472,8 @@ exports[`basic stingify basic block with header, start and end, end invalid  1`]
 ### Note Ref Error
 
 end anchor badheader not found  
+
+
 "
 `;
 
@@ -462,6 +482,8 @@ exports[`basic stingify basic block with header, start and end, offset  1`] = `
 
 
 task1
+
+
 "
 `;
 
@@ -472,6 +494,8 @@ exports[`basic stingify basic block with wildcard as 1st elem  1`] = `
 ## Header1
 
 task1
+
+
 "
 `;
 
@@ -480,6 +504,8 @@ exports[`basic stingify basic block with wildcard as 2nd elem  1`] = `
 
 
 task1
+
+
 "
 `;
 
@@ -491,6 +517,8 @@ exports[`basic stingify ref with ref, inf recursion 1`] = `
 # Foo.Two
 
 ERROR: Too many nested note references
+
+
 "
 `;
 
@@ -515,7 +543,9 @@ exports[`basic stingify renderWithOutline 1`] = `
 task1
 
 
+
 </div>    
 </div>
+
 "
 `;

--- a/packages/engine-server/src/topics/markdown/remark-abbr.d.ts
+++ b/packages/engine-server/src/topics/markdown/remark-abbr.d.ts
@@ -1,0 +1,14 @@
+declare module "remark-abbr" {
+  import { Plugin } from "unified";
+
+  namespace remarkAbbr {
+    type Abbr = Plugin<[Options?]>;
+
+    interface Options {
+      expandFirst?: boolean;
+    }
+  }
+
+  const plugin: remarkAbbr.Abbr;
+  export = plugin;
+}

--- a/packages/engine-server/src/topics/markdown/utils.ts
+++ b/packages/engine-server/src/topics/markdown/utils.ts
@@ -7,6 +7,8 @@ import markdownItRegex from "markdown-it-regex";
 import Token from "markdown-it/lib/token";
 import os from "os";
 import remark from "remark";
+/// <reference path="remark-abbr.d.ts"/>
+import abbrPlugin from "remark-abbr";
 import frontmatterPlugin from "remark-frontmatter";
 import markdownParse from "remark-parse";
 // import wikiLinkPlugin from "remark-wiki-link";
@@ -102,6 +104,7 @@ export function parse(markdown: string): Node {
     processor ||
     unified()
       .use(markdownParse, { gfm: true })
+      .use(abbrPlugin)
       .use(frontmatterPlugin, ["yaml"])
       .use(dendronLinksPlugin);
   return processor.parse(markdown);
@@ -326,6 +329,7 @@ export function getProcessor(opts?: {
   const { root, renderWithOutline, replaceRefs } = opts || {};
   return remark()
     .use(markdownParse, { gfm: true })
+    .use(abbrPlugin)
     .use(frontmatterPlugin, ["yaml"])
     .use(dendronLinksPlugin)
     .use(dendronRefsPlugin, { root, renderWithOutline, replaceRefs })

--- a/packages/engine-server/src/topics/markdown/utilsv2.ts
+++ b/packages/engine-server/src/topics/markdown/utilsv2.ts
@@ -6,6 +6,7 @@ import {
 } from "@dendronhq/common-all";
 import _ from "lodash";
 import remark from "remark";
+import abbrPlugin from "remark-abbr";
 import frontmatterPlugin from "remark-frontmatter";
 import markdownParse from "remark-parse";
 import {
@@ -42,6 +43,7 @@ export class ParserUtilsV2 {
     const { dendronLinksOpts } = _.defaults(opts, { dendronLinksOpts: {} });
     return remark()
       .use(markdownParse, { gfm: true })
+      .use(abbrPlugin)
       .use(frontmatterPlugin, ["yaml"])
       .use(dendronLinksPlugin, dendronLinksOpts)
       .use({ settings: { listItemIndent: "1", fences: true } });


### PR DESCRIPTION
The Markdown source:

    HTML

    *[HTML]: HyperText Markup Language

Will now be preserved, allowing renderers (e.g. Jekyll) to emit:

    <abbr title="HyperText Markup Language">HTML</abbr>