### PR TITLE
feat: editor highlighting for wikilinks & references

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,19 @@ module.exports = {
     "max-len": "off",
     "prefer-template": "off",
     "consistent-return": "off",
+    // less restrictive airbnb
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
+    'no-continue': 'off',
     // don't agree with
     "dot-notation": "off",
     // prettier

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -16,6 +16,7 @@ import { DateTime } from "luxon";
 import { getConfigValue, getWS } from "../workspace";
 import { CodeConfigKeys, DateTimeFormat } from "../types";
 import { VSCodeUtils } from "../utils";
+import { containsNonDendronUri } from "../utils/md";
 
 export function updateDecorations(activeEditor: TextEditor) {
   const text = activeEditor.document.getText();
@@ -187,7 +188,7 @@ function decorateWikiLink(wikiLink: WikiLinkNoteV4, document: TextDocument) {
     )}]);
   }
 
-  if (foundNote) {
+  if (foundNote || containsNonDendronUri(wikiLink.value)) {
     decorations.push(
       [DECORATION_TYPE_WIKILINK, options]
     );

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -5,13 +5,15 @@ import {
   DendronASTTypes,
   MDUtilsV5,
   ProcMode,
+  WikiLinkNoteV4,
+  NoteRefNoteV4,
 } from "@dendronhq/engine-server";
-import { DecorationOptions, Range, TextEditor, window } from "vscode";
+import { DecorationOptions, DecorationRangeBehavior, Range, TextEditor, TextEditorDecorationType, ThemeColor, window, TextDocument } from "vscode";
 import visit from "unist-util-visit";
 import _ from "lodash";
-import { isNotUndefined, NoteUtils } from "@dendronhq/common-all";
+import { isNotUndefined, NoteUtils, Position, VaultUtils } from "@dendronhq/common-all";
 import { DateTime } from "luxon";
-import { getConfigValue } from "../workspace";
+import { getConfigValue, getWS } from "../workspace";
 import { CodeConfigKeys, DateTimeFormat } from "../types";
 import { VSCodeUtils } from "../utils";
 
@@ -25,37 +27,57 @@ export function updateDecorations(activeEditor: TextEditor) {
     { dest: DendronASTDest.MD_DENDRON }
   );
   const tree = proc.parse(text);
-  const blockAnchorDecorations: DecorationOptions[] = [];
-  let timestampDecorations: DecorationOptions[] = [];
+  const decorations: Map<TextEditorDecorationType, DecorationOptions[]> = new Map([
+    [DECORATION_TYPE_TIMESTAMP, []],
+    [DECORATION_TYPE_WIKILINK, []],
+    [DECORATION_TYPE_ALIAS, []],
+    [DECORATION_TYPE_BROKEN_WIKILINK, []],
+    [DECORATION_TYPE_BLOCK_ANCHOR, []],
+  ]);
 
   visit(tree, (node) => {
     switch (node.type) {
       case DendronASTTypes.FRONTMATTER: {
-        const decoration = decorateTimestamps(node as FrontmatterContent);
-        if (isNotUndefined(decoration)) timestampDecorations = decoration;
+        for (const decoration of decorateTimestamps(node as FrontmatterContent)) {
+          decorations.get(DECORATION_TYPE_TIMESTAMP)?.push(decoration);
+        }
         break;
       }
       case DendronASTTypes.BLOCK_ANCHOR: {
         const decoration = decorateBlockAnchor(node as BlockAnchor);
-        if (isNotUndefined(decoration)) blockAnchorDecorations.push(decoration);
+        if (isNotUndefined(decoration)) decorations.get(DECORATION_TYPE_BLOCK_ANCHOR)?.push(decoration);
         break;
       }
+      case DendronASTTypes.WIKI_LINK: {
+        for (const [type, decoration] of decorateWikiLink(node as WikiLinkNoteV4, activeEditor.document)) {
+          decorations.get(type)?.push(decoration);
+        }
+        break;
+      }
+      case DendronASTTypes.REF_LINK_V2:
+      case DendronASTTypes.REF_LINK: {
+        const out = decorateReference(node as NoteRefNoteV4);
+        if (out) {
+          const [type, decoration] = out;
+          decorations.get(type)?.push(decoration);
+        }
+        break;
+      }
+      default: /* nothing */
     }
   });
 
-  activeEditor.setDecorations(
-    DECORATION_TYPE_BLOCK_ANCHOR,
-    blockAnchorDecorations
-  );
-  activeEditor.setDecorations(DECORATION_TYPE_TIMESTAMP, timestampDecorations);
-  return { blockAnchorDecorations, timestampDecorations };
+  for (const [type, items] of decorations.entries()) {
+    activeEditor.setDecorations(type, items);
+  }
+  return decorations;
 }
 
-const DECORATION_TYPE_TIMESTAMP = window.createTextEditorDecorationType({});
+export const DECORATION_TYPE_TIMESTAMP = window.createTextEditorDecorationType({});
 
 function decorateTimestamps(frontmatter: FrontmatterContent) {
   const { value: contents, position } = frontmatter;
-  if (_.isUndefined(position)) return; // should never happen
+  if (_.isUndefined(position)) return []; // should never happen
   const tsConfig = getConfigValue(
     CodeConfigKeys.DEFAULT_TIMESTAMP_DECORATION_FORMAT
   ) as DateTimeFormat;
@@ -92,8 +114,9 @@ function decorateTimestamps(frontmatter: FrontmatterContent) {
     .filter(isNotUndefined);
 }
 
-const DECORATION_TYPE_BLOCK_ANCHOR = window.createTextEditorDecorationType({
+export const DECORATION_TYPE_BLOCK_ANCHOR = window.createTextEditorDecorationType({
   opacity: "40%",
+  rangeBehavior: DecorationRangeBehavior.ClosedOpen,
 });
 
 function decorateBlockAnchor(blockAnchor: BlockAnchor) {
@@ -104,4 +127,90 @@ function decorateBlockAnchor(blockAnchor: BlockAnchor) {
     range: VSCodeUtils.position2VSCodeRange(position),
   };
   return decoration;
+}
+
+/** Decoration for wikilinks that point to valid notes. */
+export const DECORATION_TYPE_WIKILINK = window.createTextEditorDecorationType({
+  color: new ThemeColor("editorLink.activeForeground"),
+  rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+});
+
+/** Decoration for wikilinks that do *not* point to valid notes (e.g. broken). */
+export const DECORATION_TYPE_BROKEN_WIKILINK = window.createTextEditorDecorationType({
+  color: new ThemeColor("editorWarning.foreground"),
+  backgroundColor: new ThemeColor("editorWarning.background"),
+  rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+});
+
+
+function doesLinkedNoteExist({fname, vaultName}: {fname: string, vaultName?: string}) {
+  const {notes, vaults} = getWS().getEngine();
+  const vault = vaultName ? VaultUtils.getVaultByName({vname: vaultName, vaults}) : undefined;
+  // Vault specified, but can't find it.
+  if (vaultName && !vault) return false;
+  const found = NoteUtils.getNotesByFname({
+    fname,
+    vault,
+    notes,
+  });
+  return found.length > 0;
+}
+
+/** Decoration for the alias part of wikilinks. */
+export const DECORATION_TYPE_ALIAS = window.createTextEditorDecorationType({
+  fontStyle: "italic",
+});
+
+const RE_ALIAS = /(?<beforeAlias>\[\[)(?<alias>[^|]+)\|/;
+
+function decorateWikiLink(wikiLink: WikiLinkNoteV4, document: TextDocument) {
+  const position = wikiLink.position;
+  if (_.isUndefined(position)) return []; // should never happen
+
+  const foundNote = doesLinkedNoteExist({fname: wikiLink.value, vaultName: wikiLink.data.vaultName});
+  const wikiLinkrange = VSCodeUtils.position2VSCodeRange(position);
+  const options: DecorationOptions = {
+    range: wikiLinkrange,
+  };
+  const decorations: [TextEditorDecorationType, DecorationOptions][] = [];
+  
+  // Highlight the alias part
+  const linkText = document.getText(options.range);
+  const aliasMatch = linkText.match(RE_ALIAS);
+  if (aliasMatch && aliasMatch.groups?.beforeAlias && aliasMatch.groups?.alias) {
+    const {beforeAlias, alias} = aliasMatch.groups;
+    decorations.push([DECORATION_TYPE_ALIAS, { range: new Range(
+      wikiLinkrange.start.line,
+      wikiLinkrange.start.character + beforeAlias.length,
+      wikiLinkrange.start.line,
+      wikiLinkrange.start.character + beforeAlias.length + alias.length,
+    )}]);
+  }
+
+  if (foundNote) {
+    decorations.push(
+      [DECORATION_TYPE_WIKILINK, options]
+    );
+  } else {
+    decorations.push(
+      [DECORATION_TYPE_BROKEN_WIKILINK, options]
+    );
+  }
+  return decorations;
+}
+
+function decorateReference(reference: NoteRefNoteV4): [TextEditorDecorationType, DecorationOptions] | undefined {
+  const position = reference.position as Position;
+  if (_.isUndefined(position)) return undefined;
+
+  const foundNote = doesLinkedNoteExist({fname: reference.data.link.from.fname, vaultName: reference.data.link.data.vaultName});
+  const options: DecorationOptions = {
+    range: VSCodeUtils.position2VSCodeRange(position),
+  };
+
+  if (foundNote) {
+    return [DECORATION_TYPE_WIKILINK, options];
+  } else {
+    return [DECORATION_TYPE_BROKEN_WIKILINK, options]
+  }
 }

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import { VSCodeUtils } from "../../utils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-import { updateDecorations } from "../../features/windowDecorations";
+import { DECORATION_TYPE_ALIAS, DECORATION_TYPE_BLOCK_ANCHOR, DECORATION_TYPE_BROKEN_WIKILINK, DECORATION_TYPE_TIMESTAMP, DECORATION_TYPE_WIKILINK, updateDecorations } from "../../features/windowDecorations";
 import _ from "lodash";
 
 /** Check if the ranges decorated by `decorations` contains `text` */
@@ -21,14 +21,12 @@ function isTextDecorated(
 }
 
 suite("windowDecorations", function () {
-  let ctx: vscode.ExtensionContext;
-
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
-  describe("decorations", function () {
-    test("basic", function (done) {
+  describe("decorations", () => {
+    test("basic", (done) => {
       const CREATED = "1625648278263";
       const UPDATED = "1625758878263";
       const FNAME = "bar";
@@ -45,6 +43,12 @@ suite("windowDecorations", function () {
               "* Aut suscipit veniam nobis veniam reiciendis. ^anchor-2",
               "  * Sit sed accusamus saepe voluptatem sint animi quis animi. ^anchor-3",
               "* Dolores suscipit maiores nulla accusamus est.",
+              "",
+              "[[root]]",
+              "",
+              "[[with alias|root]]",
+              "",
+              "[[does.not.exist]]",
             ].join("\n"),
             props: {
               created: _.toInteger(CREATED),
@@ -63,30 +67,49 @@ suite("windowDecorations", function () {
           });
           const editor = await VSCodeUtils.openNote(note!);
           const document = editor.document;
-          const { timestampDecorations, blockAnchorDecorations } =
-            updateDecorations(editor);
+          const decorations = updateDecorations(editor);
 
-          expect(timestampDecorations.length).toEqual(2);
+          const timestampDecorations = decorations.get(DECORATION_TYPE_TIMESTAMP);
+          expect(timestampDecorations?.length).toEqual(2);
           // check that the decorations are at the right locations
           expect(
-            isTextDecorated(CREATED, timestampDecorations, document)
+            isTextDecorated(CREATED, timestampDecorations!, document)
           ).toBeTruthy();
           expect(
-            isTextDecorated(UPDATED, timestampDecorations, document)
+            isTextDecorated(UPDATED, timestampDecorations!, document)
           ).toBeTruthy();
 
-          expect(blockAnchorDecorations.length).toEqual(3);
+          const blockAnchorDecorations = decorations.get(DECORATION_TYPE_BLOCK_ANCHOR);
+          expect(blockAnchorDecorations?.length).toEqual(3);
           // check that the decorations are at the right locations
           expect(
-            isTextDecorated("^anchor-1", blockAnchorDecorations, document)
+            isTextDecorated("^anchor-1", blockAnchorDecorations!, document)
           ).toBeTruthy();
           expect(
-            isTextDecorated("^anchor-2", blockAnchorDecorations, document)
+            isTextDecorated("^anchor-2", blockAnchorDecorations!, document)
           ).toBeTruthy();
           expect(
-            isTextDecorated("^anchor-3", blockAnchorDecorations, document)
+            isTextDecorated("^anchor-3", blockAnchorDecorations!, document)
           ).toBeTruthy();
 
+          const wikilinkDecorations = decorations.get(DECORATION_TYPE_WIKILINK);
+          expect(wikilinkDecorations?.length).toEqual(2);
+          expect(
+            isTextDecorated("[[root]]", wikilinkDecorations!, document)
+          ).toBeTruthy();
+          expect(
+            isTextDecorated("[[with alias|root]]", wikilinkDecorations!, document)
+          ).toBeTruthy();
+
+          const aliasDecorations = decorations.get(DECORATION_TYPE_ALIAS);
+          expect(aliasDecorations?.length).toEqual(1);
+          expect(isTextDecorated("with alias", aliasDecorations!, document));
+
+          const brokenWikilinkDecorations = decorations.get(DECORATION_TYPE_BROKEN_WIKILINK);
+          expect(brokenWikilinkDecorations?.length).toEqual(1);
+          expect(
+            isTextDecorated("[[does.not.exist]]", brokenWikilinkDecorations!, document)
+          ).toBeTruthy();
           done();
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3275,10 +3275,24 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/graphql@^4.6.4":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.4.tgz#0c3f5bed440822182e972317122acb65d311a5ed"
+  integrity sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
 "@octokit/openapi-types@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz#0f6992db9854af15eca77d71ab0ec7fad2f20411"
   integrity sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw==
+
+"@octokit/openapi-types@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-8.2.1.tgz#102e752a7378ff8d21057c70fd16f1c83856d8c5"
+  integrity sha512-BJz6kWuL3n+y+qM8Pv+UGbSxH6wxKf/SBs5yzGufMHwDefsa+Iq7ZGy1BINMD2z9SkXlIzk1qiu988rMuGXEMg==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
@@ -3323,6 +3337,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.2.0":
   version "5.4.15"
   resolved "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
@@ -3331,6 +3354,18 @@
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^6.7.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.0.tgz#6084861b6e4fa21dc40c8e2a739ec5eff597e672"
+  integrity sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
@@ -3370,6 +3405,13 @@
   integrity sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==
   dependencies:
     "@octokit/openapi-types" "^7.0.0"
+
+"@octokit/types@^6.16.1":
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.18.1.tgz#a6db178536e649fd5d67a7b747754bcc43940be4"
+  integrity sha512-5YsddjO1U+xC8ZYKV8yZYebW55PCc7qiEEeZ+wZRr6qyclynzfyD65KZ5FdtIeP0/cANyFaD7hV69qElf1nMsQ==
+  dependencies:
+    "@octokit/openapi-types" "^8.2.1"
 
 "@opentelemetry/api@0.14.0":
   version "0.14.0"
@@ -4448,6 +4490,13 @@ ajv-errors@^1.0.0:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.0.tgz#96eaf83e38d32108b66d82a9cb0cfa24886cdfeb"
+  integrity sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -4463,7 +4512,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
+ajv@^8.0.0, ajv@^8.0.1:
   version "8.6.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz#ae65764bf1edde8cd861281cda5057852364a295"
   integrity sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==


### PR DESCRIPTION
Wikilinks are now highlighted, with the aliases being italicized. If the note is not found, then these are highlighted differently to make them stand out.

I'm not sure if these are a good way to highlight wikilinks, so I'd like some feedback on what people think.

Dark theme: 
![dark theme](https://i.imgur.com/ohPYMsI.png)

Light theme:
![light theme](https://i.imgur.com/8kZSrb5.png)