### PR TITLE
enhance: Telemetry respects VSCode preferences

### DIFF
--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -12,7 +12,7 @@ export const CONSTANTS = {
   DENDRON_CACHE_FILE: ".dendron.cache.json",
   DENDRON_ID: ".dendron.uuid",
   DENDRON_NO_TELEMETRY: ".dendron.no-telemetry",
-  DENDRON_YES_TELEMETRY: ".dendron.telemetry",
+  DENDRON_TELEMETRY: ".dendron.telemetry",
   DENDRON_HOOKS_BASE: "hooks",
   DENDRON_LOCAL_SITE_PORT: 8080,
 };

--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -12,6 +12,7 @@ export const CONSTANTS = {
   DENDRON_CACHE_FILE: ".dendron.cache.json",
   DENDRON_ID: ".dendron.uuid",
   DENDRON_NO_TELEMETRY: ".dendron.no-telemetry",
+  DENDRON_FORCE_TELEMETRY: ".dendron.force-telemetry",
   DENDRON_HOOKS_BASE: "hooks",
   DENDRON_LOCAL_SITE_PORT: 8080,
 };

--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -12,7 +12,7 @@ export const CONSTANTS = {
   DENDRON_CACHE_FILE: ".dendron.cache.json",
   DENDRON_ID: ".dendron.uuid",
   DENDRON_NO_TELEMETRY: ".dendron.no-telemetry",
-  DENDRON_FORCE_TELEMETRY: ".dendron.force-telemetry",
+  DENDRON_YES_TELEMETRY: ".dendron.telemetry",
   DENDRON_HOOKS_BASE: "hooks",
   DENDRON_LOCAL_SITE_PORT: 8080,
 };

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -57,7 +57,6 @@ enum UserTier {
 }
 
 export type SegmentClientOpts = {
-  optOut?: boolean;
   key?: string;
   forceNew?: boolean;
 };
@@ -71,10 +70,27 @@ type SegmentExtraArg = {
   context?: any;
 };
 
