### PR TITLE
fix: hashtags include punctuation and quotation marks

### DIFF
--- a/packages/engine-server/src/markdown/remark/hashtag.ts
+++ b/packages/engine-server/src/markdown/remark/hashtag.ts
@@ -6,16 +6,54 @@ import { DendronASTDest, DendronASTTypes, HashTag } from "../types";
 import { MDUtilsV4 } from "../utils";
 import { Element } from "hast";
 
+/** All sorts of punctuation marks and quotation marks from different languages. Please add any that may be missing.
+ * 
+ * Be warned that this excludes period (.) as it has a special meaning in Dendron. Make sure to handle it appropriately depending on the context.
+ * 
+ * Mind that this may have non regex-safe characters, run it through `_.escapeRegExp` if needed.
+ */
+export const PUNCTUATION_MARKS = ",;:'\"<>?!`~«‹»›„“‟”’❝❞❮❯⹂〝〞〟＂‚‘‛❛❜❟［］【】…‥「」『』·؟،।॥‽⸘¡¿⁈⁉";
+
+/** Can't start with a number or period */
+const GOOD_FIRST_CHARACTER = `[^0-9#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+/** Can have numbers and period in the middle */
+const GOOD_MIDDLE_CHARACTER = `[^#|\\[\\]\\s${PUNCTUATION_MARKS}]`;
+/** Can have numbers, but not period in the end */
+const GOOD_END_CHARACTER = `[^#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+
 /** Hashtags have the form #foo, or #foo.bar, or #f123
  *
  * Hashtags are not allowed to start with numbers: this is to reserve them in
  * case we want to add Github issues integration, where issues look like #123
  *
- * Other then the reservation on the first character, hashtags can contain any
- * character that a note name can.
+ * Hashtags are also not allowed to contain any punctuation or quotation marks.
+ * This allows them to be more easily mixed into text, for example:
+ * 
+ * ```
+ * This issue is #important, and should be prioritized.
+ * ```
+ * 
+ * Here, the tag is `#important` without the following comma.
  */
-export const HASHTAG_REGEX = /^(?<hashTag>#)(?<tagContents>[^0-9#|>[\]\s][^#|>[\]\s]*)/;
-export const HASHTAG_REGEX_LOOSE = /(?<hashTag>#)(?<tagContents>[^0-9#|>[\]\s][^#|>[\]\s]*)/;
+export const HASHTAG_REGEX = new RegExp(`^(?<hashTag>#)(?<tagContents>` + 
+  // 2 or more characters, like #a1x or #a.x. This MUST come before 1 character case, or regex will match 1 character and stop.
+  `${GOOD_FIRST_CHARACTER}${GOOD_MIDDLE_CHARACTER}*${GOOD_END_CHARACTER}` +
+  // or
+  "|" +
+  // Just 1 character, like #a
+  `${GOOD_FIRST_CHARACTER}` +
+  ")"
+);
+/** Same as `HASHTAG_REGEX`, except that that it doesn't have to be at the start of the string. */
+export const HASHTAG_REGEX_LOOSE = new RegExp(`^(?<hashTag>#)(?<tagContents>` + 
+  // 2 or more characters, like #a1x or #a.x. This MUST come before 1 character case, or regex will match 1 character and stop.
+  `${GOOD_FIRST_CHARACTER}${GOOD_MIDDLE_CHARACTER}*${GOOD_END_CHARACTER}` +
+  // or
+  "|" +
+  // Just 1 character, like #a
+  `${GOOD_FIRST_CHARACTER}` +
+  ")"
+);
 
 /**
  *

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -28,12 +28,12 @@
     "prebuild": "yarn clean && yarn format && yarn lint && echo Using TypeScript && tsc --version",
     "build": "yarn compile",
     "compile": "tsc -p tsconfig.build.json",
-    "test": "env LOG_LEVEL=error npx jest --bail",
+    "test": "cross-env LOG_LEVEL=error npx jest --bail",
     "coverage": "jest --coverage",
     "watch": "yarn compile --watch",
     "test:unit": "jest ",
     "test:updateSnapshots": "jest -u",
-    "test:unit:debug": "NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:unit:debug": "cross-env NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:watch": "jest --watch"
   },
   "devDependencies": {
@@ -68,6 +68,7 @@
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^7.0.1",
     "@types/sinon": "^9.0.9",
+    "cross-env": "^7.0.3",
     "fs-extra": "^9.0.1",
     "jest": "26",
     "lodash": "^4.17.20",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
@@ -75,6 +75,22 @@ describe("hashtag", () => {
       const resp = proc().parse("#123-hash-tag");
       expect(getDescendantNode(resp, 0, 0).type).toEqual(DendronASTTypes.TEXT);
     });
+
+    test("doesn't parse trailing punctuation", () => {
+      const resp1 = proc().parse("Dolorem vero sed sapiente #dolores. Et quam id maxime et ratione.");
+      expect(getDescendantNode(resp1, 0, 1).type).toEqual(DendronASTTypes.HASHTAG);
+      expect(getDescendantNode(resp1, 0, 1).value).toEqual("#dolores");
+
+      const resp2 = proc().parse("Dolorem vero sed sapiente #dolores, et quam id maxime et ratione.");
+      expect(getDescendantNode(resp2, 0, 1).type).toEqual(DendronASTTypes.HASHTAG);
+      expect(getDescendantNode(resp2, 0, 1).value).toEqual("#dolores");
+    });
+
+    test("doesn't parse trailing unicode punctuation", () => {
+      const resp1 = proc().parse("彼女に「#よろしく」言って下さい。");
+      expect(getDescendantNode(resp1, 0, 1).type).toEqual(DendronASTTypes.HASHTAG);
+      expect(getDescendantNode(resp1, 0, 1).value).toEqual("#よろしく");
+    });
   });
 
   describe("rendering", () => {

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -1,6 +1,6 @@
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { describe } from "mocha";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { runLegacyMultiWorkspaceTest, runTestButSkipForWindows, setupBeforeAfter } from "../testUtilsV3";
 import _ from "lodash";
 import {
   provideBlockCompletionItems,
@@ -132,7 +132,7 @@ suite("completionProvider", function () {
     });
   });
 
-  describe("blocks", () => {
+  runTestButSkipForWindows()("blocks", () => {
     test("doesn't provide outside wikilink", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,


### PR DESCRIPTION
Hashtags are now not allowed to contain any punctuation or quotation marks. This allows them to be more easily mixed into text, for example:

```
This issue is #important, and should be prioritized.

This issue is #important. It should be prioritized.

They said "This issue is #important", so it should be prioritized.
```

In all these examples, the tag is `#important` without the following marks.

#1048