### PR TITLE
Reference dendron gem for publishing

### DIFF
--- a/packages/plugin-core/assets/jekyll/Gemfile
+++ b/packages/plugin-core/assets/jekyll/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll"
-# TODO: use official gem
-#gem "just-the-docs", path: "/Users/kevinlin/projects/dendronv2/dendron-just-the-docs/"
+# uncomment to preview locally
+# gem "dendron-jekyll"

--- a/packages/plugin-core/assets/jekyll/_config.yml
+++ b/packages/plugin-core/assets/jekyll/_config.yml
@@ -1,5 +1,5 @@
 # uncomment to preview locally
-#theme: "just-the-docs"
+#theme: "dendron-jekyll"
 remote_theme: dendronhq/dendron-jekyll
 title: Dendron
 logo: "/assets/images/logo.png"


### PR DESCRIPTION
Hi. While [running the publishing jekyll server locally](https://www.dendron.so/notes/63b184f7-1901-4580-af40-97ef87069a04.html), I noticed two jekyll files were out of date. I think these changes are correct but perhaps I'm mistaken. Cheers