### PR TITLE
feat: Block reference support in HTML

### DIFF
--- a/packages/common-test-utils/src/utils.ts
+++ b/packages/common-test-utils/src/utils.ts
@@ -38,6 +38,60 @@ export class AssertUtils {
     );
     return true;
   }
+
+  /** Asserts that the gives strings appear the expected number of times in this string.
+   *
+   * parameters `match`, `fewerThan`, and `moreThan` should look like:
+   *     [ [2, "Lorem ipsum"], [1, "foo bar"] ]
+   *
+   * @param match Must appear exactly this many times.
+   * @param fewerThan Must appear fewer than this many times.
+   * @param moreThan Must appear more than this many times.
+   */
+  static async assertTimesInString({
+    body,
+    match,
+    fewerThan,
+    moreThan,
+  }: {
+    body: string;
+    match?: [number, string][];
+    fewerThan?: [number, string][];
+    moreThan?: [number, string][];
+  }): Promise<boolean> {
+    function countMatches(match: string) {
+      const matches = body.match(new RegExp(match, "g")) || [];
+      return matches.length;
+    }
+    await Promise.all(
+      (match || []).map(([count, match]) => {
+        const foundCount = countMatches(match);
+        if (foundCount != count) {
+          throw `${match} found ${foundCount} times, expected equal to ${count} in ${body}`;
+        }
+        return true;
+      })
+    );
+    await Promise.all(
+      (fewerThan || []).map(([count, match]) => {
+        const foundCount = countMatches(match);
+        if (foundCount >= count) {
+          throw `${match} found ${foundCount} times, expected fewer than ${count} in ${body}`;
+        }
+        return true;
+      })
+    );
+    await Promise.all(
+      (moreThan || []).map(([count, match]) => {
+        const foundCount = countMatches(match);
+        if (foundCount <= count) {
+          throw `${match} found ${foundCount} times, expected more than ${count} in ${body}`;
+        }
+        return true;
+      })
+    );
+    return true;
+  }
 }
 
 export abstract class EngineTest<TPreSetupOut = any, TPostSetupOut = any> {

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -518,6 +518,8 @@ function convertNoteRefHelperAST(
 ): Required<RespV2<Parent>> {
   const { proc, refLvl, link, note } = opts;
   const noteRefProc = proc();
+  // proc is the parser that was parsing the note the reference was in, so need to update fname to reflect that we are parsing the referred note
+  MDUtilsV4.setDendronData(noteRefProc, { fname: link.from.fname });
   const engine = MDUtilsV4.getEngineFromProc(noteRefProc);
   MDUtilsV4.setNoteRefLvl(noteRefProc, refLvl);
   const procOpts = MDUtilsV4.getProcOpts(noteRefProc);
@@ -586,6 +588,8 @@ function convertNoteRefHelper(
 ): Required<RespV2<string>> {
   const { body, proc, refLvl, link } = opts;
   const noteRefProc = proc();
+  // proc is the parser that was parsing the note the reference was in, so need to update fname to reflect that we are parsing the referred note
+  MDUtilsV4.setDendronData(noteRefProc, { fname: link.from.fname });
   MDUtilsV4.setNoteRefLvl(noteRefProc, refLvl);
   const bodyAST = noteRefProc.parse(body) as DendronASTNode;
   const { anchorStart, anchorEnd, anchorStartOffset } = link.data;

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -69,6 +69,9 @@ function attachParser(proc: Unified.Processor) {
     if (match) {
       const linkMatch = match[1].trim();
       const link = parseNoteRefV2(linkMatch);
+      // If the link is same file [[#header]], it's implicitly to the same file it's located in
+      if (link.from.fname === "")
+        link.from.fname = MDUtilsV4.getDendronData(proc).fname;
       const { value } = LinkUtils.parseLink(linkMatch);
 
       let refNote: NoteRefNoteV4 = {

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -1,38 +1,36 @@
+import { AnchorUtils, LinkUtils } from "./utils";
 import {
   CONSTANTS,
-  DendronConfig,
-  DendronError,
   DNodeUtils,
   DNoteLoc,
   DNoteRefLink,
   DUtils,
-  getSlugger,
+  DendronConfig,
+  DendronError,
   NoteProps,
   NoteUtils,
   RespV2,
   VaultUtils,
+  getSlugger,
 } from "@dendronhq/common-all";
-import { file2Note } from "@dendronhq/common-server";
-import _ from "lodash";
-import { List } from "mdast";
-import { html, paragraph, root } from "mdast-builder";
-import { Eat } from "remark-parse";
-import Unified, { Plugin } from "unified";
-import { Node, Parent } from "unist";
-import visit from "unist-util-visit";
-import { SiteUtils } from "../../topics/site";
-import { parseNoteRefV2 } from "../../utils";
 import {
-  BlockAnchor,
   DendronASTDest,
   DendronASTNode,
   DendronASTTypes,
   NoteRefNoteV4,
   NoteRefNoteV4_LEGACY,
 } from "../types";
-import { MDUtilsV4, renderFromNoteProps } from "../utils";
-import { AnchorUtils, LinkUtils } from "./utils";
+import { file2Note } from "@dendronhq/common-server";
+import { MDUtilsV4, ParentWithIndex, renderFromNoteProps } from "../utils";
+import { Node, Parent } from "unist";
+import Unified, { Plugin } from "unified";
+import { html, paragraph, root } from "mdast-builder";
+
+import { Eat } from "remark-parse";
+import { SiteUtils } from "../../topics/site";
 import { WikiLinksOpts } from "./wikiLinks";
+import _ from "lodash";
+import { parseNoteRefV2 } from "../../utils";
 
 const LINK_REGEX = /^\!\[\[(.+?)\]\]/;
 
@@ -244,7 +242,6 @@ function convertNoteRef(opts: ConvertNoteRefOpts): {
         return data;
       }
     } catch (err) {
-      debugger;
       const msg = `error reading file, ${npath}`;
       errors.push(new DendronError({ message: msg }));
       return msg;
@@ -368,7 +365,6 @@ export function convertNoteRefASTV2(
         return paragraph(data);
       }
     } catch (err) {
-      debugger;
       const msg = `error reading file, ${npath}`;
       errors.push(new DendronError({ message: msg }));
       throw Error(msg);
@@ -376,6 +372,142 @@ export function convertNoteRefASTV2(
     }
   });
   return { error, data: out };
+}
+
+/** For any List in `nodes`, removes the children before or after the index of the following ListItem in `nodes`. */
+function removeListItems({
+  nodes,
+  remove,
+}: {
+  nodes: ParentWithIndex[];
+  remove: "before-index" | "after-index";
+}): void {
+  for (let i = 0; i < nodes.length; i++) {
+    const list = nodes[i];
+    const listItem = nodes[i + 1];
+    if (list.ancestor.type !== DendronASTTypes.LIST) continue;
+    if (_.isUndefined(listItem)) {
+      console.error(
+        "Found a list that has a list anchor in it, but no list items"
+      );
+      continue; // Should never happen, but let's try to render at least the whole list if it does
+    }
+    if (remove === "after-index") {
+      list.ancestor.children = list.ancestor.children.slice(
+        undefined,
+        listItem.index + 1
+      );
+    } else {
+      // keep === after-index
+      list.ancestor.children = list.ancestor.children.slice(
+        listItem.index,
+        undefined
+      );
+    }
+  }
+}
+
+/** If there are nested lists with a single item in them, replaces the outer single-item lists with the first multi-item list. */
+function removeSingleItemNestedLists(nodes: ParentWithIndex[]): void {
+  let outermost: ParentWithIndex | undefined;
+  for (let i = 0; i < nodes.length; i++) {
+    const list = nodes[i];
+    if (list.ancestor.type !== DendronASTTypes.LIST) continue;
+    // Find the outermost list
+    if (_.isUndefined(outermost)) {
+      outermost = list;
+      // If the outermost list has multiple children, we have nothing to do
+      if (outermost.ancestor.children.length > 1) return;
+      continue;
+    } else {
+      // Found the nested list which will replace the outermost one
+      outermost.ancestor.children = list.ancestor.children;
+      // The nested list is the new outermost now
+      outermost = list;
+      // If we found a list with multiple children, stop because we want to keep it
+      if (outermost.ancestor.children.length > 1) return;
+    }
+  }
+}
+
+function prepareNoteRefIndices<T>({
+  anchorStart,
+  anchorEnd,
+  bodyAST,
+  makeErrorData,
+}: {
+  anchorStart?: string;
+  anchorEnd?: string;
+  bodyAST: DendronASTNode;
+  makeErrorData: (anchorName: string, anchorType: "Start" | "End") => T;
+}): {
+  start: FindAnchorResult;
+  end: FindAnchorResult;
+  data: T | null;
+  error: any;
+} {
+  // TODO: can i just strip frontmatter when reading?
+  let start: FindAnchorResult = {
+    type: "header",
+    index: bodyAST.children[0].type === "yaml" ? 1 : 0,
+  };
+  let end: FindAnchorResult = null;
+
+  if (anchorStart) {
+    start = findAnchor({
+      nodes: bodyAST.children,
+      match: anchorStart,
+    });
+    if (_.isNull(start)) {
+      return {
+        data: makeErrorData(anchorStart, "Start"),
+        start: null,
+        end: null,
+        error: null,
+      };
+    }
+  }
+
+  if (anchorEnd) {
+    end = findAnchor({
+      nodes: bodyAST.children.slice(start.index),
+      match: anchorEnd,
+    });
+    if (_.isNull(end)) {
+      return {
+        data: makeErrorData(anchorEnd, "End"),
+        start: null,
+        end: null,
+        error: null,
+      };
+    }
+    end.index += start.index;
+  } else if (start.type === "block") {
+    // If no end is specified and the start is a block anchor referencing a block, the end is implicitly the end of the referenced block.
+    end = { type: "block", index: start.index };
+  } else if (start.type === "list") {
+    // If no end is specified and the start is a block anchor in a list, the end is the list element referenced by the start.
+    end = { ...start };
+  }
+
+  // Handle anchors inside lists. Lists need to slice out sibling list items, and extract out nested lists.
+  // We need to remove elements before the start or after the end.
+  // We do end first and start second in case they refer to the same list, so that the indices don't shift.
+  if (end && end.type === "list") {
+    removeListItems({ nodes: end.ancestors, remove: "after-index" });
+  }
+  if (start && start.type === "list") {
+    removeListItems({ nodes: start.ancestors, remove: "before-index" });
+  }
+  // If removing items left single-item nested lists at the start of the ancestors, we trim these out.
+  if (end && end.type === "list") {
+    removeSingleItemNestedLists(end.ancestors);
+  }
+  if (start && start.type === "list") {
+    removeSingleItemNestedLists(start.ancestors);
+  }
+
+  return { start, end, data: null, error: null };
 }
 
 function convertNoteRefHelperAST(
@@ -402,68 +534,22 @@ function convertNoteRefHelperAST(
     anchorStartOffset: 0,
   });
 
-  // TODO: can i just strip frontmatter when reading?
-  let anchorStartIndex = bodyAST.children[0].type === "yaml" ? 1 : 0;
-  let secondaryStartIndex: number | undefined;
-  let anchorEndIndex = bodyAST.children.length;
-  let secondaryEndIndex: number | undefined;
-
-  if (anchorStart) {
-    [anchorStartIndex, secondaryStartIndex] = findAnchor({
-      nodes: bodyAST.children,
-      match: anchorStart,
-    });
-    if (anchorStartIndex < 0) {
-      const data = MDUtilsV4.genMDMsg(`Start anchor ${anchorStart} not found`);
-      return { data, error: null };
-    }
-  }
-
-  if (anchorEnd) {
-    [anchorEndIndex, secondaryEndIndex] = findAnchor({
-      nodes: bodyAST.children.slice(anchorStartIndex + 1),
-      match: anchorEnd,
-    });
-    if (anchorEndIndex < 0) {
-      const data = MDUtilsV4.genMDMsg(`end anchor ${anchorEnd} not found`);
-      return { data, error: null };
-    }
-    anchorEndIndex += anchorStartIndex + 1;
-  } else if (AnchorUtils.isBlockAnchor(anchorStart)) {
-    // If no end is specified and the start is a block anchor, the end is implicitly the end of the referenced block.
-    anchorEndIndex = anchorStartIndex + 1;
-  }
-
-  if (bodyAST.children[anchorStartIndex].type === "list") {
-    if (anchorStartIndex === anchorEndIndex) {
-      // Within the same list
-      (bodyAST.children[anchorStartIndex] as List).children.slice(
-        secondaryStartIndex,
-        secondaryEndIndex
-      );
-    } else {
-      // Start anchor is in the list, but the end anchor is either not in the list, or is in a different list
-      (bodyAST.children[anchorStartIndex] as List).children.slice(
-        secondaryStartIndex
-      );
-    }
-  }
-  if (
-    bodyAST.children[anchorEndIndex].type === "list" &&
-    anchorStartIndex !== anchorEndIndex
-  ) {
-    // The end anchor is in the list, but the start anchor is either not in the list, or is in a different list
-    (bodyAST.children[anchorEndIndex] as List).children.slice(
-      secondaryEndIndex
-    );
-  }
+  let { start, end, data, error } = prepareNoteRefIndices({
+    anchorStart,
+    anchorEnd,
+    bodyAST,
+    makeErrorData: (anchorName, anchorType) => {
+      return MDUtilsV4.genMDMsg(`${anchorType} anchor ${anchorName} not found`);
+    },
+  });
+  if (data) return { data, error };
 
   // slice of interested range
   try {
     let out = root(
       bodyAST.children.slice(
-        anchorStartIndex + anchorStartOffset,
-        anchorEndIndex
+        (start ? start.index : 0) + anchorStartOffset,
+        end ? end.index + 1 : undefined
       )
     );
     let tmpProc = MDUtilsV4.procFull({ ...procOpts });
@@ -480,7 +566,6 @@ function convertNoteRefHelperAST(
       return { error: null, data: out };
     }
   } catch (err) {
-    debugger;
     console.log("ERROR WITH RE in AST");
     console.log(JSON.stringify(err));
     return {
@@ -502,66 +587,19 @@ function convertNoteRefHelper(
   const bodyAST = noteRefProc.parse(body) as DendronASTNode;
   const { anchorStart, anchorEnd, anchorStartOffset } = link.data;
 
-  // TODO: can i just strip frontmatter when reading?
-  let anchorStartIndex = bodyAST.children[0].type === "yaml" ? 1 : 0;
-  let secondaryStartIndex: number | undefined;
-  let anchorEndIndex = bodyAST.children.length;
-  let secondaryEndIndex: number | undefined;
-
-  if (anchorStart) {
-    if (anchorStart[0] === "^") {
-    } else {
-      [anchorStartIndex, secondaryStartIndex] = findAnchor({
-        nodes: bodyAST.children,
-        match: anchorStart,
-      });
-    }
-    if (anchorStartIndex < 0) {
-      return { data: `Start anchor ${anchorStart} not found`, error: null };
-    }
-  }
-
-  if (anchorEnd) {
-    [anchorEndIndex, secondaryEndIndex] = findAnchor({
-      nodes: bodyAST.children.slice(anchorStartIndex + 1),
-      match: anchorEnd,
-    });
-    if (anchorEndIndex < 0) {
-      return { data: `end anchor ${anchorEnd} not found`, error: null };
-    }
-    anchorEndIndex += anchorStartIndex + 1;
-  } else if (AnchorUtils.isBlockAnchor(anchorStart)) {
-    // If no end is specified and the start is a block anchor, the end is implicitly the end of the referenced block.
-    anchorEndIndex = anchorStartIndex + 1;
-  }
-
-  if (bodyAST.children[anchorStartIndex].type === "list") {
-    if (anchorStartIndex === anchorEndIndex) {
-      // Within the same list
-      (bodyAST.children[anchorStartIndex] as List).children.slice(
-        secondaryStartIndex,
-        secondaryEndIndex
-      );
-    } else {
-      // Start anchor is in the list, but the end anchor is either not in the list, or is in a different list
-      (bodyAST.children[anchorStartIndex] as List).children.slice(
-        secondaryStartIndex
-      );
-    }
-  }
-  if (
-    bodyAST.children[anchorEndIndex].type === "list" &&
-    anchorStartIndex !== anchorEndIndex
-  ) {
-    // The end anchor is in the list, but the start anchor is either not in the list, or is in a different list
-    (bodyAST.children[anchorEndIndex] as List).children.slice(
-      secondaryEndIndex
-    );
-  }
+  let { start, end, data, error } = prepareNoteRefIndices({
+    anchorStart,
+    anchorEnd,
+    bodyAST,
+    makeErrorData: (anchorName, anchorType) => {
+      return `${anchorType} anchor ${anchorName} not found`;
+    },
+  });
+  if (data) return { data, error };
 
   // slice of interested range
   try {
-    bodyAST.children = bodyAST.children.slice(anchorStartIndex, anchorEndIndex);
+    bodyAST.children = bodyAST.children.slice(start?.index, end?.index);
     let out = noteRefProc
       .processSync(noteRefProc.stringify(bodyAST))
       .toString();
@@ -582,13 +620,23 @@ function convertNoteRefHelper(
   }
 }
 
+type FindAnchorResult =
+  | {
+      type: "header" | "block";
+      index: number;
+    }
+  | {
+      type: "list";
+      index: number;
+      ancestors: ParentWithIndex[];
+    }
+  | null;
+
 /** Searches for anchors, then returns the index for the top-level ancestor.
  *
  * @param nodes The list of nodes to search through.
  * @param match The block anchor string, like "header-anchor" or "^block-anchor"
- * @returns The index of the top-level ancestor node in the list where the anchor was found.
- *   If the anchor was a block anchor and was found in a list, then the second index is the
- *   index of the list element where the anchor was found.
+ * @returns The index of the top-level ancestor node in the list where the anchor was found, or -1 if not found.
  */
 function findAnchor({
   nodes,
@@ -596,12 +644,12 @@ function findAnchor({
 }: {
   nodes: DendronASTNode["children"];
   match: string;
-}): [number] | [number, number] {
+}): FindAnchorResult {
   if (AnchorUtils.isBlockAnchor(match)) {
     const anchorId = match.slice(1);
     return findBlockAnchor({ nodes, match: anchorId });
   } else {
-    return [findHeader({ nodes, match, slugger: getSlugger() })];
+    return findHeader({ nodes, match, slugger: getSlugger() });
   }
 }
 
@@ -613,20 +661,19 @@ function findHeader({
   nodes: DendronASTNode["children"];
   match: string;
   slugger: ReturnType<typeof getSlugger>;
-}) {
+}): FindAnchorResult {
   const foundIndex = MDUtilsV4.findIndex(nodes, function (node: Node) {
     return MDUtilsV4.matchHeading(node, match, { slugger });
   });
-  return foundIndex;
+  if (foundIndex < 0) return null;
+  return { type: "header", index: foundIndex };
 }
 
 /** Searches for block anchors, then returns the index for the top-level ancestor.
  *
  * @param nodes The list of nodes to search through.
  * @param match The block anchor string, like "header-anchor" or "^block-anchor"
- * @returns The index of the top-level ancestor node in the list where the anchor was found.
- *   If the anchor was found in a list, then the second index is the index of the list element
- *   where the anchor was found.
+ * @returns The index of the top-level ancestor node in the list where the anchor was found, or -1 if not found.
  */
 function findBlockAnchor({
   nodes,
@@ -634,29 +681,37 @@ function findBlockAnchor({
 }: {
   nodes: Node[];
   match: string;
-}): [number] | [number, number] {
-  function findMatch(node: Node) {
-    let found = false;
-    visit(node, DendronASTTypes.BLOCK_ANCHOR, (anchor: BlockAnchor) => {
-      found = anchor.id === match;
-      if (found) return false; // stop traversal
-      return; // continue traversal
-    });
-    return found;
-  }
+}): FindAnchorResult {
+  // Find the anchor in the nodes
+  let foundIndex: number | undefined;
+  let foundAncestors: ParentWithIndex[] = [];
+  MDUtilsV4.visitParentsIndices({
+    nodes,
+    test: DendronASTTypes.BLOCK_ANCHOR,
+    visitor: ({ node, index, ancestors }) => {
+      if (node.id === match) {
+        // found anchor!
+        foundIndex = ancestors.length > 0 ? ancestors[0].index : index;
+        foundAncestors = ancestors;
+        return false; // stop traversal
+      }
+      return true; // continue traversal
+    },
+  });
 
-  let foundIndex = MDUtilsV4.findIndex(nodes, findMatch);
-  if (foundIndex >= 0) {
-    const parent = nodes[foundIndex] as Parent;
-    if (parent.type === "list") {
-      // If it's in a list, we'll need to slice the children of the list so we need that index too.
-      const listItemIndex = MDUtilsV4.findIndex(parent.children, findMatch);
-      return [foundIndex, listItemIndex];
+  if (_.isUndefined(foundIndex)) return null;
+  if (!_.isEmpty(foundAncestors)) {
+    if (foundAncestors[0].ancestor.children.length === 1) {
+      // If located by itself after a block, then the block anchor refers to the previous block
+      return { type: "block", index: foundIndex - 1 };
     }
-    // If located independently after a block, then the block anchor refers to the previous block
-    if (parent.children.length === 1) return [foundIndex - 1];
+    if (foundAncestors[0].ancestor.type === DendronASTTypes.LIST) {
+      // The block anchor is in a list, which will need special handling to slice the list elements
+      return { type: "list", index: foundIndex, ancestors: foundAncestors };
+    }
   }
-  return [foundIndex];
+  // Otherwise, it's an anchor inside some regular block. The anchor refers to the block it's inside of.
+  return { type: "block", index: foundIndex };
 }
 
 function renderPretty(opts: { content: string; title: string; link: string }) {

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -276,6 +276,7 @@ export class AnchorUtils {
   }
 
   static isBlockAnchor(anchor?: string): boolean {
+    // not undefined, not an empty string, and the first character is ^
     return !!anchor && anchor[0] === "^";
   }
 }

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -274,6 +274,10 @@ export class AnchorUtils {
       return {};
     }
   }
+
+  static isBlockAnchor(anchor?: string): boolean {
+    return !!anchor && anchor[0] === "^";
+  }
 }
 
 function walk(node: Node, fn: any) {

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -307,19 +307,6 @@ export class RemarkUtils {
     });
   }
 
-  static findHeaders(content: string): Heading[] {
-    const remark = MDUtilsV4.remark();
-    let out = remark.parse(content);
-    let out2: Heading[] = selectAll(DendronASTTypes.HEADING, out) as Heading[];
-    return out2;
-  }
-
-  static findBlockAnchors(content: string): BlockAnchor[] {
-    const parser = MDUtilsV4.remark().use(blockAnchors);
-    const parsed = parser.parse(content);
-    return selectAll(DendronASTTypes.BLOCK_ANCHOR, parsed) as BlockAnchor[];
-  }
-
   static findAnchors(content: string): Anchor[] {
     const parser = MDUtilsV4.remark().use(blockAnchors);
     const parsed = parser.parse(content);

--- a/packages/engine-server/src/markdown/types.ts
+++ b/packages/engine-server/src/markdown/types.ts
@@ -40,7 +40,9 @@ export enum DendronASTTypes {
   REF_LINK_V2 = "refLinkV2",
   PARAGRAPH = "paragraph",
   BLOCK_ANCHOR = "blockAnchor",
-  HEADING = "heading", // Not dendron-specific, included here for convenience
+  // Not dendron-specific, included here for convenience
+  HEADING = "heading",
+  LIST = "list",
 }
 
 export enum DendronASTDest {

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -130,7 +130,7 @@ export const renderFromNoteWithCustomBody = (opts: {
   return contents;
 };
 
-type ParentWithIndex = {
+export type ParentWithIndex = {
   ancestor: Parent;
   index: number;
 };

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -130,7 +130,7 @@ export const renderFromNoteWithCustomBody = (opts: {
   return contents;
 };
 export class MDUtilsV4 {
-  static findIndex(array: Node[], fn: (node: Node, index: number) => boolean) {
+  static findIndex<T>(array: T[], fn: (node: T, index: number) => boolean) {
     for (var i = 0; i < array.length; i++) {
       if (fn(array[i], i)) {
         return i;

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -130,7 +130,7 @@ export const renderFromNoteWithCustomBody = (opts: {
   return contents;
 };
 export class MDUtilsV4 {
-  static findIndex(array: Node[], fn: any) {
+  static findIndex(array: Node[], fn: (node: Node, index: number) => boolean) {
     for (var i = 0; i < array.length; i++) {
       if (fn(array[i], i)) {
         return i;

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -216,11 +216,13 @@ export function parseFileLink(ref: string): DNoteRefLink {
   return { from: { fname }, data: clean, type: "ref" };
 }
 
+/** .from.fname in the return may be an empty string if the link is a same-file reference to a header or block (e.g `[[#header]]`) */
 export function parseNoteRefV2(ref: string): DNoteRefLink {
+  const optWikiFileName = /([^\]:#]*)/.source;
   const wikiFileName = /([^\]:#]+)/.source;
   const reLink = new RegExp(
     "" +
-      `(?<name>${wikiFileName})` +
+      `(?<name>${optWikiFileName})` +
       `(${
         new RegExp(
           // anchor start

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -401,6 +401,38 @@ task2
 }
 `;
 
+exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_FM_TITLE": bond 1`] = `
+VFile {
+  "contents": "# Foo
+
+# Foo Bar
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
+<a href=\\"foo.md\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>        
+
+## Header2
+
+task2
+
+</div>    
+</div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_NOTE_LINK_TITLE" 1`] = `
 VFile {
   "contents": "# Foo
@@ -1136,7 +1168,7 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.
-^block-anchor</p>
+<a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1165,7 +1197,7 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.
-^block-anchor</p>
+<a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1193,11 +1225,8 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><ul>
-<li>Sapiente sed accusamus eum.</li>
-<li>Ullam optio est quia.</li>
-<li>Reprehenderit doloribus.</li>
 <li>Sint minus fuga omnis non.
-^block-anchor</li>
+<a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
 </ul>
 </div></div><p></p><p></p>
 <hr>
@@ -1226,11 +1255,8 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><ul>
-<li>Sapiente sed accusamus eum.</li>
-<li>Ullam optio est quia.</li>
-<li>Reprehenderit doloribus.</li>
 <li>Sint minus fuga omnis non.
-^block-anchor</li>
+<a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
 </ul>
 </div></div><p></p><p></p>
 <hr>
@@ -1259,7 +1285,7 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
-Sint minus fuga omnis non. ^block-anchor</p>
+Sint minus fuga omnis non. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1287,7 +1313,7 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
-Sint minus fuga omnis non. ^block-anchor</p>
+Sint minus fuga omnis non. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1403,10 +1429,7 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><ul>
-<li>Sapiente sed accusamus eum.</li>
-<li>Ullam optio est quia.</li>
-<li>Reprehenderit doloribus. ^block-anchor</li>
-<li>Sint minus fuga omnis non.</li>
+<li>Reprehenderit doloribus. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
 </ul>
 </div></div><p></p><p></p>
 <hr>
@@ -1435,10 +1458,65 @@ VFile {
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><ul>
-<li>Sapiente sed accusamus eum.</li>
-<li>Ullam optio est quia.</li>
-<li>Reprehenderit doloribus. ^block-anchor</li>
-<li>Sint minus fuga omnis non.</li>
+<li>Reprehenderit doloribus. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: nested list element" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Reprehenderit doloribus. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: nested list element" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Reprehenderit doloribus. <a id=\\"^block-anchor\\" href=\\"#^block-anchor\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^block-anchor</a></li>
 </ul>
 </div></div><p></p><p></p>
 <hr>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -1530,3 +1530,453 @@ VFile {
   "messages": Array [],
 }
 `;
+
+exports[`noteRefV2 with block anchors compile "HTML: range across multiple lists" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+</ul>
+<p>Sapiente sed accusamus eum.</p>
+<ul>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range across multiple lists" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+</ul>
+<p>Sapiente sed accusamus eum.</p>
+<ul>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a block anchor to a header" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></p>
+<h1 id=\\"end\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#end\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>end</h1>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a block anchor to a header" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></p>
+<h1 id=\\"end\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#end\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>end</h1>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a header to a block anchor" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"start\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#start\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>start</h1>
+<p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a header to a block anchor" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"start\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#start\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>start</h1>
+<p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a list to a paragraph" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+</ul>
+<p>Sapiente sed accusamus eum.
+Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a list to a paragraph" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+</ul>
+<p>Sapiente sed accusamus eum.
+Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a paragraph to a list" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></p>
+<ul>
+<li>Reprehenderit doloribus.</li>
+<li>Ullam optio est quia. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range from a paragraph to a list" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Sint minus fuga omnis non.
+Sapiente sed accusamus eum. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></p>
+<ul>
+<li>Reprehenderit doloribus.</li>
+<li>Ullam optio est quia. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range within list" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range within list" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+<li>Reprehenderit doloribus.</li>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range within nested lists" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.
+<ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+</ul>
+</li>
+<li>Reprehenderit doloribus.
+<ul>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range within nested lists" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.
+<ul>
+<li>Ullam optio est quia. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start</a></li>
+</ul>
+</li>
+<li>Reprehenderit doloribus.
+<ul>
+<li>Sint minus fuga omnis non. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
+</ul>
+</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -401,7 +401,7 @@ task2
 }
 `;
 
-exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_FM_TITLE": bond 1`] = `
+exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_FM_TITLE" 1`] = `
 VFile {
   "contents": "# Foo
 
@@ -854,6 +854,166 @@ VFile {
 </div></div>
 
 ",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: a reference inside a reference" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Ullam optio est quia. <a id=\\"^start2\\" href=\\"#^start2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start2</a></p>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Aut id architecto quia. <a id=\\"^start1\\" href=\\"#^start1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start1</a></p>
+<p>Sapiente sed accusamus eum. <a id=\\"^end1\\" href=\\"#^end1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end1</a></p>
+</div></div><p></p><p></p>
+<p>Reprehenderit doloribus. <a id=\\"^end2\\" href=\\"#^end2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end2</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: a reference inside a reference" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Ullam optio est quia. <a id=\\"^start2\\" href=\\"#^start2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start2</a></p>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Aut id architecto quia. <a id=\\"^start1\\" href=\\"#^start1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start1</a></p>
+<p>Sapiente sed accusamus eum. <a id=\\"^end1\\" href=\\"#^end1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end1</a></p>
+</div></div><p></p><p></p>
+<p>Reprehenderit doloribus. <a id=\\"^end2\\" href=\\"#^end2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end2</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: a reference inside a reference, all using same file references" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Ullam optio est quia. <a id=\\"^start2\\" href=\\"#^start2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start2</a></p>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Aut id architecto quia. <a id=\\"^start1\\" href=\\"#^start1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start1</a></p>
+<p>Sapiente sed accusamus eum. <a id=\\"^end1\\" href=\\"#^end1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end1</a></p>
+</div></div><p></p><p></p>
+<p>Reprehenderit doloribus. <a id=\\"^end2\\" href=\\"#^end2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end2</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: a reference inside a reference, all using same file references" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Ullam optio est quia. <a id=\\"^start2\\" href=\\"#^start2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start2</a></p>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Aut id architecto quia. <a id=\\"^start1\\" href=\\"#^start1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^start1</a></p>
+<p>Sapiente sed accusamus eum. <a id=\\"^end1\\" href=\\"#^end1\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end1</a></p>
+</div></div><p></p><p></p>
+<p>Reprehenderit doloribus. <a id=\\"^end2\\" href=\\"#^end2\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end2</a></p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -1830,6 +1990,114 @@ Sapiente sed accusamus eum. <a id=\\"^start\\" href=\\"#^start\\" style=\\"font-
 <li>Reprehenderit doloribus.</li>
 <li>Ullam optio est quia. <a id=\\"^end\\" href=\\"#^end\\" style=\\"font-size: 0.8em; opacity: 75%;\\">^end</a></li>
 </ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range that has an invalid end block anchor" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>End anchor ^invalid-end not found</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range that has an invalid end block anchor" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>End anchor ^invalid-end not found</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range that has an invalid start block anchor" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^invalid-start not found</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: range that has an invalid start block anchor" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^invalid-start not found</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -844,8 +844,6 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.</p>
-<p>^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -874,8 +872,6 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.</p>
-<p>^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -906,8 +902,6 @@ VFile {
 <li>Sapiente sed accusamus eum.</li>
 <li>Ullam optio est quia.</li>
 </ul>
-<p>^block-anchor</p>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -934,7 +928,10 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^block-anchor not found</p>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+</ul>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -979,8 +976,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>^block-anchor</p>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1025,8 +1020,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>^block-anchor</p>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1071,8 +1064,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>^block-anchor</p>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1117,8 +1108,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>^block-anchor</p>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1148,7 +1137,6 @@ VFile {
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.
 ^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1178,7 +1166,6 @@ VFile {
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non.
 ^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1273,7 +1260,6 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non. ^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1302,7 +1288,6 @@ VFile {
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
 Sint minus fuga omnis non. ^block-anchor</p>
-<p>Soluta ex qui.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1347,7 +1332,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>Iure neque alias dolorem.</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -1392,34 +1376,6 @@ VFile {
 
 
 <table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
-<p>Iure neque alias dolorem.</p>
-</div></div><p></p><p></p>
-<hr>
-<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
-<ol>
-<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
-</ol>",
-  "cwd": "<PROJECT_ROOT>",
-  "data": Object {},
-  "history": Array [],
-  "messages": Array [],
-}
-`;
-
-exports[`noteRefV2 with block anchors compile "HTML: in table" 3`] = `
-VFile {
-  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
-<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
-<p></p><p></p><div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\">
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
-<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^block-anchor not found</p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -401,38 +401,6 @@ task2
 }
 `;
 
-exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_FM_TITLE": bond 1`] = `
-VFile {
-  "contents": "# Foo
-
-# Foo Bar
-
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
-<a href=\\"foo.md\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>        
-
-## Header2
-
-task2
-
-</div>    
-</div>
-
-",
-  "cwd": "<PROJECT_ROOT>",
-  "data": Object {},
-  "history": Array [],
-  "messages": Array [],
-}
-`;
-
 exports[`noteRefV2 compile "MD_ENHANCED_PREVIEW: WITH_NOTE_LINK_TITLE" 1`] = `
 VFile {
   "contents": "# Foo
@@ -854,6 +822,674 @@ VFile {
 </div></div>
 
 ",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after a paragraph block" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non.</p>
+<p>^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after a paragraph block" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non.</p>
+<p>^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after list block" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+</ul>
+<p>^block-anchor</p>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after list block" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^block-anchor not found</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after table block" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>^block-anchor</p>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after table block" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>^block-anchor</p>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after table" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>^block-anchor</p>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: after table" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>^block-anchor</p>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: immediately after a paragraph" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non.
+^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: immediately after a paragraph" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non.
+^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: immediately after last list element" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+<li>Reprehenderit doloribus.</li>
+<li>Sint minus fuga omnis non.
+^block-anchor</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: immediately after last list element" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+<li>Reprehenderit doloribus.</li>
+<li>Sint minus fuga omnis non.
+^block-anchor</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: in paragraph" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non. ^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: in paragraph" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Reprehenderit doloribus.
+Sint minus fuga omnis non. ^block-anchor</p>
+<p>Soluta ex qui.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: in table" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: in table" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th>Sapiente</th><th>accusamus</th></tr></thead><tbody><tr><td>Laborum</td><td>libero</td></tr><tr><td>Ullam</td><td>optio</td></tr></tbody></table>
+<p>Iure neque alias dolorem.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: in table" 3`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>Start anchor ^block-anchor not found</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: list element" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+<li>Reprehenderit doloribus. ^block-anchor</li>
+<li>Sint minus fuga omnis non.</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: list element" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li>Sapiente sed accusamus eum.</li>
+<li>Ullam optio est quia.</li>
+<li>Reprehenderit doloribus. ^block-anchor</li>
+<li>Sint minus fuga omnis non.</li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
@@ -1,6 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`utils findHeaders one header: bond 1`] = `
+exports[`RemarkUtils and LinkUtils findAnchors one block anchor: bond 1`] = `
+Array [
+  Object {
+    "id": "block-anchor",
+    "position": Position {
+      "end": Object {
+        "column": 53,
+        "line": 2,
+        "offset": 98,
+      },
+      "indent": Array [],
+      "start": Object {
+        "column": 40,
+        "line": 2,
+        "offset": 85,
+      },
+    },
+    "type": "blockAnchor",
+    "value": "^block-anchor",
+  },
+]
+`;
+
+exports[`RemarkUtils and LinkUtils findAnchors one header: bond 1`] = `
 Array [
   Object {
     "children": Array [
@@ -41,9 +64,9 @@ Array [
 ]
 `;
 
-exports[`utils findLinks empty link 1`] = `Array []`;
+exports[`RemarkUtils and LinkUtils findLinks empty link 1`] = `Array []`;
 
-exports[`utils findLinks one link: bond 1`] = `
+exports[`RemarkUtils and LinkUtils findLinks one link: bond 1`] = `
 Array [
   Object {
     "alias": "bar",
@@ -70,7 +93,7 @@ Array [
 ]
 `;
 
-exports[`utils findLinks xvault link 1`] = `
+exports[`RemarkUtils and LinkUtils findLinks xvault link 1`] = `
 Array [
   Object {
     "alias": "bar",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RemarkUtils and LinkUtils findAnchors one block anchor: bond 1`] = `
+exports[`RemarkUtils and LinkUtils findAnchors one block anchor 1`] = `
 Array [
   Object {
     "id": "block-anchor",
@@ -23,7 +23,7 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findAnchors one header: bond 1`] = `
+exports[`RemarkUtils and LinkUtils findAnchors one header 1`] = `
 Array [
   Object {
     "children": Array [
@@ -66,7 +66,7 @@ Array [
 
 exports[`RemarkUtils and LinkUtils findLinks empty link 1`] = `Array []`;
 
-exports[`RemarkUtils and LinkUtils findLinks one link: bond 1`] = `
+exports[`RemarkUtils and LinkUtils findLinks one link 1`] = `
 Array [
   Object {
     "alias": "bar",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -727,13 +727,13 @@ describe("noteRefV2", () => {
           await checkVFile(
             resp,
             "Reprehenderit doloribus.",
-            "Sint minus fuga omnis non.",
-            "Soluta ex qui."
+            "Sint minus fuga omnis non."
           );
           await checkNotInVFile(
             resp,
             "Sapiente sed accusamus eum.",
-            "Ullam optio est quia."
+            "Ullam optio est quia.",
+            "Soluta ex qui."
           );
         },
       },
@@ -774,13 +774,13 @@ describe("noteRefV2", () => {
           await checkVFile(
             resp,
             "Reprehenderit doloribus.",
-            "Sint minus fuga omnis non.",
-            "Soluta ex qui."
+            "Sint minus fuga omnis non."
           );
           await checkNotInVFile(
             resp,
             "Sapiente sed accusamus eum.",
-            "Ullam optio est quia."
+            "Ullam optio est quia.",
+            "Soluta ex qui."
           );
         },
       },
@@ -822,13 +822,13 @@ describe("noteRefV2", () => {
           await checkVFile(
             resp,
             "Reprehenderit doloribus.",
-            "Sint minus fuga omnis non.",
-            "Soluta ex qui."
+            "Sint minus fuga omnis non."
           );
           await checkNotInVFile(
             resp,
             "Sapiente sed accusamus eum.",
-            "Ullam optio est quia."
+            "Ullam optio est quia.",
+            "Soluta ex qui."
           );
         },
       },
@@ -950,7 +950,7 @@ describe("noteRefV2", () => {
           const { resp } = extra;
           await checkVFile(
             resp,
-            "Sint minus fuga omnis non.",
+            "Sapiente sed accusamus eum.",
             "Ullam optio est quia."
           );
           await checkNotInVFile(
@@ -1118,17 +1118,6 @@ describe("noteRefV2", () => {
       },
     });
 
-    runAllTests({
-      name: "compile",
-      testCases: [
-        ...LIST_ELEMENT,
-        ...AFTER_LIST,
-        ...AFTER_LIST_BLOCK,
-        ...IN_TABLE,
-        ...AFTER_TABLE,
-        ...AFTER_TABLE_BLOCK,
-      ],
-    });
     runAllTests({
       name: "compile",
       testCases: [

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -18,7 +18,7 @@ describe("RemarkUtils and LinkUtils", () => {
         async ({ engine }) => {
           const body = engine.notes["foo"].body;
           const out = RemarkUtils.findAnchors(body);
-          expect(out).toMatchSnapshot("bond");
+          expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].depth).toEqual(1);
           expect(out[0].type).toEqual(DendronASTTypes.HEADING);
@@ -44,9 +44,8 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const body = engine.notes["foo"].body;
-          debugger;
           const out = RemarkUtils.findAnchors(body);
-          expect(out).toMatchSnapshot("bond");
+          expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].type).toEqual(DendronASTTypes.BLOCK_ANCHOR);
         },
@@ -76,7 +75,7 @@ describe("RemarkUtils and LinkUtils", () => {
       async ({ engine }) => {
         const note = engine.notes["foo"];
         const links = LinkUtils.findLinks({ note, engine });
-        expect(links).toMatchSnapshot("bond");
+        expect(links).toMatchSnapshot();
         expect(links[0].to?.fname).toEqual("bar");
       },
       {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -5,27 +5,61 @@ import {
   MDUtilsV4,
   RemarkUtils,
   LinkUtils,
+  DendronASTTypes,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { DVault, runEngineTestV5, testWithEngine } from "../../../engine";
 import { checkString } from "../../../utils";
 
-describe("utils", () => {
-  describe("findHeaders", async () => {
+describe("RemarkUtils and LinkUtils", () => {
+  describe("findAnchors", async () => {
     test("one header", async () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const body = engine.notes["foo"].body;
-          const out = RemarkUtils.findHeaders(body);
+          const out = RemarkUtils.findAnchors(body);
           expect(out).toMatchSnapshot("bond");
           expect(_.size(out)).toEqual(1);
           expect(out[0].depth).toEqual(1);
+          expect(out[0].type).toEqual(DendronASTTypes.HEADING);
         },
         {
           preSetupHook: async ({ vaults, wsRoot }) => {
             await NoteTestUtilsV4.createNote({
               fname: "foo",
-              body: "# h1",
+              body: [
+                "# h1",
+                "",
+                "Repellendus possimus voluptates tempora quia.",
+              ].join("\n"),
+              vault: vaults[0],
+              wsRoot,
+            });
+          },
+          expect,
+        }
+      );
+    });
+    test("one block anchor", async () => {
+      await runEngineTestV5(
+        async ({ engine }) => {
+          const body = engine.notes["foo"].body;
+          debugger;
+          const out = RemarkUtils.findAnchors(body);
+          expect(out).toMatchSnapshot("bond");
+          expect(_.size(out)).toEqual(1);
+          expect(out[0].type).toEqual(DendronASTTypes.BLOCK_ANCHOR);
+        },
+        {
+          preSetupHook: async ({ vaults, wsRoot }) => {
+            await NoteTestUtilsV4.createNote({
+              fname: "foo",
+              body: [
+                "Repellendus possimus voluptates tempora quia.",
+                "Eum deleniti sit delectus officia rem. ^block-anchor",
+                "",
+                "Consectetur blanditiis facilis nulla mollitia.",
+              ].join("\n"),
               vault: vaults[0],
               wsRoot,
             });

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utils.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utils.ts
@@ -3,7 +3,6 @@ import {
   DEngineClient,
   DuplicateNoteAction,
   DVault,
-  WorkspaceOpts,
 } from "@dendronhq/common-all";
 import { AssertUtils, TestPresetEntryV4 } from "@dendronhq/common-test-utils";
 import {
@@ -172,14 +171,16 @@ export const processText = (opts: { text: string; proc: Processor }) => {
   return { proc, respParse, respProcess, respRehype };
 };
 
-export const processTextV2 = async (opts: {
+type ProcessTextV2Opts = {
   text: string;
   dest: DendronASTDest.HTML;
   engine: DEngineClient;
   fname: string;
   vault: DVault;
   configOverride?: DendronConfig;
-}) => {
+};
+
+export const processTextV2 = async (opts: ProcessTextV2Opts) => {
   const { engine, text, fname, vault, configOverride } = opts;
   if (opts.dest !== DendronASTDest.HTML) {
     const proc = MDUtilsV4.procDendron({
@@ -204,13 +205,9 @@ export const processTextV2 = async (opts: {
   }
 };
 
-export const processNote = (opts: {
-  fname: string;
-  proc: Processor;
-  wopts: WorkspaceOpts;
-}) => {
-  const { fname, wopts, proc } = opts;
-  const npath = path.join(wopts.wsRoot, wopts.vaults[0].fsPath, fname + ".md");
-  const text = fs.readFileSync(npath, { encoding: "utf8" });
-  return processText({ text, proc });
+export const processNote = async (opts: Omit<ProcessTextV2Opts, "text">) => {
+  const { fname, engine, vault } = opts;
+  const npath = path.join(engine.wsRoot, vault.fsPath, fname + ".md");
+  const text = await fs.readFile(npath, { encoding: "utf8" });
+  return await processTextV2({ text, ...opts });
 };


### PR DESCRIPTION
This pull request adds support for block references in HTML. It includes support for:

* Single block anchor references `![[note#^anchor]]`
* Range block anchor references `![[note#^anchor1:#^anchor2]]`
* Same file block references `![[#^anchor]]` and `![[#header]]`

Range block anchor references are allowed to be mixed with headers too, so it's possible to do `![[#header:#^anchor]]` or `![[#^anchor:#header]]` to reference only a part of a section.

It's also possible to reference single items in lists, or parts of lists. Consider the following list

```
* Aut id architecto quia.
* Sapiente sed accusamus eum.
  * Ullam optio est quia. ^one
* Reprehenderit doloribus.
  * Sint minus fuga omnis non. ^two
  * Iure neque alias dolorem. ^three
```

The reference `![[#^one]]` would only reference the list element it's next to. `![[#^two:#^three]]` would reference both elements, and anything in between.

An interesting case is something like `![[#^one:#^two]]` where the referenced items are nested in different levels of the list. In this case, the reference refers to anything after the start anchor and before the end anchor, and also the parent of the start anchor up to a common ancestor with the end. In other words, the output looks like:

```
* Sapiente sed accusamus eum.
  * Ullam optio est quia. ^one
* Reprehenderit doloribus.
  * Sint minus fuga omnis non. ^two
```

This allows you to refer to regions of lists across different depths while preserving the required context for the items you selected within the region, and avoids ending up with a broken list.