### PR TITLE
chore: test compat on windows

### DIFF
--- a/packages/plugin-core/src/logger.ts
+++ b/packages/plugin-core/src/logger.ts
@@ -25,7 +25,12 @@ export class Logger {
     fs.ensureDirSync(context.logPath);
     const logPath = path.join(context.logPath, "dendron.log");
     if (fs.existsSync(logPath)) {
-      fs.moveSync(logPath, `${logPath}.old`, { overwrite: true });
+      try {
+        fs.moveSync(logPath, `${logPath}.old`, { overwrite: true });
+      }
+      catch {
+        Logger.error({ ctx, msg: `Unable to rename ${logPath}. Logs will be appended.`});
+      }
     }
     fs.ensureFileSync(logPath);
     const conf = workspace.getConfiguration();

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -58,9 +58,11 @@ suite("BacklinksTreeDataProvider", function () {
       },
       onInit: async ({ wsRoot, vaults }) => {
         await VSCodeUtils.openNote(noteWithTarget);
+
+        const expectedUri = vscode.Uri.file(path.join(wsRoot, vaults[0].fsPath, "beta.md"));
         const out = toPlainObject(await getChildren()) as any;
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          path.join(wsRoot, vaults[0].fsPath, "beta.md")
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
         expect(out.length).toEqual(1);
         done();
@@ -88,8 +90,9 @@ suite("BacklinksTreeDataProvider", function () {
         await new ReloadIndexCommand().run();
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          path.join(wsRoot, vaults[0].fsPath, "beta.md")
+        const expectedUri = vscode.Uri.file(path.join(wsRoot, vaults[0].fsPath, "beta.md"));
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
         expect(out.length).toEqual(1);
         done();
@@ -118,8 +121,9 @@ suite("BacklinksTreeDataProvider", function () {
         const notePath = path.join(wsRoot, vaults[0].fsPath, "alpha.md");
         await VSCodeUtils.openFileInEditor(Uri.file(notePath));
         const out = toPlainObject(await getChildren()) as any;
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          path.join(wsRoot, vaults[1].fsPath, "beta.md")
+        const expectedUri = vscode.Uri.file(path.join(wsRoot, vaults[1].fsPath, "beta.md"));
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
         expect(out.length).toEqual(1);
         done();
@@ -148,8 +152,9 @@ suite("BacklinksTreeDataProvider", function () {
         const notePath = path.join(wsRoot, vaults[0].fsPath, "alpha.md");
         await VSCodeUtils.openFileInEditor(Uri.file(notePath));
         const out = toPlainObject(await getChildren()) as any;
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          path.join(wsRoot, vaults[1].fsPath, "beta.md")
+        const expectedUri = vscode.Uri.file(path.join(wsRoot, vaults[1].fsPath, "beta.md"));
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
         expect(out.length).toEqual(1);
         done();
@@ -176,11 +181,14 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async () => {
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          NoteUtils.getFullPath({
-            note: noteWithLink,
-            wsRoot: DendronWorkspace.wsRoot(),
-          })
+
+        const expectedUri = vscode.Uri.file(NoteUtils.getFullPath({
+          note: noteWithLink,
+          wsRoot: DendronWorkspace.wsRoot(),
+        }));
+
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
         expect(out.length).toEqual(1);
         done();
@@ -207,14 +215,10 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async ({ wsRoot }) => {
         await VSCodeUtils.openNote(noteWithTarget);
         const out = toPlainObject(await getChildren()) as any;
-        // assert.strictEqual(
-        //   out[0].command.arguments[0].path as string,
-        //   NoteUtils.getPathV4({ note: noteWithLink, wsRoot })
-        // );
-        expect(out[0].command.arguments[0].path as string).toEqual(
-          NoteUtils.getFullPath({ note: noteWithLink, wsRoot })
+        const expectedUri = vscode.Uri.file(NoteUtils.getFullPath({ note: noteWithLink, wsRoot }));
+        expect(out[0].command.arguments[0].path.toLowerCase() as string).toEqual(
+          expectedUri.path.toLowerCase()
         );
-        // assert.strictEqual(out.length, 1);
         expect(out.length).toEqual(1);
         done();
       },

--- a/packages/plugin-core/src/test/suite-integ/ConfigureCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureCommand.test.ts
@@ -18,8 +18,8 @@ suite("ConfigureCommand", () => {
         onInit: async ({ wsRoot }) => {
           await new ConfigureCommand().run();
           expect(
-            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath
-          ).toEqual(path.join(wsRoot, "dendron.yml"));
+            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
+          ).toEqual(path.join(wsRoot, "dendron.yml").toLowerCase());
           done();
         },
       });

--- a/packages/plugin-core/src/test/suite-integ/CreateHookCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateHookCommand.test.ts
@@ -40,10 +40,10 @@ suite(DENDRON_COMMANDS.CREATE_HOOK.key, function () {
           expect(config.hooks).toEqual({
             onCreate: [{ id: hook, pattern: "*", type: "js" }],
           });
-          expect(editor.document.uri.fsPath).toEqual(
+          expect(editor.document.uri.fsPath.toLowerCase()).toEqual(
             path.join(
               HookUtils.getHookScriptPath({ basename: `${hook}.js`, wsRoot })
-            )
+            ).toLowerCase()
           );
           expect(
             AssertUtils.assertInString({

--- a/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
@@ -56,8 +56,8 @@ suite("DefinitionProvider", function () {
         onInit: async () => {
           const editor = await VSCodeUtils.openNote(noteWithTarget);
           const location = (await provide(editor)) as vscode.Location;
-          expect(location.uri.fsPath).toEqual(
-            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithLink })
+          expect(location.uri.fsPath.toLowerCase()).toEqual(
+            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithLink }).toLowerCase()
           );
           done();
         },
@@ -72,8 +72,8 @@ suite("DefinitionProvider", function () {
           const beta = engine.notes["beta"];
           const editor = await VSCodeUtils.openNote(note);
           const location = (await provide(editor)) as vscode.Location;
-          expect(location.uri.fsPath).toEqual(
-            NoteUtils.getFullPath({ wsRoot, note: beta })
+          expect(location.uri.fsPath.toLowerCase()).toEqual(
+            NoteUtils.getFullPath({ wsRoot, note: beta }).toLowerCase()
           );
           done();
         },
@@ -140,8 +140,8 @@ suite("DefinitionProvider", function () {
         onInit: async () => {
           const editor = await VSCodeUtils.openNote(noteWithLink);
           const location = (await provide(editor)) as vscode.Location;
-          expect(location.uri.fsPath).toEqual(
-            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithTarget })
+          expect(location.uri.fsPath.toLowerCase()).toEqual(
+            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithTarget }).toLowerCase()
           );
           done();
         },
@@ -205,8 +205,8 @@ suite("DefinitionProvider", function () {
             LocationTestUtils.getPresetWikiLinkPosition(),
             null as any
           )) as vscode.Location;
-          expect(locations.uri.fsPath).toEqual(
-            path.join(wsRoot, vaults[1].fsPath, "beta.md")
+          expect(locations.uri.fsPath.toLowerCase()).toEqual(
+            path.join(wsRoot, vaults[1].fsPath, "beta.md").toLowerCase()
           );
           done();
         },
@@ -235,8 +235,8 @@ suite("DefinitionProvider", function () {
             LocationTestUtils.getPresetWikiLinkPosition(),
             null as any
           )) as vscode.Location;
-          expect(locations.uri.fsPath).toEqual(
-            path.join(wsRoot, vaults[1].fsPath, "beta.md")
+          expect(locations.uri.fsPath.toLowerCase()).toEqual(
+            path.join(wsRoot, vaults[1].fsPath, "beta.md").toLowerCase()
           );
           done();
         },
@@ -272,9 +272,9 @@ suite("DefinitionProvider", function () {
           const editor = await VSCodeUtils.openNote(noteWithLink);
           const locations = (await provide(editor)) as vscode.Location[];
           expect(locations.length).toEqual(2);
-          expect(locations.map((l) => l.uri.fsPath)).toEqual([
-            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteTarget1 }),
-            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteTarget2 }),
+          expect(locations.map((l) => l.uri.fsPath.toLowerCase())).toEqual([
+            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteTarget1 }).toLowerCase(),
+            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteTarget2 }).toLowerCase(),
           ]);
           done();
         },
@@ -311,8 +311,8 @@ suite("DefinitionProvider", function () {
             pos,
             null as any
           )) as vscode.Location;
-          expect(loc.uri.fsPath).toEqual(
-            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithTarget })
+          expect(loc.uri.fsPath.toLowerCase()).toEqual(
+            NoteUtils.getFullPath({ wsRoot: _wsRoot, note: noteWithTarget }).toLowerCase()
           );
           done();
         },

--- a/packages/plugin-core/src/test/suite-integ/GoToSibling.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoToSibling.test.ts
@@ -387,6 +387,7 @@ suite("GoToSibling", function () {
             const notePath = path.join(vpath, "foo.journal.2020.08.30.md");
             await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
             const resp = await new GoToSiblingCommand().execute({ direction });
+
             await runJestHarnessV2(
               [
                 {
@@ -396,7 +397,7 @@ suite("GoToSibling", function () {
                 {
                   actual:
                     VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
-                      `${path.basename(vault.fsPath)}/foo.journal.2020.08.31.md`
+                      (path.join(`${path.basename(vault.fsPath)}`, "foo.journal.2020.08.31.md"))
                     ),
                   expected: true,
                 },

--- a/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
@@ -556,7 +556,7 @@ suite("Lookup, notesv2", function () {
           });
           expect(
             (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
-              "vault1/alpha.md"
+              path.join("vault1", "alpha.md")
             )
           ).toBeTruthy();
           done();
@@ -596,7 +596,7 @@ suite("Lookup, notesv2", function () {
           });
           expect(
             (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
-              "vault2/alpha.md"
+              path.join("vault2", "alpha.md")
             )
           ).toBeTruthy();
           done();

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -195,7 +195,7 @@ suite("MoveNoteCommand", function () {
         });
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.fileName.endsWith(
-            "vault1/bar.md"
+            path.join("vault1", "bar.md")
           )
         ).toBeTruthy();
         // note not in old vault
@@ -308,7 +308,7 @@ suite("MoveNoteCommand", function () {
         });
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.fileName.endsWith(
-            "vault1/bar.md"
+            path.join("vault1", "bar.md")
           )
         ).toBeTruthy();
         expect(
@@ -356,7 +356,7 @@ suite("MoveNoteCommand", function () {
         });
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.fileName.endsWith(
-            "vault2/foo.md"
+            path.join("vault2", "foo.md")
           )
         ).toBeTruthy();
         // note not in old vault

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -370,5 +370,5 @@ async function changeConfig(
   // Commit this change, otherwise it will be a tracked file with changes which breaks git pull
   const git = new Git({ localUrl: wsRoot });
   await git.add("dendron.yml");
-  await git.commit({ msg: "update config" });
+  await git.commit({ msg: "update-config" });
 }

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -225,7 +225,7 @@ suite("VaultRemoveCommand", function () {
 
           // check that "vault2" is gone from payload
           expect(config.site.duplicateNoteBehavior!.payload).toEqual([
-            vault.fsPath.replace("../", ""),
+            path.parse(vault.fsPath).base,
             "vault3",
           ]);
           done();


### PR DESCRIPTION
Fixing test compat issues that prevent the tests from running/succeeding on Windows:

1) Various Path Issues
  - Some API's have a lower case vs upper-case for the drive prefix; i.e. `c:\` vs `C:\`.  We need to always  do case-insensitive string comparisons when doing file path checks.
  - The usual `\` vs `/` issues.
  - Some parameter spacing problems when invoking the Git command
2) Logger Issues - There's a file handle problem that occurs on Windows with fs/fs-extra that prevents a rename on the log file and leads to the following error.  We can just wrap in try/catch as it's not very important where the log ends up during the test:

```log
    Error: EPERM: operation not permitted, rename 'C:\Users\jonat\AppData\Local\Temp\tmp-3032-7f5nAzN3323h\dendron.log' -> 'C:\Users\jonat\AppData\Local\Temp\tmp-3032-7f5nAzN3323h\dendron.log.old'
  	at Object.renameSync (fs.js:772:3)
  	at rename (c:\Code\_dendron\dendron\packages\plugin-core\node_modules\fs-extra\lib\move-sync\move-sync.js:31:8)
  	at doRename (c:\Code\_dendron\dendron\packages\plugin-core\node_modules\fs-extra\lib\move-sync\move-sync.js:23:12)
  	at Object.moveSync (c:\Code\_dendron\dendron\packages\plugin-core\node_modules\fs-extra\lib\move-sync\move-sync.js:17:10)
  	at Function.configure (c:\Code\_dendron\dendron\packages\plugin-core\out\src\logger.js:21:32)
  	at Context.<anonymous> (c:\Code\_dendron\dendron\packages\plugin-core\out\src\test\testUtilsV3.js:191:25)
  	at processImmediate (internal/timers.js:461:21)
  	at process.callbackTrampoline (internal/async_hooks.js:131:14)
 ```

There are still some outstanding issues:
 - Some formatting differences in hover causing failures in `ReferenceProvider.test.ts` - I'll follow up with @SeriousBug 
 - Also an outstanding issue with the `homedir` mock. I'll try to tackle this one later

@kevinslin - is there a way to add a windows flavor to the github CI pass? 


