### PR TITLE
feat: add local note graph

### DIFF
--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -1,4 +1,8 @@
-import { DendronTreeViewKey, NoteProps } from "@dendronhq/common-all";
+import {
+  DendronTreeViewKey,
+  DendronWebViewKey,
+  NoteProps,
+} from "@dendronhq/common-all";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 type Theme = "light" | "dark" | "unknown";
@@ -7,7 +11,7 @@ type InitialState = {
   noteActive: NoteProps | undefined;
   theme: Theme;
   views: {
-    [key in DendronTreeViewKey]: {
+    [key in DendronTreeViewKey | DendronWebViewKey]: {
       ready: boolean;
     };
   };

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import { useReducer } from "react";
 import { useState } from "react";
 import { useThemeSwitcher } from "react-css-theme-switcher";
+import { createLogger } from "../../common-frontend/lib";
 import { GraphConfig, GraphConfigItem } from "../lib/graph";
 import AntThemes from "../styles/theme-antd";
 const { Panel } = Collapse;
@@ -24,7 +25,6 @@ type FilterProps = {
 };
 
 const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
-  const configEntries = Object.entries(config);
   const sortedSections = [
     "vaults",
     "connections",
@@ -66,69 +66,41 @@ const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
       }}
     >
       <Collapse>
-        {sortedSections.map((section, i) => (
-          <Panel header={_.capitalize(section)} key={i}>
-            <Space direction="vertical" style={{ width: "100%" }}>
-              {configEntries
-                .filter(([key]) => key.includes(section))
-                .map(([key, entry]) => {
-                  const keyArray = key.split(".");
-                  const label =
-                    entry?.label ||
-                    `${keyArray[keyArray.length - 1]
-                      .split("-")
-                      .map((k) => _.capitalize(k))
-                      .join(" ")}`;
-
-                  return (
-                    <Space
-                      direction="horizontal"
-                      style={{ justifyContent: "space-between", width: "100%" }}
-                      key={key}
-                    >
-                      {_.isBoolean(entry?.value) && (
-                        <>
-                          <Typography>{label}</Typography>
-                          <Switch
-                            checked={entry?.value}
-                            onChange={(newValue) =>
-                              updateConfigField(key, newValue)
-                            }
-                            disabled={!entry?.mutable}
-                          />
-                        </>
-                      )}
-                      {_.isNumber(entry?.value) && (
-                        <>
-                          <Typography>{label}</Typography>
-                          <InputNumber
-                            defaultValue={entry?.value}
-                            onChange={(newValue) =>
-                              updateConfigField(key, newValue)
-                            }
-                            disabled={!entry?.mutable}
-                          />
-                        </>
-                      )}
-                      {_.isString(entry?.value) &&
-                        !_.isUndefined(entry) &&
-                        !_.isUndefined(key) && (
-                          <>
-                            <FilterViewStringInput
-                              fieldKey={key}
-                              label={label}
-                              entry={entry as GraphConfigItem<string>}
-                              updateConfigField={updateConfigField}
-                              nodeCount={config["information.nodes"].value}
-                            />
-                          </>
-                        )}
-                    </Space>
-                  );
-                })}
-            </Space>
-          </Panel>
-        ))}
+        <Panel header="Vaults" key="vaults">
+          <FilterViewSection
+            section="vaults"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Connections" key="connections">
+          <FilterViewSection
+            section="connections"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Filter" key="filter">
+          <FilterViewSection
+            section="filter"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Options" key="options">
+          <FilterViewSection
+            section="options"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Information" key="information">
+          <FilterViewSection
+            section="information"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
       </Collapse>
     </div>
   );
@@ -185,6 +157,74 @@ const FilterViewStringInput = ({
           maxWidth: 200,
         }}
       />
+    </Space>
+  );
+};
+
+const FilterViewSection = ({
+  section,
+  config,
+  updateConfigField,
+}: {
+  section: string;
+  config: GraphConfig;
+  updateConfigField: (key: string, value: string | number | boolean) => void;
+}) => {
+  return (
+    <Space direction="vertical" style={{ width: "100%" }}>
+      {Object.entries(config)
+        .filter(([key]) => key.includes(section))
+        .map(([key, entry]) => {
+          const keyArray = key.split(".");
+          const label =
+            entry?.label ||
+            `${keyArray[keyArray.length - 1]
+              .split("-")
+              .map((k) => _.capitalize(k))
+              .join(" ")}`;
+
+          return (
+            <Space
+              direction="horizontal"
+              style={{ justifyContent: "space-between", width: "100%" }}
+              key={key}
+            >
+              {_.isBoolean(entry?.value) && (
+                <>
+                  <Typography>{label}</Typography>
+                  <Switch
+                    checked={entry?.value}
+                    onChange={(newValue) => updateConfigField(key, newValue)}
+                    disabled={!entry?.mutable}
+                  />
+                </>
+              )}
+              {_.isNumber(entry?.value) && (
+                <>
+                  <Typography>{label}</Typography>
+                  <InputNumber
+                    value={entry?.value}
+                    onChange={(newValue) => updateConfigField(key, newValue)}
+                    disabled={!entry?.mutable}
+                  />
+                </>
+              )}
+              {_.isString(entry?.value) &&
+                !_.isUndefined(entry) &&
+                !_.isUndefined(key) && (
+                  <>
+                    <FilterViewStringInput
+                      fieldKey={key}
+                      label={label}
+                      entry={entry as GraphConfigItem<string>}
+                      updateConfigField={updateConfigField}
+                      nodeCount={config["information.nodes"].value}
+                    />
+                  </>
+                )}
+            </Space>
+          );
+        })}
     </Space>
   );
 };

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -18,9 +18,10 @@ type FilterProps = {
   type: "note" | "schema";
   config: GraphConfig;
   setConfig: React.Dispatch<React.SetStateAction<GraphConfig>>;
+  isVisible: boolean;
 };
 
