### PR TITLE
Add Doctor command to create missing linked notes

### DIFF
--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import {
   VaultUtils,
   DLink,
   NoteUtils,
+  DVault,
 } from "@dendronhq/common-all";
 import {
   DendronASTDest,
@@ -73,7 +74,7 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   }
 
   getWildLinkDestinations(notes: NoteProps[], wsRoot: string) {
-    let wildWikiLinks = [] as DLink[];
+    let wildWikiLinks: DLink[] = [];
     _.forEach(notes, (note) => {
       const links = note.links;
       if (_.isEmpty(links)) {
@@ -90,22 +91,22 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             vault: destVault,
             notes: notes,
             wsRoot: wsRoot,
-          }) as NoteProps;
+          });
           return !noteExists;
         })
       );
       return true;
     });
-    const uniqueCandidates = _.map(
+    const uniqueCandidates: NoteProps[] = _.map(
       _.uniqBy(wildWikiLinks, "to.fname"),
       (link) => {
         const destVault = link.to!.vault ? link.to!.vault : link.from.vault;
-        return {
-          fname: link.to!.fname,
-          vault: destVault,
-        };
+        return NoteUtils.create({
+          fname: link.to!.fname!,
+          vault: destVault!,
+        });
       }
-    ) as NoteProps[];
+    );
     return uniqueCandidates;
   }
 

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -4,7 +4,6 @@ import {
   VaultUtils,
   DLink,
   NoteUtils,
-  DVault,
 } from "@dendronhq/common-all";
 import {
   DendronASTDest,

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -33,6 +33,7 @@ export enum DoctorActions {
   HI_TO_H2 = "h1ToH2",
   REMOVE_STUBS = "removeStubs",
   OLD_NOTE_REF_TO_NEW = "oldNoteRefToNew",
+  CREATE_MISSING_LINKED_NOTES = "createMissingLinkedNotes",
 }
 
 export { CommandOpts as DoctorCLICommandOpts };

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
@@ -7,7 +7,9 @@ import {
   DoctorCLICommandOpts,
 } from "@dendronhq/dendron-cli";
 import path from "path";
+import fs from "fs-extra";
 import { createEngineFromServer, runEngineTestV5 } from "../../../engine";
+import _ from "lodash";
 
 const setupBasic = async (opts: WorkspaceOpts) => {
   const { wsRoot, vaults } = opts;
@@ -22,6 +24,74 @@ const setupBasic = async (opts: WorkspaceOpts) => {
     vault: vaults[0],
     fname: "bar",
     body: [`# Bar Header`, `## Bar Content`].join("\n"),
+  });
+};
+
+const setupWithWikilink = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo",
+    body: "[[foo.bar]]\n",
+  });
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo.bar",
+    body: "[[fake.link]]\n",
+  });
+};
+
+const setupMultiWithWikilink = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo",
+    body: "[[foo.bar]]\n",
+  });
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo.bar",
+    body: "[[fake.link]]\n",
+  });
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[1],
+    fname: "baz",
+    body: "[[baz.qaaz]]\n",
+  });
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[1],
+    fname: "baz.qaaz",
+    body: "[[fake]]\n",
+  });
+};
+
+const setupWithAliasedWikilink = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo",
+    body: ["[[foo bar|foo.bar]]", "[[foobaz|foo.baz]]"].join("\n"),
+  });
+};
+
+const setupWithXVaultWikilink = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "foo",
+    body: [
+      "[[dendron://vault2/bar]]",
+      "[[baz|dendron://vault2/baz]]",
+      "[[qaaaz note|dendron://vault2/qaaaz]]",
+    ].join("\n"),
   });
 };
 
