### PR TITLE
feat: scratch modifier for lookup V3

### DIFF
--- a/packages/plugin-core/src/commands/LookupCommand.ts
+++ b/packages/plugin-core/src/commands/LookupCommand.ts
@@ -17,6 +17,10 @@ export enum LookupNoteTypeEnum {
   "journal" = "journal",
   "scratch" = "scratch",
 }
+export enum LookupSelectionTypeEnum {
+  "selection2link" = "selection2link",
+  "selectionExtract" = "selectionExtract",
+}
 
 /**
  * Mode for prompting the user on which vault should be used to 

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -13,6 +13,8 @@ import {
   JournalBtn,
   ScratchBtn,
   MultiSelectBtn,
+  Selection2LinkBtn,
+  SelectionExtractBtn,
 } from "../components/lookup/buttons";
 import { LookupControllerV3 } from "../components/lookup/LookupControllerV3";
 import {
@@ -35,6 +37,8 @@ import {
   LookupFilterType,
   LookupNoteType,
   LookupNoteTypeEnum,
+  LookupSelectionType,
+  LookupSelectionTypeEnum,
 } from "./LookupCommand";
 
 type CommandRunOpts = {
@@ -43,6 +47,7 @@ type CommandRunOpts = {
   fuzzThreshold?: number;
   multiSelect?: boolean;
   noteType?: LookupNoteType;
+  selectionType?: LookupSelectionType;
   /**
    * NOTE: currently, only one filter is supported
    */
@@ -138,6 +143,8 @@ export class NoteLookupCommand extends BaseCommand<
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")
         ),
