### PR TITLE
feat: Basic block reference link functionality

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -46,7 +46,7 @@ export type DNoteAnchor = {
   /**
    * In the future, we could have ID based anchors
    */
-  type: "header";
+  type: "header" | "block";
   value: string;
 };
 

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -105,6 +105,17 @@ export const NOTE_PRESETS_V4 = {
     fname: "beta",
     body: `[[alpha#h3]]`,
   }),
+  NOTE_WITH_BLOCK_ANCHOR_TARGET: CreateNoteFactory({
+    fname: "anchor-target",
+    body: [
+      "Lorem ipsum dolor amet",
+      "Maiores exercitationem officiis adipisci voluptate",
+      "",
+      "^block-id",
+      "",
+      "Alias eos velit aspernatur",
+    ].join("\n"),
+  }),
   NOTE_WITH_CAPS_AND_SPACE: CreateNoteFactory({
     fname: "000 Index.md",
     body: "[[alpha]]",

--- a/packages/engine-server/src/markdown/remark/blockAnchors.ts
+++ b/packages/engine-server/src/markdown/remark/blockAnchors.ts
@@ -50,7 +50,7 @@ function attachParser(proc: Unified.Processor) {
         type: "blockAnchor",
         value,
         id: match[1],
-      } as BlockAnchor);
+      });
     }
     return;
   }

