### PR TITLE
fix: clear out decoration types that have no decorations

### DIFF
--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -95,11 +95,24 @@ export function updateDecorations(activeEditor: TextEditor) {
   for (const [type, decorations] of allDecorations.entries()) {
     activeEditor.setDecorations(type, decorations);
   }
-  // Clean out the now-unused tag decorations
+
+  // Clean out now-unused tag decorations
   for (const [key, type] of DECORATION_TYPE_TAG.entries()) {
     if (!allDecorations.has(type)) {
       type.dispose();
       DECORATION_TYPE_TAG.delete(key);
+    }
+  }
+  const allTypes = [
+    DECORATION_TYPE_TIMESTAMP,
+    DECORATION_TYPE_BLOCK_ANCHOR,
+    DECORATION_TYPE_WIKILINK,
+    DECORATION_TYPE_BROKEN_WIKILINK,
+    DECORATION_TYPE_ALIAS,
+  ];
+  for (const type of allTypes) {
+    if (!allDecorations.has(type)) {
+      type.dispose();
     }
   }
   return {allDecorations, allWarnings};


### PR DESCRIPTION
When only a single wikilink is left, erasing a part of it so that it's no longer a valid wikilink would not update the decoration, leaving the broken wikilink highlighted.

#1039