### PR TITLE
fix(preview): show current active note when exec ShowPreview command

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreviewV2.ts
+++ b/packages/plugin-core/src/commands/ShowPreviewV2.ts
@@ -24,16 +24,7 @@ export class ShowPreviewV2Command extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
-  private activeTextEditor: vscode.TextEditor | undefined;
-
   key = DENDRON_COMMANDS.SHOW_PREVIEW_V2.key;
-
-  constructor(_name?: string) {
-    super(_name);
-    // save reference to the activeTextEditor when the command was trigger
-    // this makes sure that the `note` retrieval from `activeTextEditor` works in `NoteViewMessageType.onGetActiveEditor` because there it would be `undefined` since focus changed to the preview window
-    this.activeTextEditor = VSCodeUtils.getActiveTextEditor();
-  }
 
   static onDidChangeHandler(document: vscode.TextDocument) {
     const ctx = "ShowPreviewV2:onDidChangeHandler";
@@ -140,9 +131,10 @@ export class ShowPreviewV2Command extends BasicCommand<
         }
         case NoteViewMessageType.onGetActiveEditor: {
           // only entered on "init" in `plugin-core/src/views/utils.ts:87`
+          const activeTextEditor = VSCodeUtils.getActiveTextEditor();
           const note =
-            this.activeTextEditor &&
-            VSCodeUtils.getNoteFromDocument(this.activeTextEditor.document);
+            activeTextEditor &&
+            VSCodeUtils.getNoteFromDocument(activeTextEditor.document);
           if (note) {
             ShowPreviewV2Command.refresh(note);
           }


### PR DESCRIPTION
The issue has been reported this way:
- had a proj note open where I first tried out the preview V2, and it did switch back and forth between my journal and the proj note when I switched focus. I closed the preview and opened it back again on a different note but it will open up a preview of the proj note no matter what my current active window is.
   * Steps to reproduce:
      + Open preview on a note.
      + Close preview.
      + Switch to a different note.
      + Open preview again.

What was happening is that the first time the command was executed a
reference to the current active note was made and been reused everytime
the the preview has been reopened. The issue this implementation was
targeting seems to not be a problem anymore so I removed it.