+        Selection2LinkBtn.create(copts.selectionType === LookupSelectionTypeEnum.selection2link),
+        SelectionExtractBtn.create(copts.selectionType === LookupSelectionTypeEnum.selectionExtract),
       ],
     });
     this._provider = new NoteLookupProvider("lookup", {
@@ -270,6 +277,9 @@ export class NoteLookupCommand extends BaseCommand<
         ? picker.vault
         : PickerUtilsV2.getOrPromptVaultForOpenEditor();
       nodeNew = NoteUtils.create({ fname, vault });
+      if (picker.selectionProcessFunc !== undefined) {
+        nodeNew = await picker.selectionProcessFunc(nodeNew) as NoteProps;
+      }
     }
     const resp = await engine.writeNote(nodeNew, {
       newNode: true,

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -67,7 +67,7 @@ type CommandOpts = {
   selectedItems: readonly NoteQuickInput[];
 } & CommandGatherOutput;
 
-type CommandOutput = {
+export type CommandOutput = {
   quickpick: DendronQuickPickerV2;
   controller: LookupControllerV3;
   provider: ILookupProviderV3;

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -11,6 +11,7 @@ import { Uri } from "vscode";
 import {
   DirectChildFilterBtn,
   JournalBtn,
+  ScratchBtn,
   MultiSelectBtn,
 } from "../components/lookup/buttons";
 import { LookupControllerV3 } from "../components/lookup/LookupControllerV3";
@@ -130,7 +131,9 @@ export class NoteLookupCommand extends BaseCommand<
         "lookupConfirmVaultOnCreate"
       ),
       extraButtons: [
+        //todo: mirror v2 button sequence
         JournalBtn.create(copts.noteType === LookupNoteTypeEnum.journal),
+        ScratchBtn.create(copts.noteType === LookupNoteTypeEnum.scratch),
         MultiSelectBtn.create(copts.multiSelect),
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -6,6 +6,8 @@ import { VSCodeUtils } from "../../utils";
 import { getWS } from "../../workspace";
 import {
   DendronBtn,
+  ButtonCategory,
+  getButtonCategory,
   IDendronQuickInputButton,
   VaultSelectButton,
 } from "./buttons";
@@ -179,6 +181,16 @@ export class LookupControllerV3 {
       type: btnType,
     }) as DendronBtn;
     btnTriggered.pressed = !btnTriggered.pressed;
+    const btnCategory = getButtonCategory(btnTriggered);
+    if (!_.includes(["effect"] as ButtonCategory[], btnCategory)) {
+      _.filter(this.state.buttons, (ent) => ent.type !== btnTriggered.type).map(
+        (ent) => {
+          if (getButtonCategory(ent) === btnCategory) {
+            ent.pressed = false;
+          }
+        }
+      );
+    }
     // update button state
     PickerUtilsV2.refreshButtons({ quickpick, buttons, buttonsPrev });
     // modify button behavior

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -31,7 +31,8 @@ export type ButtonCategory =
   | "note"
   | "split"
   | "filter"
-  | "effect";
+  | "effect"
+  | "v2"; //TODO: better category name?
 
 export type ButtonHandleOpts = { quickPick: DendronQuickPickerV2 };
 
@@ -50,6 +51,9 @@ export function getButtonCategory(button: DendronBtn): ButtonCategory {
   }
   if (isEffectButton(button)) {
     return "effect";
+  }
+  if (button.type === "v2") {
+    return "v2"; //TODO: better type name
   }
   throw Error(`unknown btn type ${button}`);
 }
@@ -141,7 +145,7 @@ export class DendronBtn implements IDendronQuickInputButton {
   }
 }
 
-class Selection2LinkBtn extends DendronBtn {
+export class Selection2LinkBtn extends DendronBtn {
   static create(pressed?: boolean) {
     return new DendronBtn({
       title: "Selection to Link",
@@ -193,15 +197,31 @@ export class JournalBtn extends DendronBtn {
   }
 }
 
-class ScratchBtn extends DendronBtn {
+export class ScratchBtn extends DendronBtn {
   static create(pressed?: boolean) {
-    return new DendronBtn({
+    return new ScratchBtn({
       title: "Create Scratch Note",
       iconOff: "new-file",
       iconOn: "menu-selection",
       type: LookupNoteTypeEnum.scratch,
       pressed,
     });
+  }
+
+  async onEnable({ quickPick }: ButtonHandleOpts) {
+    quickPick.modifyPickerValueFunc = (value: string) => {
+      return DendronClientUtilsV2.genNoteName("SCRATCH", {
+        overrides: { domain: value },
+      });
+    };
+    quickPick.rawValue = quickPick.value;
+    quickPick.value = quickPick.modifyPickerValueFunc(quickPick.rawValue);
+    return;
+  }
+
+  async onDisable({ quickPick }: ButtonHandleOpts) {
+    quickPick.modifyPickerValueFunc = undefined;
+    quickPick.value = quickPick.rawValue;
   }
 }
 class HorizontalSplitBtn extends DendronBtn {

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -27,7 +27,7 @@ export type ButtonType =
   | LookupSelectionType
   | LookupSplitType
   | LookupFilterType
-  | "v2";
+  | "other";
 
 export type ButtonCategory =
   | "selection"
@@ -35,7 +35,7 @@ export type ButtonCategory =
   | "split"
   | "filter"
   | "effect"
-  | "v2"; //TODO: better category name?
+  | "other"; //TODO: better category name?
 
 export type ButtonHandleOpts = { quickPick: DendronQuickPickerV2 };
 
@@ -55,8 +55,8 @@ export function getButtonCategory(button: DendronBtn): ButtonCategory {
   if (isEffectButton(button)) {
     return "effect";
   }
-  if (button.type === "v2") {
-    return "v2"; //TODO: better type name
+  if (button.type === "other") {
+    return "other";
   }
   throw Error(`unknown btn type ${button}`);
 }
@@ -405,7 +405,7 @@ export class VaultSelectButton extends DendronBtn {
       title: "Select Vault",
       iconOff: "package",
       iconOn: "menu-selection",
-      type: "v2" as LookupEffectType,
+      type: "other" as LookupEffectType,
       pressed,
       canToggle: false,
     });

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -1,6 +1,7 @@
 import {
   DNodePropsQuickInputV2,
   DNodeProps,
+  NoteProps,
   DVault,
   NoteQuickInput,
 } from "@dendronhq/common-all";
@@ -14,6 +15,7 @@ export type LookupControllerState = {
 
 type FilterQuickPickFunction = (items: NoteQuickInput[]) => NoteQuickInput[];
 type ModifyPickerValueFunc = (value: string) => string;
+type SelectionProcessFunc = (note: NoteProps) => Promise<NoteProps | undefined>;
 
 export type DendronQuickPickItemV2 = QuickPick<DNodePropsQuickInputV2>;
 export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
@@ -66,6 +68,10 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    * Modify picker value
    */
   modifyPickerValueFunc?: ModifyPickerValueFunc;
+  /**
+   * Method to process selected text in active note.
+   */
+  selectionProcessFunc?: SelectionProcessFunc;
   /**
    * Should show a subsequent picker?
    */

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -610,14 +610,16 @@ export class PickerUtilsV2 {
   }) {
     const buttonsEnabled = _.filter(opts.buttons, { pressed: true });
     const buttonsDisabled = _.filter(opts.buttons, { pressed: false });
-    await Promise.all(
-      buttonsEnabled.map((bt) => {
-        bt.onEnable({ quickPick: opts.quickpick });
-      })
-    );
+    // call onDisable first so that
+    // they don't modify state of the quickpick after onEnable.
     await Promise.all(
       buttonsDisabled.map((bt) => {
         bt.onDisable({ quickPick: opts.quickpick });
+      })
+    );
+    await Promise.all(
+      buttonsEnabled.map((bt) => {
+        bt.onEnable({ quickPick: opts.quickpick });
       })
     );
   }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -10,6 +10,7 @@ import { describe } from "mocha";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
 import * as vscode from "vscode";
+import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
 import { PickerUtilsV2 } from "../../components/lookup/utils";
@@ -225,11 +226,7 @@ suite("NoteLookupCommand", function () {
   });
 
   describe("modifiers", () => {
-<<<<<<< HEAD
     test("Journal note modifier behaviors", (done) => {
-=======
-    test.only("Journal note modifier behavior", (done) => {
->>>>>>> 98451d01 (spike: add tests for journal modifier)
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
@@ -238,8 +235,6 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-
-<<<<<<< HEAD
           // with journal note modifier enabled,
           await VSCodeUtils.openNote(engine.notes["foo"]);
           const out = (await cmd.run({
@@ -260,12 +255,7 @@ suite("NoteLookupCommand", function () {
           await journalBtn?.onDisable({ quickPick: out!.quickpick });
           // the quickpick value should turn back to name of current note.
           expect(out?.quickpick.value).toEqual("foo");
-
-=======
-          await VSCodeUtils.openNote(engine.notes["foo"]);
-          const opts = (await cmd.run());
-          console.log(opts);
->>>>>>> 98451d01 (spike: add tests for journal modifier)
+          
           done();
         }
       });

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -5,7 +5,7 @@ import {
   ENGINE_HOOKS_MULTI,
   TestEngineUtils
 } from "@dendronhq/engine-test-utils";
-import _, { get } from "lodash";
+import _ from "lodash";
 import { describe } from "mocha";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
@@ -49,20 +49,20 @@ function getJournalAndScratchButton(
   journalBtn: JournalBtn,
   scratchBtn: ScratchBtn
 } {
-  const [journalBtn, scratchBtn] = [
-    LookupNoteTypeEnum.journal,
-    LookupNoteTypeEnum.scratch
-  ].map((btnType) => {
-    return _.find(buttons, (button) => {
-      return button.type === btnType;
-    }
-  }) as vscode.QuickInputButton[] & DendronBtn[];
+  const [journalBtn, scratchBtn] = _.map(
+    _.values(LookupNoteTypeEnum), 
+    (btnType) => {
+      return _.find(buttons, (button) => button.type === btnType );
+    }) as vscode.QuickInputButton[] & DendronBtn[];
   return { journalBtn, scratchBtn };
 }
 
 suite("NoteLookupCommand", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this);
+  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
+    afterHook: async () => {
+      sinon.restore();
+    },
+  });
 
   // NOTE: think these tests are wrong
   describe("updateItems", () => {

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -5,14 +5,14 @@ import {
   ENGINE_HOOKS_MULTI,
   TestEngineUtils
 } from "@dendronhq/engine-test-utils";
-import _ from "lodash";
+import _, { get } from "lodash";
 import { describe } from "mocha";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
 import * as vscode from "vscode";
 import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
-import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
-import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
+import { NoteLookupCommand, CommandOutput } from "../../commands/NoteLookupCommand";
+import { JournalBtn, ScratchBtn, DendronBtn } from "../../components/lookup/buttons";
 import { PickerUtilsV2 } from "../../components/lookup/utils";
 import { VSCodeUtils } from "../../utils";
 import { expect } from "../testUtilsv2";
@@ -41,6 +41,23 @@ function expectCreateNew({
   if (fname) {
     expect(item.fname).toEqual(fname);
   }
+}
+
+function getJournalAndScratchButton(
+  buttons: vscode.QuickInputButton[] & DendronBtn[]
+): {
+  journalBtn: JournalBtn,
+  scratchBtn: ScratchBtn
+} {
+  const [journalBtn, scratchBtn] = [
+    LookupNoteTypeEnum.journal,
+    LookupNoteTypeEnum.scratch
+  ].map((btnType) => {
+    return _.find(buttons, (button) => {
+      return button.type === btnType;
+    }
+  }) as vscode.QuickInputButton[] & DendronBtn[];
+  return { journalBtn, scratchBtn };
 }
 
 suite("NoteLookupCommand", function () {
@@ -225,8 +242,8 @@ suite("NoteLookupCommand", function () {
     });
   });
 
-  describe("modifiers", () => {
-    test("Journal note modifier behaviors", (done) => {
+  describe.only("modifiers", () => {
+    test("journal note basic", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
@@ -240,25 +257,168 @@ suite("NoteLookupCommand", function () {
           const out = (await cmd.run({
             noteType: LookupNoteTypeEnum.journal,
             noConfirm: true,
-          }));
+          })) as CommandOutput;
           
           expect(engine.config.journal.dateFormat).toEqual("y.MM.dd");
           // quickpick value should be `foo.journal.yyyy.mm.dd`
-          expect(out?.quickpick.value.startsWith("foo.journal")).toBeTruthy();
+          const today = ((new Date()).toISOString().split("T")[0]).split("-").join(".");
+          expect(out.quickpick.value).toEqual(`foo.journal.${today}`)
 
-          // at this point, the button: 
-          const journalBtn = _.find(out?.quickpick.buttons, (button) => {
-            return button.type === LookupNoteTypeEnum.journal
-          });
-          
-          // and if you trigger it again (disable),
-          await journalBtn?.onDisable({ quickPick: out!.quickpick });
-          // the quickpick value should turn back to name of current note.
-          expect(out?.quickpick.value).toEqual("foo");
-          
           done();
         }
       });
+    });
+
+    test("scratch note basic", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults, engine }) => {
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+
+          // with scratch note modifier enabled,
+          await VSCodeUtils.openNote(engine.notes["foo"]);
+          const out = (await cmd.run({
+            noteType: LookupNoteTypeEnum.scratch,
+            noConfirm: true,
+          })) as CommandOutput;
+          
+          // quickpick value should be `scratch.yyyy.mm.dd.ts`
+          const today = ((new Date()).toISOString().split("T")[0]).split("-").join(".");
+          expect(out.quickpick.value.startsWith(`scratch.${today}.`)).toBeTruthy();
+
+          done();
+        }
+      });
+    });
+
+    test("journal modifier toggle", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults, engine }) => {
+          await VSCodeUtils.openNote(engine.notes["foo"]);
+
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+
+          const { controller } = await cmd.gatherInputs({
+            noteType: LookupNoteTypeEnum.journal
+          });
+
+          controller.quickpick.show();
+          let { journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          )
+
+          expect(journalBtn.pressed).toBeTruthy();
+          expect(scratchBtn.pressed).toBeFalsy();
+          expect(controller.quickpick.value.startsWith("foo.journal."));
+          
+          await controller.onTriggerButton(journalBtn);
+
+          ({ journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          ));
+          expect(journalBtn.pressed).toBeFalsy();
+          expect(scratchBtn.pressed).toBeFalsy();
+          expect(controller.quickpick.value).toEqual("foo");
+
+          done();
+        }
+      });
+    });
+
+    test("scratch modifier toggle", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults, engine }) => {
+          await VSCodeUtils.openNote(engine.notes["foo"]);
+
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+
+          const { controller } = await cmd.gatherInputs({
+            noteType: LookupNoteTypeEnum.scratch
+          });
+
+          controller.quickpick.show();
+          let { journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          )
+
+          expect(journalBtn.pressed).toBeFalsy();
+          expect(scratchBtn.pressed).toBeTruthy();
+          expect(controller.quickpick.value.startsWith("scratch."));
+          
+          await controller.onTriggerButton(scratchBtn);
+
+          ({ journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          ));
+          expect(journalBtn.pressed).toBeFalsy();
+          expect(scratchBtn.pressed).toBeFalsy();
+          expect(controller.quickpick.value).toEqual("foo");
+
+          done();
+        }
+      });
+    });
+
+    test("scratch and journal modifiers toggle each other off when triggered", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults, engine }) => {
+          await VSCodeUtils.openNote(engine.notes["foo"]);
+
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+
+          const { controller } = await cmd.gatherInputs({
+            noteType: LookupNoteTypeEnum.journal
+          });
+
+          controller.quickpick.show();
+          let { journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          )
+
+          expect(journalBtn.pressed).toBeTruthy();
+          expect(scratchBtn.pressed).toBeFalsy();
+          expect(controller.quickpick.value.startsWith("foo.journal."));
+          
+          await controller.onTriggerButton(scratchBtn);
+          
+          ({ journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          ));
+          expect(journalBtn.pressed).toBeFalsy();
+          expect(scratchBtn.pressed).toBeTruthy();
+          expect(controller.quickpick.value.startsWith("scratch."));
+
+          await controller.onTriggerButton(scratchBtn);
+
+          ({ journalBtn, scratchBtn } = getJournalAndScratchButton(
+            controller.quickpick.buttons
+          ));
+          expect(journalBtn.pressed).toBeFalsy();
+          expect(scratchBtn.pressed).toBeFalsy();
+          expect(controller.quickpick.value).toEqual("foo");
+
+          done();
+        }
+      }); 
     });
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -225,7 +225,11 @@ suite("NoteLookupCommand", function () {
   });
 
   describe("modifiers", () => {
+<<<<<<< HEAD
     test("Journal note modifier behaviors", (done) => {
+=======
+    test.only("Journal note modifier behavior", (done) => {
+>>>>>>> 98451d01 (spike: add tests for journal modifier)
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
@@ -235,6 +239,7 @@ suite("NoteLookupCommand", function () {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
+<<<<<<< HEAD
           // with journal note modifier enabled,
           await VSCodeUtils.openNote(engine.notes["foo"]);
           const out = (await cmd.run({
@@ -256,6 +261,11 @@ suite("NoteLookupCommand", function () {
           // the quickpick value should turn back to name of current note.
           expect(out?.quickpick.value).toEqual("foo");
 
+=======
+          await VSCodeUtils.openNote(engine.notes["foo"]);
+          const opts = (await cmd.run());
+          console.log(opts);
+>>>>>>> 98451d01 (spike: add tests for journal modifier)
           done();
         }
       });

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -10,8 +10,8 @@ import { describe } from "mocha";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
 import * as vscode from "vscode";
-import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
 import { PickerUtilsV2 } from "../../components/lookup/utils";
 import { VSCodeUtils } from "../../utils";
 import { expect } from "../testUtilsv2";

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -242,7 +242,7 @@ suite("NoteLookupCommand", function () {
     });
   });
 
-  describe.only("modifiers", () => {
+  describe("modifiers", () => {
     test("journal note basic", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4470,9 +4470,14 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/uuid@^8.0.0":
+  version "8.3.0"
+  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/vscode@1.58":
   version "1.58.1"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.1.tgz#7deae08792adc73fa57383244a0c79d3530df4f7"
+  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.58.1.tgz#7deae08792adc73fa57383244a0c79d3530df4f7"
   integrity sha512-sa76rDXiSif09he8KoaWWUQxsuBr2+uND0xn1GUbEODkuEjp2p7Rqd3t5qlvklfmAedLFdL7MdnsPa57uzwcOw==
 
 "@types/warning@^3.0.0":


### PR DESCRIPTION
This PR:
- Adds scratch modifier to lookup V3
- Adds tests for scratch modifier
- Adds tests for interaction between the scratch and journal modifier

fyi: this branch is already rebased to be on top of `feat/journal-lookupv3`. See #1009