### PR TITLE
fix: block anchor parsing in wikilinks and multi-line paragraphs

### DIFF
--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -395,10 +395,16 @@ export class FileStorage implements DStore {
             note: n,
             engine: this.engine,
           });
-          const anchors = await AnchorUtils.findAnchors({
-            note: n,
-            wsRoot: wsRoot,
-          });
+          const anchors = await AnchorUtils.findAnchors(
+            {
+              note: n,
+              wsRoot: wsRoot,
+            },
+            {
+              engine: this.engine,
+              fname: n.fname,
+            }
+          );
           cacheUpdates[n.fname].data.links = links;
           cacheUpdates[n.fname].data.anchors = anchors;
           n.links = links;

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -431,10 +431,16 @@ export class DendronEngineV2 implements DEngine {
             //   this.history.add({ source: "engine", action: "create", uri });
           }
           const links = LinkUtils.findLinks({ note: ent.note, engine: this });
-          const anchors = await AnchorUtils.findAnchors({
-            note: ent.note,
-            wsRoot: this.wsRoot,
-          });
+          const anchors = await AnchorUtils.findAnchors(
+            {
+              note: ent.note,
+              wsRoot: this.wsRoot,
+            },
+            {
+              engine: this,
+              fname: ent.note.fname,
+            }
+          );
           ent.note.links = links;
           ent.note.anchors = anchors;
           this.notes[id] = ent.note;

--- a/packages/engine-server/src/markdown/remark/blockAnchors.ts
+++ b/packages/engine-server/src/markdown/remark/blockAnchors.ts
@@ -9,7 +9,8 @@ import { html } from "mdast-builder";
 
 // Letters, digits, dashes, and underscores.
 // The underscores are an extension over Obsidian.
-export const BLOCK_LINK_REGEX = /^\^([\w-]+)$/;
+// Another extension is that it allows whitespace after the anchor.
+export const BLOCK_LINK_REGEX = /^\^([\w-]+)\w*(\n|$)/;
 export const BLOCK_LINK_REGEX_LOOSE = /\^([\w-]+)/;
 
 /**

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -328,6 +328,7 @@ export class MDUtilsV4 {
     const errors: DendronError[] = [];
     let _proc = remark()
       .use(remarkParse, { gfm: true })
+      .use(frontmatterPlugin, ["yaml"])
       .use(wikiLinks)
       .use(blockAnchors)
       .data("errors", errors);

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RemarkUtils and LinkUtils doesn't find block anchor within code block 1`] = `Array []`;
+
+exports[`RemarkUtils and LinkUtils doesn't find block anchor within inline code 1`] = `Array []`;
+
+exports[`RemarkUtils and LinkUtils findAnchors doesn't find block anchor within wikilink 1`] = `Array []`;
+
 exports[`RemarkUtils and LinkUtils findAnchors one block anchor 1`] = `
 Array [
   Object {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -16,8 +16,12 @@ describe("RemarkUtils and LinkUtils", () => {
     test("one header", async () => {
       await runEngineTestV5(
         async ({ engine }) => {
-          const body = engine.notes["foo"].body;
-          const out = RemarkUtils.findAnchors(body);
+          const note = engine.notes["foo"];
+          const body = note.body;
+          const out = RemarkUtils.findAnchors(body, {
+            engine,
+            fname: note.fname,
+          });
           expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].depth).toEqual(1);
@@ -43,8 +47,12 @@ describe("RemarkUtils and LinkUtils", () => {
     test("one block anchor", async () => {
       await runEngineTestV5(
         async ({ engine }) => {
-          const body = engine.notes["foo"].body;
-          const out = RemarkUtils.findAnchors(body);
+          const note = engine.notes["foo"];
+          const body = note.body;
+          const out = RemarkUtils.findAnchors(body, {
+            engine,
+            fname: note.fname,
+          });
           expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].type).toEqual(DendronASTTypes.BLOCK_ANCHOR);
@@ -67,6 +75,102 @@ describe("RemarkUtils and LinkUtils", () => {
         }
       );
     });
+    test("doesn't find block anchor within wikilink", async () => {
+      await runEngineTestV5(
+        async ({ engine }) => {
+          const note = engine.notes["foo"];
+          const body = note.body;
+          const out = RemarkUtils.findAnchors(body, {
+            engine,
+            fname: note.fname,
+          });
+          expect(out).toMatchSnapshot();
+          expect(_.size(out)).toEqual(0);
+        },
+        {
+          preSetupHook: async ({ vaults, wsRoot }) => {
+            await NoteTestUtilsV4.createNote({
+              fname: "foo",
+              body: [
+                "Repellendus possimus voluptates tempora quia.",
+                "Eum deleniti sit delectus officia rem.",
+                "",
+                "[[bar#^block-anchor]]",
+                "",
+                "Consectetur blanditiis facilis nulla mollitia.",
+              ].join("\n"),
+              vault: vaults[0],
+              wsRoot,
+            });
+          },
+          expect,
+        }
+      );
+    });
+  });
+  test("doesn't find block anchor within inline code", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const note = engine.notes["foo"];
+        const body = note.body;
+        const out = RemarkUtils.findAnchors(body, {
+          engine,
+          fname: note.fname,
+        });
+        expect(out).toMatchSnapshot();
+        expect(_.size(out)).toEqual(0);
+      },
+      {
+        preSetupHook: async ({ vaults, wsRoot }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: "foo",
+            body: [
+              "Repellendus possimus voluptates tempora quia.",
+              "Eum deleniti sit delectus officia rem. `^block-anchor`",
+              "",
+              "Consectetur blanditiis facilis nulla mollitia.",
+            ].join("\n"),
+            vault: vaults[0],
+            wsRoot,
+          });
+        },
+        expect,
+      }
+    );
+  });
+  test("doesn't find block anchor within code block", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const note = engine.notes["foo"];
+        const body = note.body;
+        const out = RemarkUtils.findAnchors(body, {
+          engine,
+          fname: note.fname,
+        });
+        expect(out).toMatchSnapshot();
+        expect(_.size(out)).toEqual(0);
+      },
+      {
+        preSetupHook: async ({ vaults, wsRoot }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: "foo",
+            body: [
+              "Repellendus possimus voluptates tempora quia.",
+              "Eum deleniti sit delectus officia rem.",
+              "",
+              "```",
+              "^block-anchor",
+              "```",
+              "",
+              "Consectetur blanditiis facilis nulla mollitia.",
+            ].join("\n"),
+            vault: vaults[0],
+            wsRoot,
+          });
+        },
+        expect,
+      }
+    );
   });
 
   describe("findLinks", async () => {


### PR DESCRIPTION
Block anchors were not being parsed for the following examples:

```
This would get parsed as a block anchor, even though it's part of the wikilink.
[[note#^anchor]]

This would get parsed as part of the paragraph,
even though it's a block anchor inside a paragraph
that spans multiple lines.

Lorem ipsum ^anchor
dolor amet.
```

This pull request fixes both issues, and adds test for them.