### PR TITLE
chore: lift scope restriction for doctor command `createMissingLinkedNotes`

### DIFF
--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -295,16 +295,8 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
-        // this action is disabled for workspace scope for now.
-        // if (_.isUndefined(candidates)) {
-        //   console.log(
-        //     `doctor ${DoctorActions.CREATE_MISSING_LINKED_NOTES} requires explicitly passing one candidate note.`
-        //   );
-        //   return;
-        // }
         notes = this.getWildLinkDestinations(notes, engine);
         doctorAction = async (note: NoteProps) => {
-          // const vname = VaultUtils.getName(note.vault);
           await engineGetNoteByPath({
             npath: note.fname,
             createIfNew: true,

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -101,6 +101,7 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           const destVault = link.to?.vaultName
             ? VaultUtils.getVaultByName({ vaults, vname: link.to.vaultName })!
             : note.vault;
+          if (!destVault) return false;
           const noteExists = NoteUtils.getNoteByFnameV5({
             fname: link.to!.fname as string,
             vault: destVault,
@@ -271,12 +272,12 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
         // this action is disabled for workspace scope for now.
-        if (_.isUndefined(candidates)) {
-          console.log(
-            `doctor ${DoctorActions.CREATE_MISSING_LINKED_NOTES} requires explicitly passing one candidate note.`
-          );
-          return;
-        }
+        // if (_.isUndefined(candidates)) {
+        //   console.log(
+        //     `doctor ${DoctorActions.CREATE_MISSING_LINKED_NOTES} requires explicitly passing one candidate note.`
+        //   );
+        //   return;
+        // }
         notes = this.getWildLinkDestinations(notes, engine);
         doctorAction = async (note: NoteProps) => {
           const vname = VaultUtils.getName(note.vault);
@@ -285,9 +286,6 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             createIfNew: true,
             vault: note.vault,
           });
-          console.log(
-            `doctor ${DoctorActions.CREATE_MISSING_LINKED_NOTES} ${note.fname} ${vname}`
-          );
           numChanges += 1;
         };
         break;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -595,6 +595,12 @@ export class LinkUtils {
     });
     return linkCandidates;
   }
+  
+  static hasVaultPrefix(link: DLink) {
+    if (link.to?.vaultName) {
+      return true;
+    } else return false;
+  }
 }
 
 export class AnchorUtils {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -180,12 +180,6 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
-        // if (opts.scope === "workspace") {
-        //   window.showInformationMessage(
-        //     "This action is currently not supported in workspace scope."
-        //   );
-        //   break;
-        // }
         const cmd = new DoctorCLICommand();
         let notes;
         if (_.isUndefined(note)) {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -123,7 +123,6 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       "",
       `## The following files will be created`,
     ];
-    console.log("it's here");
     _.forEach(_.sortBy(candidates, ["vault.fsPath"]), (candidate) => {
       content = content.concat(
         `- ${candidate.vault.fsPath}/${candidate.fname}\n`

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -123,7 +123,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       "",
       `## The following files will be created`,
     ];
-
+    console.log("it's here");
     _.forEach(_.sortBy(candidates, ["vault.fsPath"]), (candidate) => {
       content = content.concat(
         `- ${candidate.vault.fsPath}/${candidate.fname}\n`

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -163,7 +163,6 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
 
     let note;
     if (opts.scope === "file") {
-      console.log("scoped for active file");
       const document = VSCodeUtils.getActiveTextEditor()?.document;
       if (_.isUndefined(document)) {
         throw Error("No note open");
@@ -182,12 +181,12 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActions.CREATE_MISSING_LINKED_NOTES: {
-        if (opts.scope === "workspace") {
-          window.showInformationMessage(
-            "This action is currently not supported in workspace scope."
-          );
-          break;
-        }
+        // if (opts.scope === "workspace") {
+        //   window.showInformationMessage(
+        //     "This action is currently not supported in workspace scope."
+        //   );
+        //   break;
+        // }
         const cmd = new DoctorCLICommand();
         let notes;
         if (_.isUndefined(note)) {
@@ -196,7 +195,6 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         } else {
           notes = [note];
         }
-
         const uniqueCandidates = cmd.getWildLinkDestinations(notes, engine);
         if (uniqueCandidates.length > 0) {
           // show preview before creating

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -540,7 +540,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
     });
   });
 
-  test("workspace scope should do nothing", (done) => {
+  test("should do nothing in multivault workspace if vault prefix isn't there", (done) => {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async (opts) => {
@@ -610,8 +610,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
     });
   });
 
-  // TODO: enable this once we enable workspace scope for CREATE_MISSING_LINKED_NOTES
-  test.skip("wild links in multiple vaults with workspace scope", (done) => {
+  test("wild links in multiple vaults with workspace scope", (done) => {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async (opts) => {
@@ -623,9 +622,10 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         await NoteTestUtilsV4.createNote({
           fname: "first",
           body: [
-            "[[wild]]",
-            "[[somenote|somenote]]",
-            "[[some note|something]]",
+            "[[dendron://vault2/cross2]]",
+            "[[dendron://vault1/wild]]",
+            "[[somenote|dendron://vault1/somenote]]",
+            "[[some note|dendron://vault1/something]]",
           ].join("\n"),
           vault: vault1,
           wsRoot,
@@ -633,9 +633,10 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         await NoteTestUtilsV4.createNote({
           fname: "second",
           body: [
-            "[[wild2]]",
-            "[[somenote|somenote2]]",
-            "[[some note|something2]]",
+            "[[dendron://vault1/cross1]]",
+            "[[dendron://vault2/wild2]]",
+            "[[somenote|dendron://vault2/somenote2]]",
+            "[[some note|dendron://vault2/something2]]",
           ].join("\n"),
           vault: vault2,
           wsRoot,
@@ -655,7 +656,12 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
           );
         await cmd.run();
         const firstVaultPath = vault2Path({ vault: vault1, wsRoot });
-        const firstVaultFileNames = ["wild.md", "somenote.md", "something.md"];
+        const firstVaultFileNames = [
+          "cross1.md",
+          "wild.md",
+          "somenote.md",
+          "something.md"
+        ];
         _.forEach(firstVaultFileNames, (fileName) => {
           const containsNew = _.includes(
             fs.readdirSync(firstVaultPath),
@@ -665,6 +671,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         });
         const secondVaultPath = vault2Path({ vault: vault2, wsRoot });
         const secondVaultFileNames = [
+          "cross2.md",
           "wild2.md",
           "somenote2.md",
           "something2.md",


### PR DESCRIPTION
This PR:
- Removes scope restriction that was on `createMissingLinkedNotes` of Doctor command
- Add default behavior said command in multi-vault workspace to ignore missing links that don't specify vault prefix.
- Enable tests that were marked as skipped because of scope restriction
- Add tests for newly added default behavior on multi-vault workspaces.