-const GraphFilterView = ({ config, setConfig }: FilterProps) => {
+const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
   const configEntries = Object.entries(config);
   const sortedSections = [
     "vaults",
@@ -58,6 +59,8 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
         background: AntThemes[currentTheme].graph.filterView.background,
         borderRadius: AntThemes[currentTheme].graph.filterView.borderRadius,
         minWidth: AntThemes[currentTheme].graph.filterView.minWidth,
+        opacity: isVisible ? 1 : 0,
+        transition: "opacity 0.2s",
       }}
     >
       <Collapse>

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -8,6 +8,8 @@ import {
   Spin,
 } from "antd";
 import _ from "lodash";
+import { useEffect } from "react";
+import { useReducer } from "react";
 import { useState } from "react";
 import { useThemeSwitcher } from "react-css-theme-switcher";
 import { GraphConfig, GraphConfigItem } from "../lib/graph";
@@ -82,6 +84,7 @@ const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
                     <Space
                       direction="horizontal"
                       style={{ justifyContent: "space-between", width: "100%" }}
+                      key={key}
                     >
                       {_.isBoolean(entry?.value) && (
                         <>

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -8,11 +8,8 @@ import {
   Spin,
 } from "antd";
 import _ from "lodash";
-import { useEffect } from "react";
-import { useReducer } from "react";
 import { useState } from "react";
 import { useThemeSwitcher } from "react-css-theme-switcher";
-import { createLogger } from "../../common-frontend/lib";
 import { GraphConfig, GraphConfigItem } from "../lib/graph";
 import AntThemes from "../styles/theme-antd";
 const { Panel } = Collapse;

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -100,6 +100,7 @@ export default function Graph({
   const graphRef = useRef<HTMLDivElement>(null);
   const { themes, currentTheme } = useThemeSwitcher();
   const [cy, setCy] = useState<Core>();
+  const [isGraphLoaded, setIsGraphLoaded] = useState(false);
 
   useSyncGraphWithIDE({
     graph: cy,
@@ -165,6 +166,15 @@ export default function Graph({
   };
 
   useEffect(() => {
+    if (cy && !isGraphLoaded) {
+      cy.on("layoutstop", () => {
+        logger.log("GRAPH READY");
+        setIsGraphLoaded(true);
+      });
+    }
+  }, [cy, isGraphLoaded]);
+
+  useEffect(() => {
     // If the graph already has rendered elements, don't re-render
     // Otherwise, the graph re-renders when elements are selected
     if (cy && cy.elements("*").length > 1) return;
@@ -213,7 +223,12 @@ export default function Graph({
           position: "relative",
         }}
       >
-        <GraphFilterView type={type} config={config} setConfig={setConfig} />
+        <GraphFilterView
+          type={type}
+          config={config}
+          setConfig={setConfig}
+          isVisible={isGraphLoaded}
+        />
         <div
           ref={graphRef}
           style={{

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -186,7 +186,6 @@ export default function Graph({
 
       // Show UI when layout is finished. As a fallback, show on interaction with graph.
       network.on("layoutstop viewport", () => {
-        logger.log("GRAPH READY");
         if (!isGraphLoaded) setIsGraphLoaded(true);
       });
 
@@ -195,15 +194,6 @@ export default function Graph({
       setCy(network);
     }
   };
-
-  // useEffect(() => {
-  //   if (cy && !isGraphLoaded) {
-  //     cy.on("ready", () => {
-  //       logger.log("GRAPH READY");
-  //       setIsGraphLoaded(true);
-  //     });
-  //   }
-  // }, [cy, isGraphLoaded]);
 
   useEffect(() => {
     // If changed from local graph to full graph, re-render graph to show all elements

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -15,6 +15,11 @@ import useSyncGraphWithIDE from "../hooks/useSyncGraphWithIDE";
 
 const getCytoscapeStyle = (themes: any, theme: string | undefined) => {
   if (_.isUndefined(theme)) return "";
+
+  // Cytoscape's "diamond" node is smaller than it's "circle" node, so
+  // this modifier adjusts to make parent and child nodes similarly sized.
+  const PARENT_NODE_SIZE_MODIFIER = 1.25;
+
   return `
   node {
     width: ${AntThemes[theme].graph.node.size};
@@ -43,8 +48,8 @@ const getCytoscapeStyle = (themes: any, theme: string | undefined) => {
   
   .parent {
     shape: diamond;
-    width: ${AntThemes[theme].graph.node.size * 1.25};
-    height: ${AntThemes[theme].graph.node.size * 1.25};
+    width: ${AntThemes[theme].graph.node.size * PARENT_NODE_SIZE_MODIFIER};
+    height: ${AntThemes[theme].graph.node.size * PARENT_NODE_SIZE_MODIFIER};
   }
 
   .links {

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -184,20 +184,26 @@ export default function Graph({
 
       network.layout(getEulerConfig(shouldAnimate)).run();
 
+      // Show UI when layout is finished. As a fallback, show on interaction with graph.
+      network.on("layoutstop viewport", () => {
+        logger.log("GRAPH READY");
+        if (!isGraphLoaded) setIsGraphLoaded(true);
+      });
+
       network.on("select", (e) => onSelect(e));
 
       setCy(network);
     }
   };
 
-  useEffect(() => {
-    if (cy && !isGraphLoaded) {
-      cy.on("layoutstop", () => {
-        logger.log("GRAPH READY");
-        setIsGraphLoaded(true);
-      });
-    }
-  }, [cy, isGraphLoaded]);
+  // useEffect(() => {
+  //   if (cy && !isGraphLoaded) {
+  //     cy.on("ready", () => {
+  //       logger.log("GRAPH READY");
+  //       setIsGraphLoaded(true);
+  //     });
+  //   }
+  // }, [cy, isGraphLoaded]);
 
   useEffect(() => {
     // If changed from local graph to full graph, re-render graph to show all elements

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -13,6 +13,13 @@ import useApplyGraphConfig from "../hooks/useApplyGraphConfig";
 import { DendronProps } from "../lib/types";
 import useSyncGraphWithIDE from "../hooks/useSyncGraphWithIDE";
 
+export class GraphUtils {
+  static isLocalGraph(config: GraphConfig) {
+    if (_.isUndefined(config["options.show-local-graph"])) return false;
+    return config["options.show-local-graph"].value;
+  }
+}
+
 const getCytoscapeStyle = (themes: any, theme: string | undefined) => {
   if (_.isUndefined(theme)) return "";
 
@@ -131,9 +138,6 @@ export default function Graph({
 
   const { nodes, edges } = elements;
   const isLargeGraph = nodes.length + Object.values(edges).flat().length > 1000;
-  const isLocalGraph = config["options.show-local-graph"]
-    ? config["options.show-local-graph"].value
-    : false;
 
   const renderGraph = () => {
     if (graphRef.current && nodes && edges) {
@@ -175,7 +179,8 @@ export default function Graph({
       });
 
       const shouldAnimate =
-        type === "schema" || (!isLargeGraph && !isLocalGraph);
+        type === "schema" ||
+        (!isLargeGraph && !GraphUtils.isLocalGraph(config));
 
       network.layout(getEulerConfig(shouldAnimate)).run();
 
@@ -200,7 +205,12 @@ export default function Graph({
 
     // If the graph already has rendered elements, don't re-render
     // Otherwise, the graph re-renders when elements are selected
-    if (!isLocalGraph && !wasLocalGraph && cy && cy.elements("*").length > 1)
+    if (
+      !GraphUtils.isLocalGraph(config) &&
+      !wasLocalGraph &&
+      cy &&
+      cy.elements("*").length > 1
+    )
       return;
     renderGraph();
   }, [graphRef, elements]);

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -527,6 +527,8 @@ const useGraphElements = ({
   const [noteCount, setNoteCount] = useState(0);
   const [schemaCount, setSchemaCount] = useState(0);
 
+  const isLocalGraph = GraphUtils.isLocalGraph(config);
+
   useEffect(() => {
     if (type === "note" && engine.notes) {
       // Prevent unnecessary parsing if no notes have been added/deleted
@@ -537,7 +539,7 @@ const useGraphElements = ({
       if (!wasLocalGraph && noteCount === newNoteCount) return;
       setNoteCount(newNoteCount);
 
-      if (!GraphUtils.isLocalGraph(config)) {
+      if (!isLocalGraph) {
         setElements(
           getFullNoteGraphElements({
             notes: engine.notes,
@@ -547,16 +549,11 @@ const useGraphElements = ({
         );
       }
     }
-  }, [engine.notes, config["options.show-local-graph"]]);
+  }, [engine.notes, isLocalGraph]);
 
   // Get new elements if active note changes
   useEffect(() => {
-    if (
-      type === "note" &&
-      engine.notes &&
-      GraphUtils.isLocalGraph(config) &&
-      noteActive
-    ) {
+    if (type === "note" && engine.notes && isLocalGraph && noteActive) {
       setElements(
         getLocalNoteGraphElements({
           notes: engine.notes,
@@ -566,7 +563,7 @@ const useGraphElements = ({
         })
       );
     }
-  }, [noteActive, config["options.show-local-graph"]]);
+  }, [noteActive, engine.notes, isLocalGraph]);
 
   useEffect(() => {
     if (type === "schema" && engine.schemas) {

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -7,11 +7,7 @@ import {
   SchemaProps,
   VaultUtils,
 } from "@dendronhq/common-all";
-import {
-  createLogger,
-  engineSlice,
-  ideSlice,
-} from "@dendronhq/common-frontend";
+import { createLogger, engineSlice } from "@dendronhq/common-frontend";
 import { EdgeDefinition } from "cytoscape";
 import _ from "lodash";
 import { useRouter } from "next/router";

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -554,7 +554,7 @@ const useGraphElements = ({
     if (
       type === "note" &&
       engine.notes &&
-      !GraphUtils.isLocalGraph(config) &&
+      GraphUtils.isLocalGraph(config) &&
       noteActive
     ) {
       setElements(

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -554,13 +554,11 @@ const useGraphElements = ({
 
   // Get new elements if active note changes
   useEffect(() => {
-    logger.log("get new local note elements");
     const isLocalGraph = config["options.show-local-graph"]
       ? config["options.show-local-graph"].value
       : false;
 
     if (type === "note" && engine.notes && isLocalGraph && noteActive) {
-      logger.log("GETTING LOCAL GRAPH ELEMENTS FOR", noteActive.fname);
       setElements(
         getLocalNoteGraphElements({
           notes: engine.notes,

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -16,6 +16,7 @@ import { EdgeDefinition } from "cytoscape";
 import _ from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { GraphUtils } from "../components/graph";
 import {
   GraphConfig,
   GraphEdges,
@@ -527,10 +528,6 @@ const useGraphElements = ({
   const [schemaCount, setSchemaCount] = useState(0);
 
   useEffect(() => {
-    const isLocalGraph = config["options.show-local-graph"]
-      ? config["options.show-local-graph"].value
-      : false;
-
     if (type === "note" && engine.notes) {
       // Prevent unnecessary parsing if no notes have been added/deleted
       const wasLocalGraph =
@@ -540,7 +537,7 @@ const useGraphElements = ({
       if (!wasLocalGraph && noteCount === newNoteCount) return;
       setNoteCount(newNoteCount);
 
-      if (!isLocalGraph) {
+      if (!GraphUtils.isLocalGraph(config)) {
         setElements(
           getFullNoteGraphElements({
             notes: engine.notes,
@@ -554,11 +551,12 @@ const useGraphElements = ({
 
   // Get new elements if active note changes
   useEffect(() => {
-    const isLocalGraph = config["options.show-local-graph"]
-      ? config["options.show-local-graph"].value
-      : false;
-
-    if (type === "note" && engine.notes && isLocalGraph && noteActive) {
+    if (
+      type === "note" &&
+      engine.notes &&
+      !GraphUtils.isLocalGraph(config) &&
+      noteActive
+    ) {
       setElements(
         getLocalNoteGraphElements({
           notes: engine.notes,

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -1,3 +1,4 @@
+import { NoteProps } from "@dendronhq/common-all";
 import {
   DVault,
   NotePropsDict,
@@ -6,23 +7,262 @@ import {
   SchemaProps,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { createLogger, engineSlice } from "@dendronhq/common-frontend";
+import {
+  createLogger,
+  engineSlice,
+  ideSlice,
+} from "@dendronhq/common-frontend";
 import { EdgeDefinition } from "cytoscape";
 import _ from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { GraphEdges, GraphElements } from "../lib/graph";
+import {
+  GraphConfig,
+  GraphEdges,
+  GraphElements,
+  GraphNodes,
+} from "../lib/graph";
 
 const getVaultClass = (vault: DVault) => {
   const vaultName = VaultUtils.getName(vault);
   return `vault-${vaultName}`;
 };
 
-const getNoteGraphElements = (
-  notes: NotePropsDict,
-  wsRoot: string,
-  vaults: DVault[] | undefined
-): GraphElements => {
+const getLocalNoteGraphElements = ({
+  notes,
+  noteActive,
+  vaults,
+  wsRoot,
+}: {
+  notes: NotePropsDict;
+  wsRoot: string;
+  vaults: DVault[] | undefined;
+  noteActive: NoteProps | undefined;
+}): GraphElements => {
+  const logger = createLogger("getLocalNoteGraphElements");
+
+  if (!noteActive)
+    return {
+      nodes: [],
+      edges: {},
+    };
+
+  const activeNote = notes[noteActive.id];
+  const parentNote = activeNote.parent ? notes[activeNote.parent] : undefined;
+  const connectedNotes = NoteUtils.getNotesWithLinkTo({
+    note: activeNote,
+    notes,
+  });
+
+  // Add active node
+  const nodes: GraphNodes = [
+    {
+      data: {
+        id: activeNote.id,
+        label: activeNote.title,
+        group: "nodes",
+        fname: activeNote.fname,
+        stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
+        localRoot: true,
+      },
+      classes: `${getVaultClass(activeNote.vault)}`,
+      selected: true,
+    },
+  ];
+
+  // Add parent node
+  if (parentNote) {
+    nodes.push({
+      data: {
+        id: parentNote.id,
+        label: parentNote.title,
+        group: "nodes",
+        fname: parentNote.fname,
+        stub: _.isUndefined(parentNote.stub) ? false : parentNote.stub,
+      },
+      classes: `parent ${getVaultClass(parentNote.vault)}`,
+    });
+  }
+
+  // Add connected nodes
+  nodes.push(
+    ...Object.values(connectedNotes).map((note) => {
+      return {
+        data: {
+          id: note.id,
+          label: note.title,
+          group: "nodes",
+          fname: note.fname,
+          stub: _.isUndefined(note.stub) ? false : note.stub,
+        },
+        classes: `${getVaultClass(note.vault)}`,
+      };
+    })
+  );
+
+  // Initialize edges
+  const edges: GraphEdges = {
+    hierarchy: [],
+    links: [],
+  };
+
+  // Get children of active note
+  const noteVaultClass = getVaultClass(activeNote.vault);
+
+  // If note has a parent, add a connection to it
+  if (parentNote) {
+    edges.hierarchy.push({
+      data: {
+        group: "edges",
+        id: `${parentNote.id}_${activeNote.id}`,
+        source: parentNote.id,
+        target: activeNote.id,
+        fname: parentNote.fname,
+        stub: _.isUndefined(parentNote.stub) ? false : parentNote.stub,
+      },
+      classes: `hierarchy ${noteVaultClass}`,
+    });
+  }
+
+  activeNote.children.forEach((child) => {
+    const childNote = notes[child];
+    nodes.push({
+      data: {
+        id: child,
+        label: childNote.title,
+        group: "nodes",
+        fname: childNote.fname,
+        stub: _.isUndefined(childNote.stub) ? false : childNote.stub,
+      },
+      classes: `${getVaultClass(childNote.vault)}`,
+    });
+
+    edges.hierarchy.push({
+      data: {
+        group: "edges",
+        id: `${activeNote.id}_${child}`,
+        source: activeNote.id,
+        target: child,
+        fname: activeNote.fname,
+        stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
+      },
+      classes: `hierarchy ${noteVaultClass}`,
+    });
+  });
+
+  // Get notes linking to active note
+  const linkConnections = connectedNotes.map((connectedNote) => {
+    return {
+      data: {
+        group: "edges",
+        id: `${activeNote.id}_${connectedNote.id}`,
+        source: activeNote.id,
+        target: connectedNote.id,
+        fname: activeNote.fname,
+        stub:
+          _.isUndefined(activeNote.stub) && _.isUndefined(connectedNote.stub)
+            ? false
+            : activeNote.stub || connectedNote.stub
+            ? true
+            : false,
+      },
+      classes: `links ${noteVaultClass}`,
+    };
+  });
+
+  // Find and add linked notes
+  activeNote.links.forEach((link) => {
+    if (link.type === "backlink") return;
+    if (link.to && link.to.fname && activeNote.id && vaults) {
+      const fnameArray = link.to.fname.split("/");
+
+      const toFname = link.to.fname.includes("/")
+        ? fnameArray[fnameArray.length - 1]
+        : link.to.fname;
+      const toVaultName =
+        link.to.vaultName ||
+        fnameArray[fnameArray.length - 2] ||
+        VaultUtils.getName(activeNote.vault);
+
+      const toVault = VaultUtils.getVaultByName({
+        vname: toVaultName,
+        vaults,
+      });
+
+      if (_.isUndefined(toVault)) {
+        logger.log(
+          `Couldn't find vault of note ${toFname}, aborting link creation`
+        );
+        return;
+      }
+
+      const to = NoteUtils.getNoteByFnameV5({
+        fname: fnameArray[fnameArray.length - 1],
+        vault: toVault,
+        notes: notes,
+        wsRoot,
+      });
+
+      if (!to) {
+        logger.log(
+          `Failed to link note ${VaultUtils.getName(activeNote.vault)}/${
+            activeNote.fname
+          } to ${VaultUtils.getName(toVault)}/${
+            link.to.fname
+          }. Most likely, this note does not exist.`
+        );
+        return;
+      }
+
+      const isStub =
+        _.isUndefined(activeNote.stub) && _.isUndefined(to.stub)
+          ? false
+          : activeNote.stub || to.stub
+          ? true
+          : false;
+
+      nodes.push({
+        data: {
+          id: to.id,
+          label: to.title,
+          group: "nodes",
+          fname: to.fname,
+          stub: isStub,
+        },
+        classes: `${getVaultClass(to.vault)}`,
+      });
+
+      linkConnections.push({
+        data: {
+          group: "edges",
+          id: `${activeNote.id}_${to.id}`,
+          source: activeNote.id,
+          target: to.id,
+          fname: activeNote.fname,
+          stub: isStub,
+        },
+        classes: `links ${noteVaultClass}`,
+      });
+    }
+  });
+
+  edges.links.push(...linkConnections);
+
+  return {
+    nodes,
+    edges,
+  };
+};
+
+const getFullNoteGraphElements = ({
+  notes,
+  wsRoot,
+  vaults,
+}: {
+  notes: NotePropsDict;
+  wsRoot: string;
+  vaults: DVault[] | undefined;
+}): GraphElements => {
   const logger = createLogger("graph - getNoteGraphElements");
 
   // ADD NODES
@@ -268,10 +508,15 @@ const getSchemaGraphElements = (
 const useGraphElements = ({
   type,
   engine,
+  config,
+  noteActive,
 }: {
   type: "note" | "schema";
   engine: engineSlice.EngineState;
+  config: GraphConfig;
+  noteActive?: NoteProps | undefined;
 }) => {
+  const logger = createLogger("useGraphElements");
   const router = useRouter();
   const [elements, setElements] = useState<GraphElements>({
     nodes: [],
@@ -282,21 +527,50 @@ const useGraphElements = ({
   const [schemaCount, setSchemaCount] = useState(0);
 
   useEffect(() => {
+    const isLocalGraph = config["options.show-local-graph"]
+      ? config["options.show-local-graph"].value
+      : false;
+
     if (type === "note" && engine.notes) {
       // Prevent unnecessary parsing if no notes have been added/deleted
+      const wasLocalGraph =
+        elements.nodes.filter((node) => !!node.data.localRoot).length > 0;
+
       const newNoteCount = Object.keys(engine.notes).length;
-      if (noteCount === newNoteCount) return;
+      if (!wasLocalGraph && noteCount === newNoteCount) return;
       setNoteCount(newNoteCount);
 
+      if (!isLocalGraph) {
+        setElements(
+          getFullNoteGraphElements({
+            notes: engine.notes,
+            wsRoot: router.query.ws as string,
+            vaults: engine.vaults,
+          })
+        );
+      }
+    }
+  }, [engine.notes, config["options.show-local-graph"]]);
+
+  // Get new elements if active note changes
+  useEffect(() => {
+    logger.log("get new local note elements");
+    const isLocalGraph = config["options.show-local-graph"]
+      ? config["options.show-local-graph"].value
+      : false;
+
+    if (type === "note" && engine.notes && isLocalGraph && noteActive) {
+      logger.log("GETTING LOCAL GRAPH ELEMENTS FOR", noteActive.fname);
       setElements(
-        getNoteGraphElements(
-          engine.notes,
-          router.query.ws as string,
-          engine.vaults
-        )
+        getLocalNoteGraphElements({
+          notes: engine.notes,
+          wsRoot: router.query.ws as string,
+          vaults: engine.vaults,
+          noteActive,
+        })
       );
     }
-  }, [engine.notes]);
+  }, [noteActive, config["options.show-local-graph"]]);
 
   useEffect(() => {
     if (type === "schema" && engine.schemas) {

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -259,15 +259,18 @@ const getFullNoteGraphElements = ({
   notes,
   wsRoot,
   vaults,
+  noteActive,
 }: {
   notes: NotePropsDict;
   wsRoot: string;
   vaults: DVault[] | undefined;
+  noteActive: NoteProps | undefined;
 }): GraphElements => {
   const logger = createLogger("graph - getNoteGraphElements");
 
   // ADD NODES
   const nodes = Object.values(notes).map((note) => {
+    const isActive = noteActive && note.id === noteActive.id;
     return {
       data: {
         id: note.id,
@@ -277,6 +280,7 @@ const getFullNoteGraphElements = ({
         stub: _.isUndefined(note.stub) ? false : note.stub,
       },
       classes: `${getVaultClass(note.vault)}`,
+      selected: isActive,
     };
   });
 
@@ -545,6 +549,7 @@ const useGraphElements = ({
             notes: engine.notes,
             wsRoot: router.query.ws as string,
             vaults: engine.vaults,
+            noteActive,
           })
         );
       }

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -191,7 +191,7 @@ const getLocalNoteGraphElements = ({
       });
 
       if (_.isUndefined(toVault)) {
-        logger.log(
+        logger.error(
           `Couldn't find vault of note ${toFname}, aborting link creation`
         );
         return;
@@ -205,7 +205,7 @@ const getLocalNoteGraphElements = ({
       });
 
       if (!to) {
-        logger.log(
+        logger.warn(
           `Failed to link note ${VaultUtils.getName(activeNote.vault)}/${
             activeNote.fname
           } to ${VaultUtils.getName(toVault)}/${

--- a/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
@@ -4,6 +4,7 @@ import { createLogger } from "@dendronhq/common-frontend";
 import { engineSlice } from "@dendronhq/common-frontend";
 import { DendronProps } from "../lib/types";
 import { GraphConfig } from "../lib/graph";
+import { GraphUtils } from "../components/graph";
 
 const EngineSliceUtils = engineSlice.EngineSliceUtils;
 
@@ -21,10 +22,12 @@ const useSyncGraphWithIDE = ({ graph, ide, engine, config }: Props) => {
   const logger = createLogger("useSyncGraphWithIDE");
 
   useEffect(() => {
-    const isLocalGraph = config["options.show-local-graph"]
-      ? config["options.show-local-graph"].value
-      : false;
-    if (noteActive && engineInitialized && graph && !isLocalGraph) {
+    if (
+      noteActive &&
+      engineInitialized &&
+      graph &&
+      !GraphUtils.isLocalGraph(config)
+    ) {
       const selected = graph.$(`:selected`);
       const graphActiveNode = graph.$(`[id = "${noteActive.id}"]`);
 

--- a/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
@@ -3,14 +3,16 @@ import { useEffect, useState } from "react";
 import { createLogger } from "@dendronhq/common-frontend";
 import { engineSlice } from "@dendronhq/common-frontend";
 import { DendronProps } from "../lib/types";
+import { GraphConfig } from "../lib/graph";
 
 const EngineSliceUtils = engineSlice.EngineSliceUtils;
 
 type Props = DendronProps & {
   graph: cytoscape.Core | undefined;
+  config: GraphConfig;
 };
 
-const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
+const useSyncGraphWithIDE = ({ graph, ide, engine, config }: Props) => {
   const [lastSelectedID, setLastSelectedID] = useState("");
 
   const { noteActive } = ide;
@@ -19,7 +21,10 @@ const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
   const logger = createLogger("useSyncGraphWithIDE");
 
   useEffect(() => {
-    if (noteActive && engineInitialized && graph) {
+    const isLocalGraph = config["options.show-local-graph"]
+      ? config["options.show-local-graph"].value
+      : false;
+    if (noteActive && engineInitialized && graph && !isLocalGraph) {
       const selected = graph.$(`:selected`);
       const graphActiveNode = graph.$(`[id = "${noteActive.id}"]`);
 
@@ -49,7 +54,7 @@ const useSyncGraphWithIDE = ({ graph, ide, engine }: Props) => {
         setLastSelectedID(graphActiveNode.id());
       }
     }
-  }, [noteActive?.id, engineInitialized]);
+  }, [noteActive?.id, engineInitialized, config["options.show-local-graph"]]);
 };
 
 export default useSyncGraphWithIDE;

--- a/packages/dendron-next-server/lib/graph.ts
+++ b/packages/dendron-next-server/lib/graph.ts
@@ -34,8 +34,10 @@ export type NoteGraphConfig = {
   "connections.links"?: GraphConfigItem<boolean>;
   
   "information.edges-links"?: GraphConfigItem<number>;
-
+  
   "filter.show-stubs"?: GraphConfigItem<boolean>;
+  
+  "options.show-local-graph"?: GraphConfigItem<boolean>;
 };
 
 export type SchemaGraphConfig = {
@@ -82,7 +84,7 @@ const coreGraphConfig: CoreGraphConfig = {
 
 const noteGraphConfig: NoteGraphConfig = {
   "connections.links": {
-    value: false,
+    value: true,
     mutable: true,
   },
   "information.edges-links": {
@@ -93,7 +95,10 @@ const noteGraphConfig: NoteGraphConfig = {
     value: true,
     mutable: true,
   },
-
+  "options.show-local-graph": {
+    value: true,
+    mutable: true,
+  },
 };
 
 const schemaGraphConfig: SchemaGraphConfig = {

--- a/packages/dendron-next-server/pages/vscode/graph-note.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-note.tsx
@@ -1,11 +1,4 @@
-import {
-  createLogger,
-  engineSlice,
-  ideHooks,
-  ideSlice,
-  postVSCodeMessage,
-  useVSCodeMessage,
-} from "@dendronhq/common-frontend";
+import { postVSCodeMessage } from "@dendronhq/common-frontend";
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
 import { EventHandler } from "cytoscape";
@@ -19,7 +12,6 @@ import Graph from "../../components/graph";
 import { graphConfig, GraphConfig } from "../../lib/graph";
 import useGraphElements from "../../hooks/useGraphElements";
 import { DendronProps } from "../../lib/types";
-import { DendronWebViewKey } from "@dendronhq/common-all";
 
 export default function FullNoteGraph({ engine, ide }: DendronProps) {
   const [config, setConfig] = useState<GraphConfig>(graphConfig.note);

--- a/packages/dendron-next-server/pages/vscode/graph-schema.tsx
+++ b/packages/dendron-next-server/pages/vscode/graph-schema.tsx
@@ -14,7 +14,7 @@ import { DendronProps } from "../../lib/types";
 
 export default function FullSchemaGraph({ engine, ide }: DendronProps) {
   const [config, setConfig] = useState<GraphConfig>(graphConfig.schema);
-  const elements = useGraphElements({ type: "schema", engine });
+  const elements = useGraphElements({ type: "schema", engine, config });
 
   const onSelect: EventHandler = (e) => {
     const { id, source, vault } = e.target[0]._private.data;

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -10,6 +10,7 @@ import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
+import vscode from "vscode";
 
 type CommandOpts = {};
 
@@ -66,6 +67,9 @@ export class ShowNoteGraphCommand extends BasicCommand<
       switch (msg.type) {
         case GraphViewMessageType.onSelect: {
           const note = getEngine().notes[msg.data.id];
+          await vscode.commands.executeCommand(
+            "workbench.action.focusFirstEditorGroup"
+          );
           await new GotoNoteCommand().execute({
             qs: note.fname,
             vault: note.vault,

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -3,6 +3,7 @@ import {
   DendronWebViewKey,
   GraphViewMessage,
   GraphViewMessageType,
+  NoteProps,
 } from "@dendronhq/common-all";
 import { ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
@@ -11,6 +12,7 @@ import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
 import vscode from "vscode";
+import { VSCodeUtils } from "../utils";
 
 type CommandOpts = {};
 
@@ -23,6 +25,20 @@ export class ShowNoteGraphCommand extends BasicCommand<
   key = DENDRON_COMMANDS.SHOW_NOTE_GRAPH_V2.key;
   async gatherInputs(): Promise<any> {
     return {};
+  }
+  static refresh(note: NoteProps) {
+    const panel = getWS().getWebView(DendronWebViewKey.NOTE_GRAPH);
+    if (panel) {
+      // panel.title = `${title} ${note.fname}`;
+      panel.webview.postMessage({
+        type: "onDidChangeActiveTextEditor",
+        data: {
+          note,
+          sync: true,
+        },
+        source: "vscode",
+      });
+    }
   }
   async execute() {
     const title = "Note Graph";
@@ -47,7 +63,10 @@ export class ShowNoteGraphCommand extends BasicCommand<
     const panel = window.createWebviewPanel(
       "dendronIframe", // Identifies the type of the webview. Used internally
       title, // Title of the panel displayed to the user
-      ViewColumn.Two, // Editor column to show the new webview panel in.
+      {
+        viewColumn: ViewColumn.Beside,
+        preserveFocus: true,
+      }, // Editor column to show the new webview panel in.
       {
         enableScripts: true,
         retainContextWhenHidden: true,
@@ -76,23 +95,16 @@ export class ShowNoteGraphCommand extends BasicCommand<
           });
           break;
         }
-        // case GraphViewMessageType.onGetActiveEditor: {
-        //   const document = VSCodeUtils.getActiveTextEditor()?.document;
-        //   if (document) {
-        //     if (
-        //       !getWS().workspaceService?.isPathInWorkspace(document.uri.fsPath)
-        //     ) {
-        //       // not in workspace
-        //       return;
-        //     }
-        //     const note = VSCodeUtils.getNoteFromDocument(document);
-        //     if (note) {
-        //       // refresh note
-        //       this.refresh(note);
-        //     }
-        //   }
-        //   break;
-        // }
+        case GraphViewMessageType.onGetActiveEditor: {
+          const activeTextEditor = VSCodeUtils.getActiveTextEditor();
+          const note =
+            activeTextEditor &&
+            VSCodeUtils.getNoteFromDocument(activeTextEditor.document);
+          if (note) {
+            ShowNoteGraphCommand.refresh(note);
+          }
+          break;
+        }
         // case GraphViewMessageType.onReady: {
         //   const profile = getDurationMilliseconds(start);
         //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -12,6 +12,7 @@ import { BasicCommand } from "./base";
 import { getWS } from "../workspace";
 import { VSCodeUtils } from "../utils";
 import path from "path";
+import vscode from "vscode";
 
 type CommandOpts = {};
 
@@ -72,6 +73,9 @@ export class ShowSchemaGraphCommand extends BasicCommand<
 
           const wsRoot = ws._enginev2?.wsRoot;
 
+          await vscode.commands.executeCommand(
+            "workbench.action.focusFirstEditorGroup"
+          );
           if (msg.data.vault && wsRoot) {
             const vaults = engine.vaults.filter(
               (v) => VaultUtils.getName(v) === msg.data.vault

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -49,7 +49,10 @@ export class ShowSchemaGraphCommand extends BasicCommand<
     const panel = window.createWebviewPanel(
       "dendronIframe", // Identifies the type of the webview. Used internally
       title, // Title of the panel displayed to the user
-      ViewColumn.Two, // Editor column to show the new webview panel in.
+      {
+        viewColumn: ViewColumn.Beside,
+        preserveFocus: true,
+      }, // Editor column to show the new webview panel in.
       {
         enableScripts: true,
         retainContextWhenHidden: true,

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -53,4 +53,4 @@ dev:
     nextServerUrl: 'http://localhost:3000'
     engineServerPort: 3005
 initializeRemoteVaults: true
-dendronVersion: 0.48.0
+dendronVersion: 0.48.1


### PR DESCRIPTION
This is a DRAFT PR 🚧. More testing will be done, as this is a fairly substantial addition to the V2 graph.

Changed/added:
- Added local note graph, a one-level-deep graph with direct hierarchical and linked connections from the current active note
- Made local note graph the default graph, with an option to view the full graph
- Enabled link connections on by default to fill out the local note graph
- Minor styling/rendering tweaks to enable graph switching and ease of use 