### PR TITLE
fix: anchors now update when note is modified

### DIFF
--- a/packages/engine-server/src/markdown/remark/index.ts
+++ b/packages/engine-server/src/markdown/remark/index.ts
@@ -4,6 +4,7 @@ export * from "./noteRefs";
 export * from "./transformLinks";
 export {
   LinkUtils,
+  AnchorUtils,
   RemarkUtils,
   mdastBuilder,
   select,

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -9,6 +9,7 @@ import {
 import { file2Note, string2Note } from "@dendronhq/common-server";
 import { HistoryService, LinkUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
+import { AnchorUtils } from "@dendronhq/engine-server";
 import path from "path";
 import * as vscode from "vscode";
 import { Logger } from "./logger";
@@ -91,6 +92,11 @@ export class VaultWatcher {
     note = NoteUtils.hydrate({ noteRaw: note, noteHydrated });
     const links = LinkUtils.findLinks({ note, engine: eclient });
     note.links = links;
+    const anchors = AnchorUtils.findAnchors(
+      { note, wsRoot: eclient.wsRoot },
+      { fname, engine: eclient }
+    );
+    note.anchors = await anchors;
     this.L.info({ ctx, fname, msg: "exit" });
     return await eclient.updateNote(note);
   }

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -92,11 +92,11 @@ export class VaultWatcher {
     note = NoteUtils.hydrate({ noteRaw: note, noteHydrated });
     const links = LinkUtils.findLinks({ note, engine: eclient });
     note.links = links;
-    const anchors = AnchorUtils.findAnchors(
+    const anchors = await AnchorUtils.findAnchors(
       { note, wsRoot: eclient.wsRoot },
       { fname, engine: eclient }
     );
-    note.anchors = await anchors;
+    note.anchors = anchors;
     this.L.info({ ctx, fname, msg: "exit" });
     return await eclient.updateNote(note);
   }


### PR DESCRIPTION
Should work for #817, as well as intermittent issues with GoToNote on anchors not working.