### PR TITLE
fix: load config defaults

### DIFF
--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -132,7 +132,6 @@ function CalendarView({ engine, ide }: DendronProps) {
     (date) => {
       logger.info({ ctx: "onSelect", date });
       const dateKey = getDateKey(date);
-      debugger;
       const selectedNote = _.first(groupedDailyNotes[dateKey]);
 
       postVSCodeMessage({

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -99,7 +99,11 @@ export class DendronEngineV2 implements DEngine {
   static create({ wsRoot, logger }: { logger?: DLogger; wsRoot: string }) {
     const LOGGER = logger || createLogger();
     const cpath = DConfig.configPath(wsRoot);
-    const config = readYAML(cpath) as DendronConfig;
+    const config = _.defaultsDeep(
+      readYAML(cpath) as DendronConfig,
+      DConfig.genDefaultConfig()
+    );
+
     return new DendronEngineV2({
       wsRoot,
       vaults: config.vaults,
@@ -317,7 +321,11 @@ export class DendronEngineV2 implements DEngine {
 
   async getConfig() {
     const cpath = DConfig.configPath(this.configRoot);
-    const config = readYAML(cpath) as DendronConfig;
+    const config = _.defaultsDeep(
+      readYAML(cpath) as DendronConfig,
+      DConfig.genDefaultConfig()
+    );
+
     return {
       error: null,
       data: config,


### PR DESCRIPTION
When creating an engine (workspace/sync) or accessing configs (config/get) of the engine the defaults defined in `packages/engine-server/src/config.ts` will be merged/used.