### PR TITLE
feat: add selection modifier buttons to lookup V3

### DIFF
--- a/packages/plugin-core/src/commands/LookupCommand.ts
+++ b/packages/plugin-core/src/commands/LookupCommand.ts
@@ -17,6 +17,10 @@ export enum LookupNoteTypeEnum {
   "journal" = "journal",
   "scratch" = "scratch",
 }
+export enum LookupSelectionTypeEnum {
+  "selection2link" = "selection2link",
+  "selectionExtract" = "selectionExtract",
+}
 
 /**
  * Mode for prompting the user on which vault should be used to 

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -13,6 +13,8 @@ import {
   JournalBtn,
   ScratchBtn,
   MultiSelectBtn,
+  Selection2LinkBtn,
+  SelectionExtractBtn,
 } from "../components/lookup/buttons";
 import { LookupControllerV3 } from "../components/lookup/LookupControllerV3";
 import {
@@ -138,6 +140,8 @@ export class NoteLookupCommand extends BaseCommand<
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")
         ),
+        Selection2LinkBtn.create(),
+        SelectionExtractBtn.create(),
       ],
     });
     this._provider = new NoteLookupProvider("lookup", {
@@ -270,6 +274,9 @@ export class NoteLookupCommand extends BaseCommand<
         ? picker.vault
         : PickerUtilsV2.getOrPromptVaultForOpenEditor();
       nodeNew = NoteUtils.create({ fname, vault });
+      if (picker.selectionProcessFunc !== undefined) {
+        nodeNew = await picker.selectionProcessFunc(nodeNew) as NoteProps;
+      }
     }
     const resp = await engine.writeNote(nodeNew, {
       newNode: true,

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -37,6 +37,8 @@ import {
   LookupFilterType,
   LookupNoteType,
   LookupNoteTypeEnum,
+  LookupSelectionType,
+  LookupSelectionTypeEnum,
 } from "./LookupCommand";
 
 type CommandRunOpts = {
@@ -45,6 +47,7 @@ type CommandRunOpts = {
   fuzzThreshold?: number;
   multiSelect?: boolean;
   noteType?: LookupNoteType;
+  selectionType?: LookupSelectionType;
   /**
    * NOTE: currently, only one filter is supported
    */
@@ -140,8 +143,8 @@ export class NoteLookupCommand extends BaseCommand<
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")
         ),
-        Selection2LinkBtn.create(),
-        SelectionExtractBtn.create(),
+        Selection2LinkBtn.create(copts.selectionType === LookupSelectionTypeEnum.selection2link),
+        SelectionExtractBtn.create(copts.selectionType === LookupSelectionTypeEnum.selectionExtract),
       ],
     });
     this._provider = new NoteLookupProvider("lookup", {

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -1,6 +1,7 @@
 import {
   DNodePropsQuickInputV2,
   DNodeProps,
+  NoteProps,
   DVault,
   NoteQuickInput,
 } from "@dendronhq/common-all";
@@ -14,6 +15,7 @@ export type LookupControllerState = {
 
 type FilterQuickPickFunction = (items: NoteQuickInput[]) => NoteQuickInput[];
 type ModifyPickerValueFunc = (value: string) => string;
+type SelectionProcessFunc = (note: NoteProps) => Promise<NoteProps | undefined>;
 
 export type DendronQuickPickItemV2 = QuickPick<DNodePropsQuickInputV2>;
 export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
@@ -66,6 +68,10 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    * Modify picker value
    */
   modifyPickerValueFunc?: ModifyPickerValueFunc;
+  /**
+   * Method to process selected text in active note.
+   */
+  selectionProcessFunc?: SelectionProcessFunc;
   /**
    * Should show a subsequent picker?
    */


### PR DESCRIPTION
This PR:
- Adds modifier buttons for `selection2link` and `selectionExtract`
***
- [x] Implement button
- [x] Implement onTrigger behaviors
- [x] Add tests