### PR TITLE
enhance: Workspace sync improvements

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -156,6 +156,19 @@ export type DendronConfig = {
    * Development related options
    */
   dev?: DendronDevConfig;
+
+  /**
+   * How workspace vaults should be handled when using workspace "add and commit" and "sync" commands.
+   *
+   * Options are:
+   * * skip: Skip them entirely. You must manage the repository manually.
+   * * noPush: Commit any changes and pull updates, but don't push. You can watch the repository and make local changes without sharing them back.
+   * * noCommit: Pull and push updates if the workspace is clean, but don't commit. You manually commit your local changes, but automatically share them once you committed.
+   * * sync: Commit changes, and pull and push updates. Treats workspace vaults like regular vaults.
+   *
+   * Defaults to `noCommit`.
+   */
+  workspaceVaultSync?: "skip" | "noPush" | "noCommit" | "sync";
 };
 
 export type DendronDevConfig = {

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -14,6 +14,13 @@ export enum DVaultVisibility {
   PRIVATE = "private",
 }
 
+export enum DVaultSync {
+  SKIP = "skip",
+  NO_PUSH = "noPush",
+  NO_COMMIT = "noCommit",
+  SYNC = "sync",
+}
+
 export type DVault = {
   /** Name of vault */
   name?: string;
@@ -31,6 +38,20 @@ export type DVault = {
    * If this is enabled, don't apply workspace push commands
    */
   noAutoPush?: boolean;
+  /**
+   * How the vault should be handled when using "add and commit" and "sync" commands.
+   *
+   * Options are:
+   * * skip: Skip them entirely. You must manage the repository manually.
+   * * noPush: Commit any changes and pull updates, but don't push. You can watch the repository and make local changes without sharing them back.
+   * * noCommit: Pull and push updates if the workspace is clean, but don't commit. You manually commit your local changes, but automatically share them once you committed.
+   * * sync: Commit changes, and pull and push updates. Treats workspace vaults like regular vaults.
+   *
+   * This setting overrides the `workspaceVaultSync` setting for the vault, even if the vault is a workspace vault.
+   *
+   * Defaults to `sync`.
+   */
+  sync?: DVaultSync;
 };
 
 export type DWorkspace = {
@@ -168,7 +189,7 @@ export type DendronConfig = {
    *
    * Defaults to `noCommit`.
    */
-  workspaceVaultSync?: "skip" | "noPush" | "noCommit" | "sync";
+  workspaceVaultSync?: DVaultSync;
 };
 
 export type DendronDevConfig = {

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -190,8 +190,14 @@ export class GitUtils {
   }
 
   static async getGitRoot(uri: string): Promise<string> {
-    const response = await this.execute("git rev-parse --show-toplevel", uri);
-    return response.stdout.trim();
+    try {
+      const response = await this.execute("git rev-parse --show-toplevel", uri);
+      return response.stdout.trim();
+    } catch (err) {
+      // Not in a git repository
+      if (err.failed) return "";
+      throw err;
+    }
   }
 
   static async getGithubFileUrl(

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -189,13 +189,13 @@ export class GitUtils {
     return fs.existsSync(src) && fs.existsSync(path.join(src, ".git"));
   }
 
-  static async getGitRoot(uri: string): Promise<string> {
+  static async getGitRoot(uri: string): Promise<string | undefined> {
     try {
       const response = await this.execute("git rev-parse --show-toplevel", uri);
       return response.stdout.trim();
     } catch (err) {
       // Not in a git repository
-      if (err.failed) return "";
+      if (err.failed) return undefined;
       throw err;
     }
   }

--- a/packages/dendron-cli/src/commands/workspaceCLICommand.ts
+++ b/packages/dendron-cli/src/commands/workspaceCLICommand.ts
@@ -65,7 +65,7 @@ export class WorkspaceCLICommand extends CLICommand<
         }
         case WorkspaceCommands.ADD_AND_COMMIT: {
           const ws = new WorkspaceService({ wsRoot });
-          await ws.commidAndAddAll();
+          await ws.commitAndAddAll();
           break;
         }
         case WorkspaceCommands.PUSH: {
@@ -76,7 +76,7 @@ export class WorkspaceCLICommand extends CLICommand<
         case WorkspaceCommands.SYNC: {
           const ws = new WorkspaceService({ wsRoot });
           this.print("commit and add...");
-          await ws.commidAndAddAll();
+          await ws.commitAndAddAll();
           this.print("pull...");
           await ws.pullVaults();
           this.print("push...");

--- a/packages/engine-server/src/topics/git.ts
+++ b/packages/engine-server/src/topics/git.ts
@@ -56,7 +56,7 @@ export class Git {
     return localUrl;
   }
 
-  /** Adds the `remoteUrl` set in the constructor as a remote, and sets it as the upstream for the main/master branch. */
+  /** Adds the `remoteUrl` set in the constructor as a remote. */
   async remoteAdd() {
     const { remoteUrl } = this.opts;
     await this._execute(`git remote add origin ${remoteUrl}`);
@@ -121,8 +121,13 @@ export class Git {
     return stdout.trim();
   }
 
-  async hasChanges() {
-    const { stdout } = await this._execute("git status --short");
+  async hasChanges(opts?: { untrackedFiles?: "all" | "no" | "normal" }) {
+    let untrackedFilesArg = "";
+    if (opts && opts.untrackedFiles)
+      untrackedFilesArg = ` --untracked-files=${opts.untrackedFiles}`;
+    const { stdout } = await this._execute(
+      `git status --porcelain${untrackedFilesArg}`
+    );
     return !_.isEmpty(stdout);
   }
 

--- a/packages/engine-server/src/workspace.ts
+++ b/packages/engine-server/src/workspace.ts
@@ -220,9 +220,17 @@ export class WorkspaceService {
         const git = new Git({ localUrl: root });
         if (!this.shouldWorkspaceVaultSync("commit", root)) return undefined;
         if (await git.hasChanges()) {
-          await git.addAll();
-          await git.commit({ msg: "update" });
-          return root;
+          try {
+            await git.addAll();
+            await git.commit({ msg: "update" });
+            return root;
+          } catch (err) {
+            const stderr = err.stderr ? `: ${err.stderr}` : "";
+            throw new DendronError({
+              message: `error adding and committing vault${stderr}`,
+              payload: { err, repoPath: root },
+            });
+          }
         }
         return undefined;
       })
@@ -453,8 +461,9 @@ export class WorkspaceService {
         try {
           await git.pull();
         } catch (err) {
+          const stderr = err.stderr ? `: ${err.stderr}` : "";
           throw new DendronError({
-            message: "error pulling vault",
+            message: `error pulling vault${stderr}`,
             payload: { err, repoPath: root },
           });
         }
@@ -479,8 +488,9 @@ export class WorkspaceService {
             await git.push();
             return root;
           } catch (err) {
+            const stderr = err.stderr ? `: ${err.stderr}` : "";
             throw new DendronError({
-              message: "error pushing vault",
+              message: `error pushing vault${stderr}`,
               payload: { err, repoPath: root },
             });
           }

--- a/packages/engine-server/src/workspace.ts
+++ b/packages/engine-server/src/workspace.ts
@@ -476,6 +476,7 @@ export class WorkspaceService {
   /** Returns the list of vaults that were attempted to be pushed, even if there was nothing to push. */
   async pushVaults(): Promise<string[]> {
     const vaults = this.config.vaults;
+    const vaultsPushed = new Set<string>();
     const out = await Promise.all(
       vaults.map(async (vault) => {
         const root = await this.getVaultRepo(vault);
@@ -483,6 +484,8 @@ export class WorkspaceService {
         const git = new Git({ localUrl: root });
         if (!(await git.hasRemote())) return undefined;
         if (!this.shouldWorkspaceVaultSync("push", root)) return undefined;
+        if (vaultsPushed.has(root)) return undefined; // The vault already has been pushed
+        vaultsPushed.add(root);
         if (this.user.canPushVault(vault)) {
           try {
             await git.push();

--- a/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
@@ -1,7 +1,11 @@
 import { DVault, NoteProps } from "@dendronhq/common-all";
 import { tmpDir } from "@dendronhq/common-server";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
-import { DConfig, WorkspaceService } from "@dendronhq/engine-server";
+import {
+  DConfig,
+  SyncActionStatus,
+  WorkspaceService,
+} from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import path from "path";
 import { TestConfigUtils } from "../../config";
@@ -187,8 +191,11 @@ describe("WorkspaceService", () => {
       });
       const resp = await new WorkspaceService({
         wsRoot,
-      }).commidAndAddAll();
-      expect(resp.length).toEqual(2);
+      }).commitAndAddAll();
+      expect(resp.length).toEqual(3);
+      expect(
+        resp.filter((r) => r.status === SyncActionStatus.DONE).length
+      ).toEqual(2);
     },
     { initGit: true }
   );

--- a/packages/plugin-core/src/commands/AddAndCommit.ts
+++ b/packages/plugin-core/src/commands/AddAndCommit.ts
@@ -15,7 +15,7 @@ export class AddAndCommit extends BasicCommand<CommandOpts, void> {
   async execute(opts?: CommandOpts) {
     const ctx = "execute";
     L.info({ ctx, opts });
-    const resp = await getWS().workspaceService!.commidAndAddAll();
+    const resp = await getWS().workspaceService!.commitAndAddAll();
     if (_.isEmpty(resp)) {
       window.showInformationMessage(`no files to add or commit`);
       return;

--- a/packages/plugin-core/src/commands/BrowseNoteCommand.ts
+++ b/packages/plugin-core/src/commands/BrowseNoteCommand.ts
@@ -27,7 +27,7 @@ export class BrowseNoteCommand extends BasicCommand<
       if (!folder) {
         return;
       }
-      const root = await GitUtils.getGitRoot(folder.uri.fsPath);
+      const root = (await GitUtils.getGitRoot(folder.uri.fsPath)) || "";
       const file = editor.document.fileName.substring(root.length);
       const startLine = editor.selection.start.line;
       const endLine = editor.selection.end.line;

--- a/packages/plugin-core/src/commands/Sync.ts
+++ b/packages/plugin-core/src/commands/Sync.ts
@@ -6,15 +6,25 @@ import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
 import { getWS } from "../workspace";
 import { BasicCommand } from "./base";
+import { SyncActionResult, SyncActionStatus } from "@dendronhq/engine-server";
 const L = Logger;
 
 type CommandOpts = {};
 type CommandReturns =
-  | { committed: string[]; pulled: string[]; pushed: string[] }
+  | {
+      committed: SyncActionResult[];
+      pulled: SyncActionResult[];
+      pushed: SyncActionResult[];
+    }
   | undefined;
 
 export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
   static key = DENDRON_COMMANDS.SYNC.key;
+
+  static countDone(results: SyncActionResult[]): number {
+    return results.filter((result) => result.status === SyncActionStatus.DONE)
+      .length;
+  }
 
   async execute(opts?: CommandOpts) {
     const ctx = "execute";
@@ -26,16 +36,37 @@ export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
         severity: ERROR_SEVERITY.FATAL,
       });
 
-    const committed = await workspaceService.commidAndAddAll();
-    L.info(`Committed changes in ${committed.length} vaults`);
+    const committed = await workspaceService.commitAndAddAll();
+    L.info(committed);
 
     const pulled = await workspaceService.pullVaults();
-    L.info(`Pulled changes for ${pulled.length} vaults`);
+    L.info(pulled);
 
     const pushed = await workspaceService.pushVaults();
-    L.info(`Pushed changes for ${pushed.length} vaults`);
+    L.info(pushed);
 
-    window.showInformationMessage("finish sync");
+    const message = ["Finished sync."];
+    const uncommitted = pulled.filter(
+      (result) => result.status === SyncActionStatus.UNCOMMITTED_CHANGES
+    );
+    if (uncommitted.length > 0) {
+      const uncommittedChanges: string = uncommitted
+        .map((result) => result.repo)
+        .join(", ");
+      message.push(
+        `Skipped pulling repos ${uncommittedChanges} because they had uncommitted changes.`
+      );
+    }
+
+    const committedDone = SyncCommand.countDone(committed);
+    const pulledDone = SyncCommand.countDone(pulled);
+    const pushedDone = SyncCommand.countDone(pushed);
+    const repos = (count: number) => (count == 1 ? "repo" : "repos");
+    message.push(`Committed ${committedDone} ${repos(committedDone)},`);
+    message.push(`tried pulling ${pulledDone}`);
+    message.push(`and pushing ${pushedDone} ${repos(pushedDone)}.`);
+
+    window.showInformationMessage(message.join(" "));
     return {
       committed,
       pulled,

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -111,7 +111,7 @@ suite("workspace sync command", function () {
           expect(committed.length).toEqual(0);
           // Should pull and push since configuration allows it
           expect(pulled.length).toEqual(1);
-          expect(pushed.length).toEqual(3);
+          expect(pushed.length).toEqual(1);
           done();
         },
       });
@@ -191,7 +191,7 @@ suite("workspace sync command", function () {
           // Should try doing everything since the config requires so
           expect(committed.length).toEqual(1);
           expect(pulled.length).toEqual(1);
-          expect(pushed.length).toEqual(3);
+          expect(pushed.length).toEqual(1);
           done();
         },
       });

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -7,17 +7,38 @@ import { GitTestUtils } from "@dendronhq/engine-test-utils";
 import { tmpDir } from "@dendronhq/common-server";
 import { describe } from "mocha";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import { getWS } from "../../workspace";
+import { Git } from "@dendronhq/engine-server";
+import { DendronConfig } from "@dendronhq/common-all";
 
 suite("workspace sync command", function () {
   let ctx: vscode.ExtensionContext;
   ctx = setupBeforeAfter(this, {});
+
+  describe("no repo", () => {
+    test("commit", (done) => {
+      runLegacyMultiWorkspaceTest({
+        onInit: async ({}) => {
+          const out = await new SyncCommand().run();
+          expect(out).toBeTruthy();
+          const { committed, pulled, pushed } = out as any;
+          // Nothin should have happened since there is no repository
+          expect(committed.length).toEqual(0);
+          expect(pulled.length).toEqual(0);
+          expect(pushed.length).toEqual(0);
+          done();
+        },
+        ctx,
+      });
+    });
+  });
 
   describe("no remote", () => {
     test("commit", (done) => {
       runLegacyMultiWorkspaceTest({
         onInit: async ({ wsRoot, vaults }) => {
           await GitTestUtils.createRepoForWorkspace(wsRoot);
-          NoteTestUtilsV4.createNote({
+          await NoteTestUtilsV4.createNote({
             fname: "my-new-note",
             body: "Lorem ipsum",
             wsRoot,
@@ -45,7 +66,7 @@ suite("workspace sync command", function () {
         onInit: async ({ wsRoot, vaults }) => {
           const remoteDir = tmpDir().name;
           await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-          NoteTestUtilsV4.createNote({
+          await NoteTestUtilsV4.createNote({
             fname: "my-new-note",
             body: "Lorem ipsum",
             wsRoot,
@@ -67,4 +88,128 @@ suite("workspace sync command", function () {
       });
     });
   });
+
+  describe("with remote and workspace vaults", async () => {
+    test("no commit", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({ wsRoot, vaults }) => {
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          await changeConfig(wsRoot, { workspaceVaultSync: "noCommit" });
+          // Create a new note so there are some changes
+          await NoteTestUtilsV4.createNote({
+            fname: "my-new-note",
+            body: "Lorem ipsum",
+            wsRoot,
+            vault: vaults[0],
+          });
+
+          const out = await new SyncCommand().run();
+          const { committed, pulled, pushed } = out as any;
+          // Nothing should get committed since "noCommit" is used
+          expect(committed.length).toEqual(0);
+          // Should pull and push since configuration allows it
+          expect(pulled.length).toEqual(1);
+          expect(pushed.length).toEqual(3);
+          done();
+        },
+      });
+    });
+
+    test("no push", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({ wsRoot, vaults }) => {
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          await changeConfig(wsRoot, { workspaceVaultSync: "noPush" });
+          // Create a new note so there are some changes
+          await NoteTestUtilsV4.createNote({
+            fname: "my-new-note",
+            body: "Lorem ipsum",
+            wsRoot,
+            vault: vaults[0],
+          });
+
+          const out = await new SyncCommand().run();
+          const { committed, pulled, pushed } = out as any;
+          // The note added should get committed
+          expect(committed.length).toEqual(1);
+          // Should try to pull since allowed by configuration
+          expect(pulled.length).toEqual(1);
+          // Should not push since "noPush" is used
+          expect(pushed.length).toEqual(0);
+          done();
+        },
+      });
+    });
+
+    test("skip", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({ wsRoot, vaults }) => {
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          await changeConfig(wsRoot, { workspaceVaultSync: "skip" });
+          // Create a new note so there are some changes
+          await NoteTestUtilsV4.createNote({
+            fname: "my-new-note",
+            body: "Lorem ipsum",
+            wsRoot,
+            vault: vaults[0],
+          });
+
+          const out = await new SyncCommand().run();
+          const { committed, pulled, pushed } = out as any;
+          // Nothing should be done since "skip" is used
+          expect(committed.length).toEqual(0);
+          expect(pulled.length).toEqual(0);
+          expect(pushed.length).toEqual(0);
+          done();
+        },
+      });
+    });
+
+    test("sync", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({ wsRoot, vaults }) => {
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          await changeConfig(wsRoot, { workspaceVaultSync: "sync" });
+          // Create a new note so there are some changes
+          await NoteTestUtilsV4.createNote({
+            fname: "my-new-note",
+            body: "Lorem ipsum",
+            wsRoot,
+            vault: vaults[0],
+          });
+
+          const out = await new SyncCommand().run();
+          const { committed, pulled, pushed } = out as any;
+          // Should try doing everything since the config requires so
+          expect(committed.length).toEqual(1);
+          expect(pulled.length).toEqual(1);
+          expect(pushed.length).toEqual(3);
+          done();
+        },
+      });
+    });
+  });
 });
+
+async function changeConfig(
+  wsRoot: string,
+  overrideConfig: Partial<DendronConfig>
+) {
+  // Get old config, and override it with the new config
+  const serv = getWS().workspaceService!;
+  const config = serv.config;
+  await serv.setConfig(_.merge(config, overrideConfig));
+
+  // Commit this change, otherwise it will be a tracked file with changes which breaks git pull
+  const git = new Git({ localUrl: wsRoot });
+  await git.add("dendron.yml");
+  await git.commit({ msg: "update config" });
+}

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -16,10 +16,10 @@ suite("workspace sync command", function () {
   ctx = setupBeforeAfter(this, {});
 
   describe("no repo", () => {
-    test("commit", (done) => {
+    test("do nothing", (done) => {
       runLegacyMultiWorkspaceTest({
         onInit: async ({}) => {
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           expect(out).toBeTruthy();
           const { committed, pulled, pushed } = out as any;
           // Nothin should have happened since there is no repository
@@ -45,7 +45,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           expect(out).toBeTruthy();
           const { committed, pulled, pushed } = out as any;
           // The note created above should get committed
@@ -73,7 +73,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           expect(out).toBeTruthy();
           const { committed, pulled, pushed } = out as any;
           // The files that default wsRoot created should get committed
@@ -105,7 +105,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           const { committed, pulled, pushed } = out as any;
           // Nothing should get committed since "noCommit" is used
           expect(committed.length).toEqual(0);
@@ -132,7 +132,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           const { committed, pulled, pushed } = out as any;
           // The note added should get committed
           expect(committed.length).toEqual(1);
@@ -160,7 +160,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           const { committed, pulled, pushed } = out as any;
           // Nothing should be done since "skip" is used
           expect(committed.length).toEqual(0);
@@ -186,7 +186,7 @@ suite("workspace sync command", function () {
             vault: vaults[0],
           });
 
-          const out = await new SyncCommand().run();
+          const out = await new SyncCommand().execute();
           const { committed, pulled, pushed } = out as any;
           // Should try doing everything since the config requires so
           expect(committed.length).toEqual(1);


### PR DESCRIPTION
Workspace vault sync is now configurable, so users can choose whether they want workspace vaults to get synchronized, skipped, committed and pulled but not pushed, or pulled and pushed but not committed.

Non-repository vault handling has been improved. It fixes exceptions that would be thrown when:
* If some vaults were in repositories but not others.
* If a vault is not in a repository, but the Dendron workspace is.