### PR TITLE
Capitalize Command

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -94,6 +94,11 @@
         "desc": "Go to a note"
       },
       {
+        "command": "dendron.capitalize",
+        "title": "Dendron: Capitalize",
+        "desc": "Capitalized the selected text"
+      },
+      {
         "command": "dendron.createDailyJournalNote",
         "title": "Dendron: Create Daily Journal Note",
         "desc": "Create a global journal note",

--- a/packages/plugin-core/src/commands/CapitalizeCommand.ts
+++ b/packages/plugin-core/src/commands/CapitalizeCommand.ts
@@ -1,0 +1,35 @@
+import { window } from "vscode";
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {};
+
+type CommandInput = {};
+
+type CommandOutput = void;
+
+export class CapitalizeCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CAPITALIZE.key;
+  async gatherInputs(): Promise<CommandInput | undefined> {
+    return {};
+  }
+  async execute() {
+    const editor = window.activeTextEditor;
+
+		if (editor) {
+			const document = editor.document;
+			const selection = editor.selection;
+
+			// Get the word within the selection
+			const word = document.getText(selection);
+			const capatalized = word.toUpperCase();
+			editor.edit(editBuilder => {
+				editBuilder.replace(selection, capatalized);
+			});
+			window.showInformationMessage("Capitalize command used.");
+		} 
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -7,6 +7,7 @@ import { ConfigureCommand } from "./ConfigureCommand";
 import { ConfigurePodCommand } from "./ConfigurePodCommand";
 import { ConfigureWithUICommand } from "./ConfigureWithUI";
 import { ContributeCommand } from "./Contribute";
+import { CapitalizeCommand } from "./CapitalizeCommand";
 import { CopyNoteLinkCommand } from "./CopyNoteLink";
 import { CopyNoteRefCommand } from "./CopyNoteRef";
 import { CopyNoteURLCommand } from "./CopyNoteURL";
@@ -65,6 +66,7 @@ const ALL_COMMANDS = [
   ConfigurePodCommand,
   ConfigureGraphStylesCommand,
   ContributeCommand,
+  CapitalizeCommand,
   CopyNoteLinkCommand,
   CopyNoteRefCommand,
   CopyNoteURLCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -163,6 +163,13 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
       when: "editorFocus",
     },
   },
+  CAPITALIZE: {
+    key: "dendron.capitalize",
+    // no prefix, we don't want to show this command
+    title: `${CMD_PREFIX} Capitalize`,
+    group: "notes",
+    desc: "Capitalized the selected text",
+  },
   CREATE_DAILY_JOURNAL_NOTE: {
     key: "dendron.createDailyJournalNote",
     title: `${CMD_PREFIX} Create Daily Journal Note`,

--- a/packages/plugin-core/src/test/suite-integ/CapitalizeCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CapitalizeCommand.test.ts
@@ -1,0 +1,33 @@
+import { DendronWebViewKey } from "@dendronhq/common-all";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { test } from "mocha";
+import { ExtensionContext } from "vscode";
+import { CapitalizeCommand } from "../../commands/CapitalizeCommand";
+import { VSCodeUtils } from "../../utils";
+import { DendronWorkspace } from "../../workspace";
+import { expect } from "../testUtilsv2";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+
+
+suite("CapitalizeCommand", function () {
+  let ctx: ExtensionContext;
+  ctx = setupBeforeAfter(this);
+
+	test("ok: capitalize tests", (done) => {
+
+		runLegacyMultiWorkspaceTest({
+			ctx,
+			preSetupHook: ENGINE_HOOKS.setupBasic,
+			onInit: async ({ engine }) => {
+				const note = engine.notes["foo"];
+				await VSCodeUtils.openNote(note)
+				await new CapitalizeCommand().execute();
+				const preview = DendronWorkspace.instance().getWebView(DendronWebViewKey.NOTE_PREVIEW);
+				expect(preview?.visible).toBeTruthy();
+				done();
+			},
+		});
+
+	});
+	
+});


### PR DESCRIPTION
Select the text in the editor, then use the command 'Dendron: Capitalize' to change the selected text to all capital letters.