### PR TITLE
Don't throw an exception in genNoteNameOnly when opts are passed

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupController.ts
+++ b/packages/plugin-core/src/components/lookup/LookupController.ts
@@ -7,6 +7,7 @@ import { LookupCommandOpts } from "../../commands/LookupCommand";
 import { CONFIG } from "../../constants";
 import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../utils";
+import { DendronClientUtilsV2 } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
 import {
   ButtonType,
@@ -76,13 +77,23 @@ export class LookupController {
     // determine value
     switch (noteResp?.type) {
       case "journal": {
-        const value = VSCodeUtils.genNoteName("JOURNAL");
+        let value: string;
+        if (DendronWorkspace.lsp()) {
+          value = DendronClientUtilsV2.genNoteName("JOURNAL");
+        } else {
+          value = VSCodeUtils.genNoteName("JOURNAL");
+        }
         quickPick.value = value;
         provider.onUpdatePickerItem(quickPick, provider.opts);
         break;
       }
       case "scratch": {
-        const value = VSCodeUtils.genNoteName("SCRATCH");
+        let value: string;
+        if (DendronWorkspace.lsp()) {
+          value = DendronClientUtilsV2.genNoteName("SCRATCH");
+        } else {
+          value = VSCodeUtils.genNoteName("SCRATCH");
+        }
         quickPick.value = value;
         provider.onUpdatePickerItem(quickPick, provider.opts);
         break;

--- a/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
@@ -39,6 +39,15 @@ import {
   TIMEOUT,
 } from "../testUtils";
 
+// TODO: This could be cleaned up further+extended, but better for now
+let vaultPath: string;
+const createOneNoteOneSchemaPresetCallback = async (_vaultPath: string) => {
+  vaultPath = _vaultPath;
+  return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
+    vaultDir: vaultPath,
+  });
+};
+
 suite("schemas", function () {
   let root: DirResult;
   let ctx: vscode.ExtensionContext;
@@ -83,11 +92,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -115,11 +120,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -147,11 +148,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
   });
@@ -187,11 +184,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -221,11 +214,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -249,11 +238,7 @@ suite("schemas", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
   });
@@ -565,11 +550,7 @@ suite("notes", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -603,11 +584,7 @@ suite("notes", function () {
       });
       setupDendronWorkspace(root.name, ctx, {
         lsp: true,
-        useCb: async (vaultPath) => {
-          return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-            vaultDir: vaultPath,
-          });
-        },
+        useCb: createOneNoteOneSchemaPresetCallback
       });
     });
 
@@ -903,7 +880,6 @@ suite("notes", function () {
 suite("scratch notes", function () {
   let root: DirResult;
   let ctx: vscode.ExtensionContext;
-  let vaultPath: string;
   let noteType = "SCRATCH";
   let lookupOpts: LookupCommandOpts = {
     noteType: "scratch",
@@ -912,6 +888,7 @@ suite("scratch notes", function () {
     flavor: "note",
   };
   this.timeout(TIMEOUT);
+
 
   beforeEach(function () {
     root = FileTestUtils.tmpDir();
@@ -933,12 +910,7 @@ suite("scratch notes", function () {
     });
     setupDendronWorkspace(root.name, ctx, {
       lsp: true,
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 
@@ -956,12 +928,7 @@ suite("scratch notes", function () {
         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
           "childOfCurrent",
       },
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 
@@ -979,12 +946,7 @@ suite("scratch notes", function () {
         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
           "childOfDomain",
       },
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 });
@@ -992,7 +954,6 @@ suite("scratch notes", function () {
 suite("journal notes", function () {
   let root: DirResult;
   let ctx: vscode.ExtensionContext;
-  let vaultPath: string;
   let noteType = "JOURNAL";
   let lookupOpts: LookupCommandOpts = {
     noteType: "journal",
@@ -1021,12 +982,7 @@ suite("journal notes", function () {
     });
     setupDendronWorkspace(root.name, ctx, {
       lsp: true,
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 
@@ -1044,17 +1000,28 @@ suite("journal notes", function () {
         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
           "childOfDomainNamespace",
       },
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 
   test.skip("add: diff name", function (_done) {});
-  test.skip("add: asOwnDomain", function (_done) {});
+
+  // test creating a daily journal with no note open
+  test("add: asOwnDomain", function (done) {
+    onWSInit(async () => {
+      await new LookupCommand().execute(lookupOpts);
+      assert.ok(getActiveEditorBasename().startsWith("journal"));
+      done();
+    });
+    setupDendronWorkspace(root.name, ctx, {
+      lsp: true,
+      configOverride: {
+        [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+          "asOwnDomain",
+      },
+      useCb: createOneNoteOneSchemaPresetCallback
+    });
+  });
 
   test("add: childOfCurrent", function (done) {
     onWSInit(async () => {
@@ -1070,12 +1037,7 @@ suite("journal notes", function () {
         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
           "childOfCurrent",
       },
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 
@@ -1093,12 +1055,7 @@ suite("journal notes", function () {
         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
           "childOfDomain",
       },
-      useCb: async (_vaultPath) => {
-        vaultPath = _vaultPath;
-        return NodeTestPresetsV2.createOneNoteOneSchemaPreset({
-          vaultDir: vaultPath,
-        });
-      },
+      useCb: createOneNoteOneSchemaPresetCallback
     });
   });
 });

--- a/packages/plugin-core/src/utils.ts
+++ b/packages/plugin-core/src/utils.ts
@@ -421,6 +421,13 @@ export class DendronClientUtilsV2 {
     return out;
   }
 
+  /**
+   * Generates a file name for a journal or scratch note. Must be derived by an
+   * open note, or passed as an option.
+   * @param type 'JOURNAL' | 'SCRATCH'
+   * @param opts Options to control how the note will be named
+   * @returns The file name of the new note
+   */
   static genNoteName(
     type: "JOURNAL" | "SCRATCH",
     opts?: CreateFnameOpts
@@ -445,15 +452,18 @@ export class DendronClientUtilsV2 {
         } must be one of following ${_noteAddBehaviorEnum.join(", ")}`
       );
     }
+
     const editorPath = vscode.window.activeTextEditor?.document.uri.fsPath;
-    if (!editorPath) {
-      throw Error("not currently in a note");
+    const currentNoteFname =
+      opts?.overrides?.domain ||
+      (editorPath ? path.basename(editorPath, ".md") : undefined);
+    if (!currentNoteFname) {
+      throw Error("Must be run from within a note");
     }
+
     const engine = DendronWorkspace.instance().getEngine();
-    const cNoteFname =
-      opts?.overrides?.domain || path.basename(editorPath, ".md");
     const prefix = DendronClientUtilsV2.genNotePrefix(
-      cNoteFname,
+      currentNoteFname,
       addBehavior as AddBehavior,
       {
         engine,


### PR DESCRIPTION
Fixes #122

- Don't throw an exception in genNoteNameOnly when called from outside of a note if opts.overrides.domain is passed.
- Call DendronClientUtilsV2 rather than VSCodeUtils when creating a journal or scratch from LookupController