### PR TITLE
Clean up config after vault remove command

### DIFF
--- a/packages/engine-server/src/workspace.ts
+++ b/packages/engine-server/src/workspace.ts
@@ -170,8 +170,10 @@ export class WorkspaceService {
     const config = this.config;
     config.vaults = _.reject(config.vaults, { fsPath: vault.fsPath });
 
-    if (!config.site.duplicateNoteBehavior) {
-    } else if (_.isArray(config.site.duplicateNoteBehavior.payload)) {
+    if (
+      config.site.duplicateNoteBehavior &&
+      _.isArray(config.site.duplicateNoteBehavior.payload)
+    ) {
       if (config.vaults.length == 1) {
         // if there is only one vault left, remove duplicateNoteBehavior setting
         config.site = _.omit(config.site, ["duplicateNoteBehavior"]);

--- a/packages/engine-server/src/workspace.ts
+++ b/packages/engine-server/src/workspace.ts
@@ -169,6 +169,20 @@ export class WorkspaceService {
   async removeVault({ vault }: { vault: DVault }) {
     const config = this.config;
     config.vaults = _.reject(config.vaults, { fsPath: vault.fsPath });
+
+    if (!config.site.duplicateNoteBehavior) {
+    } else if (_.isArray(config.site.duplicateNoteBehavior.payload)) {
+      if (config.vaults.length == 1) {
+        // if there is only one vault left, remove duplicateNoteBehavior setting
+        config.site = _.omit(config.site, ["duplicateNoteBehavior"]);
+      } else {
+        // otherwise pull the removed vault from payload
+        config.site.duplicateNoteBehavior.payload = _.pull(
+          config.site.duplicateNoteBehavior.payload,
+          vault.fsPath
+        );
+      }
+    }
     await this.setConfig(config);
   }
 

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -18,12 +18,8 @@ import _ from "lodash";
 import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
-import {
-  VaultAddCommand,
-  VaultRemoteSource,
-} from "../../commands/VaultAddCommand";
+import { VaultAddCommand } from "../../commands/VaultAddCommand";
 import { WorkspaceFolderRaw, WorkspaceSettings } from "../../types";
-import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
 import { expect, runSingleVaultTest } from "../testUtilsv2";
 import {
@@ -31,43 +27,8 @@ import {
   getConfig,
   runLegacySingleWorkspaceTest,
   setupBeforeAfter,
+  stubVaultInput,
 } from "../testUtilsV3";
-
-const stubVaultInput = (opts: {
-  cmd?: VaultAddCommand;
-  sourceType: VaultRemoteSource;
-  sourcePath: string;
-  sourcePathRemote?: string;
-  sourceName?: string;
-}): void => {
-  if (opts.cmd) {
-    sinon.stub(opts.cmd, "gatherInputs").returns(
-      Promise.resolve({
-        type: opts.sourceType,
-        name: opts.sourceName,
-        path: opts.sourcePath,
-        pathRemote: opts.sourcePathRemote,
-      })
-    );
-  }
-
-  let acc = 0;
-  // @ts-ignore
-  VSCodeUtils.showQuickPick = async () => ({ label: opts.sourceType });
-
-  VSCodeUtils.showInputBox = async () => {
-    if (acc === 0) {
-      acc += 1;
-      return opts.sourcePath;
-    } else if (acc === 1) {
-      acc += 1;
-      return opts.sourceName;
-    } else {
-      throw Error("exceed acc limit");
-    }
-  };
-  return;
-};
 
 const getWorkspaceFolders = () => {
   const wsPath = DendronWorkspace.workspaceFile().fsPath;

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -10,7 +10,7 @@ import { VaultRemoveCommand } from "../../commands/VaultRemoveCommand";
 import { WorkspaceSettings } from "../../types";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
-import { runMultiVaultTest, runSingleVaultTest } from "../testUtilsv2";
+import { expect, runMultiVaultTest, runSingleVaultTest } from "../testUtilsv2";
 import { setupBeforeAfter, stubVaultInput } from "../testUtilsV3";
 
 suite("VaultRemoveCommand", function () {
@@ -77,7 +77,7 @@ suite("VaultRemoveCommand", function () {
 
         const config = readYAML(configPath) as DendronConfig;
         // confirm that duplicateNoteBehavior option exists
-        assert(config.site.duplicateNoteBehavior);
+        expect(config.site.duplicateNoteBehavior).toBeTruthy();
 
         const vaults = DendronWorkspace.instance().vaultsv4;
 
@@ -89,7 +89,7 @@ suite("VaultRemoveCommand", function () {
 
         const configNew = readYAML(configPath) as DendronConfig;
         // confirm that duplicateNoteBehavior setting is gone
-        assert(!configNew.site.duplicateNoteBehavior);
+        expect(configNew.site.duplicateNoteBehavior).toBeFalsy();
 
         done();
       },
@@ -118,10 +118,11 @@ suite("VaultRemoveCommand", function () {
         );
         const configOrig = readYAML(configPathOrig) as DendronConfig;
         // check what we are starting from.
-        assert.deepStrictEqual(
-          configOrig.vaults.map((ent) => ent.fsPath),
-          [vaults[0].fsPath, vaults[1].fsPath, vaults[2].fsPath]
-        );
+        expect(configOrig.vaults.map((ent) => ent.fsPath)).toEqual([
+          vaults[0].fsPath,
+          vaults[1].fsPath,
+          vaults[2].fsPath,
+        ]);
 
         // @ts-ignore
         VSCodeUtils.showQuickPick = () => {
@@ -135,7 +136,7 @@ suite("VaultRemoveCommand", function () {
         const config = readYAML(configPath) as DendronConfig;
 
         // check that "vault2" is gone from payload
-        assert.deepStrictEqual(config.site.duplicateNoteBehavior?.payload, [
+        expect(config.site.duplicateNoteBehavior!.payload).toEqual([
           vault.fsPath.replace("../", ""),
           "vault3",
         ]);

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -100,7 +100,6 @@ suite("VaultRemoveCommand", function () {
     runSingleVaultTest({
       ctx,
       onInit: async ({ wsRoot, vault }) => {
-        // // add 2 vaults in workspace root
         // add two more vaults
 
         const vpath2 = path.join(wsRoot, "vault2");

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -5,12 +5,13 @@ import assert from "assert";
 import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
+import { VaultAddCommand } from "../../commands/VaultAddCommand";
 import { VaultRemoveCommand } from "../../commands/VaultRemoveCommand";
 import { WorkspaceSettings } from "../../types";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
-import { runMultiVaultTest } from "../testUtilsv2";
-import { setupBeforeAfter } from "../testUtilsV3";
+import { runMultiVaultTest, runSingleVaultTest } from "../testUtilsv2";
+import { setupBeforeAfter, stubVaultInput } from "../testUtilsV3";
 
 suite("VaultRemoveCommand", function () {
   let ctx: vscode.ExtensionContext;
@@ -55,6 +56,90 @@ suite("VaultRemoveCommand", function () {
           DendronWorkspace.workspaceFile().fsPath
         ) as WorkspaceSettings;
         assert.deepStrictEqual(settings.folders, [{ path: vaults[0].fsPath }]);
+        done();
+      },
+    });
+  });
+
+  test("omit duplicateNoteBehavior when only one vault left", (done) => {
+    runSingleVaultTest({
+      ctx,
+      onInit: async ({ wsRoot }) => {
+        const configPath = DConfig.configPath(
+          DendronWorkspace.wsRoot() as string
+        );
+
+        // add a second vault
+        const vpath2 = path.join(wsRoot, "vault2");
+
+        stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
+        await new VaultAddCommand().run();
+
+        const config = readYAML(configPath) as DendronConfig;
+        // confirm that duplicateNoteBehavior option exists
+        assert(config.site.duplicateNoteBehavior);
+
+        const vaults = DendronWorkspace.instance().vaultsv4;
+
+        // @ts-ignore
+        VSCodeUtils.showQuickPick = () => {
+          return { data: vaults[1] };
+        };
+        await new VaultRemoveCommand().run();
+
+        const configNew = readYAML(configPath) as DendronConfig;
+        // confirm that duplicateNoteBehavior setting is gone
+        assert(!configNew.site.duplicateNoteBehavior);
+
+        done();
+      },
+    });
+  });
+
+  test("pull removed vault from duplicateNoteBehavior payload", (done) => {
+    runSingleVaultTest({
+      ctx,
+      onInit: async ({ wsRoot, vault }) => {
+        // // add 2 vaults in workspace root
+        // add two more vaults
+
+        const vpath2 = path.join(wsRoot, "vault2");
+        const vpath3 = path.join(wsRoot, "vault3");
+
+        stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
+        await new VaultAddCommand().run();
+
+        stubVaultInput({ sourceType: "local", sourcePath: vpath3 });
+        await new VaultAddCommand().run();
+
+        const vaults = DendronWorkspace.instance().vaultsv4;
+
+        const configPathOrig = DConfig.configPath(
+          DendronWorkspace.wsRoot() as string
+        );
+        const configOrig = readYAML(configPathOrig) as DendronConfig;
+        // check what we are starting from.
+        assert.deepStrictEqual(
+          configOrig.vaults.map((ent) => ent.fsPath),
+          [vaults[0].fsPath, vaults[1].fsPath, vaults[2].fsPath]
+        );
+
+        // @ts-ignore
+        VSCodeUtils.showQuickPick = () => {
+          return { data: vaults[1] };
+        };
+        await new VaultRemoveCommand().run();
+
+        const configPath = DConfig.configPath(
+          DendronWorkspace.wsRoot() as string
+        );
+        const config = readYAML(configPath) as DendronConfig;
+
+        // check that "vault2" is gone from payload
+        assert.deepStrictEqual(config.site.duplicateNoteBehavior?.payload, [
+          vault.fsPath.replace("../", ""),
+          "vault3",
+        ]);
         done();
       },
     });

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -15,6 +15,7 @@ import {
   EngineTestUtilsV4,
   PreSetupCmdHookFunction,
   PreSetupHookFunction,
+  sinon,
 } from "@dendronhq/common-test-utils";
 import {
   DConfig,
@@ -30,6 +31,10 @@ import {
   SetupWorkspaceCommand,
   SetupWorkspaceOpts,
 } from "../commands/SetupWorkspace";
+import {
+  VaultAddCommand,
+  VaultRemoteSource,
+} from "../commands/VaultAddCommand";
 import { WorkspaceConfig } from "../settings";
 import { WorkspaceFolderRaw, WorkspaceSettings } from "../types";
 import { VSCodeUtils } from "../utils";
@@ -333,4 +338,40 @@ export const createEngineFactory = (
     return engine;
   };
   return createEngine;
+};
+
+export const stubVaultInput = (opts: {
+  cmd?: VaultAddCommand;
+  sourceType: VaultRemoteSource;
+  sourcePath: string;
+  sourcePathRemote?: string;
+  sourceName?: string;
+}): void => {
+  if (opts.cmd) {
+    sinon.stub(opts.cmd, "gatherInputs").returns(
+      Promise.resolve({
+        type: opts.sourceType,
+        name: opts.sourceName,
+        path: opts.sourcePath,
+        pathRemote: opts.sourcePathRemote,
+      })
+    );
+  }
+
+  let acc = 0;
+  // @ts-ignore
+  VSCodeUtils.showQuickPick = async () => ({ label: opts.sourceType });
+
+  VSCodeUtils.showInputBox = async () => {
+    if (acc === 0) {
+      acc += 1;
+      return opts.sourcePath;
+    } else if (acc === 1) {
+      acc += 1;
+      return opts.sourceName;
+    } else {
+      throw Error("exceed acc limit");
+    }
+  };
+  return;
 };


### PR DESCRIPTION
Closes #505 

- clean up `duplicateNoteBehavior` configuration after vault is removed
- test said fix
- move `stubVaultInput` to test utils. (Sorry if this is introducing noise to the PR, but I needed that stub to write the tests for my fixes 😅 )