### PR TITLE
Consolidate testing convention

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -2,16 +2,15 @@ import { NotePropsV2, NoteUtilsV2 } from "@dendronhq/common-all";
 import {
   NoteTestUtilsV4,
   NOTE_PRESETS_V4,
-  toPlainObject,
+  toPlainObject
 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import path from "path";
 import * as vscode from "vscode";
 import { Uri } from "vscode";
 import BacklinksTreeDataProvider from "../../features/BacklinksTreeDataProvider";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
-import { runMultiVaultTest } from "../testUtilsv2";
+import { expect, runMultiVaultTest } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 const getChildren = async () => {
@@ -59,11 +58,10 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async ({ wsRoot, vaults }) => {
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        assert.strictEqual(
-          out[0].command.arguments[0].path as string,
+        expect(out[0].command.arguments[0].path as string).toEqual(
           path.join(wsRoot, vaults[0].fsPath, "beta.md")
-        );
-        assert.strictEqual(out.length, 1);
+        )
+        expect(out.length).toEqual(1);
         done();
       },
     });
@@ -90,11 +88,10 @@ suite("BacklinksTreeDataProvider", function () {
         const notePath = path.join(wsRoot, vaults[0].fsPath, "alpha.md");
         await VSCodeUtils.openFileInEditor(Uri.file(notePath));
         const out = toPlainObject(await getChildren()) as any;
-        assert.strictEqual(
-          out[0].command.arguments[0].path as string,
+        expect(out[0].command.arguments[0].path as string).toEqual(
           path.join(wsRoot, vaults[1].fsPath, "beta.md")
-        );
-        assert.strictEqual(out.length, 1);
+        )
+        expect(out.length).toEqual(1)
         done();
       },
     });
@@ -119,14 +116,13 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async () => {
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        assert.strictEqual(
-          out[0].command.arguments[0].path as string,
+        expect(out[0].command.arguments[0].path as string).toEqual(
           NoteUtilsV2.getPathV4({
             note: noteWithLink,
             wsRoot: DendronWorkspace.wsRoot(),
           })
         );
-        assert.strictEqual(out.length, 1);
+        expect(out.length).toEqual(1);
         done();
       },
     });
@@ -151,11 +147,15 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async ({ wsRoot }) => {
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        assert.strictEqual(
-          out[0].command.arguments[0].path as string,
+        // assert.strictEqual(
+        //   out[0].command.arguments[0].path as string,
+        //   NoteUtilsV2.getPathV4({ note: noteWithLink, wsRoot })
+        // );
+        expect(out[0].command.arguments[0].path as string).toEqual(
           NoteUtilsV2.getPathV4({ note: noteWithLink, wsRoot })
         );
-        assert.strictEqual(out.length, 1);
+        // assert.strictEqual(out.length, 1);
+        expect(out.length).toEqual(1);
         done();
       },
     });