--- a/packages/engine-server/src/markdown/remark/blockAnchors.ts
+++ b/packages/engine-server/src/markdown/remark/blockAnchors.ts
@@ -66,10 +66,10 @@ function attachParser(proc: Unified.Processor) {
 function attachCompiler(proc: Unified.Processor, _opts?: CompilerOpts) {
   const Compiler = proc.Compiler;
   const visitors = Compiler.prototype.visitors;
-  let { dest } = MDUtilsV4.getDendronData(proc);
 
   if (visitors) {
     visitors.blockAnchor = function (node: BlockAnchor) {
+      const { dest } = MDUtilsV4.getDendronData(proc);
       switch (dest) {
         case DendronASTDest.MD_DENDRON:
         case DendronASTDest.MD_REGULAR:

--- a/packages/engine-server/src/markdown/remark/blockAnchors.ts
+++ b/packages/engine-server/src/markdown/remark/blockAnchors.ts
@@ -1,0 +1,90 @@
+import _ from "lodash";
+import { Eat } from "remark-parse";
+import Unified, { Plugin } from "unified";
+import { BlockAnchor, DendronASTDest } from "../types";
+import { MDUtilsV4 } from "../utils";
+
+// Letters, digits, dashes, and underscores.
+// The underscores are an extension over Obsidian.
+export const LINK_REGEX = /^\^([\w-]+)$/;
+export const LINK_REGEX_LOOSE = /\^([\w-]+)/;
+
+/**
+ *
+ * @param text The text to check if it matches an block anchor.
+ * @param matchLoose If true, a block anchor anywhere in the string will match. Otherwise the string must contain only the anchor.
+ * @returns The identifier for the match block anchor, or undefined if it did not match.
+ */
+export const matchBlockAnchor = (
+  text: string,
+  matchLoose: boolean = true
+): string | undefined => {
+  const match = (matchLoose ? LINK_REGEX_LOOSE : LINK_REGEX).exec(text);
+  if (match && match.length == 1) return match[1];
+  return undefined;
+};
+
+type PluginOpts = {};
+
+type CompilerOpts = {};
+
+const plugin: Plugin<[CompilerOpts?]> = function (
+  this: Unified.Processor,
+  opts?: PluginOpts
+) {
+  attachParser(this);
+  if (this.Compiler != null) {
+    attachCompiler(this, opts);
+  }
+};
+
+function attachParser(proc: Unified.Processor) {
+  function locator(value: string, fromIndex: number) {
+    return value.indexOf("^", fromIndex);
+  }
+
+  function inlineTokenizer(eat: Eat, value: string) {
+    const match = LINK_REGEX.exec(value);
+    if (match) {
+      return eat(match[0])({
+        type: "blockAnchor",
+        value,
+        id: match[1],
+      } as BlockAnchor);
+    }
+    return;
+  }
+  inlineTokenizer.locator = locator;
+
+  const Parser = proc.Parser;
+  const inlineTokenizers = Parser.prototype.inlineTokenizers;
+  const inlineMethods = Parser.prototype.inlineMethods;
+  inlineTokenizers.blockAnchor = inlineTokenizer;
+  inlineMethods.splice(inlineMethods.indexOf("link"), 0, "blockAnchor");
+}
+
+function attachCompiler(proc: Unified.Processor, _opts?: CompilerOpts) {
+  const Compiler = proc.Compiler;
+  const visitors = Compiler.prototype.visitors;
+  let { dest } = MDUtilsV4.getDendronData(proc);
+
+  if (visitors) {
+    visitors.blockAnchor = function (node: BlockAnchor) {
+      switch (dest) {
+        case DendronASTDest.MD_DENDRON:
+        case DendronASTDest.MD_REGULAR:
+        case DendronASTDest.MD_ENHANCED_PREVIEW:
+        case DendronASTDest.HTML: {
+          // Anything more to do here? Can we embed HTML into the preview?
+          // Prints ^{\^block-id} so that it gets rendered small.
+          return `^\{\\^${node.id}\}`;
+        }
+        default:
+          return `unhandled case: ${dest}`;
+      }
+    };
+  }
+}
+
+export { plugin as blockAnchors };
+export { PluginOpts as BlockAnchorOpts };

--- a/packages/engine-server/src/markdown/remark/blockAnchors.ts
+++ b/packages/engine-server/src/markdown/remark/blockAnchors.ts
@@ -6,8 +6,8 @@ import { MDUtilsV4 } from "../utils";
 
 // Letters, digits, dashes, and underscores.
 // The underscores are an extension over Obsidian.
-export const LINK_REGEX = /^\^([\w-]+)$/;
-export const LINK_REGEX_LOOSE = /\^([\w-]+)/;
+export const BLOCK_LINK_REGEX = /^\^([\w-]+)$/;
+export const BLOCK_LINK_REGEX_LOOSE = /\^([\w-]+)/;
 
 /**
  *
@@ -19,7 +19,9 @@ export const matchBlockAnchor = (
   text: string,
   matchLoose: boolean = true
 ): string | undefined => {
-  const match = (matchLoose ? LINK_REGEX_LOOSE : LINK_REGEX).exec(text);
+  const match = (matchLoose ? BLOCK_LINK_REGEX_LOOSE : BLOCK_LINK_REGEX).exec(
+    text
+  );
   if (match && match.length == 1) return match[1];
   return undefined;
 };
@@ -44,7 +46,7 @@ function attachParser(proc: Unified.Processor) {
   }
 
   function inlineTokenizer(eat: Eat, value: string) {
-    const match = LINK_REGEX.exec(value);
+    const match = BLOCK_LINK_REGEX.exec(value);
     if (match) {
       return eat(match[0])({
         type: "blockAnchor",

--- a/packages/engine-server/src/markdown/remark/index.ts
+++ b/packages/engine-server/src/markdown/remark/index.ts
@@ -4,3 +4,8 @@ export * from "./noteRefs";
 export * from "./transformLinks";
 export { LinkUtils, RemarkUtils, mdastBuilder } from "./utils";
 export { wikiLinks, WikiLinksOpts, matchWikiLink } from "./wikiLinks";
+export {
+  blockAnchors,
+  BlockAnchorOpts,
+  matchBlockAnchor,
+} from "./blockAnchors";

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -17,6 +17,7 @@ import { selectAll } from "unist-util-select";
 import { VFile } from "vfile";
 import { normalizev2 } from "../../utils";
 import {
+  BlockAnchor,
   DendronASTDest,
   DendronASTRoot,
   DendronASTTypes,
@@ -27,6 +28,7 @@ import {
 import { MDUtilsV4 } from "../utils";
 const toString = require("mdast-util-to-string");
 import * as mdastBuilder from "mdast-builder";
+import { blockAnchors } from "./blockAnchors";
 export { mdastBuilder };
 
 export const ALIAS_DIVIDER = "|";
@@ -252,6 +254,12 @@ export class RemarkUtils {
     let out = remark.parse(content);
     let out2: Heading[] = selectAll("heading", out) as Heading[];
     return out2;
+  }
+
+  static findBlockAnchors(content: string): BlockAnchor[] {
+    const parser = MDUtilsV4.remark().use(blockAnchors);
+    const parsed = parser.parse(content);
+    return selectAll("blockAnchor", parsed) as BlockAnchor[];
   }
 
   static findIndex(array: Node[], fn: any) {

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -80,6 +80,7 @@ export class LinkUtils {
     let remark = MDUtilsV4.procParse({
       dest: DendronASTDest.MD_DENDRON,
       engine,
+      fname: note.fname,
     });
     let out = remark.parse(content);
     let out2: WikiLinkNoteV4[] = selectAll("wikiLink", out) as WikiLinkNoteV4[];

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -141,13 +141,11 @@ export class LinkUtils {
     };
   }
 
-  /**Either value or anchorHeader will always be present if the function did not
-   * return null. A missing value means that the file containing this link is
-   * the value.
+  /** Either value or anchorHeader will always be present if the function did not
+   *  return null. A missing value means that the file containing this link is
+   *  the value.
    */
-  static parseLinkV2(
-    linkString: string
-  ):
+  static parseLinkV2(linkString: string):
     | {
         alias?: string;
         value: string;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -138,7 +138,26 @@ export class LinkUtils {
     };
   }
 
-  static parseLinkV2(linkString: string) {
+  /**Either value or anchorHeader will always be present if the function did not
+   * return null. A missing value means that the file containing this link is
+   * the value.
+   */
+  static parseLinkV2(
+    linkString: string
+  ):
+    | {
+        alias?: string;
+        value: string;
+        anchorHeader?: string;
+        vaultName?: string;
+      }
+    | {
+        alias?: string;
+        value?: string;
+        anchorHeader: string;
+        vaultName?: string;
+      }
+    | null {
     const LINK_NAME = "[^#\\|>]+";
     const re = new RegExp(
       "" +

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -148,7 +148,7 @@ export class LinkUtils {
         "\\|" +
         ")?" +
         // name
-        `(?<value>${LINK_NAME})` +
+        `(?<value>${LINK_NAME})?` +
         // anchor?
         `(#(?<anchor>${LINK_NAME}))?` +
         // filters?
@@ -158,13 +158,16 @@ export class LinkUtils {
     const out = linkString.match(re);
     if (out) {
       let { alias, value, anchor } = out.groups as any;
+      if (!value && !anchor) return null; // Does not actually link to anything
       let vaultName: string | undefined;
-      ({ vaultName, link: value } = this.parseDendronURI(value));
-      if (!alias) {
-        alias = value;
+      if (value) {
+        ({ vaultName, link: value } = this.parseDendronURI(value));
+        if (!alias) {
+          alias = value;
+        }
+        alias = _.trim(alias);
+        value = _.trim(value);
       }
-      alias = _.trim(alias);
-      value = _.trim(value);
       return { alias, value, anchorHeader: anchor, vaultName };
     } else {
       return null;

--- a/packages/engine-server/src/markdown/remark/wikiLinks.ts
+++ b/packages/engine-server/src/markdown/remark/wikiLinks.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   CONSTANTS,
   DendronError,
   NoteUtils,
@@ -187,6 +188,12 @@ function attachParser(proc: Unified.Processor) {
         vault = maybeVault;
       }
       // default to current note
+    }
+    if (!out.value) {
+      // same file block reference, value is implicitly current file
+      assert(out.anchorHeader, "Link has no value or anchor"); // should never happen
+      out.value = _.trim(NoteUtils.normalizeFname(fname)); // recreate what value (and alias) would have been parsed
+      if (!out.alias) out.alias = out.value;
     }
     if (
       dest !== DendronASTDest.MD_DENDRON &&

--- a/packages/engine-server/src/markdown/remark/wikiLinks.ts
+++ b/packages/engine-server/src/markdown/remark/wikiLinks.ts
@@ -1,5 +1,4 @@
 import {
-  assert,
   CONSTANTS,
   DendronError,
   NoteUtils,
@@ -191,7 +190,6 @@ function attachParser(proc: Unified.Processor) {
     }
     if (!out.value) {
       // same file block reference, value is implicitly current file
-      assert(out.anchorHeader, "Link has no value or anchor"); // should never happen
       out.value = _.trim(NoteUtils.normalizeFname(fname)); // recreate what value (and alias) would have been parsed
       if (!out.alias) out.alias = out.value;
     }

--- a/packages/engine-server/src/markdown/types.ts
+++ b/packages/engine-server/src/markdown/types.ts
@@ -39,6 +39,7 @@ export enum DendronASTTypes {
   REF_LINK = "refLink",
   REF_LINK_V2 = "refLinkV2",
   PARAGRAPH = "paragraph",
+  BLOCK_ANCHOR = "blockAnchor",
 }
 
 export enum DendronASTDest {
@@ -102,4 +103,9 @@ export type NoteRefDataV4 = {
 
 export type NoteRefDataV4_LEGACY = {
   link: DNoteRefLink;
+};
+
+export type BlockAnchor = {
+  type: DendronASTTypes.BLOCK_ANCHOR;
+  id: string;
 };

--- a/packages/engine-server/src/markdown/types.ts
+++ b/packages/engine-server/src/markdown/types.ts
@@ -105,7 +105,7 @@ export type NoteRefDataV4_LEGACY = {
   link: DNoteRefLink;
 };
 
-export type BlockAnchor = {
+export type BlockAnchor = DendronASTNode & {
   type: DendronASTTypes.BLOCK_ANCHOR;
   id: string;
 };

--- a/packages/engine-server/src/markdown/types.ts
+++ b/packages/engine-server/src/markdown/types.ts
@@ -56,7 +56,7 @@ export enum VaultMissingBehavior {
 export type DendronASTData = {
   dest: DendronASTDest;
   vault: DVault;
-  fname?: string;
+  fname: string;
   wikiLinkOpts?: WikiLinksOpts;
   config: DendronConfig;
   overrides?: Partial<DendronPubOpts>;

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -50,6 +50,7 @@ import { noteRefsV2 } from "./remark/noteRefsV2";
 import { publishSite } from "./remark/publishSite";
 import { transformLinks } from "./remark/transformLinks";
 import { wikiLinks, WikiLinksOpts } from "./remark/wikiLinks";
+import { blockAnchors } from "./remark/blockAnchors";
 import { DendronASTData, DendronASTDest, VaultMissingBehavior } from "./types";
 
 const toString = require("mdast-util-to-string");
@@ -322,6 +323,7 @@ export class MDUtilsV4 {
         hierarchyDisplay: config.hierarchyDisplay,
       })
       .use(backlinks)
+      .use(blockAnchors)
       .use(noteRefsV2, {
         ...opts.noteRefOpts,
         wikiLinkOpts: opts.wikiLinksOpts,

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -61,6 +61,7 @@ type ProcOpts = {
 
 type ProcParseOpts = {
   dest: DendronASTDest;
+  fname: string;
 } & ProcOpts;
 
 type ProcOptsFull = ProcOpts & {
@@ -258,7 +259,7 @@ export class MDUtilsV4 {
       .use(remarkParse, { gfm: true })
       .use(wikiLinks)
       .data("errors", errors);
-    this.setDendronData(_proc, { dest: opts.dest });
+    this.setDendronData(_proc, { dest: opts.dest, fname: opts.fname });
     this.setEngine(_proc, opts.engine);
     return _proc;
   }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -2,17 +2,14 @@
 
 exports[`dendronPub no publish basic 1`] = `
 VFile {
-  "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
 <p><a data-toggle=\\"popover\\" title=\\"This page has not yet sprouted\\" style=\\"cursor: pointer\\" data-content=\\"<a href=&#x22;https://dendron.so/&#x22;>Dendron</a> (the tool used to generate this site) lets authors selective publish content. You will see this page whenever you click on a link to an unpublished page
 
 <img src=&#x27;https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/not-sprouted.png&#x27;></img>\\">an alias</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
-<li><a data-toggle=\\"popover\\" title=\\"This page has not yet sprouted\\" style=\\"cursor: pointer\\" data-content=\\"<a href=&#x22;https://dendron.so/&#x22;>Dendron</a> (the tool used to generate this site) lets authors selective publish content. You will see this page whenever you click on a link to an unpublished page
-
-<img src=&#x27;https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/not-sprouted.png&#x27;></img>\\">Bar</a></li>
-<li><a href=\\"foo.html\\">Foo</a></li>
+<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -82,7 +79,7 @@ VFile {
 
 exports[`dendronPub prefix imagePrefix 1`] = `
 VFile {
-  "contents": "# Root
+  "contents": "# Foo
 
 ![alt-text](/bond/image-url.jpg)
 
@@ -90,8 +87,7 @@ VFile {
 
 ## Children
 
-1. [Bar](bar.html)
-2. [Foo](foo.html)
+1. [Ch1](foo.ch1.html)
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -103,7 +99,7 @@ VFile {
 
 exports[`dendronPub prefix imagePrefix with forward slash 1`] = `
 VFile {
-  "contents": "# Root
+  "contents": "# Foo
 
 ![alt-text](/bond/image-url.jpg)
 
@@ -111,8 +107,7 @@ VFile {
 
 ## Children
 
-1. [Bar](bar.html)
-2. [Foo](foo.html)
+1. [Ch1](foo.ch1.html)
 
 ",
   "cwd": "<PROJECT_ROOT>",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts
@@ -20,7 +20,6 @@ function proc(
   opts?: DendronPubOpts
 ) {
   return MDUtilsV4.procFull({
-    fname: "PLACEHOLDER",
     engine,
     ...dendron,
     publishOpts: opts,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -1,7 +1,7 @@
 import {
   DendronASTData,
   DendronASTDest,
-  DEngineClientV2,
+  DEngineClient,
   MDUtilsV4,
   UnistNode,
   BlockAnchor,
@@ -12,7 +12,7 @@ import {
 import _ from "lodash";
 
 function proc(
-  engine: DEngineClientV2,
+  engine: DEngineClient,
   dendron: DendronASTData,
   opts?: BlockAnchorOpts
 ) {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -31,7 +31,7 @@ function genDendronData(opts?: Partial<DendronASTData>): DendronASTData {
  * @param indices Left-to-right indexes for children, e.g. first index is for the root, second is for the child of the root...
  * @returns Requested child. Note that this function has no way of checking types, so the child you get might not be of the right type.
  */
-function getDescendentNode<Child extends DendronASTNode>(
+function getDescendantNode<Child extends DendronASTNode>(
   node: UnistNode,
   ...indices: number[]
 ): Child {
@@ -39,14 +39,13 @@ function getDescendentNode<Child extends DendronASTNode>(
   if (_.isUndefined(index)) return node as Child;
   expect(node).toHaveProperty("children");
   expect(node.children).toHaveProperty("length");
-  // @ts-ignore
-  expect(node.children.length).toBeGreaterThanOrEqual(index);
-  // @ts-ignore
-  return getDescendentNode<Child>(node.children[index], ...indices);
+  const children = node.children as UnistNode[];
+  expect(children.length).toBeGreaterThanOrEqual(index);
+  return getDescendantNode<Child>(children[index], ...indices);
 }
 
 function getBlockAnchor(node: UnistNode): BlockAnchor {
-  return getDescendentNode<BlockAnchor>(node, 0, 0);
+  return getDescendantNode<BlockAnchor>(node, 0, 0);
 }
 
 describe("blockAnchors", () => {
@@ -76,19 +75,17 @@ describe("blockAnchors", () => {
       const resp = proc(engine, genDendronData(dendronData)).parse(
         "^block-id Lorem ipsum"
       );
-      expect(getDescendentNode(resp, 0, 0).type).toEqual("text");
-      // @ts-ignore
-      expect(resp.children[0].children.length).toEqual(1); // text only, nothing else
+      expect(getDescendantNode(resp, 0, 0).type).toEqual("text");
+      expect(getDescendantNode(resp, 0).children.length).toEqual(1); // text only, nothing else
     });
 
     test("parses anchors at the end of the line", () => {
       const resp = proc(engine, genDendronData(dendronData)).parse(
         "Lorem ipsum ^block-id"
       );
-      // @ts-ignore
-      const text = getDescendentNode(resp, 0, 0);
+      const text = getDescendantNode(resp, 0, 0);
       expect(text.type).toEqual("text");
-      const anchor = getDescendentNode<BlockAnchor>(resp, 0, 1);
+      const anchor = getDescendantNode<BlockAnchor>(resp, 0, 1);
       expect(anchor.type).toEqual("blockAnchor");
       expect(anchor.id).toEqual("block-id");
     });

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -7,6 +7,7 @@ import {
   BlockAnchor,
   blockAnchors,
   BlockAnchorOpts,
+  DendronASTNode,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 
@@ -24,9 +25,28 @@ function genDendronData(opts?: Partial<DendronASTData>): DendronASTData {
   return { ...opts } as any;
 }
 
-function getBlockAnchor(node: UnistNode): BlockAnchor {
+/** Gets the descendent (child, or child of child...) node of a given node.
+ *
+ * @param node The root node to start descending from.
+ * @param indices Left-to-right indexes for children, e.g. first index is for the root, second is for the child of the root...
+ * @returns Requested child. Note that this function has no way of checking types, so the child you get might not be of the right type.
+ */
+function getDescendentNode<Child extends DendronASTNode>(
+  node: UnistNode,
+  ...indices: number[]
+): Child {
+  const index = indices.shift();
+  if (_.isUndefined(index)) return node as Child;
+  expect(node).toHaveProperty("children");
+  expect(node.children).toHaveProperty("length");
   // @ts-ignore
-  return node.children[0].children[0];
+  expect(node.children.length).toBeGreaterThanOrEqual(index);
+  // @ts-ignore
+  return getDescendentNode<Child>(node.children[index], ...indices);
+}
+
+function getBlockAnchor(node: UnistNode): BlockAnchor {
+  return getDescendentNode<BlockAnchor>(node, 0, 0);
 }
 
 describe("blockAnchors", () => {
@@ -37,7 +57,7 @@ describe("blockAnchors", () => {
       dest: DendronASTDest.MD_REGULAR,
     };
 
-    test("basic", () => {
+    test("parses anchor by itself", () => {
       const resp = proc(engine, genDendronData(dendronData)).parse(
         "^block-0-id"
       );
@@ -50,6 +70,27 @@ describe("blockAnchors", () => {
         "`^block-id`"
       );
       expect(getBlockAnchor(resp).type).toEqual("inlineCode");
+    });
+
+    test("doesn't parse code block not at the end of the line", () => {
+      const resp = proc(engine, genDendronData(dendronData)).parse(
+        "^block-id Lorem ipsum"
+      );
+      expect(getDescendentNode(resp, 0, 0).type).toEqual("text");
+      // @ts-ignore
+      expect(resp.children[0].children.length).toEqual(1); // text only, nothing else
+    });
+
+    test("parses anchors at the end of the line", () => {
+      const resp = proc(engine, genDendronData(dendronData)).parse(
+        "Lorem ipsum ^block-id"
+      );
+      // @ts-ignore
+      const text = getDescendentNode(resp, 0, 0);
+      expect(text.type).toEqual("text");
+      const anchor = getDescendentNode<BlockAnchor>(resp, 0, 1);
+      expect(anchor.type).toEqual("blockAnchor");
+      expect(anchor.id).toEqual("block-id");
     });
   });
 });

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -1,0 +1,55 @@
+import {
+  DendronASTData,
+  DendronASTDest,
+  DEngineClientV2,
+  MDUtilsV4,
+  UnistNode,
+  BlockAnchor,
+  blockAnchors,
+  BlockAnchorOpts,
+} from "@dendronhq/engine-server";
+import _ from "lodash";
+
+function proc(
+  engine: DEngineClientV2,
+  dendron: DendronASTData,
+  opts?: BlockAnchorOpts
+) {
+  return MDUtilsV4.proc({ engine })
+    .data("dendron", dendron)
+    .use(blockAnchors, opts);
+}
+
+function genDendronData(opts?: Partial<DendronASTData>): DendronASTData {
+  return { ...opts } as any;
+}
+
+function getBlockAnchor(node: UnistNode): BlockAnchor {
+  // @ts-ignore
+  return node.children[0].children[0];
+}
+
+describe("blockAnchors", () => {
+  describe("parse", () => {
+    let engine: any;
+    let dendronData = {
+      fname: "placeholder.md",
+      dest: DendronASTDest.MD_REGULAR,
+    };
+
+    test("basic", () => {
+      const resp = proc(engine, genDendronData(dendronData)).parse(
+        "^block-0-id"
+      );
+      expect(getBlockAnchor(resp).type).toEqual("blockAnchor");
+      expect(getBlockAnchor(resp).id).toEqual("block-0-id");
+    });
+
+    test("doesn't parse inline code block", () => {
+      const resp = proc(engine, genDendronData(dendronData)).parse(
+        "`^block-id`"
+      );
+      expect(getBlockAnchor(resp).type).toEqual("inlineCode");
+    });
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -32,7 +32,7 @@ describe("dendronPub", () => {
       const out = proc(
         engine,
         {
-          fname: "placeholder.md",
+          fname: "foo",
           dest: DendronASTDest.HTML,
           vault: vaults[0],
           config: engine.config,
@@ -50,7 +50,7 @@ describe("dendronPub", () => {
         const out = proc(
           engine,
           {
-            fname: "placeholder.md",
+            fname: "foo",
             dest: DendronASTDest.HTML,
             vault: vaults[0],
             config: engine.config,
@@ -77,7 +77,7 @@ describe("dendronPub", () => {
           proc: proc(
             engine,
             {
-              fname: "placeholder.md",
+              fname: "foo",
               dest: DendronASTDest.HTML,
               vault: vaults[0],
               config,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -20,7 +20,6 @@ function proc(
   opts?: DendronPubOpts
 ) {
   return MDUtilsV4.procFull({
-    fname: "root",
     engine,
     ...dendron,
     publishOpts: opts,
@@ -33,6 +32,7 @@ describe("dendronPub", () => {
       const out = proc(
         engine,
         {
+          fname: "placeholder.md",
           dest: DendronASTDest.HTML,
           vault: vaults[0],
           config: engine.config,
@@ -50,6 +50,7 @@ describe("dendronPub", () => {
         const out = proc(
           engine,
           {
+            fname: "placeholder.md",
             dest: DendronASTDest.HTML,
             vault: vaults[0],
             config: engine.config,
@@ -76,6 +77,7 @@ describe("dendronPub", () => {
           proc: proc(
             engine,
             {
+              fname: "placeholder.md",
               dest: DendronASTDest.HTML,
               vault: vaults[0],
               config,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
@@ -39,7 +39,10 @@ function getWikiLink(node: UnistNode): WikiLinkNoteV4 {
 describe("wikiLinks", () => {
   describe("parse", () => {
     let engine: any;
-    let dendronData = { dest: DendronASTDest.MD_REGULAR };
+    let dendronData = {
+      fname: "placeholder.md",
+      dest: DendronASTDest.MD_REGULAR,
+    };
 
     test("basic", () => {
       const resp = proc(engine, genDendronData(dendronData)).parse(
@@ -63,6 +66,32 @@ describe("wikiLinks", () => {
         "`[[foo.md]]`"
       );
       expect(getWikiLink(resp).type).toEqual("inlineCode");
+    });
+
+    describe("block references", () => {
+      test("block reference to different file", () => {
+        const resp = proc(engine, genDendronData(dendronData)).parse(
+          `[[lorem-ipsum#^block-id]]`
+        );
+        const wikiLink = getWikiLink(resp);
+        expect(_.pick(wikiLink, ["type", "value"])).toEqual({
+          type: "wikiLink",
+          value: "lorem-ipsum",
+        });
+        expect(wikiLink.data.anchorHeader).toEqual("^block-id");
+      });
+
+      test("block reference to same file", () => {
+        const resp = proc(engine, genDendronData(dendronData)).parse(
+          `[[#^block-id]]`
+        );
+        const wikiLink = getWikiLink(resp);
+        expect(_.pick(wikiLink, ["type", "value"])).toEqual({
+          type: "wikiLink",
+          value: "placeholder",
+        });
+        expect(wikiLink.data.anchorHeader).toEqual("^block-id");
+      });
     });
   });
 

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -8,7 +8,7 @@ import {
 } from "@dendronhq/common-all";
 import { Heading, matchWikiLink, RemarkUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
-import { Position, Selection, Uri, window } from "vscode";
+import { TextEditor, Position, Selection, Uri, window } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
@@ -87,7 +87,14 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
         window.showErrorMessage("selection is not a valid link");
         return;
       }
-      qs = maybeLink.value as string;
+      if (maybeLink.value) {
+        // Reference to another file
+        qs = maybeLink.value as string;
+      } else {
+        // Same-file block reference, implicitly current file
+        const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
+        qs = NoteUtils.uri2Fname(editor.document.uri);
+      }
       const vaults = getWS().vaultsv4;
       if (maybeLink.vaultName) {
         vault = VaultUtils.getVaultByNameOrThrow({

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -2,7 +2,7 @@ import { NoteUtils, VaultUtils } from "@dendronhq/common-all";
 import fs from "fs-extra";
 import _ from "lodash";
 import vscode, { Location, Position, Uri } from "vscode";
-import { findHeaderPos, GotoNoteCommand } from "../commands/GotoNote";
+import { findAnchorPos, GotoNoteCommand } from "../commands/GotoNote";
 import { Logger } from "../logger";
 import { getReferenceAtPosition } from "../utils/md";
 import { DendronWorkspace, getWS } from "../workspace";
@@ -46,8 +46,8 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
       const loc = out[0];
       if (refAtPos.anchor) {
         const text = fs.readFileSync(loc.uri.fsPath, { encoding: "utf8" });
-        const pos = findHeaderPos({
-          anchor: refAtPos.anchor.value,
+        const pos = findAnchorPos({
+          anchor: refAtPos.anchor,
           text,
         });
         return new Location(loc.uri, pos);

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -175,6 +175,33 @@ suite("GotoNote", function () {
         },
       });
     });
+
+    test("block anchor", (done) => {
+      runSingleVaultTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.create({
+            wsRoot,
+            vault: vaults[0],
+          });
+        },
+        onInit: async ({ vault }) => {
+          await new GotoNoteCommand().run({
+            qs: "anchor-target",
+            vault,
+            anchor: {
+              type: "block",
+              value: "block-id",
+            },
+          });
+          expect(getActiveEditorBasename()).toEqual("anchor-target.md");
+          const selection = VSCodeUtils.getActiveTextEditor()?.selection;
+          expect(selection?.start.line).toEqual(10);
+          expect(selection?.start.character).toEqual(0);
+          done();
+        },
+      });
+    });
   });
 
   describe("using selection", () => {

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -248,33 +248,16 @@ export const getReferenceAtPosition = (
 };
 
 export const parseRef = (rawRef: string): RefT => {
-  const escapedDividerPosition = rawRef.indexOf("\\|");
-  const dividerPosition =
-    escapedDividerPosition !== -1
-      ? escapedDividerPosition
-      : rawRef.indexOf("|");
+  const parsed = LinkUtils.parseLinkV2(rawRef);
+  if (_.isNull(parsed)) throw new Error(`Unable to parse reference ${rawRef}`);
+  const { alias, value, anchorHeader, vaultName } = parsed;
 
-  const out: RefT = {
-    label: dividerPosition !== -1 ? rawRef.slice(0, dividerPosition) : "",
-    ref:
-      dividerPosition !== -1
-        ? rawRef.slice(
-            dividerPosition + (escapedDividerPosition !== -1 ? 2 : 1),
-            rawRef.length
-          )
-        : rawRef,
+  return {
+    label: alias ? alias : "",
+    ref: value,
+    anchor: anchorHeader ? { type: "header", value: anchorHeader } : undefined,
+    vaultName,
   };
-  if (out.ref.indexOf("#") >= 0) {
-    const [ref, ...anchor] = out.ref.split("#");
-    out.ref = ref;
-    out.anchor = { type: "header", value: anchor[0] };
-  }
-  const { link, vaultName } = LinkUtils.parseDendronURI(out.ref);
-  if (vaultName) {
-    out.vaultName = vaultName;
-    out.ref = link;
-  }
-  return out;
 };
 
 export const containsUnknownExt = (pathParam: string): boolean =>

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -238,7 +238,7 @@ export const getReferenceAtPosition = (
 
   return {
     // If ref is missing, it's implicitly the current file
-    ref: ref ? ref : document.fileName,
+    ref: ref ? ref : NoteUtils.uri2Fname(document.uri),
     label,
     range,
     anchor,

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -255,9 +255,20 @@ export const parseRef = (rawRef: string): RefT => {
   return {
     label: alias ? alias : "",
     ref: value,
-    anchor: anchorHeader ? { type: "header", value: anchorHeader } : undefined,
+    anchor: parseAnchor(anchorHeader),
     vaultName,
   };
+};
+
+export const parseAnchor = (anchorValue?: string): DNoteAnchor | undefined => {
+  // If undefined or empty string
+  if (!anchorValue) return undefined;
+
+  if (anchorValue[0] === "^") {
+    return { type: "block", value: anchorValue.slice(1) };
+  } else {
+    return { type: "header", value: anchorValue };
+  }
 };
 
 export const containsUnknownExt = (pathParam: string): boolean =>

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -22,7 +22,8 @@ import { DendronWorkspace } from "../workspace";
 
 export type RefT = {
   label: string;
-  ref: string;
+  /** If undefined, then the file this reference is located in is the ref */
+  ref?: string;
   anchor?: DNoteAnchor;
   vaultName?: string;
 };
@@ -236,7 +237,8 @@ export const getReferenceAtPosition = (
   }
 
   return {
-    ref,
+    // If ref is missing, it's implicitly the current file
+    ref: ref ? ref : document.fileName,
     label,
     range,
     anchor,


### PR DESCRIPTION
This pull request adds basic functionality for linking to block anchors. This allows links to manually inserted block anchors to function. For example, with the following files:

In `note-alpha.md`:
```
...
Lorem ipsum dolor amet

^my-block-anchor
```

In `note-beta.md`:
```
...
Fuga voluptas veniam ab

[[note-alpha#^my-block-anchor]]
```

Here, using the link in `note-beta` should take the user to `note-alpha` at the line of the block anchor.

The integration into VSCode is not there yet, so the block anchor must be inserted manually, and the anchor portion of the link must be written manually. It should work to place the anchors anywhere in the document, with the only limitations are: they must only contain letters, numbers, dashes, or underscores; they must appear at the end of a line or on a separate line by themselves.