### PR TITLE
feat: wikilink autocomplete sorts current vault notes before other notes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,10 @@ module.exports = {
     "consistent-return": "off",
     // don't agree with
     "dot-notation": "off",
+    // Less restrictive version of airbnb
+    "no-restricted-syntax": ["error", "ForInStatement", 'WithStatement'],
+    "no-continue": "off",
+    'no-labels': ['error', { allowLoop: true, allowSwitch: false }],
     // prettier
     indent: "off",
     quotes: "off",

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -112,6 +112,7 @@ export const provideCompletionItems = (
     item.sortText = padWithZero(index);
     // Sort notes from current vault before other vaults
     if (currentVault && !VaultUtils.isEqual(currentVault, note.vault, wsRoot)) {
+      // x will get sorted after numbers, so these will appear after notes without x
       item.sortText = 'x' + item.sortText;
     }
 

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -24,7 +24,7 @@ suite("completionProvider", function () {
           await VSCodeUtils.openNote(
             NoteUtils.getNoteOrThrow({
               fname: "root",
-              vault: vaults[0],
+              vault: vaults[1],
               wsRoot,
               notes: engine.notes,
             })
@@ -40,7 +40,7 @@ suite("completionProvider", function () {
           );
           expect(items).toBeTruthy();
           // Suggested all the notes
-          expect(items!.length).toEqual(6);
+          expect(items!.length).toEqual(7);
           for (const item of items!) {
             // All suggested items exist
             const found = NoteUtils.getNotesByFname({
@@ -49,9 +49,21 @@ suite("completionProvider", function () {
             });
             expect(found.length > 0).toBeTruthy();
           }
+          // check that same vault items are sorted before other items
+          const sortedItems = _.sortBy(items, (item) => item.sortText || item.label);
+          const testIndex = _.findIndex(sortedItems, (item) => item.label === 'test');
+          expect(testIndex != -1 && testIndex < 2).toBeTruthy();
           done();
         },
-        preSetupHook: ENGINE_HOOKS.setupBasic,
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            fname: "test",
+            vault: vaults[1],
+            wsRoot,
+          });
+          await ENGINE_HOOKS.setupBasic(opts);
+        },
       });
     });
   });

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -3,7 +3,6 @@ import {
   NoteUtils,
   OnDidChangeActiveTextEditorMsg,
 } from "@dendronhq/common-all";
-import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { ExtensionContext, window, TextEditor, Selection } from "vscode";
 import { Logger } from "./logger";
@@ -11,7 +10,7 @@ import { VSCodeUtils } from "./utils";
 import { getWS } from "./workspace";
 import { ShowPreviewV2Command } from "./commands/ShowPreviewV2";
 import visit from "unist-util-visit";
-import { DendronASTDest, MDUtilsV5, ProcMode } from "@dendronhq/engine-server";
+import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
 import { updateDecorations } from "./features/windowDecorations";
 
 export class WindowWatcher {


### PR DESCRIPTION
This pull request changes it so that notes from the current vault will appear before notes from other vaults. This order is only initially however, VSCode may change the order as the user types to narrow the selection.

This partially helps #887. I have more features planned to improve it further.