### PR TITLE
enhance: performance improvement for block/header autocomplete

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -115,10 +115,10 @@ router.post("/bulkAdd", async (req: Request, res: Response<WriteNoteResp>) => {
 router.get(
   "/blocks",
   async (req: Request, res: Response<GetNoteBlocksPayload>) => {
-    const { id, ws } = req.query as GetNoteBlocksRequest;
+    const { id, ws, filterByAnchorType } = req.query as GetNoteBlocksRequest;
     const engine = await getWS({ ws: ws || "" });
     try {
-      const out = await engine.getNoteBlocks({ id });
+      const out = await engine.getNoteBlocks({ id, filterByAnchorType });
       if (out.error instanceof DendronError)
         out.error = DendronError.createPlainError(out.error);
       res.json(out);

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -147,6 +147,7 @@ export type NoteQueryRequest = {
 
 export type GetNoteBlocksRequest = {
   id: string;
+  filterByAnchorType?: "header" | "block";
 } & WorkspaceRequest;
 
 export type SchemaDeleteRequest = {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -241,6 +241,7 @@ export type RenderNoteOpts = {
 
 export type GetNoteBlocksOpts = {
   id: string;
+  filterByAnchorType?: "header" | "block";
 };
 
 export type ConfigWriteOpts = {

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -404,9 +404,9 @@ export class DendronEngineClient implements DEngineClient {
   }
 
   async getNoteBlocks({
-    id,
+    id, filterByAnchorType
   }: GetNoteBlocksOpts): Promise<GetNoteBlocksPayload> {
-    const out = await this.api.getNoteBlocks({ id, ws: this.ws });
+    const out = await this.api.getNoteBlocks({ id, filterByAnchorType, ws: this.ws });
     return out;
   }
 }

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -567,6 +567,9 @@ export class DendronEngineV2 implements DEngine {
         note,
         engine: this,
       });
+      if (opts.filterByAnchorType) {
+        _.remove(blocks, (block) => block.anchor?.type !== opts.filterByAnchorType);
+      }
       return { data: blocks, error: null };
     } catch (err) {
       return {

--- a/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
@@ -35,12 +35,10 @@ const runGetNoteBlocks = async ({
       vault: vaults[0],
       wsRoot,
     });
-  debugger;
   const out = await engine.getNoteBlocks({
     id: note!.id,
     filterByAnchorType,
   });
-  debugger;
   return cb(out);
 };
 

--- a/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
@@ -18,12 +18,14 @@ const runGetNoteBlocks = async ({
   vaults,
   note,
   wsRoot,
+  filterByAnchorType,
   cb,
 }: {
   engine: DEngineClient;
   vaults: DVault[];
   wsRoot: string;
   note?: NoteProps;
+  filterByAnchorType?: "block" | "header";
   cb: (opts: GetNoteBlocksPayload) => TestResult[];
 }) => {
   if (_.isUndefined(note))
@@ -33,9 +35,12 @@ const runGetNoteBlocks = async ({
       vault: vaults[0],
       wsRoot,
     });
+  debugger;
   const out = await engine.getNoteBlocks({
     id: note!.id,
+    filterByAnchorType,
   });
+  debugger;
   return cb(out);
 };
 
@@ -222,6 +227,91 @@ const NOTES = {
         }),
     }
   ),
+  HEADERS_ONLY: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runGetNoteBlocks({
+        engine,
+        wsRoot,
+        vaults,
+        filterByAnchorType: "header",
+        cb: ({ data }) => {
+          return [
+            {
+              actual: data?.length,
+              expected: 1,
+            },
+            { actual: data![0].anchor?.value, expected: "et-et-quam-culpa" },
+          ];
+        },
+      });
+    },
+    {
+      preSetupHook: (opts) =>
+        preSetupHook(opts, {
+          noteBody: [
+            "# Et et quam culpa.",
+            "",
+            "Ullam vel eius reiciendis. ^paragraph",
+            "",
+            "* Cumque molestiae qui deleniti. ^item1",
+            "* Eius odit commodi harum. ^item2",
+            "  * Sequi ut non delectus tempore. ^item3",
+            "",
+            "^list",
+            "",
+            "| Sapiente | accusamus |",
+            "|----------|-----------|",
+            "| Laborum  | libero    |",
+            "| Ullam    | optio     | ^table",
+          ].join("\n"),
+        }),
+    }
+  ),
+  BLOCK_ANCHORS_ONLY: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runGetNoteBlocks({
+        engine,
+        wsRoot,
+        vaults,
+        filterByAnchorType: "block",
+        cb: ({ data }) => {
+          return [
+            {
+              actual: data?.length,
+              expected: 6,
+            },
+            { actual: data![0].anchor?.value, expected: "paragraph" },
+            { actual: data![1].anchor?.value, expected: "item1" },
+            { actual: data![2].anchor?.value, expected: "item2" },
+            { actual: data![3].anchor?.value, expected: "item3" },
+            { actual: data![4].anchor?.value, expected: "list" },
+            { actual: data![5].anchor?.value, expected: "table" },
+          ];
+        },
+      });
+    },
+    {
+      preSetupHook: (opts) =>
+        preSetupHook(opts, {
+          noteBody: [
+            "# Et et quam culpa.",
+            "",
+            "Ullam vel eius reiciendis. ^paragraph",
+            "",
+            "* Cumque molestiae qui deleniti. ^item1",
+            "* Eius odit commodi harum. ^item2",
+            "  * Sequi ut non delectus tempore. ^item3",
+            "",
+            "^list",
+            "",
+            "| Sapiente | accusamus |",
+            "|----------|-----------|",
+            "| Laborum  | libero    |",
+            "| Ullam    | optio     | ^table",
+          ].join("\n"),
+        }),
+    }
+  ),
   HEADER: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       return runGetNoteBlocks({
@@ -264,7 +354,7 @@ const NOTES = {
 };
 export const ENGINE_GET_NOTE_BLOCKS_PRESETS = {
   // use the below to test a specific test
-  //NOTES: {NOTE_REF: NOTES["NOTE_REF"]},
-  NOTES,
+  NOTES: {NOTE_REF: NOTES["HEADERS_ONLY"]},
+  //NOTES,
   SCHEMAS: {},
 };

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -36,6 +36,7 @@ import {
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../utils";
 import { DendronWorkspace, getWS } from "../workspace";
+import { getDurationMilliseconds } from "@dendronhq/common-server";
 
 function padWithZero(n: number): string {
   if (n > 99) return String(n);
@@ -402,7 +403,7 @@ export async function provideBlockCompletionItems(
       };
     })
     .filter(isNotUndefined);
-  const duration = process.hrtime(timestampStart);
+  const duration = getDurationMilliseconds(timestampStart);
   Logger.debug({ ctx, completionCount: completions.length, duration });
   return completions;
 }

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -298,20 +298,6 @@ export async function provideBlockCompletionItems(
   if (_.isUndefined(note) || token?.isCancellationRequested) return;
   Logger.debug({ ctx, fname: note.fname });
 
-  const blocks = await getWS().getEngine().getNoteBlocks({ id: note.id });
-  if (
-    _.isUndefined(blocks.data) ||
-    blocks.error?.severity === ERROR_SEVERITY.FATAL
-  ) {
-    Logger.error({
-      ctx,
-      error: blocks.error || undefined,
-      msg: `Unable to get blocks for autocomplete`,
-    });
-    return;
-  }
-  Logger.debug({ ctx, blockCount: blocks.data.length });
-
   // If there is [[^ or [[^^ , remove that because it's not a valid wikilink
   const removeTrigger = isNotUndefined(found.groups.trigger)
     ? new TextEdit(
@@ -325,22 +311,32 @@ export async function provideBlockCompletionItems(
       )
     : undefined;
 
+  let filterByAnchorType: "header" | "block" | undefined;
   // When triggered by [[#^, only show existing block anchors
   let insertValueOnly = false;
-  let completeableBlocks = blocks.data;
   if (isNotUndefined(found.groups?.anchor)) {
-    completeableBlocks = completeableBlocks.filter(
-      (block) => block.anchor?.type === "block"
-    );
+    filterByAnchorType = "block";
     // There is already #^ which we are not removing, so don't duplicate it when inserting the text
     insertValueOnly = true;
   } else if (isNotUndefined(found.groups?.hash)) {
-    // When trigger by [[#, only show headers. Without this, it also shows paragraphs that include `#`
-    completeableBlocks = completeableBlocks.filter(
-      (block) => block.anchor?.type === "header"
-    );
+    filterByAnchorType = "header"
+    // There is already # which we are not removing, so don't duplicate it when inserting the text
     insertValueOnly = true;
   }
+
+  const blocks = await getWS().getEngine().getNoteBlocks({ id: note.id, filterByAnchorType });
+  if (
+    _.isUndefined(blocks.data) ||
+    blocks.error?.severity === ERROR_SEVERITY.FATAL
+  ) {
+    Logger.error({
+      ctx,
+      error: blocks.error || undefined,
+      msg: `Unable to get blocks for autocomplete`,
+    });
+    return;
+  }
+  Logger.debug({ ctx, blockCount: blocks.data.length });
 
   // Calculate the replacement range. This must contain any text the user has typed for the block, but not the trigger symbols (#, ^, #^)
   // This is used to determine what the user has typed to narrow the options, and also to pick what will get replaced once the completion is picked.
@@ -363,7 +359,7 @@ export async function provideBlockCompletionItems(
   const range = new Range(position.line, start, position.line, end);
   Logger.debug({ ctx, start: range.start, end: range.end });
 
-  const completions = completeableBlocks
+  const completions = blocks.data
     .map((block, index) => {
       const edits: TextEdit[] = [];
       if (removeTrigger) edits.push(removeTrigger);

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -268,6 +268,7 @@ export async function provideBlockCompletionItems(
     return;
   Logger.debug({ ctx, found });
 
+  const timestampStart = process.hrtime();
   const engine = getWS().getEngine();
 
   let otherFile = false;
@@ -401,7 +402,8 @@ export async function provideBlockCompletionItems(
       };
     })
     .filter(isNotUndefined);
-  Logger.debug({ ctx, completionCount: completions.length });
+  const duration = process.hrtime(timestampStart);
+  Logger.debug({ ctx, completionCount: completions.length, duration });
   return completions;
 }
 

--- a/test-workspace/scripts/randomNote.js
+++ b/test-workspace/scripts/randomNote.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/** Creates a randomly generated note.
+ *
+ * The generated note will contain paragraphs, lists, tables, wikilinks, block
+ * anchors etc., trying to make use of Dendron features.
+ * 
+ * There is currently no options for this script, but you can edit the following variables to edit what gets generated.
+ */
+/* eslint-disable no-console */
+/* eslint-disable no-lone-blocks */
+/* eslint-disable no-plusplus */
+
+/** How many markdown elements to generate. */
+const GENERATED_LENGTH = 1000;
+/** How many items at most a generated list can have. */
+const LONGEST_LIST = 5;
+/** What ratio of paragraphs or list items should have block anchors */
+const WITH_BLOCK_ANCHOR = 0.2;
+/** What ratio of wikilinks should be to the same file */
+const SAME_FILE_WIKILINK = 0.3;
+
+
+// -----  setup  -----
+
+const RandomTextGenerator = require("./random_text_generator_node");
+
+/** An input text for the random text generator to seed it. These are excerpts from The Project Gutenberg eBook of The Adventures of Sherlock Holmes, by Arthur Conan Doyle. */
+const INPUT_TEXT = `When Mrs. Turner has brought in the tray I will make it clear to you. Now," he said as he turned hungrily on the simple fare that our landlady had provided, "I must discuss it while I eat, for I have not much time. It is nearly five now. In two hours we must be on the scene of action. Miss Irene, or Madame, rather, returns from her drive at seven. We must be at Briony Lodge to meet her. It is nothing very formidable,” he said, taking a long cigar-shaped roll from his pocket. “It is an ordinary plumber’s smoke-rocket, fitted with a cap at either end to make it self-lighting. Your task is confined to that. When you raise your cry of fire, it will be taken up by quite a number of people. You may then walk to the end of the street, and I will rejoin you in ten minutes. I hope that I have made myself clear? He disappeared into his bedroom and returned in a few minutes in the character of an amiable and simple-minded Nonconformist clergyman. His broad black hat, his baggy trousers, his white tie, his sympathetic smile, and general look of peering and benevolent curiosity were such as Mr. John Hare alone could have equalled. It was not merely that Holmes changed his costume. His expression, his manner, his very soul seemed to vary with every fresh part that he assumed. The stage lost a fine actor, even as science lost an acute reasoner, when he became a specialist in crime. It was a quarter past six when we left Baker Street, and it still wanted ten minutes to the hour when we found ourselves in Serpentine Avenue. It was already dusk, and the lamps were just being lighted as we paced up and down in front of Briony Lodge, waiting for the coming of its occupant. The house was just such as I had pictured it from Sherlock Holmes’ succinct description, but the locality appeared to be less private than I expected. On the contrary, for a small street in a quiet neighbourhood, it was remarkably animated. There was a group of shabbily dressed men smoking and laughing in a corner, a scissors-grinder with his wheel, two guardsmen who were flirting with a nurse-girl, and several well-dressed young men who were lounging up and down with cigars in their mouths. As he spoke the gleam of the sidelights of a carriage came round the curve of the avenue. It was a smart little landau which rattled up to the door of Briony Lodge. As it pulled up, one of the loafing men at the corner dashed forward to open the door in the hope of earning a copper, but was elbowed away by another loafer, who had rushed up with the same intention. A fierce quarrel broke out, which was increased by the two guardsmen, who took sides with one of the loungers, and by the scissors-grinder, who was equally hot upon the other side. A blow was struck, and in an instant the lady, who had stepped from her carriage, was the centre of a little knot of flushed and struggling men, who struck savagely at each other with their fists and sticks. Holmes dashed into the crowd to protect the lady; but, just as he reached her, he gave a cry and dropped to the ground, with the blood running freely down his face. At his fall the guardsmen took to their heels in one direction and the loungers in the other, while a number of better dressed people, who had watched the scuffle without taking part in it, crowded in to help the lady and to attend to the injured man. Irene Adler, as I will still call her, had hurried up the steps; but she stood at the top with her superb figure outlined against the lights of the hall, looking back into the street. At three o’clock precisely I was at Baker Street, but Holmes had not yet returned. The landlady informed me that he had left the house shortly after eight o’clock in the morning. I sat down beside the fire, however, with the intention of awaiting him, however long he might be. I was already deeply interested in his inquiry, for, though it was surrounded by none of the grim and strange features which were associated with the two crimes which I have already recorded, still, the nature of the case and the exalted station of his client gave it a character of its own. Indeed, apart from the nature of the investigation which my friend had on hand, there was something in his masterly grasp of a situation, and his keen, incisive reasoning, which made it a pleasure to me to study his system of work, and to follow the quick, subtle methods by which he disentangled the most inextricable mysteries. So accustomed was I to his invariable success that the very possibility of his failing had ceased to enter into my head. It was close upon four before the door opened, and a drunken-looking groom, ill-kempt and side-whiskered, with an inflamed face and disreputable clothes, walked into the room. Accustomed as I was to my friend’s amazing powers in the use of disguises, I had to look three times before I was certain that it was indeed he. With a nod he vanished into the bedroom, whence he emerged in five minutes tweed-suited and respectable, as of old. Putting his hands into his pockets, he stretched out his legs in front of the fire and laughed heartily for some minutes. Quite so; but the sequel was rather unusual. I will tell you, however. I left the house a little after eight o’clock this morning in the character of a groom out of work. There is a wonderful sympathy and freemasonry among horsey men. Be one of them, and you will know all that there is to know. I soon found Briony Lodge. It is a _bijou_ villa, with a garden at the back, but built out in front right up to the road, two stories. Chubb lock to the door. Large sitting-room on the right side, well furnished, with long windows almost to the floor, and those preposterous English window fasteners which a child could open. Behind there was nothing remarkable, save that the passage window could be reached from the top of the coach-house. I walked round it and examined it closely from every point of view, but without noting anything else of interest. I then lounged down the street and found, as I expected, that there was a mews in a lane which runs down by one wall of the garden. I lent the ostlers a hand in rubbing down their horses, and received in exchange twopence, a glass of half-and-half, two fills of shag tobacco, and as much information as I could desire about Miss Adler, to say nothing of half a dozen other people in the neighbourhood in whom I was not in the least interested, but whose biographies I was compelled to listen to. Oh, she has turned all the men’s heads down in that part. She is the daintiest thing under a bonnet on this planet. So say the Serpentine-mews, to a man. She lives quietly, sings at concerts, drives out at five every day, and returns at seven sharp for dinner. Seldom goes out at other times, except when she sings. Has only one male visitor, but a good deal of him. He is dark, handsome, and dashing, never calls less than once a day, and often twice. He is a Mr. Godfrey Norton, of the Inner Temple. See the advantages of a cabman as a confidant. They had driven him home a dozen times from Serpentine-mews, and knew all about him. When I had listened to all they had to tell, I began to walk up and down near Briony Lodge once more, and to think over my plan of campaign. This Godfrey Norton was evidently an important factor in the matter. He was a lawyer. That sounded ominous. What was the relation between them, and what the object of his repeated visits? Was she his client, his friend, or his mistress? If the former, she had probably transferred the photograph to his keeping. If the latter, it was less likely. On the issue of this question depended whether I should continue my work at Briony Lodge, or turn my attention to the gentleman’s chambers in the Temple. It was a delicate point, and it widened the field of my inquiry. I fear that I bore you with these details, but I have to let you see my little difficulties, if you are to understand the situation. I was still balancing the matter in my mind when a hansom cab drove up to Briony Lodge, and a gentleman sprang out. He was a remarkably handsome man, dark, aquiline, and moustached—evidently the man of whom I had heard. He appeared to be in a great hurry, shouted to the cabman to wait, and brushed past the maid who opened the door with the air of a man who was thoroughly at home. Away they went, and I was just wondering whether I should not do well to follow them when up the lane came a neat little landau, the coachman with his coat only half-buttoned, and his tie under his ear, while all the tags of his harness were sticking out of the buckles. It hadn’t pulled up before she shot out of the hall door and into it. I only caught a glimpse of her at the moment, but she was a lovely woman, with a face that a man might die for. I was half-dragged up to the altar, and before I knew where I was I found myself mumbling responses which were whispered in my ear, and vouching for things of which I knew nothing, and generally assisting in the secure tying up of Irene Adler, spinster, to Godfrey Norton, bachelor. It was all done in an instant, and there was the gentleman thanking me on the one side and the lady on the other, while the clergyman beamed on me in front. It was the most preposterous position in which I ever found myself in my life, and it was the thought of it that started me laughing just now. It seems that there had been some informality about their license, that the clergyman absolutely refused to marry them without a witness of some sort, and that my lucky appearance saved the bridegroom from having to sally out into the streets in search of a best man. The bride gave me a sovereign, and I mean to wear it on my watch chain in memory of the occasion.`.split(/[.?!]/);
+
+const paragraphGenerator = new RandomTextGenerator({splitter: " ", deepness: 8, minLength: 20, maxLength: 80});
+const shortGenerator = new RandomTextGenerator({splitter: " ", deepness: 8, minLength: 1, maxLength: 4});
+const wordGenerator = new RandomTextGenerator({splitter: "", deepness: 12, minLength: 1, maxLength: 16})
+for (let sentence of INPUT_TEXT) {
+  sentence = sentence.trim();
+  const words = sentence.split(" ");
+  paragraphGenerator.learn(words);
+  shortGenerator.learn(words);
+  for (const word of words) {
+    wordGenerator.learn(word.replace(/[,.!?']/));
+  }
+}
+
+function randomTimestampDuration() {
+  return Math.floor(Math.random() * 100000000000);
+}
+
+function randomTimestamp() {
+  return randomTimestampDuration() + 1500000000000;
+}
+
+const PREV_ANCHORS = new Set();
+
+const GENERATORS = {
+  paragraph: (noNewLine) => {
+    let paragraph = paragraphGenerator.generate()
+    if (Math.random() < WITH_BLOCK_ANCHOR) {
+      let newAnchor = `^${wordGenerator.generate()}`;
+      if (PREV_ANCHORS.has(newAnchor)) {
+        newAnchor = `^${randomTimestampDuration()}`;
+      }
+      PREV_ANCHORS.add(newAnchor);
+      paragraph = `${paragraph} ${newAnchor}`;
+    }
+    if (!noNewLine && Math.random() < 0.95) paragraph = `\n${paragraph}\n`;
+    return paragraph;
+  },
+  list: () => {
+    let list = "\n";
+    const itemCount = Math.ceil(Math.random() * LONGEST_LIST);
+    for (let i = 0; i < LONGEST_LIST && i < itemCount; i++) {
+      list = `${list}\n- ${GENERATORS.paragraph(true)}`;
+    }
+    list = `${list}\n\n`;
+    return list;
+  },
+  header: () => {
+    const depth = Math.ceil(Math.random() * 4);
+    let header = "";
+    for (let i = 0; i < depth; i++) {
+      header = `#${header}`;
+    }
+    header = `${header} ${shortGenerator.generate()}`;
+    return header;
+  },
+  wikilink: () => {
+    if (Math.random() < SAME_FILE_WIKILINK && PREV_ANCHORS.size > 0) {
+      const anchors = [...PREV_ANCHORS];
+      // samefile
+      return `[[#${anchors[Math.floor(Math.random() * anchors.length)]}]]`;
+    } else {
+      let wikilink = `[[${wordGenerator.generate()}`;
+      const depth = Math.floor(Math.random() * 5);
+      for (let i = 0; i < depth; i++) {
+        wikilink = `${wikilink}.${wordGenerator.generate()}`;
+      }
+      if (Math.random() < 0.3) {
+        const anchorDepth = Math.floor(Math.random() * 5);
+        wikilink = `${wikilink}#${wordGenerator.generate()}`;
+        for (let i = 0; i < anchorDepth; i++) {
+          wikilink = `${wikilink}-${wordGenerator.generate()}`;
+        }
+      } else if (Math.random() < 0.1) {
+        wikilink = `${wikilink}#${shortGenerator.generate()}`;
+      }
+      wikilink = `${wikilink}]]`;
+      return wikilink;
+    }
+  },
+}
+
+// -----  output  -----
+// generate frontmatter
+
+const created = randomTimestamp();
+console.log(
+`---
+id: ${Math.random()}
+title: ${shortGenerator.generate()}
+desc: ${shortGenerator.generate()}
+updated: ${created + randomTimestampDuration()}
+created: ${created}
+stub: false
+---`
+);
+
+const pickGenerators = Object.values(GENERATORS);
+for (let i = 0; i < GENERATED_LENGTH; i++) {
+  const pick = pickGenerators[Math.floor(Math.random() * pickGenerators.length)];
+  console.log(pick());
+}

--- a/test-workspace/scripts/random_text_generator_node.js
+++ b/test-workspace/scripts/random_text_generator_node.js
@@ -1,0 +1,388 @@
+/** Originally from https://github.com/Rafal-Majewski/random-text-generator-js
+ * 
+ * Originally released under public domain.
+ */
+function RandomTextGenerator(settings) {
+	Object.assign(this, {
+		tries: 80,
+		safeMode: true,
+		forceCombiningOrigins: false,
+		minLength: 1,
+		maxLength: 400,
+		deepness: 40,
+		trust: 2,
+		weightsLeft: {},
+		weightsRight: {},
+		splitter: "",
+		startingCharacter: String.fromCharCode(2),
+		endingCharacter: String.fromCharCode(3),
+	});
+	Object.assign(this, settings);
+}
+
+RandomTextGenerator.prototype._exampleIterator=function(example, func) {
+	for (let i=0; i<example.length-1; ++i) {
+		for (let i2=i; i2<Math.min(example.length-1, i+this.deepness); ++i2) {
+			let from=example.slice(i, i2+1).join(this.splitter);
+			let to=example[i2+1];
+			func(from, to);
+		}
+	}
+};
+
+RandomTextGenerator.prototype._learn=function(weights, example, origin, multiplier) {
+	this._exampleIterator(example, (from, to)=>{
+		if (weights[origin] == undefined) weights[origin]={};
+		if (weights[origin][from] == undefined) weights[origin][from]={};
+		if (weights[origin][from][to] == undefined) weights[origin][from][to]=0;
+		weights[origin][from][to]+=multiplier;
+	});
+};
+
+RandomTextGenerator.prototype._forget=function(weights, example, origin, multiplier) {
+	this._exampleIterator(example, (from, to)=>{
+		if (weights[origin][from] == undefined) weights[origin][from]={};
+		if (weights[origin][from][to] == undefined) weights[origin][from][to]=0;
+		weights[origin][from][to]-=multiplier;
+		if (weights[origin][from][to] <= 0) delete weights[origin][from][to];
+		if (Object.keys(weights[origin][from]).length <= 0) delete weights[origin][from];
+		if (Object.keys(weights[origin]).length <= 0) delete weights[origin];
+	});
+};
+
+RandomTextGenerator.prototype.learnLeft=function(example, origin, multiplier, isRaw) {
+	this._learn(
+		this.weightsLeft,
+		[...(isRaw)?(""):(this.endingCharacter), ...example, ...(isRaw)?(""):(this.startingCharacter)].reverse(),
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype.learnBoth=function(example, origin, multiplier, isRaw) {
+	this._learn(
+		this.weightsLeft,
+		[...(isRaw)?(""):(this.endingCharacter), ...example, ...(isRaw)?(""):(this.startingCharacter)].reverse(),
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+	this._learn(
+		this.weightsRight,
+		[...(isRaw)?(""):(this.startingCharacter), ...example, ...(isRaw)?(""):(this.endingCharacter)],
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype.learnRight=function(example, origin, multiplier, isRaw) {
+	this._learn(
+		this.weightsRight,
+		[...(isRaw)?(""):(this.startingCharacter), ...example, ...(isRaw)?(""):(this.endingCharacter)],
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype.forgetBoth=function(example, origin, multiplier, isRaw) {
+	this._forget(
+		this.weightsLeft,
+		[...(isRaw)?(""):(this.endingCharacter), ...example, ...(isRaw)?(""):(this.startingCharacter)].reverse(),
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+	this._forget(
+		this.weightsRight,
+		[...(isRaw)?(""):(this.startingCharacter), ...example, ...(isRaw)?(""):(this.endingCharacter)],
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype.forgetLeft=function(example, origin, multiplier, isRaw) {
+	this._forget(
+		this.weightsLeft,
+		[...(isRaw)?(""):(this.endingCharacter), ...example, ...(isRaw)?(""):(this.startingCharacter)].reverse(),
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype.forgetRight=function(example, origin, multiplier, isRaw) {
+	this._forget(
+		this.weightsRight,
+		[...(isRaw)?(""):(this.startingCharacter), ...example, ...(isRaw)?(""):(this.endingCharacter)],
+		origin || "_default",
+		(multiplier != null)?(multiplier):(1),
+	);
+};
+
+RandomTextGenerator.prototype._getNexts=function(weights, text, origins, safe) {
+	let nexts={};
+	let sum=0;
+	let from=text;
+	for (let origin of origins) {
+		if (!weights[origin]) continue;
+		let weightsRow=weights[origin][from];
+		if (weightsRow) {
+			for (let to of Object.keys(weightsRow)) {
+				if (!nexts[to]) nexts[to]=0;
+				sum+=weightsRow[to];
+				nexts[to]+=weightsRow[to];
+			}
+		}
+		else if (!safe && this.forceCombiningOrigins) return {};
+	}
+	if (!safe && sum < this.trust) return {};
+	for (let to of Object.keys(nexts)) nexts[to]/=sum;
+	return nexts;
+};
+
+
+RandomTextGenerator.prototype._chooseNext=function(nexts, pick) {
+	for (let to of Object.keys(nexts)) {
+		pick-=nexts[to];
+		if (pick < 0) return to;
+	}
+	return null;
+};
+
+RandomTextGenerator.prototype._predict=function(weights, splittedText, origins, obeyLimit, safe) {
+	let realLength=splittedText.length-(splittedText[0] == this.startingCharacter);
+	if (obeyLimit && realLength > this.maxLength) return null;
+	for (let i=Math.max(0, splittedText.length-this.deepness); i<splittedText.length; ++i) {
+		let from=splittedText.slice(i);
+		let nexts=this._getNexts(weights, from.join(this.splitter), origins, safe);
+		let next;
+		if (obeyLimit) {
+			if (realLength < this.minLength && nexts[this.endingCharacter]) {
+				let smaller=nexts[this.endingCharacter];
+				delete nexts[this.endingCharacter];
+				next=this._chooseNext(nexts, Math.random()*(1-smaller));
+			}
+			else if (realLength == this.maxLength) {
+				if (nexts[this.endingCharacter]) return this.endingCharacter;
+			}
+			else next=this._chooseNext(nexts, Math.random());
+		}
+		else next=this._chooseNext(nexts, Math.random());
+		if (next) return next;
+	}
+	if (this.safeMode && !safe) return this._predict(weights, splittedText, origins, obeyLimit, true);
+	return null;
+};
+
+RandomTextGenerator.prototype.predictRight=function(text, origins, isRaw, obeyLimit) {
+	if (!text) text="";
+	return this._predict(
+		this.weightsRight,
+		[...(isRaw)?(""):(this.startingCharacter), ...text],
+		origins || Object.keys(this.weightsRight), obeyLimit
+	);
+};
+
+RandomTextGenerator.prototype.predictLeft=function(text, origins, isRaw, obeyLimit) {
+	if (!text) text="";
+	return this._predict(
+		this.weightsLeft,
+		[...text, ...(isRaw)?(""):(this.startingCharacter)].reverse(),
+		origins || Object.keys(this.weightsLeft), obeyLimit
+	);
+};
+
+RandomTextGenerator.prototype.generateRight=function(text, origins, isRaw) {
+	if (!text) text="";
+	if (!origins) origins=Object.keys(this.weightsRight);
+	let splittedText;
+	let realLength;
+	let reset=()=>{
+		splittedText=[...(isRaw)?(""):(this.startingCharacter), ...text];
+		realLength=splittedText.length-!isRaw;
+	};
+	reset();
+	if (realLength >= this.maxLength) return splittedText.slice(!isRaw).join(this.splitter);
+	for (let i=0; i<this.tries; ++i) {
+		while (true) {
+			let character=this._predict(this.weightsRight, splittedText, origins, this.safeMode);
+			if (character == null) {
+				reset();
+				break;
+			}
+			if (character == this.endingCharacter) {
+				if (realLength < this.minLength) {
+					reset();
+					break;
+				}
+				return splittedText.slice(!isRaw).join(this.splitter);
+			}
+			if (realLength+1 > this.maxLength) {
+				reset();
+				break;
+			}
+			splittedText.push(character);
+			++realLength;
+		}
+	}
+	return null;
+};
+
+RandomTextGenerator.prototype.generateBoth=function(text, origins) {
+	if (!text) text="";
+	if (!origins) origins=[...new Set([...Object.keys(this.weightsRight) ,...Object.keys(this.weightsLeft)])];
+	let splittedText;
+	let leftDone;
+	let rightDone;
+	let reset=()=>{
+		splittedText=[...text];
+		leftDone=false;
+		rightDone=false;
+	};
+	reset();
+	if (splittedText.length >= this.maxLength) return splittedText.join(this.splitter);
+	for (let i=0; i<this.tries; ++i) {
+		while (true) {
+			let characterLeft;
+			let characterRight;
+			if (!leftDone) {
+				characterLeft=this._predict(this.weightsLeft, [...splittedText].reverse(), origins, this.safeMode);
+				if (!characterLeft) {
+					reset();
+					break;
+				}
+				else if (characterLeft == this.endingCharacter) leftDone=true;
+			}
+			if (!rightDone) {
+				characterRight=this._predict(this.weightsRight, splittedText, origins, this.safeMode);
+				if (!characterRight) {
+					reset();
+					break;
+				}
+				else if (characterRight == this.endingCharacter) rightDone=true;
+			}
+			if (leftDone && rightDone) {
+				if (splittedText.length < this.minLength || splittedText.length > this.maxLength) {
+					reset();
+					break;
+				}
+				else return splittedText.join(this.splitter);
+			}
+			if (!leftDone) splittedText.unshift(characterLeft);
+			if (!rightDone) splittedText.push(characterRight);
+		}
+	}
+	return null;
+};
+
+RandomTextGenerator.prototype._shrink=function(weights, origins) {
+	for (let origin of origins) {
+		if (!weights[origin]) continue;
+		for (let from of Object.keys(weights[origin])) {
+			//console.log(weights);
+			let weightsRow=weights[origin][from];
+			let sum=0;
+			for (let to of Object.keys(weightsRow)) sum+=weightsRow[to];
+			if (sum < this.trust) delete weights[origin][from];
+		}
+	}
+};
+
+RandomTextGenerator.prototype.shrinkLeft=function(origins) {
+	this._shrink(this.weightsLeft, origins || Object.keys(this.weightsLeft));
+};
+
+RandomTextGenerator.prototype.shrinkRight=function(origins) {
+	this._shrink(this.weightsRight, origins || Object.keys(this.weightsRight));
+};
+
+RandomTextGenerator.prototype.shrinkBoth=function(origins) {
+	this._shrink(this.weightsLeft, origins || Object.keys(this.weightsLeft));
+	this._shrink(this.weightsRight, origins || Object.keys(this.weightsRight));
+};
+
+RandomTextGenerator.prototype.saveToJson=function() {return JSON.stringify(this);};
+RandomTextGenerator.prototype.loadFromJson=function(json) {
+	let settings=JSON.parse(json);
+	Object.keys(generatorSettingsManager).forEach((key)=>{
+		if (settings[key] != undefined) {
+			generatorSettingsManager[key].validate(key, settings[key], generatorSettingsManager[key].type);
+			this[key]=settings[key];
+		}
+	});
+	if (this.minLength > this.maxLength) throw "minLength has to be smaller or equal to maxLength";
+};
+RandomTextGenerator.prototype.saveWeightsToJson=function() {
+	return JSON.stringify({weightsLeft: this.weightsLeft, weightsRight: this.weightsRight});
+};
+RandomTextGenerator.prototype.loadWeightsFromJson=function(json) {
+	let weights=JSON.parse(json);
+	this.weightsLeft=weights.weightsLeft;
+	this.weightsRight=weights.weightsRight;
+};
+
+RandomTextGenerator.prototype.predict=RandomTextGenerator.prototype.predictRight;
+RandomTextGenerator.prototype.learn=RandomTextGenerator.prototype.learnRight;
+RandomTextGenerator.prototype.forget=RandomTextGenerator.prototype.forgetRight;
+RandomTextGenerator.prototype.generate=RandomTextGenerator.prototype.generateRight;
+RandomTextGenerator.prototype.shrink=RandomTextGenerator.prototype.shrinkBoth;
+
+RandomTextGenerator.prototype.generateLeft=function(text, origins, isRaw) {
+	if (!text) text="";
+	if (!origins) origins=Object.keys(this.weightsLeft);
+	let splittedText;
+	let realLength;
+	let reset=()=>{
+		splittedText=[...text, ...(isRaw)?(""):(this.startingCharacter)].reverse();
+		realLength=splittedText.length-!isRaw;
+	};
+	reset();
+	if (realLength >= this.maxLength) return splittedText.slice(!isRaw).join(this.splitter);
+	for (let i=0; i<this.tries; ++i) {
+		while (true) {
+			let character=this._predict(this.weightsLeft, splittedText, origins, this.safeMode);
+			if (character == null) {
+				reset();
+				break;
+			}
+			if (character == this.endingCharacter) {
+				if (realLength < this.minLength) {
+					reset();
+					break;
+				}
+				return splittedText.slice(!isRaw).reverse().join(this.splitter);
+			}
+			if (realLength+1 > this.maxLength) {
+				reset();
+				break;
+			}
+			splittedText.push(character);
+			++realLength;
+		}
+	}
+	return null;
+};
+
+RandomTextGenerator.prototype._validate=function(weights, text, origins) {
+	let sum=0;
+	let all=0;
+	this._exampleIterator(text, (from, to)=>{	
+		let nexts=this._getNexts(weights, from, origins, this.safeMode);
+		if (nexts[to]) ++sum;
+		++all;
+	});
+	return sum/all || 0;
+}
+
+RandomTextGenerator.prototype.validateLeft=function(text, origins, isRaw) {
+	if (!text) text="";
+	if (!origins) origins=Object.keys(this.weightsLeft);
+	return this._validate(this.weightsLeft, [...(isRaw)?(""):(this.endingCharacter), ...text, ...(isRaw)?(""):(this.startingCharacter)].reverse(), origins);
+};
+
+RandomTextGenerator.prototype.validateRight=function(text, origins, isRaw) {
+	if (!text) text="";
+	if (!origins) origins=Object.keys(this.weightsRight);
+	return this._validate(this.weightsRight, [...(isRaw)?(""):(this.startingCharacter), ...text, ...(isRaw)?(""):(this.endingCharacter)], origins);
+};
+
+RandomTextGenerator.prototype.validate=RandomTextGenerator.prototype.validateRight;
+
+module.exports=RandomTextGenerator;


### PR DESCRIPTION
When doing an existing blocks only autocomplete (`[[#` or `[[#^`) the blocks are filtered on the server side rather than the client side. This improves responsiveness in the editor for long notes since less work is done within the editor.