### PR TITLE
fix: block anchors inside links are parsed as anchors

### DIFF
--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -430,16 +430,10 @@ export class FileStorage implements DStore {
             return;
           }
           try {
-            const anchors = await AnchorUtils.findAnchors(
-              {
-                note: n,
-                wsRoot: wsRoot,
-              },
-              {
-                engine: this.engine,
-                fname: n.fname,
-              }
-            );
+            const anchors = await AnchorUtils.findAnchors({
+              note: n,
+              wsRoot: wsRoot,
+            });
             cacheUpdates[n.fname].data.anchors = anchors;
             n.anchors = anchors;
           } catch (err) {

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -465,16 +465,10 @@ export class DendronEngineV2 implements DEngine {
             //   this.history.add({ source: "engine", action: "create", uri });
           }
           const links = LinkUtils.findLinks({ note: ent.note, engine: this });
-          const anchors = await AnchorUtils.findAnchors(
-            {
-              note: ent.note,
-              wsRoot: this.wsRoot,
-            },
-            {
-              engine: this,
-              fname: ent.note.fname,
-            }
-          );
+          const anchors = await AnchorUtils.findAnchors({
+            note: ent.note,
+            wsRoot: this.wsRoot,
+          });
           ent.note.links = links;
           ent.note.anchors = anchors;
           this.notes[id] = ent.note;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -40,7 +40,6 @@ import {
   WikiLinkNoteV4,
   WikiLinkProps,
 } from "../types";
-import { MDUtilsV4 } from "../utils";
 import { MDUtilsV5, ProcMode } from "../utilsv5";
 const toString = require("mdast-util-to-string");
 export { mdastBuilder };
@@ -516,17 +515,14 @@ export class AnchorUtils {
     }
   }
 
