### PR TITLE
fix(calendar-view): prevent calendar-view from popping on safe

### DIFF
--- a/packages/plugin-core/src/views/CalendarView.ts
+++ b/packages/plugin-core/src/views/CalendarView.ts
@@ -40,6 +40,12 @@ export class CalendarView implements vscode.WebviewViewProvider {
   }
 
   openTextDocument(document: vscode.TextDocument) {
+    if (_.isUndefined(document) || _.isUndefined(this._view)) {
+      return;
+    }
+    if (!this._view.visible) {
+      return;
+    }
     const ctx = "CalendarView:openTextDocument";
     if (!getWS().workspaceService?.isPathInWorkspace(document.uri.fsPath)) {
       Logger.info({
@@ -66,9 +72,6 @@ export class CalendarView implements vscode.WebviewViewProvider {
 
   async onActiveTextEditorChangeHandler() {
     const document = VSCodeUtils.getActiveTextEditor()?.document;
-    if (!this._view?.visible) {
-      return;
-    }
     if (document) {
       this.openTextDocument(document);
     } else {


### PR DESCRIPTION
[[calendar view popup on save|scratch.2021.06.20.205319.calendar-view-popup-on-save]]