### PR TITLE
fix/import pod YML errors

### DIFF
--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -65,6 +65,9 @@ export class ImportPodCommand extends BaseCommand<
         window.showErrorMessage(
           "The configuration is invalid YAML. Please fix and run this command again."
         );
+      else {
+        throw e;
+      }
       return;
     }
   }
@@ -90,11 +93,16 @@ export class ImportPodCommand extends BaseCommand<
         cancellable: false,
       },
       async () => {
-        let {importedNotes, errors} = await pod.execute({ config: opts.config, engine, wsRoot, vaults });
+        let { importedNotes, errors } = await pod.execute({
+          config: opts.config,
+          engine,
+          wsRoot,
+          vaults,
+        });
         if (errors && errors.length > 0) {
           let errorMsg = `Error while importing ${errors.length} notes:\n`;
           errors.forEach((e) => {
-            errorMsg += (e.path + "\n");
+            errorMsg += e.path + "\n";
           });
           window.showErrorMessage(errorMsg);
         }
@@ -106,6 +114,8 @@ export class ImportPodCommand extends BaseCommand<
     if (vaultWatcher) {
       vaultWatcher.pause = false;
     }
-    window.showInformationMessage(`${importedNotes.length} notes imported successfully.`);
+    window.showInformationMessage(
+      `${importedNotes.length} notes imported successfully.`
+    );
   }
 }

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -47,16 +47,26 @@ export class ImportPodCommand extends BaseCommand<
     const podChoice = inputs.podChoice;
     const podClass = podChoice.podClass;
     const podsDir = DendronWorkspace.instance().podsDir;
-    const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
-    if (!maybeConfig) {
-      const configPath = PodUtils.genConfigFile({ podsDir, podClass });
-      await VSCodeUtils.openFileInEditor(Uri.file(configPath));
-      window.showInformationMessage(
-        "Looks like this is your first time running this pod. Please fill out the configuration and then run this command again. "
-      );
+    try {
+      const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
+
+      if (!maybeConfig) {
+        const configPath = PodUtils.genConfigFile({ podsDir, podClass });
+        await VSCodeUtils.openFileInEditor(Uri.file(configPath));
+        window.showInformationMessage(
+          "Looks like this is your first time running this pod. Please fill out the configuration and then run this command again."
+        );
+        return;
+      }
+      return { podChoice, config: maybeConfig };
+    } catch (e) {
+      // The user's import configuration has YAML syntax errors:
+      if (e.name === "YAMLException")
+        window.showErrorMessage(
+          "The configuration is invalid YAML. Please fix and run this command again."
+        );
       return;
     }
-    return { podChoice, config: maybeConfig };
   }
 
   async execute(opts: CommandOpts) {
@@ -73,20 +83,29 @@ export class ImportPodCommand extends BaseCommand<
     if (vaultWatcher) {
       vaultWatcher.pause = true;
     }
-    await window.withProgress(
+    let importedNotes = await window.withProgress(
       {
         location: ProgressLocation.Notification,
-        title: "importing",
+        title: "importing notes",
         cancellable: false,
       },
       async () => {
-        await pod.execute({ config: opts.config, engine, wsRoot, vaults });
+        let {importedNotes, errors} = await pod.execute({ config: opts.config, engine, wsRoot, vaults });
+        if (errors && errors.length > 0) {
+          let errorMsg = `Error while importing ${errors.length} notes:\n`;
+          errors.forEach((e) => {
+            errorMsg += (e.path + "\n");
+          });
+          window.showErrorMessage(errorMsg);
+        }
+
+        return importedNotes;
       }
     );
     await new ReloadIndexCommand().execute();
     if (vaultWatcher) {
       vaultWatcher.pause = false;
     }
-    window.showInformationMessage(`done importing.`);
+    window.showInformationMessage(`${importedNotes.length} notes imported successfully.`);
   }
 }

--- a/packages/pods-core/src/basev3.ts
+++ b/packages/pods-core/src/basev3.ts
@@ -9,6 +9,7 @@ import {
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import { createLogger, DLogger, resolvePath } from "@dendronhq/common-server";
+import { Item } from "klaw";
 import _ from "lodash";
 import { URI } from "vscode-uri";
 import { PodKind } from "./types";
@@ -194,7 +195,7 @@ export abstract class ImportPod<T extends ImportPodConfig = ImportPodConfig> {
     const srcURL = URI.file(resolvePath(src, engine.wsRoot));
     return await this.plant({ ...opts, src: srcURL, vault });
   }
-  abstract plant(opts: ImportPodPlantOpts<T>): Promise<NoteProps[]>;
+  abstract plant(opts: ImportPodPlantOpts<T>): Promise<{importedNotes:NoteProps[], errors?:Item[]}>;
 }
 
 // === Export Pod

--- a/packages/pods-core/src/builtin/JSONPod.ts
+++ b/packages/pods-core/src/builtin/JSONPod.ts
@@ -34,7 +34,7 @@ export class JSONImportPod extends ImportPod {
     await Promise.all(
       _.map(notes, (n) => engine.writeNote(n, { newNode: true }))
     );
-    return notes;
+    return {importedNotes:notes};
   }
 
   async _entries2Notes(

--- a/packages/pods-core/src/builtin/SnapshotPod.ts
+++ b/packages/pods-core/src/builtin/SnapshotPod.ts
@@ -161,6 +161,6 @@ export class SnapshotImportPod extends ImportPod {
         });
       })
     );
-    return [];
+    return {importedNotes:[]};
   }
 }


### PR DESCRIPTION
Improving robustness / user experience in Import Pod:

- If the import configuration has invalid YAML, it shows a helpful error message to the info box.
- If any notes have issues with importation, then it won't block the rest of the import - other notes will get imported, and then an error message will show exactly which notes had issues.