### PR TITLE
Add initial note filtering, schema graph

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -522,7 +522,10 @@ export type OnDidChangeActiveTextEditorMsg = DMessage<
 >;
 
 export type TreeViewMessage = DMessage<TreeViewMessageType, { id: string }>;
-export type GraphViewMessage = DMessage<GraphViewMessageType, { id: string }>;
+export type GraphViewMessage = DMessage<
+  GraphViewMessageType,
+  { id: string; vault?: string }
+>;
 
 // --- Views
 

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -1,0 +1,114 @@
+import {
+  Typography,
+  Collapse,
+  Switch,
+  Space,
+  InputNumber,
+  Divider,
+  Input,
+} from "antd";
+import _, { values } from "lodash";
+import { GraphConfig } from "./graph";
+const { Panel } = Collapse;
+
+type FilterProps = {
+  type: "note" | "schema";
+  config: GraphConfig;
+  setField: (key: string, value: any) => void;
+};
+
+const GraphFilterView = ({ type, config, setField }: FilterProps) => {
+  const sections = new Set(Object.keys(config).map((key) => key.split(".")[0]));
+  const configEntries = Object.entries(config);
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "1rem",
+        left: "1rem",
+        background: "#F5F6F8",
+        borderRadius: 4,
+        zIndex: 10,
+        minWidth: "12rem",
+      }}
+    >
+      <Collapse>
+        {Array.from(sections).map((section, i) => (
+          <Panel header={_.capitalize(section)} key={i}>
+            <Space direction="vertical" style={{ width: "100%" }}>
+              {configEntries
+                .filter(([key]) => key.includes(section))
+                .map(([key, entry]) => {
+                  const keyArray = key.split(".");
+                  const label = _.capitalize(keyArray[keyArray.length - 1]);
+
+                  return (
+                    <Space
+                      direction="horizontal"
+                      style={{ justifyContent: "space-between", width: "100%" }}
+                    >
+                      {_.isBoolean(entry?.value) && (
+                        <>
+                          <Typography>{label}</Typography>
+                          <Switch
+                            checked={entry?.value}
+                            onChange={(newValue) => setField(key, newValue)}
+                            disabled={!entry?.mutable}
+                          />
+                        </>
+                      )}
+                      {_.isNumber(entry?.value) && (
+                        <>
+                          <Typography>{label}</Typography>
+                          <InputNumber
+                            defaultValue={entry?.value}
+                            onChange={(newValue) => setField(key, newValue)}
+                            disabled={!entry?.mutable}
+                          />
+                        </>
+                      )}
+                      {_.isString(entry?.value) && (
+                        <>
+                          <Typography>{label}</Typography>
+                          <Input
+                            defaultValue={entry?.value}
+                            onChange={(newValue) =>
+                              setField(key, newValue.target.value)
+                            }
+                            disabled={!entry?.mutable}
+                          />
+                        </>
+                      )}
+                    </Space>
+                  );
+                })}
+            </Space>
+          </Panel>
+        ))}
+        {/* {type === 'note' && (
+          <Panel header="Display" key="1">
+            <Space direction="vertical">
+              <Space direction="horizontal">
+                <Switch checked={config.display.hierarchy} onChange={(v) => setField('display.hierarchy', v)} />
+                <Typography>Hierarchy</Typography>
+              </Space>
+              <Space direction="horizontal" >
+                <Switch checked={config.display.links} onChange={(v) => setField('display.links', v)} />
+                <Typography>Links</Typography>
+              </Space>
+            </Space>
+          </Panel>
+        )}
+        <Panel header="Information" key="2">
+          <Typography>Nodes: {config['information.nodes']}</Typography>
+          <Typography>Edges: {config['information.edges']}</Typography>
+        </Panel> */}
+      </Collapse>
+    </div>
+  );
+};
+
+const FilterViewInput = () => {};
+
+export default GraphFilterView;

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -2,6 +2,7 @@ import { Typography, Collapse, Switch, Space, InputNumber, Input } from "antd";
 import _, { values } from "lodash";
 import { useThemeSwitcher } from "react-css-theme-switcher";
 import { GraphConfig } from "../lib/graph";
+import AntThemes from "../styles/theme-antd";
 const { Panel } = Collapse;
 
 type FilterProps = {
@@ -30,16 +31,18 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
     });
   };
 
