### PR TITLE
fix: stub filter errors

### DIFF
--- a/packages/dendron-next-server/hooks/useApplyGraphConfig.tsx
+++ b/packages/dendron-next-server/hooks/useApplyGraphConfig.tsx
@@ -163,12 +163,12 @@ const useApplyGraphConfig = ({
 
     // If should show stubs
     if (configItem.value) {
-      if (stubElements.hasClass(".hidden--stub")) {
+      if (stubElements.hasClass("hidden--stub")) {
         stubElements.removeClass("hidden--stub");
         if (allowRelayout) layoutGraph();
       }
     } else {
-      if (!stubElements.hasClass(".hidden--stub")) {
+      if (!stubElements.hasClass("hidden--stub")) {
         stubElements.addClass("hidden--stub");
         if (allowRelayout) layoutGraph();
       }

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -48,17 +48,26 @@ const getNoteGraphElements = (
     const noteVaultClass = getVaultClass(note.vault);
 
     edges.hierarchy.push(
-      ...note.children.map((child) => ({
-        data: {
-          group: "edges",
-          id: `${note.id}_${child}`,
-          source: note.id,
-          target: child,
-          fname: note.fname,
-          stub: _.isUndefined(note.stub) ? false : note.stub,
-        },
-        classes: `hierarchy ${noteVaultClass}`,
-      }))
+      ...note.children.map((child) => {
+        const childNote = notes[child];
+        const isStub = childNote
+          ? _.isUndefined(note.stub) && _.isUndefined(childNote.stub)
+            ? false
+            : note.stub || childNote.stub
+          : false;
+
+        return {
+          data: {
+            group: "edges",
+            id: `${note.id}_${child}`,
+            source: note.id,
+            target: child,
+            fname: note.fname,
+            stub: isStub,
+          },
+          classes: `hierarchy ${noteVaultClass}`,
+        };
+      })
     );
 
     const linkConnections: EdgeDefinition[] = [];
@@ -107,6 +116,14 @@ const getNoteGraphElements = (
           return;
         }
 
+        logger.log(
+          `Link from ${note.fname} to ${to.fname}: ${
+            _.isUndefined(note.stub) && _.isUndefined(to.stub)
+              ? false
+              : note.stub || to.stub
+          }`
+        );
+
         linkConnections.push({
           data: {
             group: "edges",
@@ -117,9 +134,7 @@ const getNoteGraphElements = (
             stub:
               _.isUndefined(note.stub) && _.isUndefined(to.stub)
                 ? false
-                : note.stub || to.stub
-                ? true
-                : false,
+                : note.stub || to.stub,
           },
           classes: `links ${noteVaultClass}`,
         });


### PR DESCRIPTION
Fixes:
- Issue where stub nodes would not reappear after being hidden
- Issue where edges connected to stub nodes would sometimes not reappear when stub visibility is re-enabled