### PR TITLE
enhance: prefill `replace prefix` input box with output of `match text` input box

### DIFF
--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -46,6 +46,7 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
     if (match) {
       replace = await VSCodeUtils.showInputBox({
         prompt: "Enter replace prefix",
+        value: match,
       });
     }
     if (_.isUndefined(replace) || !match) {


### PR DESCRIPTION
This PR:
- Passes output of `match text` input to prefill `replace prefix` input box.