### PR TITLE
fix: anchors within wikilinks interpreted as hashtags

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -409,7 +409,7 @@ suite("ReferenceProvider", function () {
             const provider = new ReferenceHoverProvider();
             const hover = await provider.provideHover(
               editor.document,
-              new vscode.Position(7, 4)
+              new vscode.Position(7, 12)
             );
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -216,25 +216,24 @@ export const getReferenceAtPosition = (
     }
   }
 
-  // check if hashtag
-  const rangeForHashTag = document.getWordRangeAtPosition(position, HASHTAG_REGEX_LOOSE);
-  if (rangeForHashTag) {
-    const docText = document.getText(rangeForHashTag);
-    const match = docText.match(HASHTAG_REGEX_LOOSE);
-    if (_.isNull(match)) return null;
-    return {
-      range: rangeForHashTag,
-      label: match[0],
-      ref: `${TAGS_HIERARCHY}${match[1]}`,
-      refText: docText,
-    }
-  }
-
-  // otherwise, this has to be a wikilink or hashtag
+  // this should be a wikilink or reference
   const re = partial ? partialRefPattern : refPattern;
   const range = document.getWordRangeAtPosition(position, new RegExp(re));
   if (!range) {
-    // it's not a reference or hashtag either, we don't know what this is
+    // if not, it could be a hashtag
+    const rangeForHashTag = document.getWordRangeAtPosition(position, HASHTAG_REGEX_LOOSE);
+    if (rangeForHashTag) {
+      const docText = document.getText(rangeForHashTag);
+      const match = docText.match(HASHTAG_REGEX_LOOSE);
+      if (_.isNull(match)) return null;
+      return {
+        range: rangeForHashTag,
+        label: match[0],
+        ref: `${TAGS_HIERARCHY}${match[1]}`,
+        refText: docText,
+      }
+    }
+    // it's not a wikilink, reference, or a hashtag. Nothing to do here.
     return null;
   }
 


### PR DESCRIPTION
Fixes issues when hovering above the header part of a wikilink.