### PR TITLE
feat: lapsed user prompt

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -8,6 +8,9 @@ export enum VSCodeEvents {
   Upgrade = "Upgrade",
   DisableTelemetry = "DisableTelemetry",
   EnableTelemetry = "EnableTelemetry",
+  ShowLapsedUserMessage = "Show_Lapsed_User_Msg",
+  LapsedUserMessageAccepted = "Lapsed_User_Msg_Accepted",
+  LapsedUserMessageRejected = "Show_Lapsed_User_Rejected"
 }
 
 export enum TutorialEvents {

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -12,9 +12,13 @@ type Metadata = Partial<{
    * When the first workspace was initialized
    */
   firstWsInitialize: number;
+  /**
+   * When the last time the lapsed user message was displayed to the user
+   */
+  lapsedUserMsgSendTime: number;
 }>;
 
-let _singleton: MetadataService | undefined = undefined;
+let _singleton: MetadataService | undefined;
 
 export class MetadataService {
   static instance() {
@@ -47,10 +51,14 @@ export class MetadataService {
   }
 
   setInitialInstall() {
-    return this.setMeta("firstInstall", Time.now().second);
+    return this.setMeta("firstInstall", Time.now().toSeconds());
   }
 
   setFirstWsInitialize() {
-    return this.setMeta("firstWsInitialize", Time.now().second);
+    return this.setMeta("firstWsInitialize", Time.now().toSeconds());
+  }
+
+  setLapsedUserMsgSendTime() {
+    return this.setMeta("lapsedUserMsgSendTime", Time.now().toSeconds());
   }
 }

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -1,18 +1,16 @@
 import {
   CleanDendronSiteConfig,
-  CONSTANTS,
-  DEngineClient,
+  CONSTANTS, DendronConfig, DEngineClient,
   DVault,
   DWorkspace,
   WorkspaceFolderRaw,
   WorkspaceOpts,
-  WorkspaceSettings,
-  DendronConfig,
+  WorkspaceSettings
 } from "@dendronhq/common-all";
 import {
   getDurationMilliseconds,
   tmpDir,
-  vault2Path,
+  vault2Path
 } from "@dendronhq/common-server";
 import {
   GenTestResults,
@@ -24,20 +22,21 @@ import {
   SetupHookFunction,
   SetupTestFunctionV4,
   sinon,
-  TestResult,
+  TestResult
 } from "@dendronhq/common-test-utils";
 import { LaunchEngineServerCommand } from "@dendronhq/dendron-cli";
 import {
   createEngine as engineServerCreateEngine,
   DConfig,
-  WorkspaceService,
+  WorkspaceService
 } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
+import os from "os";
 import path from "path";
+import { SinonStub } from "sinon";
 import { ENGINE_HOOKS } from "./presets";
 import { GitTestUtils } from "./utils";
-import os from "os";
 
 export type TestSetupWorkspaceOpts = {
   /**
@@ -349,10 +348,9 @@ export function testWithEngine(
 }
 
 export class TestEngineUtils {
-  static mockHomeDir(dir?: string) {
+  static mockHomeDir(dir?: string): SinonStub {
     if (_.isUndefined(dir)) dir = tmpDir().name;
-    sinon.stub(os, "homedir").returns(dir);
-    return dir;
+    return sinon.stub(os, "homedir").returns(dir);
   }
   static vault1(vaults: DVault[]) {
     return _.find(vaults, { fsPath: "vault1" })!;

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -752,7 +752,7 @@
     "@dendronhq/engine-test-utils": "^0.50.0",
     "@dendronhq/lsp-server": "^0.28.7-alpha.0",
     "@dendronhq/pods-core": "^0.50.0",
-    "@types/vscode": "1.57",
+    "@types/vscode": "1.58",
     "cross-path-sort": "^1.0.0",
     "execa": "^4.0.2",
     "fs-extra": "^9.0.1",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -554,23 +554,29 @@ function showLapsedUserMessage() {
     });
 }
 
-function shouldDisplayLapsedUserMsg(): boolean {
+/**
+ * Visible for Testing purposes only
+ * @returns
+ */
+export function shouldDisplayLapsedUserMsg(): boolean {
+  const ONE_DAY = Duration.fromObject({ days: 1 });
   const ONE_WEEK = Duration.fromObject({ weeks: 1 });
   const CUR_TIME = Duration.fromObject({ seconds: Time.now().toSeconds() });
   const metaData = MetadataService.instance().getMeta();
 
-  // If we haven't prompted the user yet and it's been a week since their
+  // If we haven't prompted the user yet and it's been a day since their
   // initial install OR if it's been one week since we last prompted the user
   const refreshMsg =
-    (!metaData.lapsedUserMsgSendTime &&
-      ONE_WEEK <=
+    (metaData.lapsedUserMsgSendTime === undefined &&
+      ONE_DAY <=
         CUR_TIME.minus(
           Duration.fromObject({ seconds: metaData.firstInstall })
         )) ||
-    ONE_WEEK <=
-      CUR_TIME.minus(
-        Duration.fromObject({ seconds: metaData.lapsedUserMsgSendTime })
-      );
+    (metaData.lapsedUserMsgSendTime !== undefined &&
+      ONE_WEEK <=
+        CUR_TIME.minus(
+          Duration.fromObject({ seconds: metaData.lapsedUserMsgSendTime })
+        ));
 
   // If the user has never initialized and it's time to refresh the lapsed user
   // message


### PR DESCRIPTION
Prompt users with a modal dialog to get started with Dendron under the following conditions:

1) Have not initialized a workspace before
2A) >1 week since install
2B) >1 week since last reminder prompt.