### PR TITLE
fix: Block anchors hide sibling nodes in HTML

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -32,8 +32,14 @@ type PluginOpts = NoteRefsOpts & {
 
 function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
   const proc = this;
-  let { dest, vault, fname, config, overrides, insideNoteRef } =
-    MDUtilsV4.getDendronData(proc);
+  let {
+    dest,
+    vault,
+    fname,
+    config,
+    overrides,
+    insideNoteRef,
+  } = MDUtilsV4.getDendronData(proc);
   function transformer(tree: Node, _file: VFile) {
     let root = tree as Root;
     const { error, engine } = MDUtilsV4.getEngineFromProc(proc);
@@ -66,7 +72,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         u(DendronASTTypes.HEADING, { depth: 1 }, [u("text", note.title)])
       );
     }
-    visit(tree, (node, _idx, parent) => {
+    visit(tree, (node, index, parent) => {
       if (
         node.type === DendronASTTypes.WIKI_LINK &&
         dest !== DendronASTDest.MD_ENHANCED_PREVIEW
@@ -211,9 +217,10 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
       }
       if (node.type === DendronASTTypes.BLOCK_ANCHOR) {
         const procOpts = MDUtilsV4.getProcOpts(proc);
-        parent!.children = [
-          blockAnchor2html(node as BlockAnchor, procOpts.blockAnchorsOpts),
-        ];
+        parent!.children[index] = blockAnchor2html(
+          node as BlockAnchor,
+          procOpts.blockAnchorsOpts
+        );
       }
       if (node.type === "image" && dest === DendronASTDest.HTML) {
         let imageNode = node as Image;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/blockAnchors.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/blockAnchors.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`blockAnchors rendering compile "HTML: end of paragraph" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
+<p>Lorem ipsum dolor amet <a id=\\"^my-block-anchor-0\\" href=\\"#^my-block-anchor-0\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^my-block-anchor-0</a></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"bar.html\\">Bar</a></li>
+<li><a href=\\"foo.html\\">Foo</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`blockAnchors rendering compile "HTML: hidden" 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
@@ -17,7 +34,7 @@ VFile {
 }
 `;
 
-exports[`blockAnchors rendering compile "HTML: regular" 1`] = `
+exports[`blockAnchors rendering compile "HTML: simple" 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
 <p><a id=\\"^my-block-anchor-0\\" href=\\"#^my-block-anchor-0\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^my-block-anchor-0</a></p>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -114,8 +114,8 @@ describe("blockAnchors", () => {
 
   describe("rendering", () => {
     const anchor = "^my-block-anchor-0";
-    const REGULAR_ANCHOR = createProcTests({
-      name: "regular",
+    const SIMPLE = createProcTests({
+      name: "simple",
       setupFunc: async ({ engine, vaults, extra }) => {
         const proc2 = createProcForTest({
           engine,
@@ -123,6 +123,36 @@ describe("blockAnchors", () => {
           vault: vaults[0],
         });
         const resp = await proc2.process(anchor);
+        return { resp };
+      },
+      verifyFuncDict: {
+        [DendronASTDest.HTML]: async ({ extra }) => {
+          const { resp } = extra;
+          expect(resp).toMatchSnapshot();
+          return [
+            {
+              actual: await AssertUtils.assertInString({
+                body: resp.toString(),
+                match: ["<a", `href="#${anchor}"`, `id="${anchor}"`, "</a>"],
+                nomatch: ["visibility: hidden"],
+              }),
+              expected: true,
+            },
+          ];
+        },
+      },
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    });
+
+    const END_OF_PARAGRAPH = createProcTests({
+      name: "end of paragraph",
+      setupFunc: async ({ engine, vaults, extra }) => {
+        const proc2 = createProcForTest({
+          engine,
+          dest: extra.dest,
+          vault: vaults[0],
+        });
+        const resp = await proc2.process(`Lorem ipsum dolor amet ${anchor}`);
         return { resp };
       },
       verifyFuncDict: {
@@ -180,7 +210,7 @@ describe("blockAnchors", () => {
       preSetupHook: ENGINE_HOOKS.setupBasic,
     });
 
-    const ALL_TEST_CASES = [...REGULAR_ANCHOR, ...HIDDEN_ANCHOR];
+    const ALL_TEST_CASES = [...SIMPLE, ...END_OF_PARAGRAPH, ...HIDDEN_ANCHOR];
     runAllTests({ name: "compile", testCases: ALL_TEST_CASES });
   });
 });


### PR DESCRIPTION
Block anchors were hiding their sibling nodes when generating HTML, causing them to hide the paragraph they are located in. This pull request fixes this issue, and adds a test to catch any regressions in the future.