### PR TITLE
enhance: graph quality-of-life improvements, ability to prevent re-layout on config change

### DIFF
--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -21,8 +21,14 @@ type FilterProps = {
 };
 
 const GraphFilterView = ({ config, setConfig }: FilterProps) => {
-  const sections = new Set(Object.keys(config).map((key) => key.split(".")[0]));
   const configEntries = Object.entries(config);
+  const sortedSections = [
+    "vaults",
+    "connections",
+    "filter",
+    "options",
+    "information",
+  ];
 
   const { currentTheme } = useThemeSwitcher();
 
@@ -55,7 +61,7 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
       }}
     >
       <Collapse>
-        {Array.from(sections).map((section, i) => (
+        {sortedSections.map((section, i) => (
           <Panel header={_.capitalize(section)} key={i}>
             <Space direction="vertical" style={{ width: "100%" }}>
               {configEntries

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -10,6 +10,8 @@ import GraphFilterView from "./graph-filter-view";
 import { GraphConfig, GraphConfigItem, GraphElements } from "../lib/graph";
 import { VaultUtils } from "@dendronhq/common-all";
 import useApplyGraphConfig from "../hooks/useApplyGraphConfig";
+import { DendronProps } from "../lib/types";
+import useSyncGraphWithIDE from "../hooks/useSyncGraphWithIDE";
 
 const getCytoscapeStyle = (themes: any, theme: string | undefined) => {
   if (_.isUndefined(theme)) return "";
@@ -82,18 +84,24 @@ export default function Graph({
   config,
   setConfig,
   engine,
-}: {
+  ide,
+}: DendronProps & {
   elements: GraphElements;
   onSelect: EventHandler;
   config: GraphConfig;
   setConfig: React.Dispatch<React.SetStateAction<GraphConfig>>;
-  engine: engineSlice.EngineState;
   type?: "note" | "schema";
 }) {
   const logger = createLogger("Graph");
   const graphRef = useRef<HTMLDivElement>(null);
   const { themes, currentTheme } = useThemeSwitcher();
   const [cy, setCy] = useState<Core>();
+
+  useSyncGraphWithIDE({
+    graph: cy,
+    engine,
+    ide,
+  });
 
   // On config update, handle graph changes
   useApplyGraphConfig({

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -157,7 +157,7 @@ export default function Graph({
     // Otherwise, the graph re-renders when elements are selected
     if (cy && cy.elements("*").length > 1) return;
     renderGraph();
-  }, [graphRef, nodes, edges]);
+  }, [graphRef, elements]);
 
   useEffect(() => {
     // If initial vault data received

--- a/packages/dendron-next-server/hooks/useApplyGraphConfig.tsx
+++ b/packages/dendron-next-server/hooks/useApplyGraphConfig.tsx
@@ -18,7 +18,7 @@ const useApplyGraphConfig = ({
   const { nodes, edges } = elements;
   const isLargeGraph = nodes.length + Object.values(edges).flat().length > 1000;
 
-  const applyDisplayConfig = () => {
+  const applyDisplayConfig = (allowRelayout: boolean) => {
     if (!graph || graph.$("*").length === 0) return;
 
     Object.entries(config)
@@ -35,7 +35,7 @@ const useApplyGraphConfig = ({
           // If these edges aren't rendered, add them
           if (edgeCount === 0) {
             graph.add(edges[edgeType]);
-            layoutGraph();
+            if (allowRelayout) layoutGraph();
           }
         }
 
@@ -44,12 +44,12 @@ const useApplyGraphConfig = ({
           // If these edges are rendered, remove them
           if (edgeCount > 0) {
             includedEdges.remove();
-            layoutGraph();
+            if (allowRelayout) layoutGraph();
           }
         }
       });
   };
-  const applyVaultConfig = () => {
+  const applyVaultConfig = (allowRelayout: boolean) => {
     if (!graph || graph.$("*").length === 0) return;
 
     Object.entries(config)
@@ -64,17 +64,17 @@ const useApplyGraphConfig = ({
         // If elements should be included
         if (v?.value && includedElements.hasClass("hidden--vault")) {
           includedElements.removeClass("hidden--vault");
-          layoutGraph();
+          if (allowRelayout) layoutGraph();
         }
 
         // If elements should not be included
         else if (!v?.value && !includedElements.hasClass("hidden--vault")) {
           includedElements.addClass("hidden--vault");
-          layoutGraph();
+          if (allowRelayout) layoutGraph();
         }
       });
   };
-  const applyFilterRegexConfig = () => {
+  const applyFilterRegexConfig = (allowRelayout: boolean) => {
     if (!graph || graph.$("*").length === 0) return;
 
     const regexTypes: ("whitelist" | "blacklist")[] = [
@@ -150,10 +150,10 @@ const useApplyGraphConfig = ({
         if (type === "blacklist") showElement(element);
       });
 
-      if (updatedConfig) layoutGraph();
+      if (updatedConfig && allowRelayout) layoutGraph();
     });
   };
-  const applyFilterStubsConfig = () => {
+  const applyFilterStubsConfig = (allowRelayout: boolean) => {
     if (!graph || graph.$("*").length === 0) return;
     if (_.isUndefined(config["filter.show-stubs"])) return;
 
@@ -165,12 +165,12 @@ const useApplyGraphConfig = ({
     if (configItem.value) {
       if (stubElements.hasClass(".hidden--stub")) {
         stubElements.removeClass("hidden--stub");
-        layoutGraph();
+        if (allowRelayout) layoutGraph();
       }
     } else {
       if (!stubElements.hasClass(".hidden--stub")) {
         stubElements.addClass("hidden--stub");
-        layoutGraph();
+        if (allowRelayout) layoutGraph();
       }
     }
   };
@@ -178,10 +178,12 @@ const useApplyGraphConfig = ({
   const applyConfig = () => {
     if (!graph || graph.$("*").length === 0) return;
 
-    applyDisplayConfig();
-    applyVaultConfig();
-    applyFilterRegexConfig();
-    applyFilterStubsConfig();
+    const allowRelayout = config["options.allow-relayout"].value;
+
+    applyDisplayConfig(allowRelayout);
+    applyVaultConfig(allowRelayout);
+    applyFilterRegexConfig(allowRelayout);
+    applyFilterStubsConfig(allowRelayout);
   };
 
   const layoutGraph = () => {

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -246,8 +246,16 @@ const useGraphElements = ({
     edges: {},
   });
 
+  const [noteCount, setNoteCount] = useState(0);
+  const [schemaCount, setSchemaCount] = useState(0);
+
   useEffect(() => {
     if (type === "note" && engine.notes) {
+      // Prevent unnecessary parsing if no notes have been added/deleted
+      const newNoteCount = Object.keys(engine.notes).length;
+      if (noteCount === newNoteCount) return;
+      setNoteCount(newNoteCount);
+
       setElements(
         getNoteGraphElements(
           engine.notes,
@@ -260,6 +268,11 @@ const useGraphElements = ({
 
   useEffect(() => {
     if (type === "schema" && engine.schemas) {
+      // Prevent unnecessary parsing if no schemas have been added/deleted
+      const newSchemaCount = Object.keys(engine.schemas).length;
+      if (schemaCount === newSchemaCount) return;
+      setSchemaCount(newSchemaCount);
+
       setElements(getSchemaGraphElements(engine.schemas, engine.vaults));
     }
   }, [engine.schemas]);

--- a/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
@@ -17,13 +17,12 @@ const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
   useEffect(() => {
     if (noteActive && engineInitialized && graph) {
       const selected = graph.$(`[id = "${noteActive.id}"], :selected`);
-      // const selected = graph.$('')
 
       logger.log("selected but not active:", selected.length);
 
-      // Unselect not active notes
       if (selected.length > 0) {
         selected.forEach((node) => {
+          // Select active note
           if (node.data("id") === noteActive.id) {
             node.select();
             graph.center(node);
@@ -31,12 +30,12 @@ const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
               level: 1.5, // the zoom level
               renderedPosition: node.position(),
             });
-          } else node.unselect();
+          }
+
+          // Unselect not active notes
+          else node.unselect();
         });
       }
-
-      // Select new active note
-      // if (activeNode.length > 0) activeNode.select()
     }
   }, [noteActive?.id, engineInitialized]);
 };

--- a/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
@@ -1,0 +1,44 @@
+import cytoscape from "cytoscape";
+import { useEffect } from "react";
+import { createLogger } from "../../common-frontend/lib";
+import { EngineSliceUtils } from "../../common-frontend/lib/features/engine/slice";
+import { DendronProps } from "../lib/types";
+
+type Props = DendronProps & {
+  graph: cytoscape.Core | undefined;
+};
+
+const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
+  const { noteActive } = ide;
+  const engineInitialized = EngineSliceUtils.hasInitialized(engine);
+
+  const logger = createLogger("useSyncGraphWithIDE");
+
+  useEffect(() => {
+    if (noteActive && engineInitialized && graph) {
+      const selected = graph.$(`[id = "${noteActive.id}"], :selected`);
+      // const selected = graph.$('')
+
+      logger.log("selected but not active:", selected.length);
+
+      // Unselect not active notes
+      if (selected.length > 0) {
+        selected.forEach((node) => {
+          if (node.data("id") === noteActive.id) {
+            node.select();
+            graph.center(node);
+            graph.zoom({
+              level: 1.5, // the zoom level
+              renderedPosition: node.position(),
+            });
+          } else node.unselect();
+        });
+      }
+
+      // Select new active note
+      // if (activeNode.length > 0) activeNode.select()
+    }
+  }, [noteActive?.id, engineInitialized]);
+};
+
+export default useSyncGraphWithIDE;

--- a/packages/dendron-next-server/lib/graph.ts
+++ b/packages/dendron-next-server/lib/graph.ts
@@ -25,6 +25,8 @@ export type CoreGraphConfig = {
 
   "filter.regex-whitelist": GraphConfigItem<string>;
   "filter.regex-blacklist": GraphConfigItem<string>;
+
+  "options.allow-relayout": GraphConfigItem<boolean>;
 };
 
 export type NoteGraphConfig = {
@@ -66,6 +68,10 @@ const coreGraphConfig: CoreGraphConfig = {
   "information.nodes": {
     value: 0,
     mutable: false,
+  },
+  "options.allow-relayout": {
+    value: true,
+    mutable: true,
   },
 };
 

--- a/packages/dendron-next-server/pages/vscode/graph-note.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-note.tsx
@@ -14,12 +14,9 @@ import {
 import Graph from "../../components/graph";
 import { graphConfig, GraphConfig } from "../../lib/graph";
 import useGraphElements from "../../hooks/useGraphElements";
+import { DendronProps } from "../../lib/types";
 
-export default function FullNoteGraph({
-  engine,
-}: {
-  engine: engineSlice.EngineState;
-}) {
+export default function FullNoteGraph({ engine, ide }: DendronProps) {
   const [config, setConfig] = useState<GraphConfig>(graphConfig.note);
 
   const elements = useGraphElements({ type: "note", engine });
@@ -70,6 +67,7 @@ export default function FullNoteGraph({
       config={config}
       setConfig={setConfig}
       engine={engine}
+      ide={ide}
     />
   );
 }

--- a/packages/dendron-next-server/pages/vscode/graph-schema.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-schema.tsx
@@ -10,12 +10,9 @@ import {
   GraphViewMessage,
   GraphViewMessageType,
 } from "@dendronhq/common-all";
+import { DendronProps } from "../../lib/types";
 
-export default function FullSchemaGraph({
-  engine,
-}: {
-  engine: engineSlice.EngineState;
-}) {
+export default function FullSchemaGraph({ engine, ide }: DendronProps) {
   const [config, setConfig] = useState<GraphConfig>(graphConfig.schema);
   const elements = useGraphElements({ type: "schema", engine });
 
@@ -72,6 +69,7 @@ export default function FullSchemaGraph({
       config={config}
       setConfig={setConfig}
       engine={engine}
+      ide={ide}
     />
   );
 }


### PR DESCRIPTION
Changes/additions made:
- No extra re-render/pan when switching VSCode windows
- On note open, select node in graph and focus in on it
- Add config option to prevent the graph from re-laying out when adjusting config
- Sensible and specified config option order