--- a/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
@@ -3,9 +3,8 @@ import { NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
 import {
   JSONExportPod,
   podClassEntryToPodItemV4,
-  PodUtils,
+  PodUtils
 } from "@dendronhq/pods-core";
-import assert from "assert";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
 // // You can import and use all API from the 'vscode' module
@@ -14,6 +13,7 @@ import * as vscode from "vscode";
 import { ConfigurePodCommand } from "../../commands/ConfigurePodCommand";
 import { VSCodeUtils } from "../../utils";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
+import { expect } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("ConfigurePod", function () {
@@ -38,7 +38,7 @@ suite("ConfigurePod", function () {
       };
       await cmd.run();
       const activePath = VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath;
-      assert.ok(activePath?.endsWith("pods/dendron.json/config.export.yml"));
+      expect(activePath?.endsWith("pods/dendron.json/config.export.yml")).toBeTruthy();
       done();
     });
 
@@ -73,7 +73,7 @@ suite("ConfigurePod", function () {
       writeYAML(configPath, { dest: exportDest });
       await cmd.run();
       const activePath = VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath;
-      assert.ok(activePath?.endsWith("pods/dendron.json/config.export.yml"));
+      expect(activePath?.endsWith("pods/dendron.json/config.export.yml")).toBeTruthy();
       done();
     });
 

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -3,10 +3,9 @@ import {
   DirResult,
   note2File,
   tmpDir,
-  vault2Path,
+  vault2Path
 } from "@dendronhq/common-server";
 import { ENGINE_HOOKS, NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
@@ -52,7 +51,7 @@ suite("CopyNoteRef", function () {
       const notePath = path.join(vaultPath, "foo.md");
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
       const link = await new CopyNoteRefCommand().run();
-      assert.deepStrictEqual(link, "![[foo]]");
+      expect(link).toEqual("![[foo]]");
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -72,7 +71,7 @@ suite("CopyNoteRef", function () {
       )) as vscode.TextEditor;
       editor.selection = new vscode.Selection(7, 0, 7, 12);
       const link = await new CopyNoteRefCommand().run();
-      assert.equal(link, "![[bar#foo,1:#*]]");
+      expect(link).toEqual("![[bar#foo,1:#*]]");
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -103,7 +102,7 @@ suite("CopyNoteRef", function () {
       )) as vscode.TextEditor;
       editor.selection = new vscode.Selection(7, 0, 7, 4);
       const link = await new CopyNoteRefCommand().run();
-      assert.equal(link, "![[bar#foo,1:#*]]");
+      expect(link).toEqual("![[bar#foo,1:#*]]");
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -134,7 +133,7 @@ suite("CopyNoteRef", function () {
       )) as vscode.TextEditor;
       editor.selection = new vscode.Selection(7, 0, 7, 12);
       const link = await new CopyNoteRefCommand().run();
-      assert.equal(link, "![[bar#foo,1]]");
+      expect(link).toEqual("![[bar#foo,1]]");
       done();
     });
     setupDendronWorkspace(root.name, ctx, {

--- a/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
@@ -1,10 +1,7 @@
-import assert from "assert";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
 import * as vscode from "vscode";
 import { CreateDailyJournalCommand } from "../../commands/CreateDailyJournal";
 import { getActiveEditorBasename } from "../testUtils";
-import { runSingleVaultTest } from "../testUtilsv2";
+import { expect, runSingleVaultTest } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("notes", function () {
@@ -17,7 +14,7 @@ suite("notes", function () {
       ctx,
       onInit: async ({}) => {
         await new CreateDailyJournalCommand().run();
-        assert.ok(getActiveEditorBasename().startsWith("daily.journal"));
+        expect(getActiveEditorBasename().startsWith("daily.journal")).toBeTruthy();
         done();
       },
     });

--- a/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
@@ -2,10 +2,9 @@ import { getSlugger, NotePropsV2, NoteUtilsV2 } from "@dendronhq/common-all";
 import {
   ENGINE_HOOKS_MULTI,
   NoteTestUtilsV4,
-  NOTE_PRESETS_V4,
+  NOTE_PRESETS_V4
 } from "@dendronhq/common-test-utils";
 import { callSetupHook, SETUP_HOOK_KEYS } from "@dendronhq/engine-test-utils";
-import assert from "assert";
 import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
@@ -113,8 +112,7 @@ suite("DefinitionProvider", function () {
             pos,
             null as any
           )) as vscode.Location;
-          assert.strictEqual(
-            LocationTestUtils.getBasenameFromLocation(loc),
+          expect(LocationTestUtils.getBasenameFromLocation(loc)).toEqual(
             "alpha.md"
           );
           done();
@@ -181,8 +179,7 @@ suite("DefinitionProvider", function () {
             pos,
             null as any
           )) as vscode.Location;
-          assert.strictEqual(
-            LocationTestUtils.getBasenameFromLocation(loc),
+          expect(LocationTestUtils.getBasenameFromLocation(loc)).toEqual(
             "alpha.md"
           );
           done();
@@ -275,9 +272,8 @@ suite("DefinitionProvider", function () {
         onInit: async () => {
           const editor = await VSCodeUtils.openNote(noteWithLink);
           const locations = (await provide(editor)) as vscode.Location[];
-          assert.deepStrictEqual(locations.length, 2);
-          assert.deepStrictEqual(
-            locations.map((l) => l.uri.fsPath),
+          expect(locations.length).toEqual(2);
+          expect(locations.map((l) => l.uri.fsPath)).toEqual(
             [
               NoteUtilsV2.getPathV4({ wsRoot: _wsRoot, note: noteTarget1 }),
               NoteUtilsV2.getPathV4({ wsRoot: _wsRoot, note: noteTarget2 }),
@@ -318,8 +314,7 @@ suite("DefinitionProvider", function () {
             pos,
             null as any
           )) as vscode.Location;
-          assert.strictEqual(
-            loc.uri.fsPath,
+          expect(loc.uri.fsPath).toEqual(
             NoteUtilsV2.getPathV4({ wsRoot: _wsRoot, note: noteWithTarget })
           );
           done();

--- a/packages/plugin-core/src/test/suite-integ/DeleteNodeCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DeleteNodeCommand.test.ts
@@ -2,23 +2,21 @@ import { NoteChangeEntry } from "@dendronhq/common-all";
 import {
   DirResult,
   EngineDeletePayload,
-  tmpDir,
+  tmpDir
 } from "@dendronhq/common-server";
 import {
   NodeTestPresetsV2,
-  NoteTestPresetsV2,
+  NoteTestPresetsV2
 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
 import * as vscode from "vscode";
 import { DeleteNodeCommand } from "../../commands/DeleteNodeCommand";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
+import { expect } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 const NOTE_DELETE_PRESET =
@@ -42,8 +40,8 @@ suite("notes", function () {
       await new DeleteNodeCommand().execute();
       const vaultFiles = fs.readdirSync(vaultPath);
       const noteFiles = vaultFiles.filter((ent) => ent.endsWith(".md"));
-      assert.strictEqual(noteFiles.length, 2);
-      assert.deepStrictEqual(noteFiles.sort(), ["foo.ch1.md", "root.md"]);
+      expect(noteFiles.length).toEqual(2);
+      expect(noteFiles.sort()).toEqual(["foo.ch1.md", "root.md"]);
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -69,7 +67,7 @@ suite("notes", function () {
           notes,
         }),
         (ent) => {
-          assert.deepStrictEqual(ent.expected, ent.actual);
+          expect(ent.expected).toEqual(ent.actual);
         }
       );
       done();
@@ -92,8 +90,8 @@ suite("notes", function () {
       await new DeleteNodeCommand().execute();
       const vaultFiles = fs.readdirSync(vaultPath);
       const noteFiles = vaultFiles.filter((ent) => ent.endsWith(".md"));
-      assert.strictEqual(noteFiles.length, 2);
-      assert.deepStrictEqual(noteFiles.sort(), ["foo.ch1.md", "root.md"]);
+      expect(noteFiles.length).toEqual(2);
+      expect(noteFiles.sort()).toEqual(["foo.ch1.md", "root.md"]);
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -124,12 +122,11 @@ suite("schemas", function () {
       await new DeleteNodeCommand().execute();
       const vaultFiles = fs.readdirSync(vaultPath);
       const noteFiles = vaultFiles.filter((ent) => ent.endsWith(".schema.yml"));
-      assert.strictEqual(
+      expect(
         DendronWorkspace.instance().getEngine().notes["foo"].schema,
-        undefined
-      );
-      assert.strictEqual(noteFiles.length, 1);
-      assert.deepStrictEqual(noteFiles.sort(), ["root.schema.yml"]);
+      ).toEqual(undefined);
+      expect(noteFiles.length).toEqual(1);
+      expect(noteFiles.sort()).toEqual(["root.schema.yml"]);
       done();
     });
     setupDendronWorkspace(root.name, ctx, {

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -1,16 +1,14 @@
 import { NoteUtilsV2 } from "@dendronhq/common-all";
 import { DirResult, tmpDir } from "@dendronhq/common-server";
 import { NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
 import * as vscode from "vscode";
 import { DoctorCommand } from "../../commands/Doctor";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
+import { expect } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("notes", function () {
@@ -31,9 +29,9 @@ suite("notes", function () {
       await new DoctorCommand().run();
       // cehck that frontmatter is added
       const resp = fs.readFileSync(testFile, { encoding: "utf8" });
-      assert.ok(NoteUtilsV2.RE_FM.exec(resp));
-      assert.ok(NoteUtilsV2.RE_FM_UPDATED.exec(resp));
-      assert.ok(NoteUtilsV2.RE_FM_CREATED.exec(resp));
+      expect(NoteUtilsV2.RE_FM.exec(resp)).toBeTruthy();
+      expect(NoteUtilsV2.RE_FM_UPDATED.exec(resp)).toBeTruthy();
+      expect(NoteUtilsV2.RE_FM_CREATED.exec(resp)).toBeTruthy();
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -225,16 +223,18 @@ suite("notes", function () {
       fs.removeSync(path.join(root.name, "docs"));
       await new ReloadIndexCommand().run();
       const findings = await new DoctorCommand().run();
-      assert.ok(_.find(findings?.data, { issue: "no siteRoot found" }));
+      expect(_.find(findings?.data, { issue: "no siteRoot found" })).toBeTruthy();
       const docsDir = path.join(root.name, "docs");
-      assert.ok(fs.existsSync(docsDir));
-      assert.deepStrictEqual(fs.readdirSync(docsDir), [
-        "404.md",
-        "Gemfile",
-        "_config.yml",
-        "assets",
-        "favicon.ico",
-      ]);
+      expect(fs.existsSync(docsDir)).toBeTruthy();
+      expect(fs.readdirSync(docsDir)).toEqual(
+        [
+          "404.md",
+          "Gemfile",
+          "_config.yml",
+          "assets",
+          "favicon.ico",
+        ]
+      );
       done();
     });
     setupDendronWorkspace(root.name, ctx, {

--- a/packages/plugin-core/src/test/suite-integ/DocumentLinkProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DocumentLinkProvider.test.ts
@@ -1,10 +1,9 @@
 import { NoteTestUtilsV4, toPlainObject } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import path from "path";
 import * as vscode from "vscode";
 import DocumentLinkProvider from "../../features/DocumentLinkProvider";
 import { VSCodeUtils } from "../../utils";
-import { runMultiVaultTest } from "../testUtilsv2";
+import { expect, runMultiVaultTest } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("DocumentLinkProvider", function () {
@@ -34,7 +33,7 @@ suite("DocumentLinkProvider", function () {
         const linkProvider = new DocumentLinkProvider();
         const links = linkProvider.provideDocumentLinks(doc);
 
-        assert.strictEqual(links.length, 1);
+        expect(links.length).toEqual(1);
         console.log(toPlainObject(links[0]));
         done();
       },

--- a/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
@@ -3,9 +3,8 @@ import { DirResult, note2File, tmpDir } from "@dendronhq/common-server";
 import {
   AssertUtils,
   ENGINE_HOOKS_MULTI,
-  NodeTestPresetsV2,
+  NodeTestPresetsV2
 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import _ from "lodash";
 import { describe } from "mocha";
 import path from "path";
@@ -114,7 +113,7 @@ suite("notes", function () {
         const notePath = path.join(vaultPath, "bar.md");
         const uri = vscode.Uri.file(notePath);
         const note = await watcher.onDidCreate(uri);
-        assert.ok(_.isUndefined(note));
+        expect(_.isUndefined(note)).toBeTruthy();
         done();
       });
       setupDendronWorkspace(root.name, ctx, {

--- a/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
@@ -1,12 +1,12 @@
 import { DirResult, tmpDir } from "@dendronhq/common-server";
 import { NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import path from "path";
 import * as vscode from "vscode";
 import { GoDownCommand } from "../../commands/GoDownCommand";
 import { DendronQuickPickerV2 } from "../../components/lookup/types";
 import { VSCodeUtils } from "../../utils";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
+import { expect } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("notes", function () {
@@ -29,7 +29,7 @@ suite("notes", function () {
       quickpick.onDidChangeSelection(() => {});
       quickpick.onDidChangeActive(() => {
         const item = quickpick.activeItems[0];
-        assert.strictEqual(item.id, "foo.ch1");
+        expect(item.id).toEqual("foo.ch1");
         done();
       });
     });

--- a/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
@@ -1,12 +1,12 @@
 import { DirResult } from "@dendronhq/common-server";
 import { FileTestUtils, NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
 import { GoUpCommand } from "../../commands/GoUpCommand";
 import { VSCodeUtils } from "../../utils";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
+import { expect } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("GoUpCommand", function () {
@@ -25,11 +25,9 @@ suite("GoUpCommand", function () {
       const notePath = path.join(vaultPath, "foo.md");
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
       await new GoUpCommand().run();
-      assert.ok(
-        VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
-          "root.md"
-        )
-      );
+      expect(VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
+        "root.md"
+      )).toBeTruthy();
       done();
     });
     setupDendronWorkspace(root.name, ctx, {
@@ -46,11 +44,9 @@ suite("GoUpCommand", function () {
       const notePath = path.join(vaultPath, "foo.ch1.md");
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
       await new GoUpCommand().run();
-      assert.ok(
-        VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
-          "root.md"
-        )
-      );
+      expect(VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
+        "root.md"
+      )).toBeTruthy();
       done();
     });
     setupDendronWorkspace(root.name, ctx, {

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -1,6 +1,5 @@
 import { NotePropsV2, NoteUtilsV2 } from "@dendronhq/common-all";
 import { ENGINE_HOOKS } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -12,7 +11,7 @@ import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
 import { getActiveEditorBasename } from "../testUtils";
-import { runSingleVaultTest } from "../testUtilsv2";
+import { expect, runSingleVaultTest } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 const { ANCHOR_WITH_SPECIAL_CHARS, ANCHOR } = GOTO_NOTE_PRESETS;
@@ -32,8 +31,8 @@ suite("GotoNote", function () {
           mode: "note",
           vault,
         })) as { note: NotePropsV2 };
-        assert.deepStrictEqual(out, note);
-        assert.strictEqual(getActiveEditorBasename(), "foo.md");
+        expect(out).toEqual(note);
+        expect(getActiveEditorBasename()).toEqual("foo.md");
         done();
       },
     });
@@ -55,7 +54,7 @@ suite("GotoNote", function () {
           vault,
           wsRoot: DendronWorkspace.wsRoot(),
         }) as NotePropsV2;
-        assert.deepStrictEqual(_.pick(note, ["fname", "stub"]), {
+        expect(_.pick(note, ["fname", "stub"])).toEqual({
           fname: "foo",
           stub: true,
         });
@@ -65,11 +64,11 @@ suite("GotoNote", function () {
           mode: "note",
           vault,
         })) as { note: NotePropsV2 };
-        assert.deepStrictEqual(_.pick(out, ["fname", "stub", "id"]), {
+        expect(_.pick(out, ["fname", "stub", "id"])).toEqual({
           fname: "foo",
           id: note.id,
         });
-        assert.strictEqual(getActiveEditorBasename(), "foo.md");
+        expect(getActiveEditorBasename()).toEqual("foo.md");
         done();
       },
     });
@@ -84,10 +83,10 @@ suite("GotoNote", function () {
           mode: "note",
           vault,
         })) as { note: NotePropsV2 };
-        assert.deepStrictEqual(_.pick(out, ["fname", "stub"]), {
-          fname: "foo.ch2",
+        expect(_.pick(out, ["fname", "stub"])).toEqual({
+          fname: "foo.ch2"
         });
-        assert.strictEqual(getActiveEditorBasename(), "foo.ch2.md");
+        expect(getActiveEditorBasename()).toEqual("foo.ch2.md");
         done();
       },
     });
@@ -105,9 +104,9 @@ suite("GotoNote", function () {
           mode: "note",
           vault,
         });
-        assert.deepStrictEqual(getActiveEditorBasename(), "bar.ch1.md");
+        expect(getActiveEditorBasename()).toEqual("bar.ch1.md");
         const content = VSCodeUtils.getActiveTextEditor()?.document.getText() as string;
-        assert.ok(content.indexOf("ch1 template") >= 0);
+        expect(content.indexOf("ch1 template") >= 0).toBeTruthy();
         done();
       },
     });
@@ -132,10 +131,10 @@ suite("GotoNote", function () {
             value: "H3",
           },
         });
-        assert.deepStrictEqual(getActiveEditorBasename(), "alpha.md");
+        expect(getActiveEditorBasename()).toEqual("alpha.md");
         const selection = VSCodeUtils.getActiveTextEditor()?.selection;
-        assert.strictEqual(selection?.start.line, 9);
-        assert.strictEqual(selection?.start.character, 0);
+        expect(selection?.start.line).toEqual(9);
+        expect(selection?.start.character).toEqual(0);
         done();
       },
     });
@@ -161,10 +160,10 @@ suite("GotoNote", function () {
             value: specialCharsHeader,
           },
         });
-        assert.deepStrictEqual(getActiveEditorBasename(), "alpha.md");
+        expect(getActiveEditorBasename()).toEqual("alpha.md");
         const selection = VSCodeUtils.getActiveTextEditor()?.selection;
-        assert.strictEqual(selection?.start.line, 9);
-        assert.strictEqual(selection?.start.character, 0);
+        expect(selection?.start.line).toEqual(9);
+        expect(selection?.start.character).toEqual(0);
         done();
       },
     });

--- a/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
@@ -5,9 +5,9 @@ import {
   NoteUtilsV2,
   SchemaModulePropsV2,
   SchemaUtilsV2,
-  WorkspaceOpts,
+  WorkspaceOpts
 } from "@dendronhq/common-all";
-import { vault2Path, tmpDir } from "@dendronhq/common-server";
+import { tmpDir, vault2Path } from "@dendronhq/common-server";
 import {
   ENGINE_HOOKS,
   ENGINE_QUERY_PRESETS,
@@ -16,10 +16,9 @@ import {
   NOTE_PRESETS_V4,
   runJestHarnessV2,
   sinon,
-  TestPresetEntryV4,
+  TestPresetEntryV4
 } from "@dendronhq/common-test-utils";
 import { DendronEngineV2 } from "@dendronhq/engine-server";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import { describe } from "mocha";
@@ -28,12 +27,12 @@ import path from "path";
 // // as well as import your extension to test it
 import * as vscode from "vscode";
 import { CancellationTokenSource } from "vscode-languageclient";
+import { createAllButtons } from "../../components/lookup/buttons";
 import { LookupControllerV2 } from "../../components/lookup/LookupControllerV2";
 import { LookupProviderV2 } from "../../components/lookup/LookupProviderV2";
-import { createAllButtons } from "../../components/lookup/buttons";
 import {
   createNoActiveItem,
-  PickerUtilsV2,
+  PickerUtilsV2
 } from "../../components/lookup/utils";
 import { EngineFlavor, EngineOpts } from "../../types";
 import { VSCodeUtils } from "../../utils";
@@ -46,7 +45,7 @@ import {
   runLegacyMultiWorkspaceTest,
   runLegacySingleWorkspaceTest,
   setupBeforeAfter,
-  withConfig,
+  withConfig
 } from "../testUtilsV3";
 
 const createEngineForSchemaUpdateItems = createEngineFactory({
@@ -395,8 +394,8 @@ suite("Lookup, notesv2", function () {
           );
           const quickpick = await lc.show();
           quickpick.onDidChangeActive(() => {
-            assert.equal(lc.quickPick?.activeItems.length, 1);
-            assert.equal(lc.quickPick?.activeItems[0].fname, "foo");
+            expect(lc.quickPick?.activeItems.length).toEqual(1);
+            expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
             done();
           });
           await lp.onUpdatePickerItem(
@@ -427,22 +426,19 @@ suite("Lookup, notesv2", function () {
           let note = _.find(quickpick.items, {
             fname: "foo",
           }) as DNodePropsQuickInputV2;
-          assert.ok(note.stub);
+          expect(note.stub).toBeTruthy();
           quickpick.selectedItems = [note];
           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
           lc.onDidHide(async () => {
-            assert.equal(
-              path.basename(
-                VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-              ),
-              "foo.md"
-            );
+            expect(path.basename(
+              VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+            )).toEqual("foo.md");
             const lc2 = new LookupControllerV2(engOpts);
             const quickpick2 = await lc2.show();
             note = _.find(quickpick2.items, {
               fname: "foo",
             }) as DNodePropsQuickInputV2;
-            assert.ok(!note.stub);
+            expect(note.stub).toBeFalsy();
             done();
           });
           quickpick.hide();
@@ -508,9 +504,8 @@ suite("Lookup, notesv2", function () {
             "manual",
             lc.cancelToken.token
           );
-          assert.deepStrictEqual(quickpick.items.length, 4);
-          assert.deepStrictEqual(
-            _.find(quickpick.items, { fname: "foo.ch1.gch1" }),
+          expect(quickpick.items.length).toEqual(4);
+          expect(_.find(quickpick.items, { fname: "foo.ch1.gch1" })).toEqual(
             undefined
           );
           done();

--- a/packages/plugin-core/src/test/suite-integ/LookupCommandMulti.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommandMulti.test.ts
@@ -1,7 +1,6 @@
 import { DNodeUtilsV2, DVault, NotePropsV2 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
 import { NodeTestPresetsV2, PLUGIN_CORE } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import { describe } from "mocha";
@@ -20,8 +19,8 @@ import { DendronWorkspace } from "../../workspace";
 import { _activate } from "../../_extension";
 import { createMockQuickPick, onWSInit, TIMEOUT } from "../testUtils";
 import {
-  getNoteFromTextEditor,
-  setupCodeWorkspaceMultiVaultV2,
+  expect, getNoteFromTextEditor,
+  setupCodeWorkspaceMultiVaultV2
 } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
@@ -170,7 +169,7 @@ suite.skip("Lookup notes, multi", function () {
         onInitCb: async ({ quickpick, lp, lc }) => {
           quickpick.value = "";
           await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
-          assert.strictEqual(lc.quickPick?.items.length, 4);
+          expect(lc.quickPick?.items.length).toEqual(4);
           done();
         },
       });
@@ -185,8 +184,8 @@ suite.skip("Lookup notes, multi", function () {
           quickpick.value = "";
           await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
           quickpick.onDidChangeActive(() => {
-            assert.strictEqual(lc.quickPick?.activeItems.length, 1);
-            assert.strictEqual(lc.quickPick?.activeItems[0].fname, "foo");
+            expect(lc.quickPick?.activeItems.length).toEqual(1);
+            expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
             done();
           });
         },
@@ -203,17 +202,14 @@ suite.skip("Lookup notes, multi", function () {
             "manual",
             token
           );
-          assert.deepStrictEqual(quickpick.items.length, 4);
-          assert.deepStrictEqual(
-            _.pick(_.find(quickpick.items, { fname: "foo.ch1" }), [
-              "fname",
-              "schemaStub",
-            ]),
-            {
-              fname: "foo.ch1",
-              schemaStub: true,
-            }
-          );
+          expect(quickpick.items.length).toEqual(4);
+          expect(_.pick(_.find(quickpick.items, { fname: "foo.ch1" }), [
+            "fname",
+            "schemaStub",
+          ])).toEqual({
+            fname: "foo.ch1",
+            schemaStub: true,
+          });
           done();
         },
         beforeActivateCb: async ({ vaults }) => {
@@ -271,17 +267,14 @@ suite.skip("Lookup notes, multi", function () {
             selectedItems: [createNoActiveItem(vaults[0])],
           });
           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          assert.strictEqual(
-            DNodeUtilsV2.fname(
-              VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-            ),
-            "bond"
-          );
+          expect(DNodeUtilsV2.fname(
+            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+          )).toEqual("bond");
           const txtPath = vscode.window.activeTextEditor?.document.uri
             .fsPath as string;
           const vault = { fsPath: path.dirname(txtPath) };
           const node = file2Note(txtPath, vault);
-          assert.strictEqual(node.title, "Bond");
+          expect(node.title).toEqual("Bond");
           console.log("onInitCb:exit");
           done();
         },
@@ -308,17 +301,14 @@ suite.skip("Lookup notes, multi", function () {
             selectedItems: [createNoActiveItem(vaults[0])],
           });
           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          assert.strictEqual(
-            DNodeUtilsV2.fname(
-              VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-            ),
-            "bond"
-          );
+          expect(DNodeUtilsV2.fname(
+            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+          )).toEqual("bond");
           const txtPath = vscode.window.activeTextEditor?.document.uri
             .fsPath as string;
           const vault = { fsPath: path.dirname(txtPath) };
           const node = file2Note(txtPath, vault);
-          assert.strictEqual(node.title, "Bond");
+          expect(node.title).toEqual("Bond");
           console.log("onInitCb:exit");
           done();
         },

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -2,9 +2,8 @@ import { vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
   FileTestUtils,
-  NoteTestUtilsV4,
+  NoteTestUtilsV4
 } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import path from "path";
 // // You can import and use all API from the 'vscode' module
@@ -60,7 +59,7 @@ suite("RefactorHiearchy", function () {
           return "proceed";
         };
         const resp = await new RefactorHierarchyCommandV2().run();
-        assert.strictEqual(resp.changed.length, 6);
+        expect(resp.changed.length).toEqual(6);
         const vault = vaults[0];
         const vpath = vault2Path({ vault, wsRoot });
         const notes = fs.readdirSync(vpath).join("");

--- a/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
@@ -1,6 +1,5 @@
 import { vault2Path } from "@dendronhq/common-server";
 import { ENGINE_HOOKS } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -8,6 +7,7 @@ import path from "path";
 // // as well as import your extension to test it
 import * as vscode from "vscode";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
+import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("ReloadIndex", function () {
@@ -32,7 +32,7 @@ suite("ReloadIndex", function () {
         ];
         rootFiles.map((ent) => fs.removeSync(ent));
         await new ReloadIndexCommand().run();
-        assert.ok(_.every(rootFiles.map((ent) => fs.existsSync(ent))));
+        expect(_.every(rootFiles.map((ent) => fs.existsSync(ent)))).toBeTruthy();
         done();
       },
     });
@@ -53,11 +53,9 @@ suite("ReloadIndex", function () {
         fs.appendFileSync(rootFiles[0], "bond", { encoding: "utf8" });
         fs.appendFileSync(rootFiles[1], "# bond", { encoding: "utf8" });
         await new ReloadIndexCommand().run();
-        assert.ok(
-          _.every(
-            rootFiles.map((ent) => fs.readFileSync(ent).indexOf("bond") >= 0)
-          )
-        );
+        expect(_.every(
+          rootFiles.map((ent) => fs.readFileSync(ent).indexOf("bond") >= 0)
+        )).toBeTruthy();
         done();
       },
     });

--- a/packages/plugin-core/src/test/suite-integ/SetupDWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SetupDWorkspace.test.ts
@@ -1,6 +1,5 @@
 import { FileTestUtils } from "@dendronhq/common-test-utils";
 import { EngineConnector, getPortFilePath } from "@dendronhq/engine-server";
-import * as assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import { beforeEach, describe, it } from "mocha";
@@ -9,7 +8,7 @@ import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace } from "../../workspace";
 import { _activate } from "../../_extension";
 import { onExtension } from "../testUtils";
-import { setupCodeWorkspaceV2 } from "../testUtilsv2";
+import { expect, setupCodeWorkspaceV2 } from "../testUtilsv2";
 
 const TIMEOUT = 60 * 1000 * 5;
 
@@ -39,7 +38,7 @@ suite.skip("startup", function () {
           numRetries: 0,
         })
         .catch((err) => {
-          assert.strictEqual(err.msg, "exceeded numTries");
+          expect(err.msg).toEqual("exceeded numTries");
           done();
         });
     });
@@ -47,7 +46,7 @@ suite.skip("startup", function () {
     it("server file created after init", function (done) {
       cengine.init({
         onReady: async () => {
-          assert.ok(!_.isUndefined(cengine.engine));
+          expect(_.isUndefined(cengine.engine)).toBeFalsy();
           done();
         },
       });
@@ -65,7 +64,7 @@ suite.skip("startup", function () {
           cengine
             .init({
               onReady: async () => {
-                assert.ok(!_.isUndefined(cengine.engine));
+                expect(_.isUndefined(cengine.engine)).toBeFalsy();
                 done();
               },
               numRetries: 0,

--- a/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
@@ -5,15 +5,14 @@ import {
   readYAML,
   tmpDir,
   writeJSONWithComments,
-  writeYAML,
+  writeYAML
 } from "@dendronhq/common-server";
 import {
   DConfig,
   getPortFilePath,
   getWSMetaFilePath,
-  openWSMetaFile,
+  openWSMetaFile
 } from "@dendronhq/engine-server";
-import * as assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import { describe, it } from "mocha";
@@ -27,7 +26,7 @@ import {
   expect,
   genDefaultSettings,
   genEmptyWSFiles,
-  stubWorkspaceFolders,
+  stubWorkspaceFolders
 } from "../testUtilsv2";
 import { runLegacySingleWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
@@ -52,12 +51,12 @@ suite("SetupWorkspace", function () {
           const port = getPortFilePath({ wsRoot });
           const fpath = getWSMetaFilePath({ wsRoot });
           const meta = openWSMetaFile({ fpath });
-          assert.ok(
+          expect(
             _.toInteger(fs.readFileSync(port, { encoding: "utf8" })) > 0
-          );
-          assert.strictEqual(meta.version, "0.0.1");
-          assert.ok(meta.activationTime < Time.now().toMillis());
-          assert.strictEqual(_.values(engine.notes).length, 1);
+          ).toBeTruthy();
+          expect(meta.version).toEqual("0.0.1");
+          expect(meta.activationTime < Time.now().toMillis()).toBeTruthy();
+          expect(_.values(engine.notes).length).toEqual(1);
           const vault = resolveRelToWSRoot(vaults[0].fsPath);
 
           const settings = fs.readJSONSync(

--- a/packages/plugin-core/src/test/suite-integ/UpgradeWorkspace.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/UpgradeWorkspace.spec.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert";
 import _ from "lodash";
 import { describe, it } from "mocha";
 import { ExtensionContext } from "vscode";
@@ -6,7 +5,7 @@ import { ResetConfigCommand } from "../../commands/ResetConfig";
 import { DendronWorkspace } from "../../workspace";
 import { _activate } from "../../_extension";
 import { onExtension } from "../testUtils";
-import { setupCodeWorkspaceV2 } from "../testUtilsv2";
+import { expect, setupCodeWorkspaceV2 } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
 const TIMEOUT = 60 * 1000 * 5;
@@ -56,8 +55,7 @@ suite("upgrade", function () {
       onExtension({
         action: "upgraded",
         cb: async (ev: { data: any }) => {
-          assert.deepStrictEqual(
-            ev.data.changes.configUpdate,
+          expect(ev.data.changes.configUpdate).toEqual(
             exepctedUpgradeSettings()
           );
           done();
@@ -83,9 +81,9 @@ suite("upgrade", function () {
             exepctedUpgradeSettings(),
             "pasteImage.prefix"
           );
-          assert.deepStrictEqual(ev.data.changes.configUpdate, expected);
+          expect(ev.data.changes.configUpdate).toEqual(expected);
           const config = DendronWorkspace.configuration();
-          assert.strictEqual(config.get<string>("pasteImage.prefix"), "/foo");
+          expect(config.get<string>("pasteImage.prefix")).toEqual("/foo");
           done();
         },
       });

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -3,16 +3,15 @@ import {
   NoteUtilsV2,
   SchemaUtilsV2,
   VaultUtils,
-  WorkspaceOpts,
+  WorkspaceOpts
 } from "@dendronhq/common-all";
 import {
   note2File,
   readYAML,
   schemaModuleOpts2File,
-  tmpDir,
+  tmpDir
 } from "@dendronhq/common-server";
 import { FileTestUtils, sinon } from "@dendronhq/common-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import { describe } from "mocha";
@@ -27,7 +26,7 @@ import {
   getConfig,
   runLegacySingleWorkspaceTest,
   setupBeforeAfter,
-  stubVaultInput,
+  stubVaultInput
 } from "../testUtilsV3";
 
 const getWorkspaceFolders = () => {
@@ -130,7 +129,7 @@ suite("VaultAddCommand", function () {
           const vpath = path.join(wsRoot, "vault2");
           stubVaultInput({ sourceType: "local", sourcePath: vpath });
           await new VaultAddCommand().run();
-          assert.deepStrictEqual(fs.readdirSync(vpath), [
+          expect(fs.readdirSync(vpath)).toEqual([
             "root.md",
             "root.schema.yml",
           ]);
@@ -181,7 +180,7 @@ suite("VaultAddCommand", function () {
           const vpath = path.join(wsRoot, "vault2");
           stubVaultInput({ sourceType: "local", sourcePath: vpath });
           await new VaultAddCommand().run();
-          assert.deepStrictEqual(fs.readdirSync(vpath), [
+          expect(fs.readdirSync(vpath)).toEqual([
             "root.md",
             "root.schema.yml",
           ]);
@@ -207,7 +206,7 @@ suite("VaultAddCommand", function () {
           stubVaultInput({ sourceType: "local", sourcePath });
           await new VaultAddCommand().run();
           const vpath = path.join(wsRoot, sourcePath);
-          assert.deepStrictEqual(fs.readdirSync(vpath), [
+          expect(fs.readdirSync(vpath)).toEqual([
             "root.md",
             "root.schema.yml",
           ]);
@@ -233,7 +232,7 @@ suite("VaultAddCommand", function () {
           const vaultRelPath = path.relative(wsRoot, vpath);
           stubVaultInput({ sourceType: "local", sourcePath: vpath });
           await new VaultAddCommand().run();
-          assert.deepStrictEqual(fs.readdirSync(vpath), [
+          expect(fs.readdirSync(vpath)).toEqual([
             "root.md",
             "root.schema.yml",
           ]);

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -1,7 +1,6 @@
 import { DendronConfig } from "@dendronhq/common-all";
 import { readYAML } from "@dendronhq/common-server";
 import { DConfig } from "@dendronhq/engine-server";
-import assert from "assert";
 import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
@@ -30,32 +29,28 @@ suite("VaultRemoveCommand", function () {
         await new VaultRemoveCommand().run();
 
         // check no files deleted
-        assert.deepStrictEqual(
-          fs.readdirSync(path.join(wsRoot, vaults[1].fsPath)),
-          [
-            "bar.ch1.md",
-            "bar.md",
-            "bar.schema.yml",
-            "root.md",
-            "root.schema.yml",
-          ]
-        );
+        expect(fs.readdirSync(path.join(wsRoot, vaults[1].fsPath))).toEqual([
+          "bar.ch1.md",
+          "bar.md",
+          "bar.schema.yml",
+          "root.md",
+          "root.schema.yml",
+        ]);
 
         // check config updated
         const configPath = DConfig.configPath(
           DendronWorkspace.wsRoot() as string
         );
         const config = readYAML(configPath) as DendronConfig;
-        assert.deepStrictEqual(
-          config.vaults.map((ent) => ent.fsPath),
-          [vaults[0].fsPath]
-        );
+        expect(config.vaults.map((ent) => ent.fsPath)).toEqual([
+          vaults[0].fsPath
+        ]);
 
         // check vscode settings updated
         const settings = fs.readJSONSync(
           DendronWorkspace.workspaceFile().fsPath
         ) as WorkspaceSettings;
-        assert.deepStrictEqual(settings.folders, [{ path: vaults[0].fsPath }]);
+        expect(settings.folders).toEqual([{ path: vaults[0].fsPath }]);
         done();
       },
     });


### PR DESCRIPTION
closes: #520 

- Fix all bare asserts to jest-like expect
- Omit changes to
  - test harnesses
  - commented test codes that uses bare asserts
  - test code in lsp-client
