### PR TITLE
Minor changes to clean up build.sh + TS errors

### DIFF
--- a/bootstrap/scripts/build.sh
+++ b/bootstrap/scripts/build.sh
@@ -10,8 +10,8 @@ npx lerna run build --scope @dendronhq/engine-server  || exit 1
 npx lerna run build --scope @dendronhq/lsp-server  || exit 1
 npx lerna run build --scope @dendronhq/api-server  || exit 1
 
-npx lerna run build --scope @dendronhq/dendron-cli  || exit 1
 npx lerna run build --parallel --scope @dendronhq/pods-core  --scope @dendronhq/seeds-core  || exit 1
+npx lerna run build --scope @dendronhq/dendron-cli  || exit 1
 npx lerna run build --scope @dendronhq/dendron-next-server  || exit 1
 
 npx lerna run build --scope @dendronhq/plugin-core  || exit 1

--- a/packages/dendron-next-server/pages/workspace/config.tsx
+++ b/packages/dendron-next-server/pages/workspace/config.tsx
@@ -28,6 +28,7 @@ import Head from "next/head";
 // TODO Temporarily copied here from engine-server/src/config.ts to use default
 // values for input placeholders.
 const genDefaultConfig = (): DendronConfig => ({
+  version: 1,
   vaults: [],
   site: {
     copyAssets: true,
@@ -40,6 +41,7 @@ const genDefaultConfig = (): DendronConfig => ({
 const getConfigData = (): { data: DendronConfig } => {
   return {
     data: {
+      version: 1, 
       vaults: [
         {
           fsPath: "vault",


### PR DESCRIPTION
dendron-cli was looking for dendron-pods/seeds-core so I had to interchange those values in the build script. 

I think the getConfigData was just a copy error from a few commits ago and was failing a type script check for version number. 