### PR TITLE
fix(calendar-note): correct note name from "Today" btn

### DIFF
--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -287,7 +287,9 @@ function CalendarView({ engine, ide }: DendronProps) {
         mode={activeMode}
         onSelect={onSelect}
         onPanelChange={onPanelChange}
-        value={activeDate}
+        /*
+        // @ts-ignore -- `null` initializes ant Calendar into a controlled component whereby it does not render an selected/visible date (today) when `activeDate` is `undefined`*/
+        value={activeDate || null}
         dateFullCellRender={dateFullCellRender}
         fullscreen={false}
       />

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -127,16 +127,25 @@ function CalendarView({ engine, ide }: DendronProps) {
     }
   }, [noteActive, groupedDailyNotes]);
 
-  const getDateKey = (date: Moment) => {
-    const format =
-      activeMode === "month" ? defaultJournalDateFormat || "y.MM.dd" : "y.MM"; // TODO compute format for currentMode="year" from config
-    return date.format(format);
-  };
+  const getDateKey = useCallback<
+    (date: Moment, mode?: CalendarProps["mode"]) => string
+  >(
+    (date, mode) => {
+      const format =
+        (mode || activeMode) === "month"
+          ? defaultJournalDateFormat || "y.MM.dd"
+          : "y.MM"; // TODO compute format for currentMode="year" from config
+      return date.format(format);
+    },
+    [activeMode, defaultJournalDateFormat]
+  );
 
-  const onSelect = useCallback<Exclude<CalendarProps["onSelect"], undefined>>(
-    (date) => {
+  const onSelect = useCallback<
+    (date: Moment, mode?: CalendarProps["mode"]) => void
+  >(
+    (date, mode) => {
       logger.info({ ctx: "onSelect", date });
-      const dateKey = getDateKey(date);
+      const dateKey = getDateKey(date, mode);
       const selectedNote = _.first(groupedDailyNotes[dateKey]);
 
       postVSCodeMessage({
@@ -159,7 +168,9 @@ function CalendarView({ engine, ide }: DendronProps) {
   }, []);
 
   const onClickToday = useCallback(() => {
-    onSelect(moment());
+    const mode = "month";
+    setActiveMode(mode);
+    onSelect(moment(), mode);
   }, [onSelect]);
 
   const dateFullCellRender = useCallback<

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -128,9 +128,9 @@ function CalendarView({ engine, ide }: DendronProps) {
   }, [noteActive, groupedDailyNotes]);
 
   const getDateKey = (date: Moment) => {
-    return date.format(
-      activeMode === "month" ? defaultJournalDateFormat : "y.MM" // TODO compute format for currentMode="year"
-    );
+    const format =
+      activeMode === "month" ? defaultJournalDateFormat || "y.MM.dd" : "y.MM"; // TODO compute format for currentMode="year" from config
+    return date.format(format);
   };
 
   const onSelect = useCallback<Exclude<CalendarProps["onSelect"], undefined>>(
@@ -160,7 +160,7 @@ function CalendarView({ engine, ide }: DendronProps) {
 
   const onClickToday = useCallback(() => {
     onSelect(moment());
-  }, []);
+  }, [onSelect]);
 
   const dateFullCellRender = useCallback<
     Exclude<CalendarProps["dateFullCellRender"], undefined>


### PR DESCRIPTION
This PR corrects opening today's daily note from the button with the right filename.
It additionally improves 2 things (see commits).