### PR TITLE
fixed note creation not respecting title case issue #344

### DIFF
--- a/packages/common-all/src/nodev2.ts
+++ b/packages/common-all/src/nodev2.ts
@@ -532,7 +532,7 @@ export class NoteUtilsV2 {
   }
 
   static genTitle(fname: string) {
-    return _.capitalize(DNodeUtilsV2.basename(fname, true));
+    return DNodeUtilsV2.basename(fname, true);
   }
 
   static getNotesByFname({

--- a/packages/common-all/src/nodev2.ts
+++ b/packages/common-all/src/nodev2.ts
@@ -532,6 +532,9 @@ export class NoteUtilsV2 {
   }
 
   static genTitle(fname: string) {
+    if (_.toLower(fname) == fname) {
+      return _.upperFirst(DNodeUtilsV2.basename(fname, true));
+    }
     return DNodeUtilsV2.basename(fname, true);
   }
 

--- a/packages/common-test-utils/src/presets/engine-server/write.ts
+++ b/packages/common-test-utils/src/presets/engine-server/write.ts
@@ -378,6 +378,55 @@ const NOTES = {
       },
     }
   ),
+  TITLE_MATCHES_TITLE_CASE: new TestPresetEntryV4(
+    async ({ vaults, wsRoot, engine }) => {
+      const vault = vaults[0];
+      const noteA = await NoteTestUtilsV4.createNote({
+        fname: "Upper Upper",
+        vault: vaults[0],
+        wsRoot,
+      });
+      await engine.writeNote(noteA);
+      const noteB = await NoteTestUtilsV4.createNote({
+        fname: "lower lower",
+        vault: vaults[0],
+        wsRoot,
+      });
+      await engine.writeNote(noteB);
+      const noteC = await NoteTestUtilsV4.createNote({
+        fname: "lower Upper",
+        vault: vaults[0],
+        wsRoot,
+      });
+      await engine.writeNote(noteC);
+      return [
+        {
+          actual: NoteUtilsV2.getNoteByFnameV4({
+            fname: "Upper Upper",
+            notes: engine.notes,
+            vault,
+          })?.title,
+          expected: "Upper Upper"
+        },
+        {
+          actual: NoteUtilsV2.getNoteByFnameV4({
+            fname: "lower lower",
+            notes: engine.notes,
+            vault,
+          })?.title,
+          expected: "Lower lower"
+        },
+        {
+          actual: NoteUtilsV2.getNoteByFnameV4({
+            fname: "lower Upper",
+            notes: engine.notes,
+            vault,
+          })?.title,
+          expected: "lower Upper"
+        },
+      ]
+    }
+  ),
 };
 const NOTES_MULTI = {
   NEW_DOMAIN: new TestPresetEntryV4(async ({ vaults, engine }) => {


### PR DESCRIPTION
removed the post-formatting for the title to remain true to the original input casing.