### PR TITLE
feat: add custom graph styling support

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -530,6 +530,7 @@ export enum GraphViewMessageType {
   "onSelect" = "onSelect",
   "onGetActiveEditor" = "onGetActiveEditor",
   "onReady" = "onReady",
+  "onRequestGraphStyle" = "onRequestGraphStyle"
 }
 
 export enum CalendarViewMessageType {

--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -10,6 +10,7 @@ type Theme = "light" | "dark" | "unknown";
 type InitialState = {
   noteActive: NoteProps | undefined;
   theme: Theme;
+  graphStyles: string;
   views: {
     [key in DendronTreeViewKey | DendronWebViewKey]: {
       ready: boolean;
@@ -23,6 +24,7 @@ export const ideSlice = createSlice({
   name: "ide",
   initialState: {
     noteActive: undefined,
+    graphStyles: '',
     theme: "unknown",
     views: {
       "dendron.tree-view": {
@@ -36,6 +38,9 @@ export const ideSlice = createSlice({
     },
     setTheme: (state, action: PayloadAction<Theme>) => {
       state.theme = action.payload;
+    },
+    setGraphStyles: (state, action: PayloadAction<string>) => {
+      state.graphStyles = action.payload;
     },
     setViewReady: (
       state,

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -25,8 +25,8 @@ const getVaultClass = (vault: DVault) => {
   return `vault-${vaultName}`;
 };
 
-const DEFAULT_CLASSES = 'graph-view'
-const DEFAULT_NODE_CLASSES = `${DEFAULT_CLASSES} color-fill`
+const DEFAULT_CLASSES = '' //graph-view
+const DEFAULT_NODE_CLASSES = `${DEFAULT_CLASSES}` //color-fill
 const DEFAULT_EDGE_CLASSES = `${DEFAULT_CLASSES}`
 
 const getLocalNoteGraphElements = ({

--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -1,5 +1,4 @@
-import { NoteProps } from "@dendronhq/common-all";
-import {
+import { NoteProps ,
   DVault,
   NotePropsDict,
   NoteUtils,
@@ -7,6 +6,7 @@ import {
   SchemaProps,
   VaultUtils,
 } from "@dendronhq/common-all";
+
 import { createLogger, engineSlice } from "@dendronhq/common-frontend";
 import { EdgeDefinition } from "cytoscape";
 import _ from "lodash";
@@ -24,6 +24,10 @@ const getVaultClass = (vault: DVault) => {
   const vaultName = VaultUtils.getName(vault);
   return `vault-${vaultName}`;
 };
+
+const DEFAULT_CLASSES = 'graph-view'
+const DEFAULT_NODE_CLASSES = `${DEFAULT_CLASSES} color-fill`
+const DEFAULT_EDGE_CLASSES = `${DEFAULT_CLASSES}`
 
 const getLocalNoteGraphElements = ({
   notes,
@@ -62,7 +66,7 @@ const getLocalNoteGraphElements = ({
         stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
         localRoot: true,
       },
-      classes: `${getVaultClass(activeNote.vault)}`,
+      classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(activeNote.vault)}`,
       selected: true,
     },
   ];
@@ -77,7 +81,7 @@ const getLocalNoteGraphElements = ({
         fname: parentNote.fname,
         stub: _.isUndefined(parentNote.stub) ? false : parentNote.stub,
       },
-      classes: `parent ${getVaultClass(parentNote.vault)}`,
+      classes: `${DEFAULT_NODE_CLASSES} parent ${getVaultClass(parentNote.vault)}`,
     });
   }
 
@@ -92,7 +96,7 @@ const getLocalNoteGraphElements = ({
           fname: note.fname,
           stub: _.isUndefined(note.stub) ? false : note.stub,
         },
-        classes: `${getVaultClass(note.vault)}`,
+        classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(note.vault)}`,
       };
     })
   );
@@ -117,7 +121,7 @@ const getLocalNoteGraphElements = ({
         fname: parentNote.fname,
         stub: _.isUndefined(parentNote.stub) ? false : parentNote.stub,
       },
-      classes: `hierarchy ${noteVaultClass}`,
+      classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
     });
   }
 
@@ -131,7 +135,7 @@ const getLocalNoteGraphElements = ({
         fname: childNote.fname,
         stub: _.isUndefined(childNote.stub) ? false : childNote.stub,
       },
-      classes: `${getVaultClass(childNote.vault)}`,
+      classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(childNote.vault)}`,
     });
 
     edges.hierarchy.push({
@@ -143,7 +147,7 @@ const getLocalNoteGraphElements = ({
         fname: activeNote.fname,
         stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
       },
-      classes: `hierarchy ${noteVaultClass}`,
+      classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
     });
   });
 
@@ -159,11 +163,9 @@ const getLocalNoteGraphElements = ({
         stub:
           _.isUndefined(activeNote.stub) && _.isUndefined(connectedNote.stub)
             ? false
-            : activeNote.stub || connectedNote.stub
-            ? true
-            : false,
+            : !!(activeNote.stub || connectedNote.stub),
       },
-      classes: `links ${noteVaultClass}`,
+      classes: `${DEFAULT_EDGE_CLASSES} links ${noteVaultClass}`,
     };
   });
 
@@ -196,7 +198,7 @@ const getLocalNoteGraphElements = ({
       const to = NoteUtils.getNoteByFnameV5({
         fname: fnameArray[fnameArray.length - 1],
         vault: toVault,
-        notes: notes,
+        notes,
         wsRoot,
       });
 
@@ -214,9 +216,7 @@ const getLocalNoteGraphElements = ({
       const isStub =
         _.isUndefined(activeNote.stub) && _.isUndefined(to.stub)
           ? false
-          : activeNote.stub || to.stub
-          ? true
-          : false;
+          : !!(activeNote.stub || to.stub);
 
       nodes.push({
         data: {
@@ -226,7 +226,7 @@ const getLocalNoteGraphElements = ({
           fname: to.fname,
           stub: isStub,
         },
-        classes: `${getVaultClass(to.vault)}`,
+        classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(to.vault)}`,
       });
 
       linkConnections.push({
@@ -238,7 +238,7 @@ const getLocalNoteGraphElements = ({
           fname: activeNote.fname,
           stub: isStub,
         },
-        classes: `links ${noteVaultClass}`,
+        classes: `${DEFAULT_EDGE_CLASSES} links ${noteVaultClass}`,
       });
     }
   });
@@ -275,7 +275,7 @@ const getFullNoteGraphElements = ({
         fname: note.fname,
         stub: _.isUndefined(note.stub) ? false : note.stub,
       },
-      classes: `${getVaultClass(note.vault)}`,
+      classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(note.vault)}`,
       selected: isActive,
     };
   });
@@ -307,7 +307,7 @@ const getFullNoteGraphElements = ({
             fname: note.fname,
             stub: isStub,
           },
-          classes: `hierarchy ${noteVaultClass}`,
+          classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
         };
       })
     );
@@ -343,7 +343,7 @@ const getFullNoteGraphElements = ({
         const to = NoteUtils.getNoteByFnameV5({
           fname: fnameArray[fnameArray.length - 1],
           vault: toVault,
-          notes: notes,
+          notes,
           wsRoot,
         });
 
@@ -378,7 +378,7 @@ const getFullNoteGraphElements = ({
                 ? false
                 : note.stub || to.stub,
           },
-          classes: `links ${noteVaultClass}`,
+          classes: `${DEFAULT_EDGE_CLASSES} links ${noteVaultClass}`,
         });
       }
     });
@@ -425,7 +425,7 @@ const getSchemaGraphElements = (
         vault: vaultName,
         fname: "root",
       },
-      classes: `vault-${vaultName}`,
+      classes: `${DEFAULT_NODE_CLASSES} vault-${vaultName}`,
     });
 
     filteredSchemas
@@ -441,7 +441,7 @@ const getSchemaGraphElements = (
             group: "nodes",
             fname: schema.fname,
           },
-          classes: `vault-${vaultName}`,
+          classes: `${DEFAULT_NODE_CLASSES} vault-${vaultName}`,
         });
 
         // Schema node -> root connection
@@ -453,7 +453,7 @@ const getSchemaGraphElements = (
             target: SCHEMA_ID,
             fname: schema.fname,
           },
-          classes: `hierarchy vault-${vaultName}`,
+          classes: `${DEFAULT_EDGE_CLASSES} hierarchy vault-${vaultName}`,
         });
 
         // Add subschema nodes
@@ -468,7 +468,7 @@ const getSchemaGraphElements = (
               group: "nodes",
               fname: schema.fname,
             },
-            classes: `vault-${vaultName}`,
+            classes: `${DEFAULT_NODE_CLASSES} vault-${vaultName}`,
           });
         });
 
@@ -489,7 +489,7 @@ const getSchemaGraphElements = (
                 target: CHILD_SCHEMA_ID,
                 fname: schema.fname,
               },
-              classes: `hierarchy vault-${vaultName}`,
+              classes: `${DEFAULT_EDGE_CLASSES} hierarchy vault-${vaultName}`,
             });
 
             addChildConnections(childSchema, `${vaultName}_${childSchema.id}`);

--- a/packages/dendron-next-server/pages/_app.tsx
+++ b/packages/dendron-next-server/pages/_app.tsx
@@ -83,7 +83,7 @@ function AppVSCode({ Component, pageProps }: any) {
     const { port, ws } = getWorkspaceParamsFromQueryString();
 
     if (msg.type === DMessageType.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR) {
-      let cmsg = msg as OnDidChangeActiveTextEditorMsg;
+      const cmsg = msg as OnDidChangeActiveTextEditorMsg;
       const { sync, note, syncChangedNote } = cmsg.data;
       if (sync) {
         // skip the initial ?
@@ -102,11 +102,17 @@ function AppVSCode({ Component, pageProps }: any) {
       ideDispatch(ideSlice.actions.setNoteActive(note));
       logger.info({ ctx, msg: "setNote:post" });
     } else if (msg.type === ThemeMessageType.onThemeChange) {
-      let cmsg = msg;
+      const cmsg = msg;
       const { theme } = cmsg.data;
       logger.info({ ctx, theme, msg: "theme" });
       ideDispatch(ideSlice.actions.setTheme(theme));
-    } else {
+    } else if (msg.type === "onGraphStyleLoad") {
+      const cmsg = msg;
+      const { styles } = cmsg.data;
+      logger.info({ ctx, styles, msg: "styles" });
+      ideDispatch(ideSlice.actions.setGraphStyles(styles));
+    }
+     else {
       logger.error({ ctx, msg: "unknown message" });
     }
   });

--- a/packages/dendron-next-server/pages/_app.tsx
+++ b/packages/dendron-next-server/pages/_app.tsx
@@ -119,11 +119,11 @@ function AppVSCode({ Component, pageProps }: any) {
 
   // === Render
   // Don't load children until all following conditions true
-  if (_.some([_.isUndefined(workspaceOpts), ide.theme !== "unknown", !isReady])) {
+  if (_.some([_.isUndefined(workspaceOpts), ide.theme === "unknown", !isReady])) {
     return <Spin />;
   }
 
-  let defaultTheme = workspaceOpts?.theme || "light";
+  let defaultTheme = workspaceOpts?.theme || "dark";
   if (ide.theme !== "unknown") {
     defaultTheme = ide.theme;
   }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -144,11 +144,6 @@
         "desc": "Open a random note within a configured hierarchy set"
       },
       {
-        "command": "dendron.launchTutorial",
-        "title": "Dendron: Launch Tutorial",
-        "desc": "Launch the Tutorial"
-      },
-      {
         "command": "dendron.renameNote",
         "title": "Dendron: Rename Note",
         "desc": "Rename a note and all backlinks",
@@ -439,6 +434,14 @@
         "docPreview": ""
       },
       {
+        "command": "dendron.configureGraphStyle",
+        "title": "Dendron: Configure Graph Style (css)",
+        "desc": "Modify Dendron Graph styles as raw CSS",
+        "docs": "",
+        "docLink": "",
+        "docPreview": ""
+      },
+      {
         "command": "dendron.dev.doctor",
         "title": "Dendron: Doctor",
         "desc": "Auto fix issues with frontmatter",
@@ -470,6 +473,11 @@
         "desc": "Generate diagnostics report",
         "docLink": "dendron.topic.commands.md",
         "docPreview": ""
+      },
+      {
+        "command": "dendron.launchTutorial",
+        "title": "Dendron: Launch Tutorial",
+        "desc": "Launch the Tutorial"
       }
     ],
     "configuration": {
@@ -699,6 +707,11 @@
       },
       {
         "command": "dendron.showPreview",
+        "windows": "windows+ctrl+p",
+        "mac": "cmd+ctrl+p"
+      },
+      {
+        "command": "dendron.showPreviewV2",
         "windows": "windows+ctrl+p",
         "mac": "cmd+ctrl+p"
       }

--- a/packages/plugin-core/src/commands/ConfigureGraphStyles.ts
+++ b/packages/plugin-core/src/commands/ConfigureGraphStyles.ts
@@ -1,0 +1,20 @@
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+import { GraphStyleService } from "../styles";
+
+type CommandOpts = {};
+
+type CommandOutput = void;
+
+export class ConfigureGraphStylesCommand extends BasicCommand<CommandOpts, CommandOutput> {
+  key = DENDRON_COMMANDS.CONFIGURE_GRAPH_STYLES.key;
+  async gatherInputs(): Promise<any> {
+    return {};
+  }
+  async execute() {
+    if (!GraphStyleService.doesStyleFileExist()) {
+      GraphStyleService.createStyleFile()
+    }
+    await GraphStyleService.openStyleFile()
+  }
+}

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -13,7 +13,7 @@ import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
 import { VSCodeUtils } from "../utils";
-import { MetadataService } from "packages/engine-server/src/metadata";
+import { MetadataService } from "@dendronhq/engine-server";
 
 type CommandOpts = {};
 

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -13,7 +13,7 @@ import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
 import { VSCodeUtils } from "../utils";
-import { MetadataService } from "@dendronhq/engine-server";
+import { GraphStyleService } from "../styles";
 
 type CommandOpts = {};
 
@@ -49,7 +49,6 @@ export class ShowNoteGraphCommand extends BasicCommand<
 
     // If panel already exists
     const existingPanel = ws.getWebView(DendronWebViewKey.NOTE_GRAPH);
-
 
     if (!_.isUndefined(existingPanel)) {
       try {
@@ -107,6 +106,20 @@ export class ShowNoteGraphCommand extends BasicCommand<
           }
           break;
         }
+        case GraphViewMessageType.onRequestGraphStyle: {
+          // Set graph styles
+          const styles = GraphStyleService.getParsedStyles();
+          if (styles) {
+            panel.webview.postMessage({
+              type: "onGraphStyleLoad",
+              data: {
+                styles,
+              },
+              source: "vscode",
+            });
+          }
+          break;
+        }
         // case GraphViewMessageType.onReady: {
         //   const profile = getDurationMilliseconds(start);
         //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });
@@ -120,9 +133,6 @@ export class ShowNoteGraphCommand extends BasicCommand<
           break;
       }
     });
-
-    const metadataService = MetadataService.instance();
-    // metadataService.
 
     // Update workspace-wide graph panel
     ws.setWebView(DendronWebViewKey.NOTE_GRAPH, panel);

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -13,6 +13,7 @@ import { BasicCommand } from "./base";
 import { getEngine, getWS } from "../workspace";
 import { GotoNoteCommand } from "./GotoNote";
 import { VSCodeUtils } from "../utils";
+import { MetadataService } from "packages/engine-server/src/metadata";
 
 type CommandOpts = {};
 
@@ -48,6 +49,7 @@ export class ShowNoteGraphCommand extends BasicCommand<
 
     // If panel already exists
     const existingPanel = ws.getWebView(DendronWebViewKey.NOTE_GRAPH);
+
 
     if (!_.isUndefined(existingPanel)) {
       try {
@@ -118,6 +120,9 @@ export class ShowNoteGraphCommand extends BasicCommand<
           break;
       }
     });
+
+    const metadataService = MetadataService.instance();
+    // metadataService.
 
     // Update workspace-wide graph panel
     ws.setWebView(DendronWebViewKey.NOTE_GRAPH, panel);

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -54,6 +54,7 @@ import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RandomNoteCommand } from "./RandomNote";
 import { LaunchTutorialCommand } from "./LaunchTutorialCommand";
 import { ConvertLinkCommand } from "./ConvertLink";
+import { ConfigureGraphStylesCommand } from "./ConfigureGraphStyles";
 
 const ALL_COMMANDS = [
   AddAndCommit,
@@ -62,6 +63,7 @@ const ALL_COMMANDS = [
   ChangeWorkspaceCommand,
   ConfigureCommand,
   ConfigurePodCommand,
+  ConfigureGraphStylesCommand,
   ContributeCommand,
   CopyNoteLinkCommand,
   CopyNoteRefCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -714,6 +714,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docLink: "",
     docPreview: ``,
   },
+  
   CONFIGURE_UI: {
     key: "dendron.configureUI",
     title: `${CMD_PREFIX} Configure`,
@@ -722,6 +723,15 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docs: [
       `<div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/5b6689eb76344fbb814a3d4405ef62b8" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>`,
     ].join("\n"),
+    docLink: "",
+    docPreview: ``,
+  },
+  CONFIGURE_GRAPH_STYLES: {
+    key: "dendron.configureGraphStyle",
+    title: `${CMD_PREFIX} Configure Graph Style (css)`,
+    group: "workspace",
+    desc: "Modify Dendron Graph styles as raw CSS",
+    docs: [""].join("\n"),
     docLink: "",
     docPreview: ``,
   },

--- a/packages/plugin-core/src/styles.ts
+++ b/packages/plugin-core/src/styles.ts
@@ -7,13 +7,11 @@ import { VSCodeUtils } from "./utils";
 // TODO: If you'd like to target a specific theme, pre-pend each class with either ".theme-dark" or ".theme-light"
 
 const STYLES_TEMPLATE = `/*
-Add Dendron graph styles below. The graph can be styled in two ways:
+Add Dendron graph styles below. The graph can be styled with any valid Cytoscape.js selector: https://js.cytoscape.org/#cy.style
+Full Dendron-specific styling documentation can be found here: [LINK HERE]
 
-1. Cytoscape.js style: https://js.cytoscape.org/#cy.style
-2. [WIP] Obsidian.md style: https://help.obsidian.md/Plugins/Graph+view#Custom+CSS
-
-More detailed styling documentation can be found at:
-[LINK HERE]
+Note: Empty selectors may affect parsing of following selectors, so be sure to comment/remove them when not in use.
+If styles are not applying, make sure each property is followed with a semicolon.
 */
 
 /* Any graph node */

--- a/packages/plugin-core/src/styles.ts
+++ b/packages/plugin-core/src/styles.ts
@@ -11,7 +11,7 @@ Add Dendron graph styles below. The graph can be styled with any valid Cytoscape
 Full Dendron-specific styling documentation can be found here: [LINK HERE]
 
 Note: Empty selectors may affect parsing of following selectors, so be sure to comment/remove them when not in use.
-If styles are not applying, make sure each property is followed with a semicolon.
+If style properties are not applying, make sure each property is followed with a semicolon.
 */
 
 /* Any graph node */

--- a/packages/plugin-core/src/styles.ts
+++ b/packages/plugin-core/src/styles.ts
@@ -1,0 +1,89 @@
+import path from "path";
+import os from "os";
+import fs from "fs-extra";
+import { Uri } from "vscode";
+import { VSCodeUtils } from "./utils";
+
+// TODO: If you'd like to target a specific theme, pre-pend each class with either ".theme-dark" or ".theme-light"
+
+const STYLES_TEMPLATE = `/*
+Add Dendron graph styles below. The graph can be styled in two ways:
+
+1. Cytoscape.js style: https://js.cytoscape.org/#cy.style
+2. [WIP] Obsidian.md style: https://help.obsidian.md/Plugins/Graph+view#Custom+CSS
+
+More detailed styling documentation can be found at:
+[LINK HERE]
+*/
+
+/* Any graph node */
+/* node {} */
+
+/* Any graph edge */
+/* edge {} */
+
+/* Any selected node */
+/* :selected {} */
+
+/* Any parent nodes (local note graph only) */
+/* .parent {} */
+
+/* Any link connection edge */
+/* .links {} */
+
+/* Any hierarchy connection edge */
+/* .hierarchy {} */
+`
+/*
+Obsidian.md style
+.graph-view.color-fill {}
+.graph-view.color-fill-highlight {}
+.graph-view.color-arrow {}
+.graph-view.color-circle {}
+.graph-view.color-line {}
+.graph-view.color-text {}
+*/
+/* .graph-view.color-fill-tag {} */
+/* .graph-view.color-fill-attachment {} */
+/* .graph-view.color-line-highlight {} */
+/* .graph-view.color-fill-unresolved {} */
+
+export class GraphStyleService {
+  static styleFilePath() {
+    return path.join(os.homedir(), ".dendron", "styles.css");
+  }
+
+  static doesStyleFileExist() {
+    return fs.pathExistsSync(this.styleFilePath())
+  }
+
+  static createStyleFile() {
+    fs.ensureFileSync(this.styleFilePath());
+    fs.writeFileSync(this.styleFilePath(), STYLES_TEMPLATE);
+  }
+
+  static async openStyleFile() {
+    const uri = Uri.file(this.styleFilePath());
+    await VSCodeUtils.openFileInEditor(uri);
+  }
+
+  static readStyleFile() {
+    if (this.doesStyleFileExist()) {
+      return fs.readFileSync(this.styleFilePath()).toString();
+    }
+    return undefined;
+  }
+
+  static getParsedStyles() {
+    let css = this.readStyleFile();
+    if (!css) return undefined;
+
+    // Remove comments
+    css = css.replace("/\\/\\*.+?\\*\\//",'');
+
+    // Remove ".graph-view" class, as it is only kept for Obsidian compatibility
+    css.replace(".graph-view", '')
+
+    return css;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4629,10 +4629,10 @@
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
-"@types/vscode@1.57":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.57.0.tgz#cc648e0573b92f725cd1baf2621f8da9f8bc689f"
-  integrity sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==
+"@types/vscode@1.58":
+  version "1.58.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.1.tgz#7deae08792adc73fa57383244a0c79d3530df4f7"
+  integrity sha512-sa76rDXiSif09he8KoaWWUQxsuBr2+uND0xn1GUbEODkuEjp2p7Rqd3t5qlvklfmAedLFdL7MdnsPa57uzwcOw==
 
 "@types/warning@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Additions and changes:
- [x] Add `Configure Graph Style (css)` command to open style file
- [x] Read style file and store in Redux for graph use
- [x] Apply to graph
- [x] Support Cystoscape.js format
- [d] Support Obsidian.md format
- [x] Test everything