@@ -140,6 +210,136 @@ describe("H1_TO_TITLE", () => {
         createEngine: createEngineFromServer,
         expect,
         preSetupHook: setupBasic,
+      }
+    );
+  });
+});
+
+describe("CREATE_MISSING_LINKED_NOTES", () => {
+  const action = DoctorActions.CREATE_MISSING_LINKED_NOTES;
+  test("basic", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "fake.link.md")
+        );
+        expect(fileExists).toBeTruthy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithWikilink,
+      }
+    );
+  });
+
+  test("dry run", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+          dryRun: true,
+        });
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "fake.link.md")
+        );
+        expect(fileExists).toBeFalsy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithWikilink,
+      }
+    );
+  });
+
+  test("wild link with alias", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileNames = ["foo.bar.md", "foo.baz.md"];
+        _.forEach(fileNames, async (fileName) => {
+          const fileExists = await fs.pathExists(
+            path.join(wsRoot, vault.fsPath, fileName)
+          );
+          expect(fileExists).toBeTruthy();
+        });
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithAliasedWikilink,
+      }
+    );
+  });
+
+  test("missing notes in multiple vaults", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault2 = vaults[1];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExistsVault1 = await fs.pathExists(
+          path.join(wsRoot, vault1.fsPath, "fake.link.md")
+        );
+        expect(fileExistsVault1).toBeTruthy();
+        const fileExistsVault2 = await fs.pathExists(
+          path.join(wsRoot, vault2.fsPath, "fake.md")
+        );
+        expect(fileExistsVault2).toBeTruthy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupMultiWithWikilink,
+      }
+    );
+  });
+
+  test("xvaults wild links", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault2 = vaults[1];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExistsVault1 = await fs.pathExists(
+          path.join(wsRoot, vault1.fsPath, "bar.md")
+        );
+        expect(fileExistsVault1).toBeFalsy();
+        const fileNames = ["bar.md", "baz.md", "qaaaz.md"];
+        _.forEach(fileNames, async (fileName) => {
+          const fileExistsVault2 = await fs.pathExists(
+            path.join(wsRoot, vault2.fsPath, fileName)
+          );
+          expect(fileExistsVault2).toBeTruthy();
+        });
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithXVaultWikilink,
       }
     );
   });

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -1,4 +1,9 @@
-import { DEngineClient } from "@dendronhq/common-all";
+import {
+  DEngineClient,
+  NoteUtils,
+  NoteProps,
+  DLink,
+} from "@dendronhq/common-all";
 import {
   BackfillV2Command,
   DoctorActions,
@@ -6,13 +11,16 @@ import {
 } from "@dendronhq/dendron-cli";
 import fs from "fs-extra";
 import _ from "lodash";
+import _md from "markdown-it";
 import path from "path";
-import { window } from "vscode";
+import { window, ViewColumn } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
 import { DendronWorkspace, getWS } from "../workspace";
 import { BasicCommand } from "./base";
 import { ReloadIndexCommand } from "./ReloadIndex";
+
+const md = _md();
 
 type Finding = {
   issue: string;
@@ -38,6 +46,27 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       return { action: doctorAction.label };
     }
     return;
+  }
+
+  async showPreview(candidates: NoteProps[]) {
+    const vault = candidates[0].vault.fsPath;
+    let content = [
+      "# Create Missing Linked Notes Preview",
+      "",
+      `## The following files will be created in \'${vault}\'`,
+    ];
+
+    _.forEach(candidates, (candidate) => {
+      content = content.concat(`- ${candidate.fname}\n`);
+    });
+
+    const panel = window.createWebviewPanel(
+      "doctorCreateMissingLinkedNotesPreview",
+      "Create MissingLinked Notes Preview",
+      ViewColumn.One,
+      {}
+    );
+    panel.webview.html = md.render(content.join("\n"));
   }
 
   async execute(opts: CommandOpts) {
@@ -66,6 +95,71 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         await new BackfillV2Command().execute({
           engine: engine,
         });
+        break;
+      }
+      case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
+        const notes = engine.notes;
+        // pick out wild wikilinks
+        let wildWikiLinks = [] as DLink[];
+        _.forEach(notes, (note) => {
+          const links = note.links;
+          if (_.isEmpty(links)) {
+            return false;
+          }
+          const wsRoot = DendronWorkspace.wsRoot();
+          wildWikiLinks = wildWikiLinks.concat(
+            _.filter(links, (link) => {
+              if (link.type != "wiki") {
+                return false;
+              }
+              const noteExists = NoteUtils.getNoteByFnameV5({
+                fname: link.to!.fname as string,
+                vault: note.vault,
+                notes: notes,
+                wsRoot: wsRoot,
+              }) as NoteProps;
+              return !noteExists;
+            })
+          );
+          return true;
+        });
+
+        // pick out unique candidate notes to create
+        const uniqueCandidates = _.map(
+          _.uniqBy(wildWikiLinks, "to.fname"),
+          (link) => {
+            return {
+              fname: link.to!.fname,
+              vault: link.from.vault,
+            };
+          }
+        ) as NoteProps[];
+        if (uniqueCandidates.length > 0) {
+          // show preview before creating
+          await this.showPreview(uniqueCandidates);
+          const options = ["proceed", "cancel"];
+          const shouldProceed = await VSCodeUtils.showQuickPick(options, {
+            placeHolder: "proceed",
+            ignoreFocusOut: true,
+          });
+          if (shouldProceed !== "proceed") {
+            window.showInformationMessage("cancelled");
+            break;
+          }
+          window.showInformationMessage("creating missing links...");
+          if (ws.vaultWatcher) {
+            ws.vaultWatcher.pause = true;
+          }
+          _.forEach(uniqueCandidates, async ({ fname, vault }) => {
+            await engine.getNoteByPath({
+              npath: fname,
+              createIfNew: true,
+              vault: vault,
+            });
+          });
+        } else {
+          window.showInformationMessage(`There are no missing links!`);
+        }
         break;
       }
       default: {

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -1,5 +1,5 @@
 import { NoteUtils } from "@dendronhq/common-all";
-import { DirResult, tmpDir } from "@dendronhq/common-server";
+import { DirResult, tmpDir, vault2Path } from "@dendronhq/common-server";
 import {
   ENGINE_HOOKS,
   NodeTestPresetsV2,
@@ -13,11 +13,16 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { DoctorCommand } from "../../commands/Doctor";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
+import { VSCodeUtils } from "../../utils";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
 import { expect } from "../testUtilsv2";
-import { runLegacySingleWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  runLegacyMultiWorkspaceTest,
+  runLegacySingleWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
-suite("notes", function () {
+suite("DoctorCommandTest", function () {
   let root: DirResult;
   let ctx: vscode.ExtensionContext;
 
@@ -280,7 +285,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
     },
   });
 
-  test.only("basic", (done) => {
+  test("basic proceed", (done) => {
     runLegacySingleWorkspaceTest({
       ctx,
       postSetupHook: ENGINE_HOOKS.setupBasic,
@@ -298,7 +303,209 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
           })
         );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+        quickPickStub
+          .onCall(0)
+          .returns(
+            Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+          );
         await cmd.run();
+        const vaultPath = vault2Path({ vault, wsRoot });
+        const containsNew = _.includes(
+          fs.readdirSync(vaultPath),
+          "real.fake.md"
+        );
+        expect(containsNew).toBeTruthy();
+        done();
+      },
+    });
+  });
+
+  test("basic cancelled", (done) => {
+    runLegacySingleWorkspaceTest({
+      ctx,
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      onInit: async ({ wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await NoteTestUtilsV4.createNote({
+          fname: "real",
+          body: "[[real.fake]]\n",
+          vault: vault,
+          wsRoot,
+        });
+        const cmd = new DoctorCommand();
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+        quickPickStub
+          .onCall(0)
+          .returns(
+            Promise.resolve("cancelled") as Thenable<vscode.QuickPickItem>
+          );
+        await cmd.run();
+        const vaultPath = vault2Path({ vault, wsRoot });
+        const containsNew = _.includes(
+          fs.readdirSync(vaultPath),
+          "real.fake.md"
+        );
+        expect(containsNew).toBeFalsy();
+        done();
+      },
+    });
+  });
+
+  test("wild link with alias", (done) => {
+    runLegacySingleWorkspaceTest({
+      ctx,
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      onInit: async ({ wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await NoteTestUtilsV4.createNote({
+          fname: "real",
+          body: [
+            "[[something|real.fake]]",
+            "[[something something|real.something]]",
+          ].join("\n"),
+          vault: vault,
+          wsRoot,
+        });
+        const cmd = new DoctorCommand();
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+        quickPickStub
+          .onCall(0)
+          .returns(
+            Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+          );
+        await cmd.run();
+        const vaultPath = vault2Path({ vault, wsRoot });
+        const fileNames = ["real.fake.md", "real.something.md"];
+        _.forEach(fileNames, (fileName) => {
+          const containsNew = _.includes(fs.readdirSync(vaultPath), fileName);
+          expect(containsNew).toBeTruthy();
+        });
+        done();
+      },
+    });
+  });
+
+  test("wild links in multiple vaults", (done) => {
+    runLegacyMultiWorkspaceTest({
+      ctx,
+      preSetupHook: async (opts) => {
+        await ENGINE_HOOKS.setupBasic(opts);
+      },
+      onInit: async ({ wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault2 = vaults[1];
+        await NoteTestUtilsV4.createNote({
+          fname: "first",
+          body: [
+            "[[wild]]",
+            "[[somenote|somenote]]",
+            "[[some note|something]]",
+          ].join("\n"),
+          vault: vault1,
+          wsRoot,
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "second",
+          body: [
+            "[[wild2]]",
+            "[[somenote|somenote2]]",
+            "[[some note|something2]]",
+          ].join("\n"),
+          vault: vault2,
+          wsRoot,
+        });
+        const cmd = new DoctorCommand();
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+        quickPickStub
+          .onCall(0)
+          .returns(
+            Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+          );
+        await cmd.run();
+        const firstVaultPath = vault2Path({ vault: vault1, wsRoot });
+        const firstVaultFileNames = ["wild.md", "somenote.md", "something.md"];
+        _.forEach(firstVaultFileNames, (fileName) => {
+          const containsNew = _.includes(
+            fs.readdirSync(firstVaultPath),
+            fileName
+          );
+          expect(containsNew).toBeTruthy();
+        });
+        const secondVaultPath = vault2Path({ vault: vault2, wsRoot });
+        const secondVaultFileNames = [
+          "wild2.md",
+          "somenote2.md",
+          "something2.md",
+        ];
+        _.forEach(secondVaultFileNames, (fileName) => {
+          const containsNew = _.includes(
+            fs.readdirSync(secondVaultPath),
+            fileName
+          );
+          expect(containsNew).toBeTruthy();
+        });
+        done();
+      },
+    });
+  });
+
+  test("xvault wild links", (done) => {
+    runLegacyMultiWorkspaceTest({
+      ctx,
+      preSetupHook: async (opts) => {
+        await ENGINE_HOOKS.setupBasic(opts);
+      },
+      onInit: async ({ wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault2 = vaults[1];
+        await NoteTestUtilsV4.createNote({
+          fname: "first",
+          body: [
+            "[[dendron://vault2/second]]",
+            "[[somenote|dendron://vault2/somenote]]",
+            "[[some note|dendron://vault2/something]]",
+          ].join("\n"),
+          vault: vault1,
+          wsRoot,
+        });
+        const cmd = new DoctorCommand();
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+        quickPickStub
+          .onCall(0)
+          .returns(
+            Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+          );
+        await cmd.run();
+        const sVaultPath = vault2Path({ vault: vault1, wsRoot });
+        const xVaultPath = vault2Path({ vault: vault2, wsRoot });
+        const fileNames = ["second.md", "somenote.md", "something.md"];
+        _.forEach(fileNames, (fileName) => {
+          const inSVault = _.includes(fs.readdirSync(sVaultPath), fileName);
+          const inXVault = _.includes(fs.readdirSync(xVaultPath), fileName);
+          expect(inSVault).toBeFalsy();
+          expect(inXVault).toBeTruthy();
+        });
         done();
       },
     });


### PR DESCRIPTION
This PR:
- adds a new Doctor command that goes through wikilinks in all notes and create notes that are linked but does not exist yet.

related to: #355
