### PR TITLE
spike(preview): feat - sync to currently active note when open preview

### DIFF
--- a/packages/dendron-next-server/pages/vscode/note-preview.tsx
+++ b/packages/dendron-next-server/pages/vscode/note-preview.tsx
@@ -7,6 +7,7 @@ import {
 } from "@dendronhq/common-frontend";
 import { Col, Layout, Row } from "antd";
 import * as React from "react";
+import { useState } from "react";
 import { getWsAndPort } from "../../lib/env";
 import { DendronProps } from "../../lib/types";
 
@@ -15,6 +16,10 @@ const logger = createLogger("notePreview");
 function isHTMLAnchorElement(element: Element): element is HTMLAnchorElement {
   return element.nodeName === "A";
 }
+
+type NotePreviewProps = DendronProps & {
+  initNoteId?: string;
+};
 
 function AntLayout(props: React.PropsWithChildren<any>) {
   return (
@@ -34,15 +39,16 @@ function AntLayout(props: React.PropsWithChildren<any>) {
   );
 }
 
-function Note({ engine, ide }: DendronProps) {
+function Note({ engine, ide, initNoteId }: NotePreviewProps) {
   logger.info({
     state: "enter",
   });
+  const [isFirstRender, setFirstRender] = useState(true);
 
   const dispatch = engineHooks.useEngineAppDispatch();
 
   const { noteActive } = ide;
-  const { id: noteId = "9eae08fb-5e3f-4a7e-a989-3f206825d490", contentHash } =
+  let { id: noteId = "9eae08fb-5e3f-4a7e-a989-3f206825d490", contentHash } =
     noteActive || {};
   const noteContent = engine.notesRendered[noteId || ""];
 
@@ -50,6 +56,10 @@ function Note({ engine, ide }: DendronProps) {
   const renderedNoteContentHash = React.useRef<string>();
 
   React.useEffect(() => {
+    if (initNoteId && isFirstRender) {
+      noteId = initNoteId;
+      setFirstRender(false);
+    }
     if (!noteId) {
       logger.info({ msg: "no noteId" });
       return;

--- a/packages/plugin-core/src/commands/ShowPreviewV2.ts
+++ b/packages/plugin-core/src/commands/ShowPreviewV2.ts
@@ -11,9 +11,10 @@ import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
 import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
-import { getEngine, getWS } from "../workspace";
+import { DendronWorkspace, getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
 import { Logger } from "../logger";
+import { WorkspaceUtils } from "@dendronhq/engine-server";
 
 type CommandOpts = {};
 type CommandOutput = any;
@@ -74,24 +75,10 @@ export class ShowPreviewV2Command extends BasicCommand<
     return;
   }
 
-  async execute(_opts: CommandOpts) {
-    // Get workspace information
-    const ws = getWS();
-
-    // If panel already exists
-    const existingPanel = ws.getWebView(DendronWebViewKey.NOTE_PREVIEW);
-
+  createPanel(opts?: { initNoteId?: string }) {
     const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
     const preserveFocus = true;
-
-    if (!_.isUndefined(existingPanel)) {
-      try {
-        // If error, panel disposed and needs to be recreated
-        existingPanel.reveal(viewColumn, preserveFocus);
-        return;
-      } catch {}
-    }
-
+    const ws = getWS();
     const panel = vscode.window.createWebviewPanel(
       "dendronIframe", // Identifies the type of the webview. Used internally
       title, // Title of the panel displayed to the user
@@ -110,6 +97,9 @@ export class ShowPreviewV2Command extends BasicCommand<
     const resp = WebViewUtils.genHTMLForWebView({
       title,
       view: DendronWebViewKey.NOTE_PREVIEW,
+      qs: {
+        initNoteId: opts?.initNoteId,
+      },
     });
 
     panel.webview.html = resp;
@@ -151,7 +141,6 @@ export class ShowPreviewV2Command extends BasicCommand<
         }
         default:
           assertUnreachable(msg.type);
-          break;
       }
     });
 
@@ -163,5 +152,40 @@ export class ShowPreviewV2Command extends BasicCommand<
     panel.onDidDispose(() => {
       ws.setWebView(DendronWebViewKey.NOTE_PREVIEW, undefined);
     });
+  }
+
+  async execute(_opts: CommandOpts) {
+    // Get workspace information
+    const ws = getWS();
+
+    // If panel already exists
+    const existingPanel = ws.getWebView(DendronWebViewKey.NOTE_PREVIEW);
+
+    const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
+    const preserveFocus = true;
+    const activeEditor = vscode.window.activeTextEditor;
+
+    if (!_.isUndefined(existingPanel)) {
+      try {
+        // If error, panel disposed and needs to be recreated
+        existingPanel.reveal(viewColumn, preserveFocus);
+        return;
+      } catch {}
+    } else {
+      let initNoteId = undefined;
+      if (activeEditor?.document.uri.fsPath) {
+        if (
+          WorkspaceUtils.isPathInWorkspace({
+            wsRoot: DendronWorkspace.wsRoot(),
+            vaults: ws.getEngine().vaults,
+            fpath: activeEditor?.document.uri.fsPath,
+          })
+        ) {
+          const note = VSCodeUtils.getNoteFromDocument(activeEditor.document);
+          initNoteId = note?.id;
+        }
+      }
+      this.createPanel({ initNoteId });
+    }
   }
 }

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -10,14 +10,17 @@ export class WebViewUtils {
   static genHTMLForView = ({
     title,
     view,
+    qs,
   }: {
     title: string;
     view: DendronTreeViewKey | DendronWebViewKey;
+    qs?: any;
   }) => {
     const ws = getWS();
-    const qs = DUtils.querystring.stringify({
+    qs = DUtils.querystring.stringify({
       ws: DendronWorkspace.wsRoot(),
       port: ws.port,
+      ...(qs || {}),
     });
 
     // View is `dendron.{camelCase}`
@@ -123,16 +126,23 @@ export class WebViewUtils {
     return WebViewUtils.genHTMLForView({ title, view });
   };
 
+  /**
+   *
+   * @param qs: extra query string parameters
+   * @returns
+   */
   static genHTMLForWebView = ({
     title,
     view,
+    qs,
   }: {
     title: string;
     view: DendronWebViewKey;
+    qs?: any;
   }) => {
     /**
      * Implementation might differ in the future
      */
-    return WebViewUtils.genHTMLForView({ title, view });
+    return WebViewUtils.genHTMLForView({ title, view, qs });
   };
 }

--- a/test-workspace/vault/dendron.ref.markdown.md
+++ b/test-workspace/vault/dendron.ref.markdown.md
@@ -20,6 +20,12 @@ This is more normal text
 console.log("Hello World");
 ```
 
+### Checkbox
+
+- [ ] todo1
+- [ ] todo2
+- [ ] todo3
+
 ### Math
 
 - Inline $f(x) = 5$


### PR DESCRIPTION
Initial note render, render note using passed in `noteId` via `queryParam.

Docs here -> [[Details|pkg.dendron-next-server.arch#details]]

