### PR TITLE
feat: add hideable graph filter view

### DIFF
--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -6,22 +6,25 @@ import {
   InputNumber,
   Input,
   Spin,
+  Tooltip,
+  Button,
 } from "antd";
+import { MenuUnfoldOutlined, MenuFoldOutlined } from "@ant-design/icons";
 import _ from "lodash";
-import { useState } from "react";
+import React, { useState } from "react";
 import { useThemeSwitcher } from "react-css-theme-switcher";
 import { GraphConfig, GraphConfigItem } from "../lib/graph";
 import AntThemes from "../styles/theme-antd";
+
 const { Panel } = Collapse;
 
 type FilterProps = {
-  type: "note" | "schema";
+  // type: "note" | "schema";
   config: GraphConfig;
   setConfig: React.Dispatch<React.SetStateAction<GraphConfig>>;
-  isVisible: boolean;
 };
 
-const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
+const GraphFilterView = ({ config, setConfig }: FilterProps) => {
   const sortedSections = [
     "vaults",
     "connections",
@@ -30,6 +33,7 @@ const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
     "information",
   ];
 
+  const [isVisible, setIsVisible] = useState(false);
   const { currentTheme } = useThemeSwitcher();
 
   const updateConfigField = (key: string, value: string | number | boolean) => {
@@ -49,57 +53,71 @@ const GraphFilterView = ({ config, setConfig, isVisible }: FilterProps) => {
   if (!currentTheme) return <></>;
 
   return (
-    <div
+    <Space
+      direction="vertical"
       style={{
         zIndex: 10,
         position: "absolute",
         top: AntThemes[currentTheme].graph.filterView.margin,
         left: AntThemes[currentTheme].graph.filterView.margin,
-        background: AntThemes[currentTheme].graph.filterView.background,
         borderRadius: AntThemes[currentTheme].graph.filterView.borderRadius,
         minWidth: AntThemes[currentTheme].graph.filterView.minWidth,
-        opacity: isVisible ? 1 : 0,
-        transition: "opacity 0.2s",
       }}
     >
-      <Collapse>
-        <Panel header="Vaults" key="vaults">
-          <FilterViewSection
-            section="vaults"
-            config={config}
-            updateConfigField={updateConfigField}
-          />
-        </Panel>
-        <Panel header="Connections" key="connections">
-          <FilterViewSection
-            section="connections"
-            config={config}
-            updateConfigField={updateConfigField}
-          />
-        </Panel>
-        <Panel header="Filter" key="filter">
-          <FilterViewSection
-            section="filter"
-            config={config}
-            updateConfigField={updateConfigField}
-          />
-        </Panel>
-        <Panel header="Options" key="options">
-          <FilterViewSection
-            section="options"
-            config={config}
-            updateConfigField={updateConfigField}
-          />
-        </Panel>
-        <Panel header="Information" key="information">
-          <FilterViewSection
-            section="information"
-            config={config}
-            updateConfigField={updateConfigField}
-          />
-        </Panel>
-      </Collapse>
-    </div>
+      <Tooltip
+        title={`${isVisible ? "Hide" : "Show"} Graph Configuration`}
+        placement="right"
+      >
+        <Button
+          type="primary"
+          shape="circle"
+          icon={isVisible ? <MenuFoldOutlined /> : <MenuUnfoldOutlined />}
+          onClick={() => setIsVisible((v) => !v)}
+        />
+      </Tooltip>
+        <Collapse
+          style={{
+            background: AntThemes[currentTheme].graph.filterView.background,
+            display: isVisible ? 'block' : 'none' ,
+          }}
+        >
+          <Panel header="Vaults" key="vaults">
+            <FilterViewSection
+              section="vaults"
+              config={config}
+              updateConfigField={updateConfigField}
+            />
+          </Panel>
+          <Panel header="Connections" key="connections">
+            <FilterViewSection
+              section="connections"
+              config={config}
+              updateConfigField={updateConfigField}
+            />
+          </Panel>
+          <Panel header="Filter" key="filter">
+            <FilterViewSection
+              section="filter"
+              config={config}
+              updateConfigField={updateConfigField}
+            />
+          </Panel>
+          <Panel header="Options" key="options">
+            <FilterViewSection
+              section="options"
+              config={config}
+              updateConfigField={updateConfigField}
+            />
+          </Panel>
+          <Panel header="Information" key="information">
+            <FilterViewSection
+              section="information"
+              config={config}
+              updateConfigField={updateConfigField}
+            />
+          </Panel>
+        </Collapse>
+    </Space>
   );
 };
 
@@ -146,7 +164,7 @@ const FilterViewStringInput = ({
           <Spin
             size="small"
             style={{
-              display: !!updateTimeout ? "inline-block" : "none",
+              display: updateTimeout ? "inline-block" : "none",
             }}
           />
         }

--- a/packages/dendron-next-server/components/graph-filter-view.tsx
+++ b/packages/dendron-next-server/components/graph-filter-view.tsx
@@ -19,12 +19,12 @@ import AntThemes from "../styles/theme-antd";
 const { Panel } = Collapse;
 
 type FilterProps = {
-  // type: "note" | "schema";
   config: GraphConfig;
   setConfig: React.Dispatch<React.SetStateAction<GraphConfig>>;
+  isGraphLoaded: boolean;
 };
 
-const GraphFilterView = ({ config, setConfig }: FilterProps) => {
+const GraphFilterView = ({ config, setConfig, isGraphLoaded }: FilterProps) => {
   const sortedSections = [
     "vaults",
     "connections",
@@ -33,8 +33,10 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
     "information",
   ];
 
-  const [isVisible, setIsVisible] = useState(false);
+  const [showView, setShowView] = useState(false);
   const { currentTheme } = useThemeSwitcher();
+
+  const isVisible = showView && isGraphLoaded;
 
   const updateConfigField = (key: string, value: string | number | boolean) => {
     setConfig((c) => {
@@ -72,51 +74,55 @@ const GraphFilterView = ({ config, setConfig }: FilterProps) => {
           type="primary"
           shape="circle"
           icon={isVisible ? <MenuFoldOutlined /> : <MenuUnfoldOutlined />}
-          onClick={() => setIsVisible((v) => !v)}
+          onClick={() => setShowView((v) => !v)}
+          style={{
+            opacity: isGraphLoaded ? 1 : 0,
+            transform: "0.2s opacity ease-in-out",
+          }}
         />
       </Tooltip>
-        <Collapse
-          style={{
-            background: AntThemes[currentTheme].graph.filterView.background,
-            display: isVisible ? 'block' : 'none' ,
-          }}
-        >
-          <Panel header="Vaults" key="vaults">
-            <FilterViewSection
-              section="vaults"
-              config={config}
-              updateConfigField={updateConfigField}
-            />
-          </Panel>
-          <Panel header="Connections" key="connections">
-            <FilterViewSection
-              section="connections"
-              config={config}
-              updateConfigField={updateConfigField}
-            />
-          </Panel>
-          <Panel header="Filter" key="filter">
-            <FilterViewSection
-              section="filter"
-              config={config}
-              updateConfigField={updateConfigField}
-            />
-          </Panel>
-          <Panel header="Options" key="options">
-            <FilterViewSection
-              section="options"
-              config={config}
-              updateConfigField={updateConfigField}
-            />
-          </Panel>
-          <Panel header="Information" key="information">
-            <FilterViewSection
-              section="information"
-              config={config}
-              updateConfigField={updateConfigField}
-            />
-          </Panel>
-        </Collapse>
+      <Collapse
+        style={{
+          background: AntThemes[currentTheme].graph.filterView.background,
+          display: isVisible ? "block" : "none",
+        }}
+      >
+        <Panel header="Vaults" key="vaults">
+          <FilterViewSection
+            section="vaults"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Connections" key="connections">
+          <FilterViewSection
+            section="connections"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Filter" key="filter">
+          <FilterViewSection
+            section="filter"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Options" key="options">
+          <FilterViewSection
+            section="options"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+        <Panel header="Information" key="information">
+          <FilterViewSection
+            section="information"
+            config={config}
+            updateConfigField={updateConfigField}
+          />
+        </Panel>
+      </Collapse>
     </Space>
   );
 };

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -274,10 +274,9 @@ export default function Graph({
         }}
       >
         <GraphFilterView
-          type={type}
           config={config}
           setConfig={setConfig}
-          isVisible={isGraphLoaded}
+          isGraphLoaded={isGraphLoaded}
         />
         <div
           ref={graphRef}

--- a/packages/dendron-next-server/package.json
+++ b/packages/dendron-next-server/package.json
@@ -31,6 +31,7 @@
     "**/common-all/**"
   ],
   "dependencies": {
+    "@ant-design/icons": "^4.6.2",
     "@chakra-ui/react": "^1.0.0",
     "@dendronhq/common-all": "^0.50.1",
     "@dendronhq/common-frontend": "^0.50.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,7 +67,7 @@
 
 "@ant-design/icons@^4.6.2":
   version "4.6.2"
-  resolved "https://registry.npmjs.org/@ant-design/icons/-/icons-4.6.2.tgz#290f2e8cde505ab081fda63e511e82d3c48be982"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.6.2.tgz#290f2e8cde505ab081fda63e511e82d3c48be982"
   integrity sha512-QsBG2BxBYU/rxr2eb8b2cZ4rPKAPBpzAR+0v6rrZLp/lnyvflLH3tw1vregK+M7aJauGWjIGNdFmUfpAOtw25A==
   dependencies:
     "@ant-design/colors" "^6.0.0"


### PR DESCRIPTION
Adds a small button to the top left of the graph which shows/hides the graph when clicked. Filter view will no longer be shown unless the button is clicked.