### PR TITLE
fix: wikilink aliases with apostrophes & headers containing wikilinks

### DIFF
--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -630,7 +630,7 @@ export class AnchorUtils {
         /* nothing */
       }
     });
-    return _.trim(headerText.join(" "));
+    return _.trim(headerText.join(""));
   }
 
   /** Given a *parsed* anchor node, returns the anchor id ("header" or "^block" and positioned anchor object for it. */

--- a/packages/engine-server/src/markdown/remark/wikiLinks.ts
+++ b/packages/engine-server/src/markdown/remark/wikiLinks.ts
@@ -20,11 +20,11 @@ import { MDUtilsV4 } from "../utils";
 import { MDUtilsV5, ProcMode } from "../utilsv5";
 import { addError, getNoteOrError, LinkUtils } from "./utils";
 
-export const LINK_REGEX = /^\[\[([\w\.\-_#\^\ \|:\/]+?)\]\]/;
+export const LINK_REGEX = /^\[\[([^\]\n]+)\]\]/;
 /**
  * Does not require wiki link be the start of the word
  */
-export const LINK_REGEX_LOOSE = /\[\[(.+?)\]\]/;
+export const LINK_REGEX_LOOSE = /\[\[([^\]\n]+)\]\]/;
 
 const parseWikiLink = (linkMatch: string) => {
   linkMatch = NoteUtils.normalizeFname(linkMatch);

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/wikiLink.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/wikiLink.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`wikiLinks compile "HTML: WITH_ALIAS" 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"foo.html\\">bar</a></p>
+<p><a href=\\"foo.html\\">bar doesn't foo</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
@@ -182,7 +182,7 @@ VFile {
 
 exports[`wikiLinks compile "MD_DENDRON: WITH_ALIAS" 1`] = `
 VFile {
-  "contents": "[[bar|foo]]
+  "contents": "[[bar doesn't foo|foo]]
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -328,7 +328,7 @@ exports[`wikiLinks compile "MD_ENHANCED_PREVIEW: WITH_ALIAS" 1`] = `
 VFile {
   "contents": "# Root
 
-[bar](foo.md)
+[bar doesn't foo](foo.md)
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -482,7 +482,7 @@ exports[`wikiLinks compile "MD_REGULAR: WITH_ALIAS" 1`] = `
 VFile {
   "contents": "# Root
 
-[bar](foo)
+[bar doesn't foo](foo)
 
 ",
   "cwd": "<PROJECT_ROOT>",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
@@ -45,7 +45,7 @@ function getNode(node: UnistNode): UnistNode {
 describe("wikiLinks", () => {
   describe("parse", () => {
     let engine: any;
-    let dendronData = {
+    const dendronData = {
       fname: "placeholder.md",
       dest: DendronASTDest.MD_REGULAR,
     };
@@ -283,7 +283,7 @@ describe("wikiLinks", () => {
       preSetupHook: ENGINE_HOOKS.setupBasic,
     });
 
-    const linkWithAlias = `[[bar|foo]]`;
+    const linkWithAlias = `[[bar doesn't foo|foo]]`;
     const WITH_ALIAS = createProcTests({
       name: "WITH_ALIAS",
       setupFunc: async ({ engine, vaults, extra }) => {
@@ -302,15 +302,15 @@ describe("wikiLinks", () => {
         },
         [DendronASTDest.MD_REGULAR]: async ({ extra }) => {
           const { resp } = extra;
-          await checkVFile(resp, "[bar](foo)");
+          await checkVFile(resp, "[bar doesn't foo](foo)");
         },
         [DendronASTDest.HTML]: async ({ extra }) => {
           const { resp } = extra;
-          await checkVFile(resp, '<a href="foo.html">bar</a>');
+          await checkVFile(resp, `<a href="foo.html">bar doesn't foo</a>`);
         },
         [DendronASTDest.MD_ENHANCED_PREVIEW]: async ({ extra }) => {
           const { resp } = extra;
-          await checkVFile(resp, "[bar](foo.md)");
+          await checkVFile(resp, "[bar doesn't foo](foo.md)");
         },
       },
       preSetupHook: ENGINE_HOOKS.setupBasic,

--- a/packages/plugin-core/src/test/presets/GotoNotePreset.ts
+++ b/packages/plugin-core/src/test/presets/GotoNotePreset.ts
@@ -36,7 +36,7 @@ const ANCHOR_WITH_SPECIAL_CHARS = new TestPresetEntry({
   label: "anchor with special chars",
   preSetupHook: async ({ wsRoot, vaults }) => {
     const vault = vaults[0];
-    const specialCharsHeader = `H3 &$#@`;
+    const specialCharsHeader = `H3 &$!@`;
     await NoteTestUtilsV4.createNote({
       wsRoot,
       vault,

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -61,6 +61,32 @@ suite("CopyNoteLink", function () {
       })
     });
 
+    test("with a header link containing unicode characters", (done) => {
+      let noteWithLink: NoteProps;
+      runSingleVaultTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          noteWithLink = await NoteTestUtilsV4.createNote({
+            fname: "test",
+            vault: vaults[0],
+            wsRoot,
+            body: "## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum",
+          });
+        },
+        onInit: async () => {
+          // Open and select the header
+          const editor = await VSCodeUtils.openNote(noteWithLink);
+          const start = LocationTestUtils.getPresetWikiLinkPosition();
+          const end = LocationTestUtils.getPresetWikiLinkPosition({char: 10});
+          editor.selection = new vscode.Selection(start, end);
+          // generate a wikilink for it
+          const link = await new CopyNoteLinkCommand().run();
+          expect(link).toEqual(`[[Lörem  Foo：Bar🙂Baz  Ipsum|test#lörem--foo：barbaz--ipsum]]`);
+          done();
+        }
+      })
+    });
+
     test("with anchor", (done) => {
       let noteWithTarget: NoteProps;
 

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -81,7 +81,7 @@ suite("CopyNoteLink", function () {
           editor.selection = new vscode.Selection(start, end);
           // generate a wikilink for it
           const link = await new CopyNoteLinkCommand().run();
-          expect(link).toEqual(`[[Lörem  Foo：Bar🙂Baz  Ipsum|test#lörem--foo：barbaz--ipsum]]`);
+          expect(link).toEqual(`[[Lörem Foo：Bar🙂Baz Ipsum|test#lörem-foo：barbaz-ipsum]]`);
           done();
         }
       })

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -1,6 +1,6 @@
 import { NoteProps } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
-import { AssertUtils, NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
+import { AssertUtils, NoteTestUtilsV4, NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestConfigUtils } from "@dendronhq/engine-test-utils";
 import { describe } from "mocha";
 import path from "path";
@@ -17,10 +17,8 @@ import {
 import { setupBeforeAfter } from "../testUtilsV3";
 
 suite("CopyNoteLink", function () {
-  let ctx: vscode.ExtensionContext;
+  const ctx = setupBeforeAfter(this, {});
   this.timeout(TIMEOUT);
-
-  ctx = setupBeforeAfter(this, {});
 
   describe("single", () => {
     test("basic", (done) => {
@@ -35,6 +33,32 @@ suite("CopyNoteLink", function () {
         },
         preSetupHook: ENGINE_HOOKS.setupBasic,
       });
+    });
+
+    test("with a header that's a link", (done) => {
+      let noteWithLink: NoteProps;
+      runSingleVaultTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          noteWithLink = await NoteTestUtilsV4.createNote({
+            fname: "test",
+            vault: vaults[0],
+            wsRoot,
+            body: "## [[Foo Bar|foo.bar]]",
+          });
+        },
+        onInit: async () => {
+          // Open and select the header
+          const editor = await VSCodeUtils.openNote(noteWithLink);
+          const start = LocationTestUtils.getPresetWikiLinkPosition();
+          const end = LocationTestUtils.getPresetWikiLinkPosition({char: 10});
+          editor.selection = new vscode.Selection(start, end);
+          // generate a wikilink for it
+          const link = await new CopyNoteLinkCommand().run();
+          expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
+          done();
+        }
+      })
     });
 
     test("with anchor", (done) => {

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -146,6 +146,37 @@ suite("GotoNote", function () {
       });
     });
 
+    test("go to note header with wikilink and unicode characters", (done) => {
+      // ## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ vaults, wsRoot }) => {
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "target-note",
+            body: "\n\n## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum\n\nlorem ipsum",
+          })
+        },
+        onInit: async ({ vaults }) => {
+          const vault = vaults[0];
+          await new GotoNoteCommand().run({
+            qs: "target-note",
+            vault,
+            anchor: {
+              type: "header",
+              value: "lörem-foo：barbaz-ipsum",
+            },
+          });
+          expect(getActiveEditorBasename()).toEqual("target-note.md");
+          const selection = VSCodeUtils.getActiveTextEditor()?.selection;
+          expect(selection?.start.line).toEqual(9);
+          expect(selection?.start.character).toEqual(0);
+          done();
+        },
+      });
+    })
+
     test("anchor with special chars", (done) => {
       let specialCharsHeader: string;
       runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -5,8 +5,10 @@ import {
   select,
   MDUtilsV4,
   Heading,
-  Text,
   BlockAnchor,
+  MDUtilsV5,
+  ProcMode,
+  AnchorUtils,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import vscode, {
@@ -15,6 +17,7 @@ import vscode, {
   TextEditor,
   TextEditorEdit,
 } from "vscode";
+
 
 export function isAnythingSelected(): boolean {
   return !vscode.window?.activeTextEditor?.selection?.isEmpty;
@@ -29,26 +32,22 @@ export function isAnythingSelected(): boolean {
 export function getHeaderAt({
   editor,
   position,
-  engine,
+  engine: _engine,
 }: {
   editor: TextEditor;
   position: Position;
-  engine: DEngineClient;
+  engine?: DEngineClient;
 }): undefined | string {
   const line = editor.document.lineAt(position.line);
   const headerLine = _.trim(line.text);
   if (headerLine.startsWith("#")) {
-    const proc = MDUtilsV4.procParse({
-      engine,
-      fname: NoteUtils.uri2Fname(editor.document.uri),
-      dest: DendronASTDest.MD_DENDRON,
-    });
+    const proc = MDUtilsV5.procRemarkParse({mode: ProcMode.NO_DATA}, {});
     const parsed = proc.parse(headerLine);
     const header = select(DendronASTTypes.HEADING, parsed) as Heading | null;
     if (_.isNull(header)) return undefined;
-    const headerText = select("text", header) as Text | null;
-    if (_.isNull(headerText) || !headerText.value) return undefined;
-    return _.trim(headerText.value);
+    const headerText = AnchorUtils.headerText(header);
+    if (headerText.length === 0) return undefined;
+    return headerText;
   } else {
     return undefined;
   }

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1614386308909
+updated: 1626730586158
 created: 1608518909864
 ---
 
@@ -50,3 +50,5 @@ Vault2
 ## Block References
 
 ![[dendron.ref.links.target#^123]]
+
+## [[a header that's entirely a link|dendron.apples]]

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1626730586158
+updated: 1626756808041
 created: 1608518909864
 ---
 


### PR DESCRIPTION
Wikilinks containing apostrophes were failing to parse, that's now fixed.

Also #958 and #959. The correct links should be generated now, both in the editor and in publishing, and "Copy Note Link" will recognize the link and avoid adding a block anchor.