### PR TITLE
feat: Add horizontal split modifier to lookup v3

### DIFF
--- a/packages/plugin-core/src/commands/LookupCommand.ts
+++ b/packages/plugin-core/src/commands/LookupCommand.ts
@@ -12,6 +12,9 @@ export type LookupFilterType = "directChildOnly";
 export type LookupSelectionType = "selection2link" | "selectionExtract";
 export type LookupNoteType = LookupNoteTypeEnum;
 export type LookupSplitType = "horizontal";
+export enum LookupSplitTypeEnum {
+  "horizontal" = "horizontal",
+}
 export type LookupNoteExistBehavior = "open" | "overwrite";
 export enum LookupNoteTypeEnum {
   "journal" = "journal",

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -15,6 +15,7 @@ import {
   MultiSelectBtn,
   Selection2LinkBtn,
   SelectionExtractBtn,
+  HorizontalSplitBtn,
 } from "../components/lookup/buttons";
 import { LookupControllerV3 } from "../components/lookup/LookupControllerV3";
 import {
@@ -39,6 +40,8 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionType,
   LookupSelectionTypeEnum,
+  LookupSplitType,
+  LookupSplitTypeEnum,
 } from "./LookupCommand";
 
 type CommandRunOpts = {
@@ -48,6 +51,7 @@ type CommandRunOpts = {
   multiSelect?: boolean;
   noteType?: LookupNoteType;
   selectionType?: LookupSelectionType;
+  splitType?: LookupSplitType;
   /**
    * NOTE: currently, only one filter is supported
    */
@@ -145,6 +149,7 @@ export class NoteLookupCommand extends BaseCommand<
         ),
         Selection2LinkBtn.create(copts.selectionType === LookupSelectionTypeEnum.selection2link),
         SelectionExtractBtn.create(copts.selectionType === LookupSelectionTypeEnum.selectionExtract),
+        HorizontalSplitBtn.create(copts.splitType === LookupSplitTypeEnum.horizontal),
       ],
     });
     this._provider = new NoteLookupProvider("lookup", {

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -83,7 +83,6 @@ function isSplitButton(button: DendronBtn) {
   return _.includes(["horizontal", "vertical"], button.type);
 }
 
-// TODO: make it into a utils method?
 const selectionToNoteProps = async (opts: {
   selectionType: string;
   note: NoteProps;
@@ -93,7 +92,7 @@ const selectionToNoteProps = async (opts: {
   const { document, range } = resp || {};
   const { selectionType, note } = opts;
   const { selection, text } = VSCodeUtils.getSelection();
-  //TODO: split these up?
+
   switch(selectionType) {
     case "selectionExtract": {
       if (!_.isUndefined(document)) {
@@ -305,15 +304,28 @@ export class ScratchBtn extends DendronBtn {
     quickPick.value = quickPick.rawValue;
   }
 }
-class HorizontalSplitBtn extends DendronBtn {
+export class HorizontalSplitBtn extends DendronBtn {
   static create(pressed?: boolean) {
-    return new DendronBtn({
+    return new HorizontalSplitBtn({
       title: "Split Horizontal",
       iconOff: "split-horizontal",
       iconOn: "menu-selection",
       type: "horizontal",
       pressed,
     });
+  }
+
+  async onEnable({ quickPick }: ButtonHandleOpts) {
+    quickPick.showNote = async (uri) => vscode.window.showTextDocument(
+      uri, 
+      { viewColumn: vscode.ViewColumn.Beside }
+    );
+    return;
+  }
+
+  async onDisable({ quickPick }: ButtonHandleOpts) {
+    quickPick.showNote = async (uri) => vscode.window.showTextDocument(uri);
+    return;
   }
 }
 

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -719,7 +719,7 @@ suite("NoteLookupCommand", function () {
       });
     });
 
-    test.only("horizontal split modifier toggle", (done) => {
+    test("horizontal split modifier toggle", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {


### PR DESCRIPTION
This PR:
- Adds horizontal split modifier to `NoteLookupCommand`
- Adds test for said modifier
