### PR TITLE
Check before prompting vault selection in `MoveNoteCommand`

### DIFF
--- a/packages/common-test-utils/tsconfig.build.json
+++ b/packages/common-test-utils/tsconfig.build.json
@@ -1,10 +1,9 @@
 {
-    "extends": "../../tsconfig.build.json",
-    "compilerOptions": {
-      "outDir": "./lib",
-      "rootDir": "src",
-      "skipLibCheck": true
-    },
-    "exclude": ["node_modules", "**/*-spec.ts"]
-  }
-  
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "**/*-spec.ts"]
+}

--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -50,7 +50,9 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }
 
   createLookup() {
-    const buttons = [VaultSelectButton.create(true)];
+    const vaults = getWS().config.vaults;
+    const isMultiVault = vaults.length > 1;
+    const buttons = [VaultSelectButton.create(isMultiVault)];
     const lc = new LookupControllerV3({ nodeType: "note", buttons });
     return lc;
   }
@@ -75,6 +77,7 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
           if (event.action === "done") {
             HistoryService.instance().remove("move", "lookupProvider");
             resolve(event.data);
+            lc.onHide();
           } else if (event.action === "error") {
             return;
           } else {

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -3,7 +3,6 @@ import {
   AssertUtils,
   EngineTestUtilsV4,
   ENGINE_HOOKS,
-  FileTestUtils,
   NoteTestUtilsV4,
 } from "@dendronhq/common-test-utils";
 import _ from "lodash";


### PR DESCRIPTION
This PR:
- Adds a check before prompting a user for vault selection in `MoveNoteCommand`.
  - If it's a single vault setup vault selection is skipped.
  - If there are multiple vaults the command will prompt the user for a vault selection.
- Adds tests for said changes. 

closes: #470 