### PR TITLE
fix: Ensure `runEngineTestV5` always restores mocks

### DIFF
--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -309,12 +309,10 @@ export async function runEngineTestV5(
     }
     const results = (await func(testOpts)) || [];
     await runJestHarnessV2(results, expect);
-    sinon.restore();
     return { opts: testOpts, resp: undefined, wsRoot };
-  } catch (err) {
+  } finally {
     // restore sinon so other tests can keep running
     sinon.restore();
-    throw err;
   }
 }
 


### PR DESCRIPTION
Fixes the issue with a failing test causing future tests to fail with sinon errors.