### PR TITLE
feat(community issue): graph zoom speed option

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -184,6 +184,11 @@ export type DendronConfig = {
   hierarchyDisplayTitle?: string;
 
   /**
+   * Configuration for note and schema graphs
+   */
+  graph?: DendronGraphConfig;
+
+  /**
    * Don't automatically create note when looking up definition
    */
   noAutoCreateOnDefinition?: boolean;
@@ -437,6 +442,10 @@ export type DendronSiteConfig = {
   cognitoUserPoolId?: string;
   cognitoClientId?: string;
 };
+
+export type DendronGraphConfig = {
+  scrollSpeed: number;
+}
 
 export type HierarchyConfig = {
   publishByDefault?: boolean | { [key: string]: boolean };

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -444,7 +444,7 @@ export type DendronSiteConfig = {
 };
 
 export type DendronGraphConfig = {
-  scrollSpeed: number;
+  zoomSpeed: number;
 }
 
 export type HierarchyConfig = {

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -126,8 +126,6 @@ export default function Graph({
   const [cy, setCy] = useState<Core>();
   const [isGraphLoaded, setIsGraphLoaded] = useState(false);
 
-  const { config: dendronConfig } = useDendronConfig()
-
   useSyncGraphWithIDE({
     graph: cy,
     engine,
@@ -172,8 +170,6 @@ export default function Graph({
 
       const style =  getCytoscapeStyle(themes, currentTheme, ide.graphStyles) as any
 
-      logger.log(style)
-
       const network = cytoscape({
         container: graphRef.current,
         elements: {
@@ -181,7 +177,7 @@ export default function Graph({
           edges: parsedEdges,
         },
         style,
-        wheelSensitivity: dendronConfig?.graph?.scrollSpeed || 1,
+        wheelSensitivity: engine.config?.graph?.zoomSpeed || 1,
 
         // Zoom levels
         minZoom: 0.25,

--- a/packages/dendron-next-server/components/graph.tsx
+++ b/packages/dendron-next-server/components/graph.tsx
@@ -8,10 +8,12 @@ import Head from "next/head";
 import AntThemes from "../styles/theme-antd";
 import GraphFilterView from "./graph-filter-view";
 import { GraphConfig, GraphConfigItem, GraphElements } from "../lib/graph";
-import { DMessageSource, GraphViewMessage, GraphViewMessageType, VaultUtils } from "@dendronhq/common-all";
+import { APIUtils, DMessageSource, GraphViewMessage, GraphViewMessageType, VaultUtils } from "@dendronhq/common-all";
 import useApplyGraphConfig from "../hooks/useApplyGraphConfig";
 import { DendronProps } from "../lib/types";
 import useSyncGraphWithIDE from "../hooks/useSyncGraphWithIDE";
+import { useDendronConfig } from "../lib/hooks";
+import { api } from "../lib/config";
 
 export class GraphUtils {
   static isLocalGraph(config: GraphConfig) {
@@ -124,6 +126,8 @@ export default function Graph({
   const [cy, setCy] = useState<Core>();
   const [isGraphLoaded, setIsGraphLoaded] = useState(false);
 
+  const { config: dendronConfig } = useDendronConfig()
+
   useSyncGraphWithIDE({
     graph: cy,
     engine,
@@ -177,6 +181,7 @@ export default function Graph({
           edges: parsedEdges,
         },
         style,
+        wheelSensitivity: dendronConfig?.graph?.scrollSpeed || 1,
 
         // Zoom levels
         minZoom: 0.25,

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -53,6 +53,6 @@ dev:
     nextServerUrl: 'http://localhost:3000'
     engineServerPort: 3005
 graph:
-    scrollSpeed: 0.8
+    zoomSpeed: 1
 initializeRemoteVaults: true
 dendronVersion: 0.50.0

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -52,5 +52,7 @@ dev:
     enableWebUI: true
     nextServerUrl: 'http://localhost:3000'
     engineServerPort: 3005
+graph:
+    scrollSpeed: 0.8
 initializeRemoteVaults: true
 dendronVersion: 0.50.0


### PR DESCRIPTION
**Adds:**
Ability to configure zoom speed for the graph.

**To test:**
Add the following property to your `dendron.yml`, reload the window, and open the note or schema graph. The default zoomSpeed is 1.
```
graph:
    zoomSpeed: 1
```