### PR TITLE
fix: graphviz export directory error

### DIFF
--- a/packages/pods-core/src/builtin/GraphvizPod.ts
+++ b/packages/pods-core/src/builtin/GraphvizPod.ts
@@ -128,7 +128,11 @@ export class GraphvizExportPod extends ExportPod<GraphvizExportConfig> {
 
     // verify dest exist
     const podDstPath = dest.fsPath;
-    fs.ensureDirSync(path.dirname(podDstPath));
+    try {
+      fs.ensureDirSync(podDstPath);
+    } catch {
+      await fs.promises.mkdir(podDstPath, { recursive: true });
+    }
 
     const [connections] = notes.reduce<[string[], ParentDictionary]>(
       ([connections, dictionary], note) => {

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -51,4 +51,4 @@ dev:
     nextServerUrl: 'http://localhost:3000'
     engineServerPort: 3005
 initializeRemoteVaults: true
-dendronVersion: 0.46.3-alpha.0
+dendronVersion: 0.47.1


### PR DESCRIPTION
Fixes issue where GraphViz export pod throws an error if the specified export directory does not exist.