-  static async findAnchors(
-    opts: {
-      note: NoteProps;
-      wsRoot: string;
-    },
-    parseOpts: Parameters<typeof RemarkUtils.findAnchors>[1]
-  ): Promise<{ [index: string]: DNoteAnchorPositioned }> {
+  static async findAnchors(opts: {
+    note: NoteProps;
+    wsRoot: string;
+  }): Promise<{ [index: string]: DNoteAnchorPositioned }> {
     if (opts.note.stub) return {};
     try {
       const noteContents = await note2String(opts);
-      const noteAnchors = RemarkUtils.findAnchors(noteContents, parseOpts);
+      const noteAnchors = RemarkUtils.findAnchors(noteContents);
       const slugger = getSlugger();
 
       const anchors: [string, DNoteAnchorPositioned][] = noteAnchors
@@ -592,13 +588,9 @@ export class RemarkUtils {
     });
   }
 
-  static findAnchors(
-    content: string,
-    opts: Omit<Parameters<typeof MDUtilsV4.procParse>[0], "dest">
-  ): Anchor[] {
-    const parser = MDUtilsV4.procParse({
-      dest: DendronASTDest.MD_DENDRON,
-      ...opts,
+  static findAnchors(content: string): Anchor[] {
+    const parser = MDUtilsV5.procRehypeParse({
+      mode: ProcMode.NO_DATA,
     });
     const parsed = parser.parse(content);
     return [

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/blockAnchors.spec.ts
@@ -1,37 +1,24 @@
 import { AssertUtils, TestPresetEntryV4 } from "@dendronhq/common-test-utils";
 import {
   BlockAnchor,
-  BlockAnchorOpts,
-  blockAnchors,
-  DendronASTData,
   DendronASTDest,
   DendronASTTypes,
-  DEngineClient,
-  MDUtilsV4,
+  MDUtilsV5,
   Node,
   Parent,
+  ProcMode,
   Text,
   UnistNode,
-  wikiLinks,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { runEngineTestV5 } from "../../../engine";
 import { ENGINE_HOOKS } from "../../../presets";
 import { createProcForTest, createProcTests, ProcTests } from "./utils";
 
-function proc(
-  engine: DEngineClient,
-  dendron: DendronASTData,
-  opts?: BlockAnchorOpts
-) {
-  return MDUtilsV4.proc({ engine })
-    .data("dendron", dendron)
-    .use(wikiLinks)
-    .use(blockAnchors, opts);
-}
-
-function genDendronData(opts?: Partial<DendronASTData>): DendronASTData {
-  return { ...opts } as any;
+function proc() {
+  return MDUtilsV5.procRehypeParse({
+    mode: ProcMode.NO_DATA,
+  });
 }
 
 function runAllTests(opts: { name: string; testCases: ProcTests[] }) {
@@ -73,36 +60,24 @@ function getBlockAnchor(node: UnistNode): BlockAnchor {
 
 describe("blockAnchors", () => {
   describe("parse", () => {
-    let engine: any;
-    let dendronData = {
-      fname: "placeholder.md",
-      dest: DendronASTDest.MD_REGULAR,
-    };
-
     test("parses anchor by itself", () => {
-      const resp = proc(engine, genDendronData(dendronData)).parse(
-        "^block-0-id"
-      );
+      const resp = proc().parse("^block-0-id");
       expect(getBlockAnchor(resp).type).toEqual(DendronASTTypes.BLOCK_ANCHOR);
       expect(getBlockAnchor(resp).id).toEqual("block-0-id");
     });
 
     test("doesn't parse inline code block", () => {
-      const resp = proc(engine, genDendronData(dendronData)).parse(
-        "`^block-id`"
-      );
+      const resp = proc().parse("`^block-id`");
       expect(getBlockAnchor(resp).type).toEqual("inlineCode");
     });
 
     test("doesn't parse block anchor inside a link", async () => {
-      const resp = proc(await engine, genDendronData(dendronData)).parse(
-        "[[#^block-id]]"
-      );
+      const resp = proc().parse("[[#^block-id]]");
       expect(getBlockAnchor(resp).type).toEqual(DendronASTTypes.WIKI_LINK);
     });
 
     test("parses a block anchor in the middle of a paragraph", async () => {
-      const resp = proc(await engine, genDendronData(dendronData)).parse(
+      const resp = proc().parse(
         ["Lorem ipsum ^block-id", "dolor amet."].join("\n")
       );
       expect(getDescendantNode(resp, 0, 1).type).toEqual(
@@ -111,17 +86,13 @@ describe("blockAnchors", () => {
     });
 
     test("doesn't parse code block not at the end of the line", async () => {
-      const resp = proc(await engine, genDendronData(dendronData)).parse(
-        "^block-id Lorem ipsum"
-      );
+      const resp = proc().parse("^block-id Lorem ipsum");
       expect(getDescendantNode(resp, 0, 0).type).toEqual("text");
       expect(getDescendantNode<Parent>(resp, 0).children.length).toEqual(1); // text only, nothing else
     });
 
     test("parses anchors at the end of the line", () => {
-      const resp = proc(engine, genDendronData(dendronData)).parse(
-        "Lorem ipsum ^block-id"
-      );
+      const resp = proc().parse("Lorem ipsum ^block-id");
       const text = getDescendantNode(resp, 0, 0);
       expect(text.type).toEqual("text");
       const anchor = getDescendantNode<BlockAnchor>(resp, 0, 1);
@@ -130,9 +101,7 @@ describe("blockAnchors", () => {
     });
 
     test("parses anchors at the end of headers", () => {
-      const resp = proc(engine, genDendronData(dendronData)).parse(
-        "# Lorem ipsum ^block-id"
-      );
+      const resp = proc().parse("# Lorem ipsum ^block-id");
       const header = getDescendantNode<Text>(resp, 0, 0);
       expect(header.value.trim()).toEqual("Lorem ipsum");
       const anchor = getDescendantNode<BlockAnchor>(resp, 0, 1);

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -38,10 +38,7 @@ describe("RemarkUtils and LinkUtils", () => {
         async ({ engine }) => {
           const note = engine.notes["foo"];
           const body = note.body;
-          const out = RemarkUtils.findAnchors(body, {
-            engine,
-            fname: note.fname,
-          });
+          const out = RemarkUtils.findAnchors(body);
           expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].depth).toEqual(1);
@@ -69,10 +66,7 @@ describe("RemarkUtils and LinkUtils", () => {
         async ({ engine }) => {
           const note = engine.notes["foo"];
           const body = note.body;
-          const out = RemarkUtils.findAnchors(body, {
-            engine,
-            fname: note.fname,
-          });
+          const out = RemarkUtils.findAnchors(body);
           expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(1);
           expect(out[0].type).toEqual(DendronASTTypes.BLOCK_ANCHOR);
@@ -100,10 +94,7 @@ describe("RemarkUtils and LinkUtils", () => {
         async ({ engine }) => {
           const note = engine.notes["foo"];
           const body = note.body;
-          const out = RemarkUtils.findAnchors(body, {
-            engine,
-            fname: note.fname,
-          });
+          const out = RemarkUtils.findAnchors(body);
           expect(out).toMatchSnapshot();
           expect(_.size(out)).toEqual(0);
         },
@@ -133,10 +124,7 @@ describe("RemarkUtils and LinkUtils", () => {
       async ({ engine }) => {
         const note = engine.notes["foo"];
         const body = note.body;
-        const out = RemarkUtils.findAnchors(body, {
-          engine,
-          fname: note.fname,
-        });
+        const out = RemarkUtils.findAnchors(body);
         expect(out).toMatchSnapshot();
         expect(_.size(out)).toEqual(0);
       },
@@ -163,10 +151,7 @@ describe("RemarkUtils and LinkUtils", () => {
       async ({ engine }) => {
         const note = engine.notes["foo"];
         const body = note.body;
-        const out = RemarkUtils.findAnchors(body, {
-          engine,
-          fname: note.fname,
-        });
+        const out = RemarkUtils.findAnchors(body);
         expect(out).toMatchSnapshot();
         expect(_.size(out)).toEqual(0);
       },

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -74,10 +74,10 @@ export class NoteSyncService {
     note = NoteUtils.hydrate({ noteRaw: note, noteHydrated });
     const links = LinkUtils.findLinks({ note, engine: eclient });
     note.links = links;
-    const anchors = await AnchorUtils.findAnchors(
-      { note, wsRoot: eclient.wsRoot },
-      { fname, engine: eclient }
-    );
+    const anchors = await AnchorUtils.findAnchors({
+      note,
+      wsRoot: eclient.wsRoot,
+    });
     note.anchors = anchors;
     this.L.info({ ctx, fname, msg: "exit" });
     const noteClean = await eclient.updateNote(note);


### PR DESCRIPTION
Migrated block anchor parsing to V5 parsing which seems to have solved the issue.