### PR TITLE
fix: hashtags links duplicate the text following them

### DIFF
--- a/packages/engine-server/src/markdown/remark/hashtag.ts
+++ b/packages/engine-server/src/markdown/remark/hashtag.ts
@@ -57,7 +57,7 @@ function attachParser(proc: Unified.Processor) {
     if (match) {
       return eat(match[0])({
         type: DendronASTTypes.HASHTAG,
-        value,
+        value: match[0],
         fname: `${TAGS_HIERARCHY}${match[1]}`,
       });
     }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
@@ -68,6 +68,7 @@ describe("hashtag", () => {
       expect(getDescendantNode(resp, 0, 1).type).toEqual(
         DendronASTTypes.HASHTAG
       );
+      expect(getDescendantNode(resp, 0, 1).value).toEqual("#my-hash-tag");
     });
 
     test("doesn't parse hashtag starting with number", () => {


### PR DESCRIPTION
Fixes an issue with hashtags duplicating the text following them in their links.