### PR TITLE
triaged bot update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,9 +14,10 @@ assignees: ''
  Look here -> [triage](https://dendron.so/notes/1e6c8b49-ef88-4e79-b2df-e9d614c38a53.html) 
  for help with choosing.
  Needed for Auto labeling:
- issue_labeler_regex_version=2
+ issue_labeler_regex_version=3
  
  - [X] Bug
+ - [ ] IsTriaged
  -->
 
 ## Please select the area your Bug applys to. (Multiple selections are Possible)
@@ -51,8 +52,9 @@ If applicable, add screenshots to help explain your problem.
 
 ## Desktop (please complete the following information)
 
-- OS: [e.g. mac/windows]
-- Version [e.g. v41]
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,9 @@ assignees: ''
  for help with choosing.
 
  Needed for Auto labeling:
- issue_labeler_regex_version=2
+ issue_labeler_regex_version=3
+ 
+ - [ ] IsTriaged
 
  -->
 

--- a/.github/ISSUE_TEMPLATE/pod-request-template.md
+++ b/.github/ISSUE_TEMPLATE/pod-request-template.md
@@ -13,10 +13,11 @@ assignees: kpathakota
  Select something by placing an 'x' or 'X' inside the brackets.
 
  Needed for Auto labeling:
- issue_labeler_regex_version=2
+ issue_labeler_regex_version=3
 
  - [X] Onboard. 
  - [X] Feature Request
+ - [ ] IsTriaged
 
  -->
 

--- a/.github/ISSUE_TEMPLATE/seed-request.md
+++ b/.github/ISSUE_TEMPLATE/seed-request.md
@@ -13,10 +13,11 @@ assignees: ''
  Select something by placing an 'x' or 'X' inside the brackets.
 
  Needed for Auto labeling:
- issue_labeler_regex_version=2
+ issue_labeler_regex_version=3
 
  - [X] Onboard. 
  - [X] Feature Request
+ - [ ] IsTriaged
  -->
 
 ## Proposal

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+ Do not Remove this block!
+
+ Select something by placing an 'x' or 'X' inside the brackets.
+ Needed for Auto labeling:
+ issue_labeler_regex_version=3
+ 
+ - [x] IsTriaged
+ -->
 ## Context
 
 ## Proposal

--- a/.github/config/issue-labler/labler-v3.yml
+++ b/.github/config/issue-labler/labler-v3.yml
@@ -1,0 +1,21 @@
+area.onboard:
+  - '- \[ ?(?:x|X) ?\] Onboard.'
+area.create:
+  - '- \[ ?(?:x|X) ?\] Create.'
+area.retrieve:
+  - '- \[ ?(?:x|X) ?\] Retrieve.'
+area.structure:
+  - '- \[ ?(?:x|X) ?\] Structure.'
+area.publish:
+  - '- \[ ?(?:x|X) ?\] Publish.'
+area.misc:
+  - '- \[ ?(?:x|X) ?\] Misc'
+type.bug:
+  - '- \[ ?(?:x|X) ?\] Bug'
+type.enhancement:
+  - '- \[ ?(?:x|X) ?\] Enhancement of an existing Feature.'
+type.feature:
+  - '- \[ ?(?:x|X) ?\] Request of a new feature.'
+status.triage-needed:
+  - '- \[ ] IsTriaged'
+


### PR DESCRIPTION
Had an irritating issue happen every time I triaged something but then updated the issue, the untriaged label would get added to it again. Figured this would be a good way to address it. 