### PR TITLE
Add scoping capabilities to doctor commands

### DIFF
--- a/packages/dendron-cli/src/commands/backfillV2.ts
+++ b/packages/dendron-cli/src/commands/backfillV2.ts
@@ -1,8 +1,16 @@
-import { DEngineClient, NoteUtils } from "@dendronhq/common-all";
+import {
+  DEngineClient,
+  NoteProps,
+  NotePropsDict,
+  NoteUtils,
+} from "@dendronhq/common-all";
 import _ from "lodash";
 import { BaseCommand } from "./base";
 
-type CommandOpts = { engine: DEngineClient } & CommonOpts;
+type CommandOpts = {
+  engine: DEngineClient;
+  note?: NoteProps;
+} & CommonOpts;
 
 type CommonOpts = {
   overwriteFields?: string[];
@@ -12,11 +20,14 @@ type CommandOutput = void;
 
 export class BackfillV2Command extends BaseCommand<CommandOpts, CommandOutput> {
   async execute(opts: CommandOpts) {
-    const { engine, overwriteFields } = _.defaults(opts, {
+    const { engine, note, overwriteFields } = _.defaults(opts, {
       overwriteFields: [],
     });
+    const candidates: NotePropsDict = _.isUndefined(note)
+      ? engine.notes
+      : { [note.id]: note };
     const notes = await Promise.all(
-      _.values(engine.notes)
+      _.values(candidates)
         .filter((n) => !n.stub)
         .map(async (n) => {
           overwriteFields.forEach((f) => {

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -267,6 +267,13 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
+        // this action is disabled for workspace scope for now.
+        if (_.isUndefined(candidates)) {
+          console.log(
+            `doctor ${DoctorActions.CREATE_MISSING_LINKED_NOTES} requires explicitly passing one candidate note.`
+          );
+          return;
+        }
         notes = this.getWildLinkDestinations(notes, engine.wsRoot);
         doctorAction = async (note: NoteProps) => {
           const vname = VaultUtils.getName(note.vault);
@@ -280,6 +287,7 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           );
           numChanges += 1;
         };
+        break;
       }
     }
     await _.reduce<any, Promise<any>>(

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -25,6 +25,11 @@ import {
 type CommandCLIOpts = {
   action: DoctorActions;
   query?: string;
+  /**
+   * pass in note candidates directly to
+   * limit what notes should be used in the command.
+   */
+  candidates?: NoteProps[];
   limit?: number;
   dryRun?: boolean;
   /**
@@ -122,13 +127,20 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   }
 
   async execute(opts: CommandOpts) {
-    const { action, engine, query, limit, dryRun, exit } = _.defaults(opts, {
-      limit: 99999,
-      exit: true,
-    });
-    let notes = query
-      ? engine.queryNotesSync({ qs: query }).data
-      : _.values(engine.notes);
+    const { action, engine, query, candidates, limit, dryRun, exit } =
+      _.defaults(opts, {
+        limit: 99999,
+        exit: true,
+      });
+    let notes: NoteProps[];
+    if (_.isUndefined(candidates)) {
+      notes = query
+        ? engine.queryNotesSync({ qs: query }).data
+        : _.values(engine.notes);
+    } else {
+      console.log(`${candidates.length} candidate(s) were passed`);
+      notes = candidates;
+    }
     notes = notes.filter((n) => !n.stub);
     this.L.info({ msg: "prep doctor", numResults: notes.length });
     let numChanges = 0;

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/doctor.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/doctor.spec.ts.snap
@@ -48,6 +48,54 @@ Object {
 }
 `;
 
+exports[`H1_TO_TITLE basic pass candidates opts 1`] = `
+Object {
+  "anchors": Object {},
+  "body": "## Foo Content
+
+",
+  "children": Array [],
+  "created": 1,
+  "custom": Object {},
+  "data": Object {},
+  "desc": "",
+  "fname": "foo",
+  "id": "foo",
+  "links": Array [],
+  "parent": null,
+  "title": "Foo Header",
+  "type": "note",
+  "updated": 1,
+  "vault": Object {
+    "fsPath": "vault1",
+  },
+}
+`;
+
+exports[`H1_TO_TITLE basic pass candidates opts 2`] = `
+Object {
+  "anchors": Object {},
+  "body": "# Bar Header
+## Bar Content
+",
+  "children": Array [],
+  "created": 1,
+  "custom": Object {},
+  "data": Object {},
+  "desc": "",
+  "fname": "bar",
+  "id": "bar",
+  "links": Array [],
+  "parent": null,
+  "title": "Bar",
+  "type": "note",
+  "updated": 1,
+  "vault": Object {
+    "fsPath": "vault1",
+  },
+}
+`;
+
 exports[`h1ToH2 basic 1`] = `
 Object {
   "anchors": Object {},
@@ -81,6 +129,56 @@ Object {
 
 ## Bar Content
 
+",
+  "children": Array [],
+  "created": 1,
+  "custom": Object {},
+  "data": Object {},
+  "desc": "",
+  "fname": "bar",
+  "id": "bar",
+  "links": Array [],
+  "parent": null,
+  "title": "Bar",
+  "type": "note",
+  "updated": 1,
+  "vault": Object {
+    "fsPath": "vault1",
+  },
+}
+`;
+
+exports[`h1ToH2 basic pass candidates opt 1`] = `
+Object {
+  "anchors": Object {},
+  "body": "## Foo Header
+
+## Foo Content
+
+",
+  "children": Array [],
+  "created": 1,
+  "custom": Object {},
+  "data": Object {},
+  "desc": "",
+  "fname": "foo",
+  "id": "foo",
+  "links": Array [],
+  "parent": null,
+  "title": "Foo",
+  "type": "note",
+  "updated": 1,
+  "vault": Object {
+    "fsPath": "vault1",
+  },
+}
+`;
+
+exports[`h1ToH2 basic pass candidates opt 2`] = `
+Object {
+  "anchors": Object {},
+  "body": "# Bar Header
+## Bar Content
 ",
   "children": Array [],
   "created": 1,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
@@ -143,6 +143,52 @@ describe(DoctorActions.HI_TO_H2, () => {
     );
   });
 
+  test("basic pass candidates opt", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+        });
+
+        const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
+        const noteFoo = file2Note(fpathFoo, vault);
+        expect(noteFoo).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: noteFoo.body,
+            match: [`## Foo Header`],
+          })
+        ).toBeTruthy();
+
+        // bar.md should be untouched.
+        const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
+        const note = file2Note(fpathBar, vault);
+        expect(note).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: note.body,
+            match: [`# Bar Header`],
+          })
+        ).toBeTruthy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupBasic,
+      }
+    );
+  });
+
   test("dry run", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
@@ -213,11 +259,46 @@ describe("H1_TO_TITLE", () => {
       }
     );
   });
+
+  test("basic pass candidates opts", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+        });
+        const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
+        const noteFoo = file2Note(fpathFoo, vault);
+        expect(noteFoo).toMatchSnapshot();
+        expect(noteFoo.title).toEqual("Foo Header");
+
+        const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
+        const noteBar = file2Note(fpathBar, vault);
+        expect(noteBar).toMatchSnapshot();
+        expect(noteBar.title).toEqual("Bar");
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupBasic,
+      }
+    );
+  });
 });
 
 describe("CREATE_MISSING_LINKED_NOTES", () => {
   const action = DoctorActions.CREATE_MISSING_LINKED_NOTES;
-  test("basic", async () => {
+  // skip this until we enable workspace scope
+  test.skip("basic", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
         const vault = vaults[0];
@@ -239,7 +320,60 @@ describe("CREATE_MISSING_LINKED_NOTES", () => {
     );
   });
 
-  test("dry run", async () => {
+  test("basic workspace scope should do nothing", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        await runDoctor({
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "fake.link.md")
+        );
+        expect(fileExists).toBeFalsy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithWikilink,
+      }
+    );
+  });
+
+  test("basic pass candidates opts", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+        });
+        engine;
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "fake.link.md")
+        );
+        expect(fileExists).toBeFalsy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithWikilink,
+      }
+    );
+  });
+
+  // skip this until we enable workspace scope
+  test.skip("dry run", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
         const vault = vaults[0];
@@ -262,7 +396,38 @@ describe("CREATE_MISSING_LINKED_NOTES", () => {
     );
   });
 
-  test("wild link with alias", async () => {
+  test("dry run", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+          dryRun: true,
+        });
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "fake.link.md")
+        );
+        expect(fileExists).toBeFalsy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithWikilink,
+      }
+    );
+  });
+
+  // skip this until we enable workspace scope
+  test.skip("wild link with alias", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
         const vault = vaults[0];
@@ -287,7 +452,41 @@ describe("CREATE_MISSING_LINKED_NOTES", () => {
     );
   });
 
-  test("missing notes in multiple vaults", async () => {
+  test("wild link with alias pass candidates opts", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault = vaults[0];
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExists = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "foo.bar.md")
+        );
+        expect(fileExists).toBeTruthy();
+        const fileDoesntExist = await fs.pathExists(
+          path.join(wsRoot, vault.fsPath, "foo.baz.md")
+        );
+        expect(fileDoesntExist).toBeTruthy();
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithAliasedWikilink,
+      }
+    );
+  });
+
+  // skipping this until we enable workspace scope.
+  test.skip("missing notes in multiple vaults", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
         const vault1 = vaults[0];
@@ -314,7 +513,8 @@ describe("CREATE_MISSING_LINKED_NOTES", () => {
     );
   });
 
-  test("xvaults wild links", async () => {
+  // skipping this until we enable workspace scope.
+  test.skip("xvaults wild links", async () => {
     await runEngineTestV5(
       async ({ engine, wsRoot, vaults }) => {
         const vault1 = vaults[0];
@@ -334,6 +534,60 @@ describe("CREATE_MISSING_LINKED_NOTES", () => {
             path.join(wsRoot, vault2.fsPath, fileName)
           );
           expect(fileExistsVault2).toBeTruthy();
+        });
+      },
+      {
+        createEngine: createEngineFromServer,
+        expect,
+        preSetupHook: setupWithXVaultWikilink,
+      }
+    );
+  });
+
+  test("xvaults wild links pass candidates opts", async () => {
+    await runEngineTestV5(
+      async ({ engine, wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault2 = vaults[1];
+        await NoteTestUtilsV4.createNote({
+          wsRoot,
+          vault: vault1,
+          fname: "foo2",
+          body: [
+            "[[dendron://vault2/bar2]]",
+            "[[baz|dendron://vault2/baz2]]",
+            "[[qaaaz note|dendron://vault2/qaaaz2]]",
+          ].join("\n"),
+        });
+        const resp = await engine.getNoteByPath({
+          npath: "foo",
+          createIfNew: false,
+          vault: vault1,
+        });
+        const fooFile = resp.data!.note;
+        await runDoctor({
+          candidates: [fooFile!],
+          wsRoot,
+          engine,
+          action,
+        });
+        const fileExistsVault1 = await fs.pathExists(
+          path.join(wsRoot, vault1.fsPath, "bar.md")
+        );
+        expect(fileExistsVault1).toBeFalsy();
+        const fileNames = ["bar.md", "baz.md", "qaaaz.md"];
+        _.forEach(fileNames, async (fileName) => {
+          const fileExistsVault2 = await fs.pathExists(
+            path.join(wsRoot, vault2.fsPath, fileName)
+          );
+          expect(fileExistsVault2).toBeTruthy();
+        });
+        const fileNames2 = ["bar2.md", "baz2.md", "qaaaz2.md"];
+        _.forEach(fileNames2, async (fileName) => {
+          const fileExistsVault2 = await fs.pathExists(
+            path.join(wsRoot, vault2.fsPath, fileName)
+          );
+          expect(fileExistsVault2).toBeFalsy();
         });
       },
       {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -8,12 +8,18 @@ import fs from "fs-extra";
 import _ from "lodash";
 import _md from "markdown-it";
 import path from "path";
-import { window, ViewColumn } from "vscode";
+import { window, ViewColumn, QuickPick } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
 import { DendronWorkspace, getWS } from "../workspace";
 import { BasicCommand } from "./base";
 import { ReloadIndexCommand } from "./ReloadIndex";
+import {
+  DoctorBtn,
+  ChangeScopeBtn,
+  IDoctorQuickInputButton,
+} from "../components/doctor/buttons";
+import { DoctorScopeType } from "../components/doctor/types";
 
 const md = _md();
 
@@ -21,26 +27,89 @@ type Finding = {
   issue: string;
   fix?: string;
 };
+
 type CommandOpts = {
   action: DoctorActions;
+  scope: DoctorScopeType;
 };
 
 type CommandOutput = {
   data: Finding[];
 };
 
+type CreateQuickPickOpts = {
+  title: string;
+  placeholder: string;
+  items: DoctorQuickInput[];
+  /**
+   * QuickPick.ignoreFocusOut prop
+   */
+  ignoreFocusOut?: boolean;
+  nonInteractive?: boolean;
+  buttons?: DoctorBtn[];
+};
+
+type DoctorQuickInput = {
+  label: string;
+  detail?: string;
+  alwaysShow?: boolean;
+};
+
+type DoctorQuickPickItem = QuickPick<DoctorQuickInput>;
+
 export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
   static key = DENDRON_COMMANDS.DOCTOR.key;
 
-  async gatherInputs(): Promise<CommandOpts | undefined> {
-    const values = _.map(DoctorActions, (ent) => {
-      return { label: ent };
+  createQuickPick(opts: CreateQuickPickOpts) {
+    const { title, placeholder, ignoreFocusOut, items } = _.defaults(opts, {
+      ignoreFocusOut: true,
     });
-    const doctorAction = await VSCodeUtils.showQuickPick(values);
-    if (doctorAction?.label) {
-      return { action: doctorAction.label };
+    const quickPick =
+      VSCodeUtils.createQuickPick<DoctorQuickInput>() as DoctorQuickPickItem;
+    quickPick.title = title;
+    quickPick.placeholder = placeholder;
+    quickPick.ignoreFocusOut = ignoreFocusOut;
+    quickPick.items = items;
+    quickPick.buttons = opts.buttons!;
+
+    return quickPick;
+  }
+
+  onTriggerButton = async (quickpick: DoctorQuickPickItem) => {
+    if (!quickpick) {
+      return;
     }
-    return;
+    const button = quickpick.buttons[0] as IDoctorQuickInputButton;
+    button.pressed = !button.pressed;
+    button.type = button.type == "workspace" ? "file" : "workspace";
+    quickpick.buttons = [button];
+  };
+
+  async gatherInputs(): Promise<CommandOpts | undefined> {
+    const out = new Promise<CommandOpts | undefined>(async (resolve) => {
+      const values = _.map(DoctorActions, (ent) => {
+        return { label: ent };
+      });
+      const quickPick = this.createQuickPick({
+        title: "Doctor",
+        placeholder: "doctor action",
+        items: values,
+        buttons: [ChangeScopeBtn.create(false)],
+      });
+      quickPick.onDidAccept(async () => {
+        quickPick.hide();
+        const doctorAction = quickPick.selectedItems[0].label;
+        const doctorScope = (quickPick.buttons[0] as IDoctorQuickInputButton)
+          .type;
+        return resolve({
+          action: doctorAction as DoctorActions,
+          scope: doctorScope,
+        });
+      });
+      quickPick.onDidTriggerButton(() => this.onTriggerButton(quickPick));
+      quickPick.show();
+    });
+    return out;
   }
 
   async showMissingNotePreview(candidates: NoteProps[]) {
@@ -86,17 +155,40 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
     const engine: DEngineClient =
       (await new ReloadIndexCommand().execute()) as DEngineClient;
 
+    let note;
+    if (opts.scope === "file") {
+      console.log("scoped for active file");
+      const document = VSCodeUtils.getActiveTextEditor()?.document;
+      if (_.isUndefined(document)) {
+        throw Error("No note open");
+      }
+      note = VSCodeUtils.getNoteFromDocument(document);
+    }
+
     switch (opts.action) {
       case DoctorActions.FIX_FRONTMATTER: {
         await new BackfillV2Command().execute({
           engine: engine,
+          note: note,
         });
         break;
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
+        if (opts.scope === "workspace") {
+          window.showInformationMessage(
+            "This action is currently not supported in workspace scope."
+          );
+          break;
+        }
         const cmd = new DoctorCLICommand();
-        let notes = _.values(engine.notes);
-        notes = notes.filter((note) => !note.stub);
+        let notes;
+        if (_.isUndefined(note)) {
+          notes = _.values(engine.notes);
+          notes = notes.filter((note) => !note.stub);
+        } else {
+          notes = [note];
+        }
+
         const uniqueCandidates = cmd.getWildLinkDestinations(
           notes,
           engine.wsRoot
@@ -119,6 +211,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
           }
           await cmd.execute({
             action: opts.action,
+            candidates: notes,
             engine,
             wsRoot,
             server: {},
@@ -134,8 +227,12 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       }
       default: {
         const cmd = new DoctorCLICommand();
+        const candidates: NoteProps[] | undefined = _.isUndefined(note)
+          ? undefined
+          : [note];
         await cmd.execute({
           action: opts.action,
+          candidates: candidates,
           engine,
           wsRoot,
           server: {},

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -83,6 +83,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
     button.pressed = !button.pressed;
     button.type = button.type == "workspace" ? "file" : "workspace";
     quickpick.buttons = [button];
+    quickpick.title = `Doctor (${button.type})`;
   };
 
   async gatherInputs(): Promise<CommandOpts | undefined> {
@@ -90,12 +91,15 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       const values = _.map(DoctorActions, (ent) => {
         return { label: ent };
       });
+      const changeScopeButton = ChangeScopeBtn.create(false);
       const quickPick = this.createQuickPick({
         title: "Doctor",
-        placeholder: "doctor action",
+        placeholder: "Select a Doctor Action.",
         items: values,
-        buttons: [ChangeScopeBtn.create(false)],
+        buttons: [changeScopeButton],
       });
+      const scope = (quickPick.buttons[0] as IDoctorQuickInputButton).type;
+      quickPick.title = `Doctor (${scope})`;
       quickPick.onDidAccept(async () => {
         quickPick.hide();
         const doctorAction = quickPick.selectedItems[0].label;

--- a/packages/plugin-core/src/components/doctor/buttons.ts
+++ b/packages/plugin-core/src/components/doctor/buttons.ts
@@ -1,0 +1,81 @@
+import { QuickInputButton, ThemeIcon } from "vscode";
+import { DoctorQuickPicker, DoctorScopeType } from "./types";
+
+export type ButtonType = DoctorScopeType;
+
+export type ButtonHandleOpts = { quickPick: DoctorQuickPicker };
+
+export type IDoctorQuickInputButton = QuickInputButton & {
+  type: ButtonType;
+  pressed: boolean;
+};
+
+type DoctorBtnConstructorOpts = {
+  title: string;
+  iconOff: string;
+  iconOn: string;
+  type: ButtonType;
+  pressed?: boolean;
+  canToggle?: boolean;
+};
+
+export class DoctorBtn implements IDoctorQuickInputButton {
+  public iconPathNormal: ThemeIcon;
+  public iconPathPressed: ThemeIcon;
+  public type: ButtonType;
+  public pressed: boolean;
+  public canToggle: boolean;
+  public title: string;
+  public opts: DoctorBtnConstructorOpts;
+
+  constructor(opts: DoctorBtnConstructorOpts) {
+    const { iconOff, iconOn, type, title, pressed } = opts;
+    this.iconPathNormal = new ThemeIcon(iconOff);
+    this.iconPathPressed = new ThemeIcon(iconOn);
+    this.type = type;
+    this.pressed = pressed || false;
+    this.title = title;
+    this.canToggle = opts.canToggle || true;
+    this.opts = opts;
+  }
+
+  clone(): DoctorBtn {
+    return new DoctorBtn({
+      ...this.opts,
+    });
+  }
+
+  async onEnable(_opts: ButtonHandleOpts): Promise<void> {
+    console.log("enabled");
+    return undefined;
+  }
+
+  async onDisable(_opts: ButtonHandleOpts): Promise<void> {
+    console.log("disabled");
+    return undefined;
+  }
+
+  get iconPath() {
+    return !this.pressed ? this.iconPathNormal : this.iconPathPressed;
+  }
+
+  get tooltip(): string {
+    return `${this.title}, status: ${this.pressed ? "on" : "off"}`;
+  }
+
+  toggle() {
+    this.pressed = !this.pressed;
+  }
+}
+
+export class ChangeScopeBtn extends DoctorBtn {
+  static create(pressed?: boolean) {
+    return new ChangeScopeBtn({
+      title: "Change Scope",
+      iconOff: "root-folder-opened",
+      iconOn: "symbol-file",
+      type: "workspace" as DoctorScopeType,
+      pressed,
+    });
+  }
+}

--- a/packages/plugin-core/src/components/doctor/buttons.ts
+++ b/packages/plugin-core/src/components/doctor/buttons.ts
@@ -72,8 +72,8 @@ export class ChangeScopeBtn extends DoctorBtn {
   static create(pressed?: boolean) {
     return new ChangeScopeBtn({
       title: "Change Scope",
-      iconOff: "root-folder-opened",
-      iconOn: "symbol-file",
+      iconOff: "symbol-file",
+      iconOn: "root-folder-opened",
       type: "workspace" as DoctorScopeType,
       pressed,
     });

--- a/packages/plugin-core/src/components/doctor/types.ts
+++ b/packages/plugin-core/src/components/doctor/types.ts
@@ -1,0 +1,27 @@
+import { QuickPick } from "vscode";
+import { DoctorBtn } from "./buttons";
+
+export type DoctorScopeType = "workspace" | "file";
+export type DoctorQuickInput = {
+  label: string;
+  detail?: string;
+  alwaysShow?: boolean;
+};
+export type DoctorQuickPickItem = QuickPick<DoctorQuickInput>;
+export type DoctorQuickPicker = DoctorQuickPickItem & {
+  /**
+   * Buttons control modifiers for doctor
+   */
+  buttons: DoctorBtn[];
+  nonInteractive?: boolean;
+};
+
+export type CreateQuickPickOpts = {
+  title: string;
+  placeholder: string;
+  /**
+   * QuickPick.ignoreFocusOut prop
+   */
+  ignoreFocusOut?: boolean;
+  nonInteractive?: boolean;
+};

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -44,6 +44,7 @@ suite("DoctorCommandTest", function () {
       sinon.stub(cmd, "gatherInputs").returns(
         Promise.resolve({
           action: DoctorActions.FIX_FRONTMATTER,
+          scope: "workspace",
         })
       );
       await cmd.run();
@@ -301,6 +302,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+            scope: "workspace",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -337,6 +339,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+            scope: "workspace",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -376,6 +379,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+            scope: "workspace",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -429,6 +433,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+            scope: "workspace",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -488,6 +493,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
+            scope: "workspace",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -277,7 +277,7 @@ suite("DoctorCommandTest", function () {
 //     });
 //   });
 
-suite("CREATE_MISSING_LINKED_NOTES", function () {
+suite.skip("CREATE_MISSING_LINKED_NOTES", function () {
   let ctx: vscode.ExtensionContext;
 
   ctx = setupBeforeAfter(this, {
@@ -302,7 +302,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
-            scope: "workspace",
+            scope: "file",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -339,7 +339,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
-            scope: "workspace",
+            scope: "file",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -379,7 +379,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
-            scope: "workspace",
+            scope: "file",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -433,7 +433,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
-            scope: "workspace",
+            scope: "file",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
@@ -493,7 +493,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             action: DoctorActions.CREATE_MISSING_LINKED_NOTES,
-            scope: "workspace",
+            scope: "file",
           })
         );
         const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -37,10 +37,10 @@ suite("DoctorCommandTest", function () {
 
   test("basic", (done) => {
     onWSInit(async () => {
-      const testFile = path.join(root.name, "vault", "bond2.md");
-      fs.writeFileSync(testFile, "bond", { encoding: "utf8" });
-      const testFile2 = path.join(root.name, "vault", "bond3.md");
-      fs.writeFileSync(testFile2, "bond3", { encoding: "utf8" });
+      const testFile = path.join(root.name, "vault", "bar.md");
+      fs.writeFileSync(testFile, "bar", { encoding: "utf8" });
+      const testFile2 = path.join(root.name, "vault", "baz.md");
+      fs.writeFileSync(testFile2, "baz", { encoding: "utf8" });
       await new ReloadIndexCommand().run();
       const cmd = new DoctorCommand();
       sinon.stub(cmd, "gatherInputs").returns(
@@ -72,10 +72,10 @@ suite("DoctorCommandTest", function () {
 
   test("basic file scoped", (done) => {
     onWSInit(async () => {
-      const testFile = path.join(root.name, "vault", "bond2.md");
-      fs.writeFileSync(testFile, "bond", { encoding: "utf8" });
-      const testFile2 = path.join(root.name, "vault", "bond3.md");
-      fs.writeFileSync(testFile2, "bond3", { encoding: "utf8" });
+      const testFile = path.join(root.name, "vault", "bar.md");
+      fs.writeFileSync(testFile, "bar", { encoding: "utf8" });
+      const testFile2 = path.join(root.name, "vault", "baz.md");
+      fs.writeFileSync(testFile2, "baz", { encoding: "utf8" });
       await new ReloadIndexCommand().run();
       const testFileUri = vscode.Uri.file(testFile);
       await VSCodeUtils.openFileInEditor(testFileUri);


### PR DESCRIPTION
This PR:
- Adds a scope toggle button to the Doctor plugin command quickpick.
- Can toggle between `workspace` and `file`.
- Defaults to `workspace` scope.
- `createMissingLinkedNotes` action is disabled for `workspace` scope.
- Above changes are also mirrored in DoctorCLICommand by adding a new command option `candidates` where you can explicitly pass in a list of notes.
- Fixed tests that broke due to above changes.
- Skipped tests for some `createMissingLinkedNotes` that should be re-enabled once we enable workspace scope in the future.
- Added tests to for the scoped behavior.