### PR TITLE
fix: go-down at root matches itself only

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
@@ -269,7 +269,7 @@ export class LookupControllerV2 {
         break;
       }
       default:
-        if (quickPickValue) {
+        if (quickPickValue !== undefined) {
           onUpdateValue = quickPickValue;
         } else {
           let editorPath = vscode.window.activeTextEditor?.document.uri.fsPath;


### PR DESCRIPTION
When the `go-down` command is executed at `root`, the value for the lookup is set to an empty string (will match everything) instead of `root.` (will match only itself and other notes with `root.` in the name):

https://github.com/dendronhq/dendron/blob/79580cdca8d34d2e8e0e57adc69811ddd8dcc2cc/packages/plugin-core/src/commands/GoDownCommand.ts#L22-L24

In the `LookupControllerV2`, there is a falsy check against the `quickPickValue` and when it matches the empty string, the filename of the active editor is used instead (which is `root.`):

https://github.com/dendronhq/dendron/blob/79580cdca8d34d2e8e0e57adc69811ddd8dcc2cc/packages/plugin-core/src/components/lookup/LookupControllerV2.ts#L272-L275

Seeing how `quickPickValue` is typed to be only `string` or `undefined`, I think the condition should explicitly check for `undefined` to preserve the empty string and let the `go-down` command match everything at the root level.

Closes #619