### PR TITLE
fix:minor tutorial fixes

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
@@ -6,8 +6,6 @@ updated: 1624934082241
 created: 1624333266168
 ---
 
-_You can also find this guide on our [wiki](https://wiki.dendron.so/notes/784b8d5e-58eb-4e3e-98b0-8ed1690abc74.html)._
-
 ### Create a Note
 
 To create a note, use `%KEYBINDING%+L` to bring up Dendron's lookup. This is a shortcut for the `Dendron: Lookup` command.

--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.4-rich-formatting.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.4-rich-formatting.md
@@ -15,14 +15,13 @@ Dendron supports an extended Markdown syntax, which provides a lot of options fo
 |Bold|**Hello World**|
 |Italics|_Hello World_|
 |Strikethrough|~~Hello World~~|
-|Highlight|==Hello World==|
 
 #### Images
 
 > 🌱 Copy any image onto your clipboard, and then use the `Paste Image` command while focused in your editor pane. This will automatically create a link for you and copy the file contents into the assets directory in your workspace.
 
 Sample Image Link:
-![Dendron Logo](assets/images/logo_small.png)
+![Dendron Logo](/assets/images/logo_small.png)
 
 #### Equations
 


### PR DESCRIPTION
- Delete 404 (and redundant link, it's already shown at the beginning of the tutorial)
- Fix image link
- Temporarily remove ==highlighting== example, as it doesn't work with the new preview. 