### PR TITLE
fix: avoid generating IDs containing dashes and underscores

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -55,6 +55,7 @@
     "luxon": "^1.25.0",
     "minimatch": "^3.0.4",
     "nanoid": "^3.1.23",
+    "nanoid-dictionary": "^4.3.0",
     "semver": "^7.3.2",
     "title": "^3.4.2",
     "vscode-uri": "^2.1.2",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.5",
+    "@types/nanoid-dictionary": "^4.2.0",
     "coveralls": "^3.0.2",
     "jest": "^23.6.0",
     "jest-serializer-path": "^0.1.15",

--- a/packages/common-all/src/uuid.ts
+++ b/packages/common-all/src/uuid.ts
@@ -1,26 +1,27 @@
-import { nanoid } from "nanoid";
-import { nanoid as nanoidAsync } from "nanoid/async";
-import { nanoid as nanoidInsecure } from "nanoid/non-secure";
+import { customAlphabet as nanoid } from "nanoid";
+import { customAlphabet as nanoidAsync } from "nanoid/async";
+import { customAlphabet as nanoidInsecure } from "nanoid/non-secure";
+import { alphanumeric } from "nanoid-dictionary";
+
+/** Using this length, according to [nanoid collision calculator](https://zelark.github.io/nano-id-cc/),
+ * generating 1000 IDs per second, it would take around 981 years to have 1 percent chance of a single collision.
+ * This is actually a higher chance than UUID (and default of nanoid), but still very safe for our purposes.
+ */
+const ID_LENGTH = 16;
 
 /** Generates a random identifier.
  *
- * @param size If provided, the output will be this many characters. Mind that collisions are more likely with shorter sizes.
  * @returns A url-safe, random identifier.
  */
-export function genUUID(size?: number) {
-  return nanoid(size);
-}
+export const genUUID = nanoid(alphanumeric, ID_LENGTH);
 
 /** Generates a random identifier asynchronously.
  *
  * The entropy collection is performed asynchronously, allowing other code to run in the meantime.
  *
- * @param size If provided, the output will be this many characters. Mind that collisions are more likely with shorter sizes.
  * @returns A url-safe, random identifier.
  */
-export function genUUIDasync(size?: number) {
-  return nanoidAsync(size);
-}
+export const genUUIDasync = nanoidAsync(alphanumeric, ID_LENGTH);
 
 /** Generates a random identifier, faster but with potential cryptographic risks.
  *
@@ -28,9 +29,6 @@ export function genUUIDasync(size?: number) {
  * This increases the risk of collision attacks.
  * Only use this if performance is critical and collisions are relatively unimportant.
  *
- * @param size If provided, the output will be this many characters. Mind that collisions are more likely with shorter sizes.
  * @returns A url-safe, random identifier.
  */
-export function genUUIDInsecure(size?: number) {
-  return nanoidInsecure(size);
-}
+export const genUUIDInsecure = nanoidInsecure(alphanumeric, ID_LENGTH);

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -107,7 +107,7 @@ export function addOrGetAnchorAt(opts: {
   const line = editor.document.lineAt(position.line);
   const existingAnchor = getAnchorAt(opts);
   if (!_.isUndefined(existingAnchor)) return existingAnchor;
-  if (_.isUndefined(anchor)) anchor = genUUID(8);
+  if (_.isUndefined(anchor)) anchor = genUUID();
   editBuilder.insert(line.range.end, ` ^${anchor}`);
   return `^${anchor}`;
 }

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -3,7 +3,6 @@ import {
   NoteUtils,
   OnDidChangeActiveTextEditorMsg,
 } from "@dendronhq/common-all";
-import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { ExtensionContext, window, TextEditor, Selection } from "vscode";
 import { Logger } from "./logger";
@@ -11,7 +10,7 @@ import { VSCodeUtils } from "./utils";
 import { getWS } from "./workspace";
 import { ShowPreviewV2Command } from "./commands/ShowPreviewV2";
 import visit from "unist-util-visit";
-import { DendronASTDest, MDUtilsV5, ProcMode } from "@dendronhq/engine-server";
+import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
 import { updateDecorations } from "./features/windowDecorations";
 
 export class WindowWatcher {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,6 +3777,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/nanoid-dictionary@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/nanoid-dictionary/-/nanoid-dictionary-4.2.0.tgz#5a3ae86d7c0db2d3ecf5b1233fc27f5874903f77"
+  integrity sha512-DyQddKC2AYsInXBMqKSwhom4gpouV8SF1smsCPSzR8hp20vZJ5o5Yxg7qXThCHwr/H6VMq01UArEGbF0q2FXig==
+
 "@types/node@*", "@types/node@>= 8":
   version "15.3.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
@@ -13831,6 +13836,11 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoid-dictionary@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/nanoid-dictionary/-/nanoid-dictionary-4.3.0.tgz#d4cefa1e4c06b1f576789eeb2646101f8c5419e8"
+  integrity sha512-Xw1+/QnRGWO1KJ0rLfU1xR85qXmAHyLbE3TUkklu9gOIDburP6CsUnLmTaNECGpBh5SHb2uPFmx0VT8UPyoeyw==
 
 nanoid@^3.1.22, nanoid@^3.1.23:
   version "3.1.23"


### PR DESCRIPTION
Note IDs starting with underscores break Github pages, causing 404 errors on existing pages.

For safety, revised the code to avoid underscores and dashes in generated IDs. Also shortened the ID length while keeping it long enough that a collision is still incredibly unlikely.

#945