### PR TITLE
chore: including vscode-paste-image in extension pack

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -27,7 +27,7 @@
   "main": "./out/src/extension.js",
   "extensionPack": [
     "dendron.dendron-markdown-preview-enhanced",
-    "mushan.vscode-paste-image"
+    "dendron.dendron-paste-image"
   ],
   "contributes": {
     "languages": [

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -26,7 +26,8 @@
   ],
   "main": "./out/src/extension.js",
   "extensionPack": [
-    "dendron.dendron-markdown-preview-enhanced"
+    "dendron.dendron-markdown-preview-enhanced",
+    "mushan.vscode-paste-image"
   ],
   "contributes": {
     "languages": [


### PR DESCRIPTION
Making the paste-image extension a part of the Dendron extension pack so that it will automatically install with Dendron