### PR TITLE
chore: fix deprecated division in sass

### DIFF
--- a/packages/dendron-11ty/raw-assets/sass/_portal.scss
+++ b/packages/dendron-11ty/raw-assets/sass/_portal.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Clear normal iframe styles
 iframe{
 	border: none;
@@ -87,7 +89,7 @@ iframe{
 			z-index: 50;
 		}			
 		.portal-parent-text{
-			padding:$base-line-height / 2;
+			padding:math.div($base-line-height, 2);
 			color: #5C6D73;			
 			z-index: 40;
 		}

--- a/packages/dendron-11ty/raw-assets/sass/support/_functions.scss
+++ b/packages/dendron-11ty/raw-assets/sass/support/_functions.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 @function rem($size, $unit: "") {
-  $remSize: $size / $root-font-size;
+  $remSize: math.div($size, $root-font-size);
 
   @if ($unit == false) {
     @return #{$remSize};

--- a/packages/dendron-next-server/styles/scss/_portal.scss
+++ b/packages/dendron-next-server/styles/scss/_portal.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Clear normal iframe styles
 iframe{
 	border: none;
@@ -87,7 +89,7 @@ iframe{
 			z-index: 50;
 		}			
 		.portal-parent-text{
-			padding:$base-line-height / 2;
+			padding:math.div($base-line-height, 2);
 			color: #5C6D73;			
 			z-index: 40;
 		}

--- a/packages/dendron-next-server/styles/scss/support/_functions.scss
+++ b/packages/dendron-next-server/styles/scss/support/_functions.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 @function rem($size, $unit: "") {
-  $remSize: $size / $root-font-size;
+  $remSize: math.div($size, $root-font-size);
 
   @if ($unit == false) {
     @return #{$remSize};


### PR DESCRIPTION
Division using a slash has been [deprecated in sass](https://sass-lang.com/documentation/breaking-changes/slash-div), updating to use the new syntax.