+  if (!currentTheme) return <></>;
+
   return (
     <div
       style={{
-        position: "absolute",
-        top: "1rem",
-        left: "1rem",
-        background: currentTheme === "light" ? "#F5F6F8" : "#303030",
-        borderRadius: 4,
         zIndex: 10,
-        minWidth: "12rem",
+        position: "absolute",
+        top: AntThemes[currentTheme].graph.filterView.margin,
+        left: AntThemes[currentTheme].graph.filterView.margin,
+        background: AntThemes[currentTheme].graph.filterView.background,
+        borderRadius: AntThemes[currentTheme].graph.filterView.borderRadius,
+        minWidth: AntThemes[currentTheme].graph.filterView.minWidth,
       }}
     >
       <Collapse>

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -1,17 +1,31 @@
 import { Typography, Collapse, Switch, Space, InputNumber, Input } from "antd";
 import _, { values } from "lodash";
-import { GraphConfig } from "./graph";
+import { GraphConfig } from "../lib/graph";
 const { Panel } = Collapse;
 
 type FilterProps = {
   type: "note" | "schema";
   config: GraphConfig;
-  setField: (key: string, value: any) => void;
+  setConfig: React.Dispatch<React.SetStateAction<GraphConfig>>;
 };
 
-const GraphFilterView = ({ type, config, setField }: FilterProps) => {
+const GraphFilterView = ({ config, setConfig }: FilterProps) => {
   const sections = new Set(Object.keys(config).map((key) => key.split(".")[0]));
   const configEntries = Object.entries(config);
+
+  const updateConfigField = (key: string, value: string | number | boolean) => {
+    setConfig((c) => {
+      const newConfig = {
+        ...c,
+        [key]: {
+          // @ts-ignore
+          ...c[key],
+          value,
+        },
+      };
+      return newConfig;
+    });
+  };
 
   return (
     <div
@@ -35,7 +49,10 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
                   const keyArray = key.split(".");
                   const label =
                     entry?.label ||
-                    `${_.capitalize(keyArray[keyArray.length - 1])}`;
+                    `${keyArray[keyArray.length - 1]
+                      .split("-")
+                      .map((k) => _.capitalize(k))
+                      .join(" ")}`;
 
                   return (
                     <Space
@@ -47,7 +64,9 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
                           <Typography>{label}</Typography>
                           <Switch
                             checked={entry?.value}
-                            onChange={(newValue) => setField(key, newValue)}
+                            onChange={(newValue) =>
+                              updateConfigField(key, newValue)
+                            }
                             disabled={!entry?.mutable}
                           />
                         </>
@@ -57,7 +76,9 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
                           <Typography>{label}</Typography>
                           <InputNumber
                             defaultValue={entry?.value}
-                            onChange={(newValue) => setField(key, newValue)}
+                            onChange={(newValue) =>
+                              updateConfigField(key, newValue)
+                            }
                             disabled={!entry?.mutable}
                           />
                         </>
@@ -68,7 +89,7 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
                           <Input
                             defaultValue={entry?.value}
                             onChange={(newValue) =>
-                              setField(key, newValue.target.value)
+                              updateConfigField(key, newValue.target.value)
                             }
                             disabled={!entry?.mutable}
                           />

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -41,7 +41,9 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
                 .filter(([key]) => key.includes(section))
                 .map(([key, entry]) => {
                   const keyArray = key.split(".");
-                  const label = _.capitalize(keyArray[keyArray.length - 1]);
+                  const label =
+                    entry?.label ||
+                    `${_.capitalize(keyArray[keyArray.length - 1])}`;
 
                   return (
                     <Space
@@ -86,24 +88,6 @@ const GraphFilterView = ({ type, config, setField }: FilterProps) => {
             </Space>
           </Panel>
         ))}
-        {/* {type === 'note' && (
-          <Panel header="Display" key="1">
-            <Space direction="vertical">
-              <Space direction="horizontal">
-                <Switch checked={config.display.hierarchy} onChange={(v) => setField('display.hierarchy', v)} />
-                <Typography>Hierarchy</Typography>
-              </Space>
-              <Space direction="horizontal" >
-                <Switch checked={config.display.links} onChange={(v) => setField('display.links', v)} />
-                <Typography>Links</Typography>
-              </Space>
-            </Space>
-          </Panel>
-        )}
-        <Panel header="Information" key="2">
-          <Typography>Nodes: {config['information.nodes']}</Typography>
-          <Typography>Edges: {config['information.edges']}</Typography>
-        </Panel> */}
       </Collapse>
     </div>
   );

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -1,5 +1,6 @@
 import { Typography, Collapse, Switch, Space, InputNumber, Input } from "antd";
 import _, { values } from "lodash";
+import { useThemeSwitcher } from "react-css-theme-switcher";
 import { GraphConfig } from "../lib/graph";
 const { Panel } = Collapse;
 
@@ -33,7 +34,6 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
         position: "absolute",
         top: "1rem",
         left: "1rem",
-        background: "#F5F6F8",
         borderRadius: 4,
         zIndex: 10,
         minWidth: "12rem",

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -14,6 +14,8 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
   const sections = new Set(Object.keys(config).map((key) => key.split(".")[0]));
   const configEntries = Object.entries(config);
 
+  const { themes, currentTheme } = useThemeSwitcher();
+
   const updateConfigField = (key: string, value: string | number | boolean) => {
     setConfig((c) => {
       const newConfig = {
@@ -34,6 +36,7 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
         position: "absolute",
         top: "1rem",
         left: "1rem",
+        background: currentTheme === "light" ? "#F5F6F8" : "#303030",
         borderRadius: 4,
         zIndex: 10,
         minWidth: "12rem",

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -1,12 +1,4 @@
-import {
-  Typography,
-  Collapse,
-  Switch,
-  Space,
-  InputNumber,
-  Divider,
-  Input,
-} from "antd";
+import { Typography, Collapse, Switch, Space, InputNumber, Input } from "antd";
 import _, { values } from "lodash";
 import { GraphConfig } from "./graph";
 const { Panel } = Collapse;

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -14,7 +14,7 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
   const sections = new Set(Object.keys(config).map((key) => key.split(".")[0]));
   const configEntries = Object.entries(config);
 
-  const { themes, currentTheme } = useThemeSwitcher();
+  const { currentTheme } = useThemeSwitcher();
 
   const updateConfigField = (key: string, value: string | number | boolean) => {
     setConfig((c) => {

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -42,6 +42,7 @@ const getCytoscapeStyle = (themes: any, theme: string | undefined) => {
 type GraphConfigItem<T> = {
   value: T;
   mutable: boolean;
+  label?: string;
 };
 
 type CoreGraphConfig = {
@@ -58,6 +59,10 @@ type SchemaGraphConfig = {};
 export type GraphConfig = CoreGraphConfig & NoteGraphConfig & SchemaGraphConfig;
 
 const coreGraphConfig: CoreGraphConfig = {
+  "filter.regex": {
+    value: "",
+    mutable: true,
+  },
   "information.nodes": {
     value: 0,
     mutable: false,
@@ -65,10 +70,6 @@ const coreGraphConfig: CoreGraphConfig = {
   "information.edges": {
     value: 0,
     mutable: false,
-  },
-  "filter.regex": {
-    value: "",
-    mutable: true,
   },
 };
 

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -132,10 +132,7 @@ export default function Graph({
         }
       });
 
-    // Only re-layout graph if it will be performant to do so
-    if (!isLargeGraph) {
-      cy.layout(getEulerConfig(isLargeGraph)).run();
-    }
+    cy.layout(getEulerConfig(isLargeGraph)).run();
   };
 
   const renderGraph = () => {

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -182,27 +182,6 @@ export default function Graph({
     }
   };
 
-  // const parseElements = (
-  //   elements: cytoscape.ElementsDefinition,
-  //   config: GraphConfig
-  // ) => {
-  //   if (type === "note") {
-  //     if (!config["display.hierarchy"]?.value) {
-  //       elements.nodes = elements.nodes.filter(
-  //         (n) => !n.classes?.includes(".hierarchy")
-  //       );
-  //     }
-  //     if (!config["display.links"]?.value) {
-  //       elements.nodes = elements.nodes.filter(
-  //         (n) => !n.classes?.includes(".link")
-  //       );
-  //     }
-  //   }
-
-  //   logger.log(elements);
-  //   return elements;
-  // };
-
   useEffect(() => {
     // If the graph already has rendered elements, don't re-render
     // Otherwise, the graph re-renders when elements are selected

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -125,7 +125,12 @@ const getSchemaGraphElements = (
 
           // Subschema node
           nodes.push({
-            data: { id: SUBSCHEMA_ID, label: subschema.title, group: "nodes" },
+            data: {
+              id: SUBSCHEMA_ID,
+              label: subschema.title,
+              group: "nodes",
+              fname: schema.fname,
+            },
           });
 
           // Schema -> subschema connection

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -96,14 +96,12 @@ const getSchemaGraphElements = (
         id: VAULT_ID,
         label: vaultName,
         group: "nodes",
-        selectable: false,
       },
+      selectable: false,
     });
 
     schemaArray
-      .filter((schema) => {
-        VaultUtils.getName(schema.vault) === vaultName;
-      })
+      .filter((schema) => VaultUtils.getName(schema.vault) === vaultName)
       .forEach((schema) => {
         const SCHEMA_ID = `${vaultName}_${schema.fname}`;
 

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -5,7 +5,7 @@ import {
   SchemaModuleDict,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { engineSlice } from "@dendronhq/common-frontend";
+import { createLogger, engineSlice } from "@dendronhq/common-frontend";
 import { EdgeDefinition, NodeDefinition } from "cytoscape";
 import _ from "lodash";
 import { useRouter } from "next/router";
@@ -79,11 +79,16 @@ const getSchemaGraphElements = (
   vaults: DVault[] | undefined
 ): GraphElements => {
   const schemaArray = Object.values(schemas);
+  const filteredSchemas = schemaArray.filter(
+    (schema) => schema.fname !== "root"
+  );
 
   const nodes: any[] = [];
   const edges: GraphEdges = {
     hierarchy: [],
   };
+
+  const logger = createLogger("useGraphElements");
 
   if (_.isUndefined(vaults)) return { nodes, edges };
 
@@ -96,11 +101,11 @@ const getSchemaGraphElements = (
         id: VAULT_ID,
         label: vaultName,
         group: "nodes",
+        vault: vaultName,
       },
-      selectable: false,
     });
 
-    schemaArray
+    filteredSchemas
       .filter((schema) => VaultUtils.getName(schema.vault) === vaultName)
       .forEach((schema) => {
         const SCHEMA_ID = `${vaultName}_${schema.fname}`;

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -3,6 +3,7 @@ import {
   NotePropsDict,
   NoteUtils,
   SchemaModuleDict,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { engineSlice } from "@dendronhq/common-frontend";
 import { EdgeDefinition, NodeDefinition } from "cytoscape";
@@ -87,21 +88,24 @@ const getSchemaGraphElements = (
   if (_.isUndefined(vaults)) return { nodes, edges };
 
   vaults.map((vault) => {
-    const VAULT_ID = `${vault.name}`;
+    const vaultName = VaultUtils.getName(vault);
+    const VAULT_ID = `${vaultName}`;
 
     nodes.push({
       data: {
         id: VAULT_ID,
-        label: vault.name,
+        label: vaultName,
         group: "nodes",
         selectable: false,
       },
     });
 
     schemaArray
-      .filter((schema) => schema.vault.name === vault.name)
+      .filter((schema) => {
+        VaultUtils.getName(schema.vault) === vaultName;
+      })
       .forEach((schema) => {
-        const SCHEMA_ID = `${vault.name}_${schema.fname}`;
+        const SCHEMA_ID = `${vaultName}_${schema.fname}`;
 
         // Base schema node
         nodes.push({
@@ -121,7 +125,7 @@ const getSchemaGraphElements = (
 
         // Children schemas
         Object.values(schema.schemas).forEach((subschema) => {
-          const SUBSCHEMA_ID = `${vault.name}_${subschema.id}`;
+          const SUBSCHEMA_ID = `${vaultName}_${subschema.id}`;
 
           // Subschema node
           nodes.push({

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -1,0 +1,163 @@
+import {
+  NotePropsDict,
+  NoteUtils,
+  SchemaModuleDict,
+} from "@dendronhq/common-all";
+import { engineSlice } from "@dendronhq/common-frontend";
+import { EdgeDefinition, NodeDefinition } from "cytoscape";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { GraphEdges, GraphElements, GraphNodes } from "../lib/graph";
+
+const getNoteGraphElements = (
+  notes: NotePropsDict,
+  wsRoot: string
+): GraphElements => {
+  // ADD NODES
+  const nodes = Object.values(notes).map((note) => ({
+    data: { id: note.id, label: note.title, group: "nodes" },
+  }));
+
+  // ADD EDGES
+  const edges: GraphEdges = {
+    hierarchy: [],
+    links: [],
+  };
+
+  Object.values(notes).forEach((note) => {
+    edges.hierarchy.push(
+      ...note.children.map((child) => ({
+        data: {
+          group: "edges",
+          id: `${notes.id}_${child}`,
+          source: note.id,
+          target: child,
+        },
+        classes: "hierarchy",
+      }))
+    );
+
+    const linkConnections: EdgeDefinition[] = [];
+
+    // Find and add linked notes
+    note.links.forEach((link) => {
+      if (link.to && note.id) {
+        const to = NoteUtils.getNoteByFnameV5({
+          fname: link.to!.fname as string,
+          vault: note.vault,
+          notes: notes,
+          wsRoot,
+        });
+
+        if (!to) return;
+        linkConnections.push({
+          data: {
+            group: "edges",
+            id: `${note.id}_${to.id}`,
+            source: note.id,
+            target: to.id,
+          },
+          classes: "links",
+        });
+      }
+    });
+
+    edges.links.push(...linkConnections);
+  });
+
+  return {
+    nodes,
+    edges,
+  };
+};
+
+const getSchemaGraphElements = (schemas: SchemaModuleDict): GraphElements => {
+  const schemaArray = Object.values(schemas);
+
+  const ROOT_NODE: NodeDefinition = {
+    data: { id: "graph_root", label: "Schemas", group: "nodes" },
+    selectable: false,
+  };
+  const nodes: any[] = [ROOT_NODE];
+  const edges: GraphEdges = {
+    hierarchy: [],
+  };
+
+  schemaArray.forEach((schema) => {
+    const SCHEMA_ID = `${schema.vault.name}_${schema.fname}`;
+
+    // Base schema node
+    nodes.push({
+      data: { id: SCHEMA_ID, label: schema.fname, group: "nodes" },
+    });
+
+    // Schema node -> root connection
+    edges.hierarchy.push({
+      data: {
+        group: "edges",
+        id: `${ROOT_NODE.data.id}_${SCHEMA_ID}`,
+        source: ROOT_NODE.data.id as string,
+        target: SCHEMA_ID,
+      },
+      classes: "hierarchy",
+    });
+
+    // Children schemas
+    Object.values(schema.schemas).forEach((subschema) => {
+      const SUBSCHEMA_ID = `${schema.vault.name}_${subschema.id}`;
+
+      // Subschema node
+      nodes.push({
+        data: { id: SUBSCHEMA_ID, label: subschema.title, group: "nodes" },
+      });
+
+      // Schema -> subschema connection
+      edges.hierarchy.push({
+        data: {
+          group: "edges",
+          id: `${SCHEMA_ID}_${SUBSCHEMA_ID}`,
+          source: SCHEMA_ID,
+          target: SUBSCHEMA_ID,
+        },
+        classes: "hierarchy",
+      });
+    });
+  });
+
+  return {
+    nodes,
+    edges,
+  };
+};
+
+const useGraphElements = ({
+  type,
+  engine,
+}: {
+  type: "note" | "schema";
+  engine: engineSlice.EngineState;
+}) => {
+  const router = useRouter();
+  const [elements, setElements] = useState<GraphElements>({
+    nodes: [],
+    edges: {},
+  });
+
+  useEffect(() => {
+    if (type === "note" && engine.notes) {
+      setElements(
+        getNoteGraphElements(engine.notes, router.query.ws as string)
+      );
+    }
+  }, [engine.notes]);
+
+  useEffect(() => {
+    if (type === "schema" && engine.schemas) {
+      setElements(getSchemaGraphElements(engine.schemas));
+    }
+  }, [engine.schemas]);
+
+  return elements;
+};
+
+export default useGraphElements;

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -98,46 +98,48 @@ const getSchemaGraphElements = (
       },
     });
 
-    schemaArray.forEach((schema) => {
-      const SCHEMA_ID = `${vault.name}_${schema.fname}`;
+    schemaArray
+      .filter((schema) => schema.vault.name === vault.name)
+      .forEach((schema) => {
+        const SCHEMA_ID = `${vault.name}_${schema.fname}`;
 
-      // Base schema node
-      nodes.push({
-        data: { id: SCHEMA_ID, label: schema.fname, group: "nodes" },
-      });
-
-      // Schema node -> root connection
-      edges.hierarchy.push({
-        data: {
-          group: "edges",
-          id: `${VAULT_ID}_${SCHEMA_ID}`,
-          source: VAULT_ID,
-          target: SCHEMA_ID,
-        },
-        classes: "hierarchy",
-      });
-
-      // Children schemas
-      Object.values(schema.schemas).forEach((subschema) => {
-        const SUBSCHEMA_ID = `${vault.name}_${subschema.id}`;
-
-        // Subschema node
+        // Base schema node
         nodes.push({
-          data: { id: SUBSCHEMA_ID, label: subschema.title, group: "nodes" },
+          data: { id: SCHEMA_ID, label: schema.fname, group: "nodes" },
         });
 
-        // Schema -> subschema connection
+        // Schema node -> root connection
         edges.hierarchy.push({
           data: {
             group: "edges",
-            id: `${SCHEMA_ID}_${SUBSCHEMA_ID}`,
-            source: SCHEMA_ID,
-            target: SUBSCHEMA_ID,
+            id: `${VAULT_ID}_${SCHEMA_ID}`,
+            source: VAULT_ID,
+            target: SCHEMA_ID,
           },
           classes: "hierarchy",
         });
+
+        // Children schemas
+        Object.values(schema.schemas).forEach((subschema) => {
+          const SUBSCHEMA_ID = `${vault.name}_${subschema.id}`;
+
+          // Subschema node
+          nodes.push({
+            data: { id: SUBSCHEMA_ID, label: subschema.title, group: "nodes" },
+          });
+
+          // Schema -> subschema connection
+          edges.hierarchy.push({
+            data: {
+              group: "edges",
+              id: `${SCHEMA_ID}_${SUBSCHEMA_ID}`,
+              source: SCHEMA_ID,
+              target: SUBSCHEMA_ID,
+            },
+            classes: "hierarchy",
+          });
+        });
       });
-    });
   });
 
   return {

--- a/packages/dendron-next-server/lib/graph.ts
+++ b/packages/dendron-next-server/lib/graph.ts
@@ -1,0 +1,88 @@
+import { EdgeDefinition, NodeDefinition } from "cytoscape";
+
+export type GraphNodes = NodeDefinition[]
+export type GraphEdges = {
+  [id: string]: EdgeDefinition[]
+}
+export type GraphElements = {
+  nodes: GraphNodes,
+  edges: GraphEdges
+}
+
+
+export type GraphConfigItem<T> = {
+  value: T;
+  mutable: boolean;
+  label?: string;
+};
+
+export type CoreGraphConfig = {
+  "connections.hierarchy"?: GraphConfigItem<boolean>;
+
+  "information.edges-hierarchy"?: GraphConfigItem<number>;
+  "information.nodes": GraphConfigItem<number>;
+  // "filter.regex": GraphConfigItem<string>;
+};
+
+export type NoteGraphConfig = {
+  "connections.links"?: GraphConfigItem<boolean>;
+  
+  "information.edges-links"?: GraphConfigItem<number>;
+};
+
+export type SchemaGraphConfig = {
+  "connections.schemas"?: GraphConfigItem<boolean>;
+
+  "information.edges"?: GraphConfigItem<number>;
+};
+
+export type GraphConfig = CoreGraphConfig & NoteGraphConfig & SchemaGraphConfig;
+
+const coreGraphConfig: CoreGraphConfig = {
+  // "filter.regex": {
+  //   value: "",
+  //   mutable: true,
+  // },
+  "connections.hierarchy": {
+    value: true,
+    mutable: true,
+  },
+
+  "information.edges-hierarchy": {
+    value: 0,
+    mutable: false,
+  },
+  "information.nodes": {
+    value: 0,
+    mutable: false,
+  },
+};
+
+const noteGraphConfig: NoteGraphConfig = {
+  "connections.links": {
+    value: false,
+    mutable: true,
+  },
+  "information.edges-links": {
+    value: 0,
+    mutable: false,
+  },
+};
+
+const schemaGraphConfig: SchemaGraphConfig = {
+  "information.edges": {
+    value: 0,
+    mutable: false,
+  },
+};
+
+export const graphConfig = {
+  note: {
+    ...noteGraphConfig,
+    ...coreGraphConfig
+  },
+  schema: {
+    ...schemaGraphConfig,
+    ...coreGraphConfig
+  },
+}

--- a/packages/dendron-next-server/lib/graph.ts
+++ b/packages/dendron-next-server/lib/graph.ts
@@ -32,8 +32,6 @@ export type NoteGraphConfig = {
 
 export type SchemaGraphConfig = {
   "connections.schemas"?: GraphConfigItem<boolean>;
-
-  "information.edges"?: GraphConfigItem<number>;
 };
 
 export type GraphConfig = CoreGraphConfig & NoteGraphConfig & SchemaGraphConfig;
@@ -70,10 +68,6 @@ const noteGraphConfig: NoteGraphConfig = {
 };
 
 const schemaGraphConfig: SchemaGraphConfig = {
-  "information.edges": {
-    value: 0,
-    mutable: false,
-  },
 };
 
 export const graphConfig = {

--- a/packages/dendron-next-server/pages/vscode/graph-note.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-note.tsx
@@ -10,14 +10,17 @@ import {
   DMessageSource,
   GraphViewMessage,
   GraphViewMessageType,
+  NoteUtils,
 } from "@dendronhq/common-all";
 import Graph from "../../components/graph";
+import { useRouter } from "next/router";
 
 export default function FullNoteGraph({
   engine,
 }: {
   engine: engineSlice.EngineState;
 }) {
+  const router = useRouter();
   const notes = engine ? engine.notes || {} : {};
 
   const logger = createLogger("Graph");
@@ -50,27 +53,27 @@ export default function FullNoteGraph({
         const linkConnections: EdgeDefinition[] = [];
 
         // Find and add linked notes
-        // note.links.forEach((link) => {
-        //   if (link.to && note.id) {
-        //     const to = NoteUtils.getNoteByFnameV5({
-        //       fname: link.to!.fname as string,
-        //       vault: note.vault,
-        //       notes: notes,
-        //       wsRoot: router.query.ws as string,
-        //     });
+        note.links.forEach((link) => {
+          if (link.to && note.id) {
+            const to = NoteUtils.getNoteByFnameV5({
+              fname: link.to!.fname as string,
+              vault: note.vault,
+              notes: notes,
+              wsRoot: router.query.ws as string,
+            });
 
-        //     if (!to) return;
-        //     linkConnections.push({
-        //       data: {
-        //         group: 'edges',
-        //         id: `${note.id}_${to.id}`,
-        //         source: note.id,
-        //         target: to.id,
-        //       },
-        //       classes: 'link'
-        //     });
-        //   }
-        // });
+            if (!to) return;
+            linkConnections.push({
+              data: {
+                group: "edges",
+                id: `${note.id}_${to.id}`,
+                source: note.id,
+                target: to.id,
+              },
+              classes: "link",
+            });
+          }
+        });
 
         return [...childConnections, ...linkConnections];
       })

--- a/packages/dendron-next-server/pages/vscode/graph-note.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-note.tsx
@@ -5,7 +5,14 @@ import {
 } from "@dendronhq/common-frontend";
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
-import { EdgeDefinition, ElementsDefinition, EventHandler } from "cytoscape";
+import cytoscape, {
+  EdgeDefinition,
+  ElementsDefinition,
+  EventHandler,
+  Core,
+  NodeDefinition,
+  EdgeDataDefinition,
+} from "cytoscape";
 import {
   DMessageSource,
   GraphViewMessage,
@@ -14,88 +21,55 @@ import {
 } from "@dendronhq/common-all";
 import Graph from "../../components/graph";
 import { useRouter } from "next/router";
+import {
+  graphConfig,
+  GraphConfig,
+  GraphEdges,
+  GraphNodes,
+} from "../../lib/graph";
+import GraphFilterView from "../../components/graph-filter-view";
+import useGraphElements from "../../hooks/useGraphElements";
 
 export default function FullNoteGraph({
   engine,
 }: {
   engine: engineSlice.EngineState;
 }) {
-  const router = useRouter();
-  const notes = engine ? engine.notes || {} : {};
+  const [config, setConfig] = useState<GraphConfig>(graphConfig.note);
+
+  const elements = useGraphElements({ type: "note", engine });
 
   const logger = createLogger("Graph");
-  logger.info({ ctx: "Graph", notes });
+  logger.log("graph elements:", elements);
 
-  const [elements, setElements] = useState<ElementsDefinition>();
-
-  // Process note notes and edges
+  // Update config
   useEffect(() => {
-    logger.log("Getting nodes...");
-    const nodes = Object.values(notes).map((note) => ({
-      data: { id: note.id, label: note.title, group: "nodes" },
-    }));
-
-    logger.log("Getting edges...");
-    const edges = Object.values(notes)
-      .map((note) => {
-        const childConnections: EdgeDefinition[] = note.children.map(
-          (child) => ({
-            data: {
-              group: "edges",
-              id: `${notes.id}_${child}`,
-              source: note.id,
-              target: child,
-            },
-            classes: "hierarchy",
-          })
-        );
-
-        const linkConnections: EdgeDefinition[] = [];
-
-        // Find and add linked notes
-        note.links.forEach((link) => {
-          if (link.to && note.id) {
-            const to = NoteUtils.getNoteByFnameV5({
-              fname: link.to!.fname as string,
-              vault: note.vault,
-              notes: notes,
-              wsRoot: router.query.ws as string,
-            });
-
-            if (!to) return;
-            linkConnections.push({
-              data: {
-                group: "edges",
-                id: `${note.id}_${to.id}`,
-                source: note.id,
-                target: to.id,
-              },
-              classes: "link",
-            });
-          }
-        });
-
-        return [...childConnections, ...linkConnections];
-      })
-      .flat();
-
-    setElements({ nodes, edges });
-  }, [notes]);
+    if (!_.isUndefined(elements)) {
+      setConfig((c) => ({
+        ...c,
+        "information.nodes": {
+          value: elements.nodes.length,
+          mutable: false,
+        },
+        "information.edges-hierarchy": {
+          value: elements.edges.hierarchy ? elements.edges.hierarchy.length : 0,
+          mutable: false,
+          label: "Hierarchical Edges",
+        },
+        "information.edges-links": {
+          value: elements.edges.links ? elements.edges.links.length : 0,
+          mutable: false,
+          label: "Linked Edges",
+        },
+      }));
+    }
+  }, [elements]);
 
   const onSelect: EventHandler = (e) => {
     const { id, source } = e.target[0]._private.data;
 
     const isNode = !source;
     if (!isNode) return;
-    // if (_.isUndefined(cy)) return;
-
-    // logger.log('Connected edges:', j.connectedEdges())
-
-    // cy.$('.open').removeClass('open');
-
-    // cy.getElementById(id).addClass('open');
-
-    logger.log(id, source);
 
     postVSCodeMessage({
       type: GraphViewMessageType.onSelect,
@@ -104,5 +78,12 @@ export default function FullNoteGraph({
     } as GraphViewMessage);
   };
 
-  return <Graph elements={elements} onSelect={onSelect} />;
+  return (
+    <Graph
+      elements={elements}
+      onSelect={onSelect}
+      config={config}
+      setConfig={setConfig}
+    />
+  );
 }

--- a/packages/dendron-next-server/pages/vscode/graph-schema.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-schema.tsx
@@ -3,72 +3,17 @@ import _ from "lodash";
 import React, { useEffect, useState } from "react";
 import { ElementsDefinition, EventHandler } from "cytoscape";
 import Graph from "../../components/graph";
+import useGraphElements from "../../hooks/useGraphElements";
+import { GraphConfig, graphConfig } from "../../lib/graph";
+import GraphFilterView from "../../components/graph-filter-view";
 
 export default function FullSchemaGraph({
   engine,
 }: {
   engine: engineSlice.EngineState;
 }) {
-  const schemas = engine ? engine.schemas || {} : {};
-
-  const logger = createLogger("Graph");
-
-  const [elements, setElements] = useState<ElementsDefinition>();
-
-  // Process schemas
-  useEffect(() => {
-    const schemaArray = Object.values(schemas);
-
-    const ROOT_NODE = {
-      data: { id: "graph_root", label: "Schemas", group: "nodes" },
-      selectable: false,
-    };
-    const nodes: any[] = [ROOT_NODE];
-    const edges: any[] = [];
-
-    schemaArray.forEach((schema) => {
-      const SCHEMA_ID = `${schema.vault.name}_${schema.fname}`;
-
-      // Base schema node
-      nodes.push({
-        data: { id: SCHEMA_ID, label: schema.fname, group: "nodes" },
-      });
-
-      // Schema node -> root connection
-      edges.push({
-        data: {
-          group: "edges",
-          id: `${ROOT_NODE.data.id}_${SCHEMA_ID}`,
-          source: ROOT_NODE.data.id,
-          target: SCHEMA_ID,
-        },
-        classes: "hierarchy",
-      });
-
-      // Children schemas
-      Object.values(schema.schemas).forEach((subschema) => {
-        const SUBSCHEMA_ID = `${schema.vault.name}_${subschema.id}`;
-
-        // Subschema node
-        nodes.push({
-          data: { id: SUBSCHEMA_ID, label: subschema.title, group: "nodes" },
-        });
-
-        // Schema -> subschema connection
-        edges.push({
-          data: {
-            group: "edges",
-            id: `${SCHEMA_ID}_${SUBSCHEMA_ID}`,
-            source: SCHEMA_ID,
-            target: SUBSCHEMA_ID,
-          },
-          classes: "hierarchy",
-        });
-      });
-    });
-
-    setElements({ nodes, edges });
-  }, [engine]);
+  const [config, setConfig] = useState<GraphConfig>(graphConfig.schema);
+  const elements = useGraphElements({ type: "schema", engine });
 
   const onSelect: EventHandler = (e) => {
     const { id, source } = e.target[0]._private.data;
@@ -84,5 +29,13 @@ export default function FullSchemaGraph({
     //   } as GraphViewMessage);
   };
 
-  return <Graph elements={elements} onSelect={onSelect} type="schema" />;
+  return (
+    <Graph
+      elements={elements}
+      onSelect={onSelect}
+      type="schema"
+      config={config}
+      setConfig={setConfig}
+    />
+  );
 }

--- a/packages/dendron-next-server/pages/vscode/graph-schema.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-schema.tsx
@@ -25,7 +25,7 @@ export default function FullSchemaGraph({
   const elements = useGraphElements({ type: "schema", engine });
 
   const onSelect: EventHandler = (e) => {
-    const { id, source } = e.target[0]._private.data;
+    const { id, source, vault } = e.target[0]._private.data;
 
     const idSections = id.split("_");
     const rootID = idSections[idSections.length - 1];
@@ -36,11 +36,19 @@ export default function FullSchemaGraph({
     const isNode = !source;
     if (!isNode) return;
 
-    postVSCodeMessage({
-      type: GraphViewMessageType.onSelect,
-      data: { id: fname },
-      source: DMessageSource.webClient,
-    } as GraphViewMessage);
+    if (vault) {
+      postVSCodeMessage({
+        type: GraphViewMessageType.onSelect,
+        data: { id: fname, vault },
+        source: DMessageSource.webClient,
+      } as GraphViewMessage);
+    } else {
+      postVSCodeMessage({
+        type: GraphViewMessageType.onSelect,
+        data: { id: fname },
+        source: DMessageSource.webClient,
+      } as GraphViewMessage);
+    }
   };
 
   // Update config

--- a/packages/dendron-next-server/pages/vscode/graph-schema.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-schema.tsx
@@ -30,12 +30,15 @@ export default function FullSchemaGraph({
     const idSections = id.split("_");
     const rootID = idSections[idSections.length - 1];
 
+    // Exists if the node is a subschema
+    const fname = e.target[0]._private.data.fname || rootID;
+
     const isNode = !source;
     if (!isNode) return;
 
     postVSCodeMessage({
       type: GraphViewMessageType.onSelect,
-      data: { id: rootID },
+      data: { id: fname },
       source: DMessageSource.webClient,
     } as GraphViewMessage);
   };

--- a/packages/dendron-next-server/styles/theme-antd.ts
+++ b/packages/dendron-next-server/styles/theme-antd.ts
@@ -19,6 +19,12 @@ export type Theme = {
       width: number;
       color: string;
     };
+    filterView: {
+      margin: string; // likely rem units
+      background: string;
+      minWidth: string;
+      borderRadius: number;
+    };
   };
 };
 
@@ -44,6 +50,11 @@ const baseTheme: RecursivePartial<Theme> = {
     edge: {
       width: 0.25,
     },
+    filterView: {
+      margin: "1rem",
+      minWidth: "12rem",
+      borderRadius: 4,
+    },
   },
 };
 
@@ -61,6 +72,9 @@ const darkTheme: RecursivePartial<Theme> = _.merge(_.cloneDeep(baseTheme), {
     edge: {
       color: "#807B7B",
     },
+    filterView: {
+      background: "#303030",
+    },
   },
 });
 
@@ -77,6 +91,9 @@ const lightTheme: RecursivePartial<Theme> = _.merge(_.cloneDeep(baseTheme), {
     },
     edge: {
       color: "#999393",
+    },
+    filterView: {
+      background: "#F5F6F8",
     },
   },
 });

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -3,13 +3,14 @@ import {
   DendronWebViewKey,
   GraphViewMessage,
   GraphViewMessageType,
+  DNodeUtils,
 } from "@dendronhq/common-all";
-import { ViewColumn, window } from "vscode";
+import { Uri, ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
-import { GotoNoteCommand } from "./GotoNote";
+import { VSCodeUtils } from "../utils";
 
 type CommandOpts = {};
 
@@ -62,11 +63,26 @@ export class ShowSchemaGraphCommand extends BasicCommand<
     panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
       switch (msg.type) {
         case GraphViewMessageType.onSelect: {
-          const schema = getEngine().schemas[msg.data.id];
-          await new GotoNoteCommand().execute({
-            qs: schema.fname,
-            vault: schema.vault,
-          });
+          const engine = getEngine();
+          const schema = engine.schemas[msg.data.id];
+
+          console.log(msg.data.id, engine.schemas);
+
+          if (schema) {
+            const fname = schema.fname;
+            const vault = schema.vault;
+
+            console.log(vault);
+
+            const path = DNodeUtils.getFullPath({
+              wsRoot: ws.rootWorkspace.uri.path,
+              vault,
+              basename: `${fname}.md`,
+            });
+
+            const uri = Uri.file(path);
+            await VSCodeUtils.openFileInEditor(uri);
+          }
           break;
         }
         // case GraphViewMessageType.onGetActiveEditor: {

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -8,7 +8,7 @@ import { Uri, ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
-import { getEngine, getWS } from "../workspace";
+import { getWS } from "../workspace";
 import { VSCodeUtils } from "../utils";
 import path from "path";
 

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -3,6 +3,7 @@ import {
   DendronWebViewKey,
   GraphViewMessage,
   GraphViewMessageType,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { Uri, ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
@@ -66,12 +67,23 @@ export class ShowSchemaGraphCommand extends BasicCommand<
           const engine = getWS().getEngine();
           const schema = engine.schemas[msg.data.id];
 
-          console.log(msg.data.id, schema);
-          console.log(ws._enginev2?.wsRoot);
-
           const wsRoot = ws._enginev2?.wsRoot;
 
-          if (schema && wsRoot) {
+          if (msg.data.vault && wsRoot) {
+            const vaults = engine.vaults.filter(
+              (v) => VaultUtils.getName(v) === msg.data.vault
+            );
+            if (_.isEmpty(vaults)) return;
+
+            const schemaPath = path.join(
+              wsRoot,
+              vaults[0].fsPath,
+              `root.schema.yml`
+            );
+            const uri = Uri.file(schemaPath);
+
+            await VSCodeUtils.openFileInEditor(uri);
+          } else if (schema && wsRoot) {
             const fname = schema.fname;
             // const vault = schema.vault;
 

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -3,7 +3,6 @@ import {
   DendronWebViewKey,
   GraphViewMessage,
   GraphViewMessageType,
-  DNodeUtils,
 } from "@dendronhq/common-all";
 import { Uri, ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
@@ -11,6 +10,7 @@ import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { VSCodeUtils } from "../utils";
+import path from "path";
 
 type CommandOpts = {};
 
@@ -70,17 +70,14 @@ export class ShowSchemaGraphCommand extends BasicCommand<
 
           if (schema) {
             const fname = schema.fname;
-            const vault = schema.vault;
+            // const vault = schema.vault;
 
-            console.log(vault);
+            const schemaPath = path.join(
+              ws.rootWorkspace.uri.fsPath,
+              `${fname}.schema.yml`
+            );
+            const uri = Uri.file(schemaPath);
 
-            const path = DNodeUtils.getFullPath({
-              wsRoot: ws.rootWorkspace.uri.path,
-              vault,
-              basename: `${fname}.md`,
-            });
-
-            const uri = Uri.file(path);
             await VSCodeUtils.openFileInEditor(uri);
           }
           break;

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -63,17 +63,21 @@ export class ShowSchemaGraphCommand extends BasicCommand<
     panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
       switch (msg.type) {
         case GraphViewMessageType.onSelect: {
-          const engine = getEngine();
+          const engine = getWS().getEngine();
           const schema = engine.schemas[msg.data.id];
 
-          console.log(msg.data.id, engine.schemas);
+          console.log(msg.data.id, schema);
+          console.log(ws._enginev2?.wsRoot);
 
-          if (schema) {
+          const wsRoot = ws._enginev2?.wsRoot;
+
+          if (schema && wsRoot) {
             const fname = schema.fname;
             // const vault = schema.vault;
 
             const schemaPath = path.join(
-              ws.rootWorkspace.uri.fsPath,
+              wsRoot,
+              schema.vault.fsPath,
               `${fname}.schema.yml`
             );
             const uri = Uri.file(schemaPath);

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -651,7 +651,6 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Show Schema Graph V2`,
     group: "workspace",
     desc: "Display the schemas in this workspace as a graph",
-    when: DendronContext.DEV_MODE,
   },
   SHOW_PREVIEW: {
     key: "dendron.showPreview",

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -43,6 +43,8 @@ export class WindowWatcher {
             return;
           }
           this.triggerUpdateDecorations();
+          this.triggerNoteGraphViewUpdate();
+          this.triggerSchemaGraphViewUpdate();
         }
       },
       null,
@@ -100,7 +102,7 @@ export class WindowWatcher {
     return;
   }
 
-  async triggerGraphViewUpdate() {
+  async triggerNoteGraphViewUpdate() {
     const noteGraphPanel = getWS().getWebView(DendronWebViewKey.NOTE_GRAPH);
     if (!_.isUndefined(noteGraphPanel)) {
       if (noteGraphPanel.visible) {
@@ -114,6 +116,31 @@ export class WindowWatcher {
         const note = VSCodeUtils.getNoteFromDocument(activeEditor.document);
 
         noteGraphPanel.webview.postMessage({
+          type: "onDidChangeActiveTextEditor",
+          data: {
+            note,
+            sync: true,
+          },
+          source: "vscode",
+        } as OnDidChangeActiveTextEditorMsg);
+      }
+    }
+    return;
+  }
+  async triggerSchemaGraphViewUpdate() {
+    const schemaGraphPanel = getWS().getWebView(DendronWebViewKey.SCHEMA_GRAPH);
+    if (!_.isUndefined(schemaGraphPanel)) {
+      if (schemaGraphPanel.visible) {
+        // TODO Logic here + test
+
+        const activeEditor = window.activeTextEditor;
+        if (!activeEditor) {
+          return;
+        }
+
+        const note = VSCodeUtils.getNoteFromDocument(activeEditor.document);
+
+        schemaGraphPanel.webview.postMessage({
           type: "onDidChangeActiveTextEditor",
           data: {
             note,


### PR DESCRIPTION
Changes made:
- Add Schema Graph V2 from dev mode
- When selecting schema node, open schema in VSCode
- Allow for note graph filtering based on hierarchy and linked note connections