### PR TITLE
Fix siteUrl typo in cli error throw output

### DIFF
--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -72,7 +72,7 @@ export class DConfig {
       throw `siteRootDir is undefined`;
     }
     if (!siteUrl) {
-      throw `siteURL is undefined`;
+      throw `siteUrl is undefined`;
     }
     if (_.size(siteHierarchies) < 1) {
       throw `siteHiearchies must have at least one hiearchy`;


### PR DESCRIPTION
Ran into this error today. Fixing the typo in the output.