### PR TITLE
Fix/import pod error reporting

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/root.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/root.md
@@ -1,0 +1,12 @@
+---
+id: root
+title: root
+desc: ''
+updated: 1605266684036
+created: 1595961348801
+stub: false
+---
+
+This is the root for your Dendron vault.
+
+If you decide to publish your entire vault, it will be your landing page. You are free to customize any part of this page except the frontmatter at the top, between the `---`. 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/root.schema.yml
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/root.schema.yml
@@ -1,0 +1,14 @@
+-
+    id: root
+    title: root
+    desc: ""
+    type: schema
+    updated: 1594075339610
+    created: 1594075339610
+    body: ""
+    fname: root.schema
+    data: {}
+    stub: false
+    custom: {}
+    parent: root
+    children: []

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.1-navigation-basics.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.1-navigation-basics.md
@@ -1,0 +1,47 @@
+---
+id: vXh-HmSTsmgGA9j9IzcZh
+title: Navigation Basics
+desc: ''
+updated: 1624446320758
+created: 1624332288808
+---
+
+Let's do a brief overview on how to navigate the Dendron UI.
+
+_Quick note on running commands in VS Code:_
+
+>If you're unfamiliar with VS Code, the command palette is used to quickly run commands, including the commands for Dendron. To bring up the command palette, use `Ctrl+Shift+P` (windows/linux) or `Cmd+Shift+P` (mac) and start typing the command. Throughout the tutorial, if you see instructions telling you to run a command, remember to bring up the command palette and then type the command name to run it.
+
+![Basic UI](/assets/images/layout.png)
+[[todo]] Re-take Screen Shot; Make Elements Bigger; Clean up the view; add 1/2/3/4/5 labels on the screen shot
+
+#### 1. Editor Pane
+
+This is where you can write and edit your notes. Notes in Dendron are Markdown files.
+
+#### 2. Preview Pane
+
+This shows the rendered Markdown of what your currently opened note looks like. If you close this pane, you can always bring it back by bringing up the command pallete (`Ctrl+Shift+P / Cmd+Shift+P`) and running the `Dendron: Show Preview` command. You can assign a [keybinding shortcut](https://code.visualstudio.com/docs/getstarted/keybindings) to this command in VS Code (or any other command for that matter).
+
+The preview pane is currently read-only and cannot be used to edit notes. All editing must be done in the editor pane.
+
+#### 3. Dendron Workspace
+
+Dendron stores your markdown notes in a flat folder on your filesystem called a vault, which you can see on the left. You can view the note markdown files as they exist in your vault here. This is the workspace view that is built into VS Code.
+
+#### 4. Tree View
+
+This shows a tree view of your notes, similar to how a folder hierarchy would look in your filesystem. You can also click in the tree view to navigate around your notes.
+
+[[todo]] - update screen shot to Treeview V2?
+
+#### 5. Backlinks
+
+This shows a list of other notes that have links to the current note. More on links in Section 3 of the tutorial.
+
+VS Code lets you reposition any of these windows as you'd like, so feel free to rearrange the windows into the view that works best for you!
+
+### Next Steps
+
+- You've completed navigation basics! You can go back to the [[tutorial]] page and check off the Navigation Basics checkbox to mark your progress.
+- Next is to learn about [[tutorial.2-taking-notes]]

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
@@ -1,0 +1,54 @@
+---
+id: DO_RXSlAbwNwbz-ILKoQa
+title: Taking Notes
+desc: ''
+updated: 1624445853580
+created: 1624333266168
+---
+
+_You can also find this guide on our [wiki](https://wiki.dendron.so/notes/784b8d5e-58eb-4e3e-98b0-8ed1690abc74.html)._
+
+### Create a Note
+
+To create a note, use `Ctrl+L` or `Cmd+L` to bring up Dendron's lookup. This is a shortcut for the `Dendron: Lookup` command.
+
+While we call it the Lookup Bar, you can also use it to create notes that don't exist. When you do a lookup on a note that hasn't been created, Dendron will create it for you.
+
+> 🌱 Try it yourself - bring up the lookup bar with Ctrl+L. Type recipes and hit Enter.
+
+This should have created a note named `recipes.md`. Notes in Dendron are just plaintext markdown. They live in your file system and are portable across any platform.
+
+The --- section at the top of each note is frontmatter. Frontmatter are custom attributes at the top of each markdown file. Dendron uses it to store metadata about each note and is used for features like publishing. Don't modify the id attribute on the front matter [[todo]] - is that accurate?
+
+### Creating a hierarchy
+
+Dendron uses flexible hierarchies to help you organize your notes. It's how people are able to manage tens of thousands of notes inside Dendron.
+
+> 🌱 To create a hierarchy, bring up lookup again. Type `recipes.vegetarian`, and then press enter.
+
+You have now created your first hierarchy. Unlike folders in your file system, hierarchies in Dendron are specified with a `.` delimiter in the file name. Take a look at the tree view in the side panel to see that the `world` note exists under the `recipes` hierarchy. You can also see in the Workspace panel that the note file is stored as `recipes.vegetarian.md`.
+
+You can create a hierarchy at any level:
+
+> 🌱 Type the following into lookup and hit enter: `lets.go.deep`
+
+You'll notice in the tree view that there is now a `+` sign next to `lets` and `go`. The plus sign indicates that this note is a stub. A stub is a placeholder for a note that hasn't actually been created. Dendron uses stubs to avoid cluttering your file system with empty notes when creating hierarchies.
+
+
+_**NOTE**: Don't create children from `root`. This is not currently supported._
+
+### Finding Notes
+
+To find notes, we use the same lookup interface that we used to create them.
+
+> 🌱 Open Lookup, and type 'reve'. This will find your `recipes.vegetarian` note, hit `Enter` to open that note.
+
+The lookup uses fuzzy search which means you can type out partial results and still see the results. In practice, you'll only need to type a couple of characters to find any note stored inside Dendron. Searching with * wildcards is also supported.
+
+When combined with hierarchies, this fast lookup system enables you to find your notes very quickly, even if you have thousands of notes.
+
+If you want to search for content within the notes, you can use VS Code's built-in search tools with `Ctrl+Shift+F` \ `Cmd+Shift+F`. You can also take advantage of the `.` delimited naming scheme for hierarchies in the include/exclude patterns of VS Code's search to find content in a sub-tree of your notes.
+
+### Next Steps
+
+- Learn about [[Links and Graphs|tutorial.3-links-and-graphs]]

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.3-links-and-graphs.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.3-links-and-graphs.md
@@ -1,0 +1,45 @@
+---
+id: hAB2tQHsi0CGuhxz5HkTI
+title: Links and Graphs
+desc: ''
+updated: 1624455055929
+created: 1624333278136
+---
+
+### Links
+
+Dendron supports links between your notes, which can help you organically link your thoughts and build up a powerful knowledge graph.
+
+> 🌱 To create a link, just start typing [[ and Dendron will show you a list of notes in your workspace that you can link to. Try it in the editor pane now.
+
+Example: [[tutorial]]
+
+#### Navigating links
+
+To navigate to the note in the link, you can just click on the link in the preview pane. In the editor pane, you can move the cursor into the link and hit `Ctrl+Enter`.
+
+You can switch back to the previous note by pressing `Ctrl+Tab`
+
+#### Backlinks
+
+Take a look at the backlinks panel on the bottom left section of your sidebar. The backlinks panel shows you all notes with links that point to the current note. This is useful for helping to establish context.
+
+#### Additional Link Features
+
+ - Create a note directly from a link - place your cursor inside this link `[[examples.note-doesn't-exist-yet]]`, hit `CTRL + ENTER`.
+ - Add an alias to a link to change how it shows in the preview. Example: [[My Alias|tutorial]]
+ - Relative Links - Link to a specific section of a page with a `#` suffix. Example: [[Additional Link Features|tutorial.3-links-and-graphs#additional-link-features]]
+ - Note References - Add a section from another note with its content inlined into the current note. [Docs Here](https://wiki.dendron.so/notes/f1af56bb-db27-47ae-8406-61a98de6c78c.html#note-reference)
+
+### Explore Your Knowledge Graph
+
+> 🌱 To get a visual representation of your notes, use the `Dendron: Show Note Graph` command.
+
+You can explore the hierarchical organization of your notes and how your knowledge is linked together. We're continually working to improve this feature so keep on the lookout for new capabilities in the graph view in the future!
+
+[[todo]] should we deprecate the old graph view yet?
+
+### Next Steps
+
+- Learn about [[Images and Diagrams|tutorial.4-images-and-diagrams]]
+[[]]

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.4-images-and-diagrams.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.4-images-and-diagrams.md
@@ -1,0 +1,78 @@
+---
+id: vAy0awBTwDaxKGHWUdSaP
+title: Images and Diagrams
+desc: ''
+updated: 1624452350303
+created: 1624352425213
+---
+After completing this section you'll know how to create rich content within your Markdown notes.
+
+### Images
+
+As you may have already noticed already in the tutorial pages, you can insert images into your notes. 
+
+> 🌱 The easiest way to do this is to first download the [Paste Image](https://marketplace.visualstudio.com/items?itemName=mushan.vscode-paste-image) extension. Once installed, copy the image onto your clipboard, and then use the `Paste Image` command into your editor pane.
+
+This will automatically create a link for you and copy the file contents into the `\assets\images\` directory in your workspace.
+
+You can take advantage of the rich ecosystem of extensions available to VS Code to enhance your note taking abilities within Dendron.
+
+You can also manually place an image in the assets folder and create the link using the Markdown format below.
+
+Sample Image Link: ![](assets\images\logo.png)
+
+[[todo]]- get smaller image
+
+### More Formatting Options
+
+Besides regular markdown formatting features, there are several expanded markdown formatting options that Dendron supports. Here are some examples:
+
+#### Math Equations
+
+Math typesetting can be written through [Katex](https://katex.org/)
+
+$$ f(x) = sin(x)$$
+
+$$
+\int_{-\infty}^\infty sin(x)
+$$
+
+#### Diagrams
+
+Various types of diagrams are supported with [mermaid](https://mermaid-js.github.io/mermaid/#/).
+
+
+Open the preview (`Dendron: Show Preview`) to see how these will get rendered.
+
+##### Flow Charts
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+```
+
+##### Sequence Diagrams
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>John: Hello John, how are you?
+    loop Healthcheck
+        John->>John: Fight against hypochondria
+    end
+    Note right of John: Rational thoughts <br/>prevail!
+    John-->>Alice: Great!
+    John->>Bob: How about you?
+    Bob-->>John: Jolly good!
+
+```
+
+### And More!
+
+As you can see, Markdown is a flexible and extensible format for supporting rich content in your notes. There are many other visualizations out there which you can explore.
+
+### Next Steps
+
+- [[Conclude the Tutorial|tutorial.5-conclusion]]

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.5-conclusion.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.5-conclusion.md
@@ -1,0 +1,25 @@
+---
+id: Jwq6452yNKOVw6WZhvQQd
+title: Conclusion
+desc: ''
+updated: 1624440901151
+created: 1624332987705
+---
+
+**Congratulations!** You've completed the Dendron Tutorial  🙌. You've taken the first small step on becoming a Dendrologist but you've just taken a giant leap to building your second brain!
+
+From here, you can start adding your notes to this workspace, or if you'd like to start fresh you can create a new workspace for your notes with the `Dendron: Initialize Workspace` Command.
+
+#### Join the community of Dendrologists
+
+Don't forget - join us on [Discord](https://discord.com/invite/AE3NRw9) to ask questions, suggest new features, or just to hang out.
+
+#### Explore the full potential of Dendron
+
+There is much more that Dendron offers. When you're ready, learn more about additional features that Dendron offers:
+
+- [ ] Import your existing notes from other sources like Obsidian, etc. with Pods
+- [ ] Publish your notes to a website with just a few clicks. Our [Dendron Wiki Site](https://wiki.dendron.so/) is created in this way!
+- [ ] Understand what vaults and workspaces are and how they work.
+
+[[todo]] complete the list of additional features; and organize it.

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.md
@@ -1,0 +1,34 @@
+---
+id: 01u0co3RYjOM1bjpc2qIU
+title: Tutorial
+desc: ''
+updated: 1624452370349
+created: 1624333847315
+---
+
+## Welcome to Dendron
+
+This guide will help you learn the basics of Dendron. You can also follow the Getting Started guides on our [website](https://wiki.dendron.so/notes/e86ac3ab-dbe1-47a1-bcd7-9df0d0490b40.html).
+
+If you close VS Code, you can always get back to this workspace by going to `File > Open Workspace` in VS Code's menu and then selecting your workspace file: [[todo]].
+
+The tutorial steps take about 10 minutes to complete. Let's get started!
+
+[[todo]] - measure for time accuracy
+
+#### Steps to get started with Dendron:
+
+- [x] Install Dendron
+- [x] Create your first workspace
+- [ ] Complete the Tutorial (Ctrl+Click on the links to go to each tutorial note)
+  - [ ] 1. [[tutorial.1-navigation-basics]]
+  - [ ] 2. [[tutorial.2-taking-notes]]
+  - [ ] 3. [[tutorial.3-links-and-graphs]]
+  - [ ] 4. [[Explore Advanced Features of Dendron|tutorial.5-conclusion]]
+
+<!-- - [[todo]] Fix the preview click navigation bugs -->
+
+#### Getting Help
+
+- If you get stuck, don't hesitate to reach out to our community of Dendrologists on [Discord](https://discord.com/invite/AE3NRw9) or tweet us on Twitter at [@dendronhq](https://twitter.com/dendronhq)
+

--- a/packages/plugin-core/assets/dendron-ws/vault/welcomeV2.html
+++ b/packages/plugin-core/assets/dendron-ws/vault/welcomeV2.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cat Coding</title>
+  </head>
+  <body>
+    <!-- <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" width="300" /> -->
+    <img
+      src="https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/logo-256.png"
+      alt="Dendron Logo"
+    />
+
+    <p>Click the following button to see the function in action</p>
+    <input type="button" id="btn" value="Initialize Workspace" />
+
+    <script>
+      var btn = document.getElementById("btn");
+      btn.addEventListener("click", function () {
+        console.log("webview - btn click callback");
+        const vscode = acquireVsCodeApi();
+
+        vscode.postMessage({
+          command: "initializeWorkspace",
+          text: "hello_world",
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -47,16 +47,26 @@ export class ImportPodCommand extends BaseCommand<
     const podChoice = inputs.podChoice;
     const podClass = podChoice.podClass;
     const podsDir = DendronWorkspace.instance().podsDir;
-    const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
-    if (!maybeConfig) {
-      const configPath = PodUtils.genConfigFile({ podsDir, podClass });
-      await VSCodeUtils.openFileInEditor(Uri.file(configPath));
-      window.showInformationMessage(
-        "Looks like this is your first time running this pod. Please fill out the configuration and then run this command again. "
-      );
+    try {
+      const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
+
+      if (!maybeConfig) {
+        const configPath = PodUtils.genConfigFile({ podsDir, podClass });
+        await VSCodeUtils.openFileInEditor(Uri.file(configPath));
+        window.showInformationMessage(
+          "Looks like this is your first time running this pod. Please fill out the configuration and then run this command again."
+        );
+        return;
+      }
+      return { podChoice, config: maybeConfig };
+    } catch (e) {
+      // The user's import configuration has YAML syntax errors:
+      if (e.name === "YAMLException")
+        window.showErrorMessage(
+          "The configuration is invalid YAML. Please fix and run this command again."
+        );
       return;
     }
-    return { podChoice, config: maybeConfig };
   }
 
   async execute(opts: CommandOpts) {
@@ -73,20 +83,29 @@ export class ImportPodCommand extends BaseCommand<
     if (vaultWatcher) {
       vaultWatcher.pause = true;
     }
-    await window.withProgress(
+    let importedNotes = await window.withProgress(
       {
         location: ProgressLocation.Notification,
-        title: "importing",
+        title: "importing notes",
         cancellable: false,
       },
       async () => {
-        await pod.execute({ config: opts.config, engine, wsRoot, vaults });
+        let {importedNotes, errors} = await pod.execute({ config: opts.config, engine, wsRoot, vaults });
+        if (errors && errors.length > 0) {
+          let errorMsg = `Error while importing ${errors.length} notes:\n`;
+          errors.forEach((e) => {
+            errorMsg += (e.path + "\n");
+          });
+          window.showErrorMessage(errorMsg);
+        }
+
+        return importedNotes;
       }
     );
     await new ReloadIndexCommand().execute();
     if (vaultWatcher) {
       vaultWatcher.pause = false;
     }
-    window.showInformationMessage(`done importing.`);
+    window.showInformationMessage(`${importedNotes.length} notes imported successfully.`);
   }
 }

--- a/packages/pods-core/src/basev3.ts
+++ b/packages/pods-core/src/basev3.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import { createLogger, DLogger, resolvePath } from "@dendronhq/common-server";
+import { Item } from "klaw";
 import _ from "lodash";
 import { URI } from "vscode-uri";
 import { PodKind } from "./types";
@@ -194,7 +195,7 @@ export abstract class ImportPod<T extends ImportPodConfig = ImportPodConfig> {
     const srcURL = URI.file(resolvePath(src, engine.wsRoot));
     return await this.plant({ ...opts, src: srcURL, vault });
   }
-  abstract plant(opts: ImportPodPlantOpts<T>): Promise<NoteProps[]>;
+  abstract plant(opts: ImportPodPlantOpts<T>): Promise<{importedNotes:NoteProps[], errors?:Item[]}>;
 }
 
 // === Export Pod

--- a/packages/pods-core/src/builtin/JSONPod.ts
+++ b/packages/pods-core/src/builtin/JSONPod.ts
@@ -34,7 +34,7 @@ export class JSONImportPod extends ImportPod {
     await Promise.all(
       _.map(notes, (n) => engine.writeNote(n, { newNode: true }))
     );
-    return notes;
+    return {importedNotes:notes};
   }
 
   async _entries2Notes(

--- a/packages/pods-core/src/builtin/SnapshotPod.ts
+++ b/packages/pods-core/src/builtin/SnapshotPod.ts
@@ -161,6 +161,6 @@ export class SnapshotImportPod extends ImportPod {
         });
       })
     );
-    return [];
+    return {importedNotes:[]};
   }
 }


### PR DESCRIPTION
Improving robustness / user experience in Import Pod:
- if the import configuration has invalid YAML, it shows a helpful error message to the info box.
- If any notes have issues with importation, then it won't block the rest of the import - other notes will get imported, and then an error message will show exactly which notes had issues. 