+export enum TelemetryStatus {
+  /** The user set that telemetry should be disabled in the workspace config. */
+  DISABLED_BY_WS_CONFIG = "disabled by ws config",
+  /** The user set that telemetry should be disabled in VSCode settings. */
+  DISABLED_BY_VSCODE_CONFIG = "disabled by vscode config",
+  /** The user used the Disable Telemetry command to disable telemetry. */
+  DISABLED_BY_COMMAND = "disabled by command",
+  /** The user disabled telemetry in configuration, but used the Enable Telemetry command to give permission. */
+  ENABLED_BY_COMMAND = "enabled by command",
+  /** The user allowed telemetry by configuration. */
+  ENABLED_BY_CONFIG = "enabled by config",
+}
+
+export type TelemetryConfig = {
+  status: TelemetryStatus;
+};
+
 export class SegmentClient {
   public _segmentInstance: Analytics;
   private _anonymousId: string;
-  public _hasOptedOut: boolean;
+  private _hasOptedOut: boolean;
   private logger: DLogger;
 
   static _singleton: undefined | SegmentClient;
@@ -86,57 +102,94 @@ export class SegmentClient {
     return this._singleton;
   }
 
-  /** If exists, Dendron telemetry has been disabled. */
+  /** Legacy: If exists, Dendron telemetry has been disabled. */
   static getDisableConfigPath() {
     return path.join(os.homedir(), CONSTANTS.DENDRON_NO_TELEMETRY);
   }
 
-  /** If exists, Dendron telemetry is enabled even if VSCode telemetry settings are off. */
-  static getEnableConfigPath() {
-    return path.join(os.homedir(), CONSTANTS.DENDRON_YES_TELEMETRY);
+  /** May contain configuration for Dendron telemetry. */
+  static getConfigPath() {
+    return path.join(os.homedir(), CONSTANTS.DENDRON_TELEMETRY);
   }
 
-  /** If true, Dendron telemetry has been disabled. */
-  static isDisabled() {
-    return fs.existsSync(this.getDisableConfigPath());
+  static readConfig(): TelemetryConfig | undefined {
+    try {
+      return fs.readJSONSync(this.getConfigPath());
+    } catch {
+      return undefined;
+    }
   }
 
-  /** If true, Dendron telemetry is enabled even if VSCode telemetry settings are off. */
-  static isEnabled() {
-    return fs.existsSync(this.getEnableConfigPath());
+  static getStatus(): TelemetryStatus {
+    // Legacy, this file would have been created if the user used the Dendron Disable command
+    if (fs.existsSync(this.getDisableConfigPath()))
+      return TelemetryStatus.DISABLED_BY_COMMAND;
+
+    const config = this.readConfig();
+    // This is actually ambiguous, could have been using the command or by default.
+    if (_.isUndefined(config)) return TelemetryStatus.ENABLED_BY_CONFIG;
+
+    return config.status;
   }
 
-  static disable() {
-    fs.removeSync(this.getEnableConfigPath());
-    fs.writeFileSync(this.getDisableConfigPath(), "");
+  static isDisabled(status?: TelemetryStatus) {
+    if (_.isUndefined(status)) status = this.getStatus();
+    switch (status) {
+      case TelemetryStatus.DISABLED_BY_COMMAND:
+      case TelemetryStatus.DISABLED_BY_VSCODE_CONFIG:
+      case TelemetryStatus.DISABLED_BY_WS_CONFIG:
+        return true;
+      default:
+        return false;
+    }
   }
 
-  static enable() {
-    fs.removeSync(this.getDisableConfigPath());
-    fs.writeFileSync(this.getEnableConfigPath(), "");
+  static isEnabled(status?: TelemetryStatus) {
+    return !this.isDisabled(status);
   }
 
-  constructor(opts?: SegmentClientOpts) {
+  static setByConfig(status?: TelemetryStatus) {
+    if (_.isUndefined(status)) status = this.getStatus();
+    switch (status) {
+      case TelemetryStatus.DISABLED_BY_COMMAND:
+      case TelemetryStatus.ENABLED_BY_COMMAND:
+        return false;
+      default:
+        return true;
+    }
+  }
+
+  static enable(
+    why: TelemetryStatus.ENABLED_BY_COMMAND | TelemetryStatus.ENABLED_BY_CONFIG
+  ) {
+    // try to remove the legacy disable, if it exists
+    try {
+      fs.removeSync(this.getDisableConfigPath());
+    } catch {
+      // expected, legacy disable config is missing.
+    }
+    fs.writeJSONSync(this.getConfigPath(), { status: why });
+  }
+
+  static disable(
+    why:
+      | TelemetryStatus.DISABLED_BY_COMMAND
+      | TelemetryStatus.DISABLED_BY_VSCODE_CONFIG
+      | TelemetryStatus.DISABLED_BY_WS_CONFIG
+  ) {
+    fs.writeJSONSync(this.getConfigPath(), { status: why });
+  }
+
+  constructor(_opts?: SegmentClientOpts) {
     const key = env("SEGMENT_VSCODE_KEY");
     this.logger = createLogger("SegmentClient");
     this._segmentInstance = new Analytics(key);
-    const enabled = SegmentClient.isEnabled();
-    if (enabled)
-      this.logger.info({
-        msg: "user enabled telemetry with Enable Telemetry command",
-      });
-    this._hasOptedOut =
-      !enabled && (opts?.optOut || SegmentClient.isDisabled() || false);
-    if (this._hasOptedOut) {
-      if (opts?.optOut)
-        this.logger.info({
-          msg: "user opted out of telemetry with workspace or VSCode configuration",
-        });
-      else if (SegmentClient.isDisabled())
-        this.logger.info({
-          msg: "user opted out of telemetry with Disable Telemetry command",
-        });
-      else this.logger.info({ msg: "user opted out of telemetry" });
+
+    const status = SegmentClient.getStatus();
+    this.logger.info({ msg: `user telemetry setting: ${status}` });
+    this._hasOptedOut = SegmentClient.isDisabled();
+
+    if (this.hasOptedOut) {
       this._anonymousId = "";
       return;
     }
@@ -206,5 +259,9 @@ export class SegmentClient {
     } catch (ex) {
       this.logger.error(ex);
     }
+  }
+
+  get hasOptedOut(): boolean {
+    return this._hasOptedOut;
   }
 }

--- a/packages/common-test-utils/src/fileUtils.ts
+++ b/packages/common-test-utils/src/fileUtils.ts
@@ -1,8 +1,10 @@
 import { DVault } from "@dendronhq/common-all";
 import { DirResult, tmp, vault2Path } from "@dendronhq/common-server";
 import fs from "fs-extra";
+import os from "os";
 import _ from "lodash";
 import path from "path";
+import sinon from "sinon";
 import { AssertUtils } from "./utils";
 export { DirResult };
 
@@ -127,5 +129,11 @@ export class FileTestUtils {
   static tmpDir(): DirResult {
     const dirPath = tmp.dirSync();
     return dirPath;
+  }
+
+  /** Creates a temporary directory, and sets up a sinon stub to make code use it. Must use `sinon.restore` after to restore the home directory. */
+  static mockHome() {
+    const tmpHome = this.tmpDir().name;
+    return { stub: sinon.stub(os, "homedir").returns(tmpHome), tmpHome };
   }
 }

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -1,0 +1,50 @@
+import { SegmentClient, tmpDir } from "@dendronhq/common-server";
+import sinon from "sinon";
+import os from "os";
+
+function mockHome() {
+  const tmpHome = tmpDir().name;
+  sinon.stub(os, "homedir").returns(tmpHome);
+}
+
+describe("SegmentClient", () => {
+  test("enabled", (done) => {
+    mockHome();
+    SegmentClient.enable();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance._hasOptedOut).toEqual(false);
+
+    sinon.restore();
+    done();
+  });
+
+  test("disabled by user", (done) => {
+    mockHome();
+    SegmentClient.disable();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance._hasOptedOut).toEqual(true);
+
+    sinon.restore();
+    done();
+  });
+
+  test("disabled by config", (done) => {
+    mockHome();
+    SegmentClient.enable();
+    const instance = SegmentClient.instance({ forceNew: true, optOut: true });
+    expect(instance._hasOptedOut).toEqual(true);
+
+    sinon.restore();
+    done();
+  });
+
+  test("force enabled by user", (done) => {
+    mockHome();
+    SegmentClient.forceEnable();
+    const instance = SegmentClient.instance({ forceNew: true, optOut: true });
+    expect(instance._hasOptedOut).toEqual(false);
+
+    sinon.restore();
+    done();
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -11,7 +11,7 @@ describe("SegmentClient", () => {
   test("enabled", (done) => {
     mockHome();
     SegmentClient.enable();
-    const instance = SegmentClient.instance({ forceNew: true });
+    const instance = SegmentClient.instance({ forceNew: true, optOut: false });
     expect(instance._hasOptedOut).toEqual(false);
 
     sinon.restore();
@@ -21,7 +21,7 @@ describe("SegmentClient", () => {
   test("disabled by user", (done) => {
     mockHome();
     SegmentClient.disable();
-    const instance = SegmentClient.instance({ forceNew: true });
+    const instance = SegmentClient.instance({ forceNew: true, optOut: false });
     expect(instance._hasOptedOut).toEqual(true);
 
     sinon.restore();
@@ -30,7 +30,6 @@ describe("SegmentClient", () => {
 
   test("disabled by config", (done) => {
     mockHome();
-    SegmentClient.enable();
     const instance = SegmentClient.instance({ forceNew: true, optOut: true });
     expect(instance._hasOptedOut).toEqual(true);
 
@@ -38,9 +37,9 @@ describe("SegmentClient", () => {
     done();
   });
 
-  test("force enabled by user", (done) => {
+  test("enabled by user", (done) => {
     mockHome();
-    SegmentClient.forceEnable();
+    SegmentClient.enable();
     const instance = SegmentClient.instance({ forceNew: true, optOut: true });
     expect(instance._hasOptedOut).toEqual(false);
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -1,49 +1,96 @@
-import { SegmentClient, tmpDir } from "@dendronhq/common-server";
-import sinon from "sinon";
-import os from "os";
-
-function mockHome() {
-  const tmpHome = tmpDir().name;
-  sinon.stub(os, "homedir").returns(tmpHome);
-}
+import { SegmentClient, TelemetryStatus } from "@dendronhq/common-server";
+import { FileTestUtils } from "@dendronhq/common-test-utils";
+import { writeFileSync } from "fs-extra";
 
 describe("SegmentClient", () => {
-  test("enabled", (done) => {
-    mockHome();
-    SegmentClient.enable();
-    const instance = SegmentClient.instance({ forceNew: true, optOut: false });
-    expect(instance._hasOptedOut).toEqual(false);
+  test("enabled by default", (done) => {
+    // this is only for the SegmentClient, telemetry as a whole respects VSCode settings by default
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
 
-    sinon.restore();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    stub.restore();
     done();
   });
 
-  test("disabled by user", (done) => {
-    mockHome();
-    SegmentClient.disable();
-    const instance = SegmentClient.instance({ forceNew: true, optOut: false });
-    expect(instance._hasOptedOut).toEqual(true);
+  test("enabled by command", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
 
-    sinon.restore();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    stub.restore();
     done();
   });
 
-  test("disabled by config", (done) => {
-    mockHome();
-    const instance = SegmentClient.instance({ forceNew: true, optOut: true });
-    expect(instance._hasOptedOut).toEqual(true);
+  test("enabled by config", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_CONFIG);
 
-    sinon.restore();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    stub.restore();
     done();
   });
 
-  test("enabled by user", (done) => {
-    mockHome();
-    SegmentClient.enable();
-    const instance = SegmentClient.instance({ forceNew: true, optOut: true });
-    expect(instance._hasOptedOut).toEqual(false);
+  test("disabled by command", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_COMMAND);
 
-    sinon.restore();
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    stub.restore();
+    done();
+  });
+
+  test("disabled by vscode config", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_VSCODE_CONFIG);
+
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    stub.restore();
+    done();
+  });
+
+  test("disabled by workspace config", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_WS_CONFIG);
+
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    stub.restore();
+    done();
+  });
+
+  test("still recognizes legacy disable", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    const disablePath = SegmentClient.getDisableConfigPath();
+    writeFileSync(disablePath, "");
+
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    stub.restore();
+    done();
+  });
+
+  test("enable command overrides legacy disable", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    const disablePath = SegmentClient.getDisableConfigPath();
+    writeFileSync(disablePath, "");
+
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
+    const instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    stub.restore();
     done();
   });
 });

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -93,4 +93,36 @@ describe("SegmentClient", () => {
     stub.restore();
     done();
   });
+
+  test("disabled then enabled with command", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_COMMAND);
+
+    let instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
+
+    instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    stub.restore();
+    done();
+  });
+
+  test("enabled then disabled with command", (done) => {
+    const { stub, tmpHome: _tmpHome } = FileTestUtils.mockHome();
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
+
+    let instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(false);
+
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_COMMAND);
+
+    instance = SegmentClient.instance({ forceNew: true });
+    expect(instance.hasOptedOut).toEqual(true);
+
+    stub.restore();
+    done();
+  });
 });

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -9,7 +9,6 @@ import {
   getDurationMilliseconds,
   getOS,
   readJSONWithComments,
-  SegmentClient,
 } from "@dendronhq/common-server";
 import {
   HistoryEvent,
@@ -31,6 +30,7 @@ import {
 import { Logger } from "./logger";
 import { migrateConfig, migrateSettings } from "./migration";
 import { Extensions } from "./settings";
+import { setupSegmentClient } from "./telemetry";
 import { VSCodeUtils, WSUtils } from "./utils";
 import { AnalyticsUtils } from "./utils/analytics";
 import { MarkdownUtils } from "./utils/md";
@@ -186,45 +186,6 @@ function subscribeToPortChange() {
       }
     }
   );
-}
-
-function isVSCodeTelemetryEnabled(): boolean | undefined {
-  // `isTelemetryEnabled` only seems to be available on VSCode 1.55 and above.
-  // Our dependencies are currently set up for 1.54, so typescript does not understand that it exists.
-  try {
-    return (vscode.env as any).isTelemetryEnabled;
-  } catch (err) {
-    Logger.error({ msg: "Error when trying to access telemetry preference" });
-    return undefined;
-  }
-}
-
-/** Creates a SegmentClient for telemetry, if enabled, and listens for vscode telemetry settings to disable it when requested. */
-function setupSegmentClient(ws: DendronWorkspace) {
-  function instantiateSegmentClient() {
-    SegmentClient.instance({
-      optOut: ws.config.noTelemetry || !isVSCodeTelemetryEnabled(),
-      forceNew: true,
-    });
-  }
-
-  // `onDidChangeTelemetryEnabled` only seems to be available on VSCode 1.55 and above.
-  // Our dependencies are currently set up for 1.54, so typescript does not understand that it exists.
-  try {
-    const onDidChangeTelemetryEnabled: vscode.Event<Boolean> | undefined = (
-      vscode.env as any
-    ).onDidChangeTelemetryEnabled;
-    if (!_.isUndefined(onDidChangeTelemetryEnabled)) {
-      const disposable = onDidChangeTelemetryEnabled(() =>
-        instantiateSegmentClient()
-      );
-      ws.addDisposable(disposable);
-    }
-  } catch (err) {
-    Logger.error({
-      msg: "Error when trying to listen to the telemetry preference change event",
-    });
-  }
 }
 
 export async function _activate(

--- a/packages/plugin-core/src/commands/DisableTelemetry.ts
+++ b/packages/plugin-core/src/commands/DisableTelemetry.ts
@@ -1,5 +1,5 @@
 import { VSCodeEvents } from "@dendronhq/common-all";
-import { SegmentClient } from "@dendronhq/common-server";
+import { SegmentClient, TelemetryStatus } from "@dendronhq/common-server";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { AnalyticsUtils } from "../utils/analytics";
@@ -21,7 +21,7 @@ export class DisableTelemetryCommand extends BasicCommand<
   }
   async execute() {
     AnalyticsUtils.track(VSCodeEvents.DisableTelemetry);
-    SegmentClient.disable();
+    SegmentClient.disable(TelemetryStatus.DISABLED_BY_COMMAND);
     window.showInformationMessage("telemetry disabled");
   }
 }

--- a/packages/plugin-core/src/commands/DisableTelemetry.ts
+++ b/packages/plugin-core/src/commands/DisableTelemetry.ts
@@ -20,8 +20,9 @@ export class DisableTelemetryCommand extends BasicCommand<
     return {};
   }
   async execute() {
-    AnalyticsUtils.track(VSCodeEvents.DisableTelemetry);
-    SegmentClient.disable(TelemetryStatus.DISABLED_BY_COMMAND);
+    const reason = TelemetryStatus.DISABLED_BY_COMMAND;
+    AnalyticsUtils.track(VSCodeEvents.DisableTelemetry, { reason });
+    SegmentClient.disable(reason);
     window.showInformationMessage("telemetry disabled");
   }
 }

--- a/packages/plugin-core/src/commands/EnableTelemetry.ts
+++ b/packages/plugin-core/src/commands/EnableTelemetry.ts
@@ -2,7 +2,6 @@ import { VSCodeEvents } from "@dendronhq/common-all";
 import { SegmentClient } from "@dendronhq/common-server";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { isVSCodeTelemetryEnabled } from "../telemetry";
 import { AnalyticsUtils } from "../utils/analytics";
 import { BasicCommand } from "./base";
 
@@ -21,8 +20,6 @@ export class EnableTelemetryCommand extends BasicCommand<
     return {};
   }
   async execute() {
-    // If telemetry is disabled in vscode settings but users asks us to enable telemetry, force enable to override vscode
-    if (!isVSCodeTelemetryEnabled()) SegmentClient.forceEnable();
     SegmentClient.enable();
     AnalyticsUtils.track(VSCodeEvents.EnableTelemetry);
     window.showInformationMessage("telemetry enabled");

--- a/packages/plugin-core/src/commands/EnableTelemetry.ts
+++ b/packages/plugin-core/src/commands/EnableTelemetry.ts
@@ -20,8 +20,9 @@ export class EnableTelemetryCommand extends BasicCommand<
     return {};
   }
   async execute() {
-    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
-    AnalyticsUtils.track(VSCodeEvents.EnableTelemetry);
+    const reason = TelemetryStatus.ENABLED_BY_COMMAND;
+    SegmentClient.enable(reason);
+    AnalyticsUtils.track(VSCodeEvents.EnableTelemetry, { reason });
     window.showInformationMessage("telemetry enabled");
   }
 }

--- a/packages/plugin-core/src/commands/EnableTelemetry.ts
+++ b/packages/plugin-core/src/commands/EnableTelemetry.ts
@@ -2,6 +2,7 @@ import { VSCodeEvents } from "@dendronhq/common-all";
 import { SegmentClient } from "@dendronhq/common-server";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { isVSCodeTelemetryEnabled } from "../telemetry";
 import { AnalyticsUtils } from "../utils/analytics";
 import { BasicCommand } from "./base";
 
@@ -20,6 +21,8 @@ export class EnableTelemetryCommand extends BasicCommand<
     return {};
   }
   async execute() {
+    // If telemetry is disabled in vscode settings but users asks us to enable telemetry, force enable to override vscode
+    if (!isVSCodeTelemetryEnabled()) SegmentClient.forceEnable();
     SegmentClient.enable();
     AnalyticsUtils.track(VSCodeEvents.EnableTelemetry);
     window.showInformationMessage("telemetry enabled");

--- a/packages/plugin-core/src/commands/EnableTelemetry.ts
+++ b/packages/plugin-core/src/commands/EnableTelemetry.ts
@@ -1,5 +1,5 @@
 import { VSCodeEvents } from "@dendronhq/common-all";
-import { SegmentClient } from "@dendronhq/common-server";
+import { SegmentClient, TelemetryStatus } from "@dendronhq/common-server";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { AnalyticsUtils } from "../utils/analytics";
@@ -20,7 +20,7 @@ export class EnableTelemetryCommand extends BasicCommand<
     return {};
   }
   async execute() {
-    SegmentClient.enable();
+    SegmentClient.enable(TelemetryStatus.ENABLED_BY_COMMAND);
     AnalyticsUtils.track(VSCodeEvents.EnableTelemetry);
     window.showInformationMessage("telemetry enabled");
   }

--- a/packages/plugin-core/src/telemetry.ts
+++ b/packages/plugin-core/src/telemetry.ts
@@ -1,0 +1,44 @@
+import { SegmentClient } from "@dendronhq/common-server";
+import * as vscode from "vscode";
+import { Logger } from "./logger";
+import { DendronWorkspace } from "./workspace";
+import _ from "lodash";
+
+export function isVSCodeTelemetryEnabled(): boolean | undefined {
+  // `isTelemetryEnabled` only seems to be available on VSCode 1.55 and above.
+  // Our dependencies are currently set up for 1.54, so typescript does not understand that it exists.
+  try {
+    return (vscode.env as any).isTelemetryEnabled;
+  } catch (err) {
+    Logger.error({ msg: "Error when trying to access telemetry preference" });
+    return undefined;
+  }
+}
+
+/** Creates a SegmentClient for telemetry, if enabled, and listens for vscode telemetry settings to disable it when requested. */
+export function setupSegmentClient(ws: DendronWorkspace) {
+  function instantiateSegmentClient() {
+    SegmentClient.instance({
+      optOut: ws.config.noTelemetry || !isVSCodeTelemetryEnabled(),
+      forceNew: true,
+    });
+  }
+
+  // `onDidChangeTelemetryEnabled` only seems to be available on VSCode 1.55 and above.
+  // Our dependencies are currently set up for 1.54, so typescript does not understand that it exists.
+  try {
+    const onDidChangeTelemetryEnabled: vscode.Event<Boolean> | undefined = (
+      vscode.env as any
+    ).onDidChangeTelemetryEnabled;
+    if (!_.isUndefined(onDidChangeTelemetryEnabled)) {
+      const disposable = onDidChangeTelemetryEnabled(() =>
+        instantiateSegmentClient()
+      );
+      ws.addDisposable(disposable);
+    }
+  } catch (err) {
+    Logger.error({
+      msg: "Error when trying to listen to the telemetry preference change event",
+    });
+  }
+}

--- a/packages/plugin-core/src/telemetry.ts
+++ b/packages/plugin-core/src/telemetry.ts
@@ -32,22 +32,25 @@ export function setupSegmentClient(ws: DendronWorkspace) {
         Logger.info({
           msg: "The user changed VSCode or workspace settings, so we are now disabling telemetry",
         });
-        AnalyticsUtils.track(VSCodeEvents.EnableTelemetry);
-        SegmentClient.enable(TelemetryStatus.ENABLED_BY_CONFIG);
+        const reason = TelemetryStatus.ENABLED_BY_CONFIG;
+        SegmentClient.enable(reason);
+        AnalyticsUtils.track(VSCodeEvents.EnableTelemetry, { reason });
       } else if (SegmentClient.isEnabled(status)) {
         // was enabled, now disabled
         if (ws.config.noTelemetry) {
           Logger.info({
             msg: "The user change workspace settings, so we are now disabling telemetry",
           });
-          SegmentClient.disable(TelemetryStatus.DISABLED_BY_WS_CONFIG);
-          AnalyticsUtils.track(VSCodeEvents.DisableTelemetry);
+          const reason = TelemetryStatus.DISABLED_BY_WS_CONFIG;
+          AnalyticsUtils.track(VSCodeEvents.DisableTelemetry, { reason });
+          SegmentClient.disable(reason);
         } else if (!isVSCodeTelemetryEnabled()) {
           Logger.info({
             msg: "The user change VSCode settings, so we are now disabling telemetry",
           });
-          SegmentClient.disable(TelemetryStatus.DISABLED_BY_VSCODE_CONFIG);
-          AnalyticsUtils.track(VSCodeEvents.DisableTelemetry);
+          const reason = TelemetryStatus.DISABLED_BY_VSCODE_CONFIG;
+          AnalyticsUtils.track(VSCodeEvents.DisableTelemetry, { reason });
+          SegmentClient.disable(reason);
         }
       }
     }

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -10,6 +10,7 @@ import {
   DENDRON_COMMANDS,
   GLOBAL_STATE,
 } from "../../constants";
+import { isVSCodeTelemetryEnabled } from "../../telemetry";
 import { getWS } from "../../workspace";
 import { _activate } from "../../_extension";
 import { expect, genEmptyWSFiles, resetCodeWorkspace } from "../testUtilsv2";
@@ -102,5 +103,16 @@ suite("Extension", function () {
     //       });
     //     });
     // });
+  });
+
+  describe("telemetry", () => {
+    test("can get VSCode telemetry settings", (done) => {
+      // Just checking that we get some expected result, and that it doesn't just crash.
+      const result = isVSCodeTelemetryEnabled();
+      expect(
+        result === true || result === false || result === undefined
+      ).toBeTruthy();
+      done();
+    });
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
@@ -1,0 +1,185 @@
+import _ from "lodash";
+import * as vscode from "vscode";
+import { getWS } from "../../workspace";
+import { expect } from "../testUtilsv2";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { describe } from "mocha";
+import sinon from "sinon";
+import { SegmentClient } from "@dendronhq/common-server";
+import { setupSegmentClient } from "../../telemetry";
+import { FileTestUtils } from "@dendronhq/common-test-utils";
+import { TestConfigUtils } from "@dendronhq/engine-test-utils";
+import { DisableTelemetryCommand } from "../../commands/DisableTelemetry";
+import { EnableTelemetryCommand } from "../../commands/EnableTelemetry";
+import { DConfig } from "@dendronhq/engine-server";
+
+suite("telemetry", function () {
+  let ctx: vscode.ExtensionContext;
+
+  ctx = setupBeforeAfter(this, {
+    beforeHook: () => {
+      FileTestUtils.mockHome();
+    },
+  });
+
+  describe("configuration", () => {
+    test("enabled by configuration", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeFalsy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("disabled by vscode configuration", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(false);
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("enabled by vscode configuration, but disabled by workspace configuration", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot }) => {
+          const config = DConfig.genDefaultConfig();
+          config.noTelemetry = true;
+          TestConfigUtils.writeConfig({ wsRoot, config });
+        },
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("enabled by vscode configuration, but disabled by workspace configuration", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot }) => {
+          const config = DConfig.genDefaultConfig();
+          config.noTelemetry = true;
+          TestConfigUtils.writeConfig({ wsRoot, config });
+        },
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("disabling by command takes precedence", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
+
+          const cmd = new DisableTelemetryCommand();
+          await cmd.run();
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("enabling by command takes precedence", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot }) => {
+          const config = DConfig.genDefaultConfig();
+          config.noTelemetry = true;
+          TestConfigUtils.writeConfig({ wsRoot, config });
+        },
+        onInit: async ({}) => {
+          const ws = getWS();
+          sinon.stub(vscode.env as any, "isTelemetryEnabled").value(false);
+
+          const cmd = new EnableTelemetryCommand();
+          await cmd.run();
+
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeFalsy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("handles configuration changing from disabled to enabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({}) => {
+          const ws = getWS();
+          const stub = sinon.stub(vscode.env as any, "isTelemetryEnabled");
+
+          stub.value(false); // telemetry is disabled
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          stub.value(true); // telemetry is enabled
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeFalsy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+
+    test("handles configuration changing from enabled to disabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        onInit: async ({}) => {
+          const ws = getWS();
+          const stub = sinon.stub(vscode.env as any, "isTelemetryEnabled");
+
+          stub.value(true); // telemetry is enabled
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeFalsy();
+
+          stub.value(false); // telemetry is disabled
+          setupSegmentClient(ws);
+          expect(SegmentClient.instance().hasOptedOut).toBeTruthy();
+
+          sinon.restore();
+          done();
+        },
+      });
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
@@ -11,7 +11,6 @@ import { FileTestUtils } from "@dendronhq/common-test-utils";
 import { TestConfigUtils } from "@dendronhq/engine-test-utils";
 import { DisableTelemetryCommand } from "../../commands/DisableTelemetry";
 import { EnableTelemetryCommand } from "../../commands/EnableTelemetry";
-import { DConfig } from "@dendronhq/engine-server";
 
 suite("telemetry", function () {
   let ctx: vscode.ExtensionContext;
@@ -21,6 +20,18 @@ suite("telemetry", function () {
       FileTestUtils.mockHome();
     },
   });
+
+  function setNoTelemetry(to: boolean) {
+    return async ({ wsRoot }: { wsRoot: string }) => {
+      TestConfigUtils.withConfig(
+        (config) => {
+          config.noTelemetry = to;
+          return config;
+        },
+        { wsRoot }
+      );
+    };
+  }
 
   describe("configuration", () => {
     test("enabled by configuration", (done) => {
@@ -58,11 +69,7 @@ suite("telemetry", function () {
     test("enabled by vscode configuration, but disabled by workspace configuration", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        preSetupHook: async ({ wsRoot }) => {
-          const config = DConfig.genDefaultConfig();
-          config.noTelemetry = true;
-          TestConfigUtils.writeConfig({ wsRoot, config });
-        },
+        preSetupHook: setNoTelemetry(true),
         onInit: async ({}) => {
           const ws = getWS();
           sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
@@ -79,11 +86,7 @@ suite("telemetry", function () {
     test("enabled by vscode configuration, but disabled by workspace configuration", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        preSetupHook: async ({ wsRoot }) => {
-          const config = DConfig.genDefaultConfig();
-          config.noTelemetry = true;
-          TestConfigUtils.writeConfig({ wsRoot, config });
-        },
+        preSetupHook: setNoTelemetry(true),
         onInit: async ({}) => {
           const ws = getWS();
           sinon.stub(vscode.env as any, "isTelemetryEnabled").value(true);
@@ -119,11 +122,7 @@ suite("telemetry", function () {
     test("enabling by command takes precedence", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        preSetupHook: async ({ wsRoot }) => {
-          const config = DConfig.genDefaultConfig();
-          config.noTelemetry = true;
-          TestConfigUtils.writeConfig({ wsRoot, config });
-        },
+        preSetupHook: setNoTelemetry(true),
         onInit: async ({}) => {
           const ws = getWS();
           sinon.stub(vscode.env as any, "isTelemetryEnabled").value(false);

--- a/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Telemetry.test.ts
@@ -8,9 +8,9 @@ import sinon from "sinon";
 import { SegmentClient } from "@dendronhq/common-server";
 import { setupSegmentClient } from "../../telemetry";
 import { FileTestUtils } from "@dendronhq/common-test-utils";
-import { TestConfigUtils } from "@dendronhq/engine-test-utils";
 import { DisableTelemetryCommand } from "../../commands/DisableTelemetry";
 import { EnableTelemetryCommand } from "../../commands/EnableTelemetry";
+import { DConfig } from "@dendronhq/engine-server";
 
 suite("telemetry", function () {
   let ctx: vscode.ExtensionContext;
@@ -23,13 +23,9 @@ suite("telemetry", function () {
 
   function setNoTelemetry(to: boolean) {
     return async ({ wsRoot }: { wsRoot: string }) => {
-      TestConfigUtils.withConfig(
-        (config) => {
-          config.noTelemetry = to;
-          return config;
-        },
-        { wsRoot }
-      );
+      const config = DConfig.genDefaultConfig();
+      config.noTelemetry = to;
+      DConfig.writeConfig({ wsRoot, config });
     };
   }
 

--- a/packages/plugin-core/src/utils.ts
+++ b/packages/plugin-core/src/utils.ts
@@ -42,8 +42,11 @@ export class DisposableStore {
     this._toDispose.add(dis);
   }
 
-  // TODO
-  public dispose() {}
+  public dispose() {
+    for (const disposable of this._toDispose) {
+      disposable.dispose();
+    }
+  }
 }
 
 // === File FUtils

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -557,9 +557,9 @@ export class DendronWorkspace {
     );
   }
 
-  addDisposable(_disposable: vscode.Disposable) {
-    // TODO
+  addDisposable(disposable: vscode.Disposable) {
     // handle all disposables
+    this.disposableStore.add(disposable);
   }
 
   // === Utils


### PR DESCRIPTION
If telemetry is disabled in VSCode preferences, it will be respected by Dendron. Additionally, users can force enable Dendron telemetry even when it's disabled in VSCode preferences by running the command `Dendron: Enable Telemetry`.

closes #711 

Also completed the `DisposableStore` stub because I happened to come across it. Let me know if I should avoid it for now and I can pick that commit out.