### PR TITLE
Toggle plugin views using 'when' contexts

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -33,12 +33,12 @@
                 {
                     "id": "dendronTreeView",
                     "name": "Dendron Tree View",
-                    "visibility": "visible"
+                    "when": "dendron:showTreeView"
                 },
                 {
                     "id": "dendron.backlinksPanel",
                     "name": "Backlinks",
-                    "visibility": "visible"
+                    "when": "dendron:showBacklinksPanel"
                 }
             ]
         },

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -270,10 +270,16 @@ export async function _activate(context: vscode.ExtensionContext) {
       return;
     }
     await ws.activateWatchers();
+
+    toggleViews(true);
+
     Logger.info({ ctx, msg: "fin startClient" });
   } else {
     // ws not active
     Logger.info({ ctx: "dendron not active" });
+
+    toggleViews(false);
+
     return false;
   }
 
@@ -288,12 +294,25 @@ export async function _activate(context: vscode.ExtensionContext) {
   return true;
 }
 
+function toggleViews(enabled: boolean) {
+  const ctx = "toggleViews";
+  Logger.info({ ctx, msg: `views enabled: ${enabled}` });
+  vscode.commands.executeCommand("setContext", "dendron:showTreeView", enabled);
+  vscode.commands.executeCommand(
+    "setContext",
+    "dendron:showBacklinksPanel",
+    enabled
+  );
+}
+
 // this method is called when your extension is deactivated
 export function deactivate() {
   const ctx = "deactivate";
   const ws = DendronWorkspace.instance();
   ws.deactivate();
   ws.L.info({ ctx });
+
+  toggleViews(false);
 }
 
 async function showWelcomeOrWhatsNew(


### PR DESCRIPTION
Hi team!

I started off a bit frustrated and almost requested a feature, but I figured it was simple enough I might be able to figure it out on my own and learn a bit of extension writing.  

Essentially, I did not like "Dendron Tree View" and "Backlinks" in my view pane while working in non-Dendron workspaces.  I know these can be toggled off, but I thought it better if Dendron managed this itself.  This PR enables Dendron view panes selectively (i.e., when Dendron is actually active) [using 'when' contexts](https://code.visualstudio.com/api/extension-guides/command#using-a-custom-when-clause-context).  I am not entirely sure if this covers every place Dendron becomes active, but the manual testing I completed shows the idea works.

I am not sure how to write a test for this.  Ideally, I would also store these keys into `constants.ts`, but I am also unsure if there should be a new enum defined or if this cleanly fits elsewhere.  Additionally, I think this should be configurable somehow, but I'm not very familiar with how to accomplish that either.  Thanks!