### PR TITLE
fix: Adding Prettier to workspace recommendations

### DIFF
--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -88,5 +88,10 @@
         "[typescript]": {
             "editor.defaultFormatter": "esbenp.prettier-vscode"
         }
+    },
+    "extensions": {
+        "recommendations": [
+            "esbenp.prettier-vscode"
+        ]
     }
 }


### PR DESCRIPTION
Minor fix to add the Prettier extension code formatter to the workspace recommended extensions