### PR TITLE
enhance: Improve startup speed by parallelizing schema loading

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -89,23 +89,26 @@ async function _createFileWatcher(
   });
 }
 
-export function file2Schema(fpath: string, wsRoot: string): SchemaModuleProps {
+export async function file2Schema(
+  fpath: string,
+  wsRoot: string
+): Promise<SchemaModuleProps> {
   const root = { fsPath: path.dirname(fpath) };
   const fname = path.basename(fpath, ".schema.yml");
   const schemaOpts = YAML.safeLoad(
-    fs.readFileSync(fpath, { encoding: "utf8" }),
+    await fs.readFile(fpath, { encoding: "utf8" }),
     {
       schema: YAML.JSON_SCHEMA,
     }
   ) as SchemaModuleOpts;
-  return SchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
+  return await SchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
 }
 
 export function genHash(contents: any) {
   return SparkMD5.hash(contents); // OR raw hash (binary string)
 }
 
-export function string2Schema({
+export async function string2Schema({
   vault,
   content,
   fname,
@@ -119,7 +122,11 @@ export function string2Schema({
   const schemaOpts = YAML.safeLoad(content, {
     schema: YAML.JSON_SCHEMA,
   }) as SchemaModuleOpts;
-  return SchemaParserV2.parseRaw(schemaOpts, { root: vault, fname, wsRoot });
+  return await SchemaParserV2.parseRaw(schemaOpts, {
+    root: vault,
+    fname,
+    wsRoot,
+  });
 }
 
 export function string2Note({

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -53,15 +53,8 @@ export class NoteTestUtilsV4 {
   };
 
   static createNote = async (opts: CreateNoteOptsV4) => {
-    const {
-      fname,
-      vault,
-      props,
-      body,
-      genRandomId,
-      noWrite,
-      wsRoot,
-    } = _.defaults(opts, { noWrite: false });
+    const { fname, vault, props, body, genRandomId, noWrite, wsRoot } =
+      _.defaults(opts, { noWrite: false });
     /**
      * Make sure snapshots stay consistent
      */
@@ -102,7 +95,7 @@ export class NoteTestUtilsV4 {
     const { fname, vault, wsRoot } = opts;
     const vpath = vault2Path({ vault, wsRoot });
     const npath = path.join(vpath, fname + ".schema.yml");
-    const schema = file2Schema(npath, wsRoot);
+    const schema = await file2Schema(npath, wsRoot);
     const newSchema = cb(schema);
     return await schemaModuleProps2File(newSchema, vpath, fname);
   }

--- a/packages/engine-server/src/drivers/file/schemaParser.ts
+++ b/packages/engine-server/src/drivers/file/schemaParser.ts
@@ -15,14 +15,14 @@ import YAML from "yamljs";
 import { ParserBase } from "./parseBase";
 
 export class SchemaParser extends ParserBase {
-  parseFile(fpath: string, root: DVault): SchemaModuleProps {
+  async parseFile(fpath: string, root: DVault): Promise<SchemaModuleProps> {
     const fname = path.basename(fpath, ".schema.yml");
     const wsRoot = this.opts.store.wsRoot;
     const vpath = vault2Path({ vault: root, wsRoot });
     const schemaOpts: any = YAML.parse(
       fs.readFileSync(path.join(vpath, fpath), "utf8")
     );
-    return cSchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
+    return await cSchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
   }
 
   async parse(
@@ -36,9 +36,9 @@ export class SchemaParser extends ParserBase {
     this.logger.info({ ctx, msg: "enter", fpaths, vault });
 
     const out = await Promise.all(
-      fpaths.flatMap((fpath) => {
+      fpaths.flatMap(async (fpath) => {
         try {
-          return this.parseFile(fpath, vault);
+          return await this.parseFile(fpath, vault);
         } catch (err) {
           return new DendronError({
             message: ERROR_STATUS.BAD_PARSE_FOR_SCHEMA,

--- a/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
@@ -106,7 +106,7 @@ describe("file2Schema", () => {
   `,
       { encoding: "utf-8" }
     );
-    const schema = file2Schema(fpath, root);
+    const schema = await file2Schema(fpath, root);
     expect(_.values(schema.schemas).length).toEqual(8);
   });
 });

--- a/packages/plugin-core/src/watchers/schemaWatcher.ts
+++ b/packages/plugin-core/src/watchers/schemaWatcher.ts
@@ -56,7 +56,7 @@ export class SchemaWatcher {
     const content = document.getText();
 
     try {
-      const maybeSchema = string2Schema({
+      const maybeSchema = await string2Schema({
         vault,
         content,
         fname,


### PR DESCRIPTION
I tested this change on our org repo. With the schema files in disk cache, this is giving me around 5% improvement. The improvement should be much higher in real world conditions when loading from cold (files not in disk cache), with slow disks, and for users with lots of schemas.