### PR TITLE
feat: obsidian import pod

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -485,8 +485,9 @@ export type DendronSiteConfig = {
 };
 
 export type DendronGraphConfig = {
-  zoomSpeed: number;
-};
+  zoomSpeed?: number;
+  stylePath?: string;
+}
 
 export type HierarchyConfig = {
   publishByDefault?: boolean | { [key: string]: boolean };

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -69,6 +69,7 @@
     "@testing-library/react-hooks": "^7.0.1",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",
+    "css": "^3.0.0",
     "fs-extra": "^9.0.1",
     "jest": "26",
     "lodash": "^4.17.20",

--- a/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
@@ -3,8 +3,8 @@ import path from "path";
 import fs, { ensureDirSync } from "fs-extra";
 import { runEngineTestV5, WorkspaceOpts } from "../../engine";
 import { ObsidianStyleImportPod } from "@dendronhq/pods-core";
+import { assert } from "@dendronhq/common-all/lib";
 import css from "css";
-import { assert } from "../../../../common-all/lib";
 
 const obsidianCSS = `.graph-view.color-fill {
 	color: red;

--- a/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
@@ -1,107 +1,178 @@
-// import { tmpDir } from "@dendronhq/common-server";
-// import { FileTestUtils } from "@dendronhq/common-test-utils";
-// import { ObsidianStyleImportPod } from "@dendronhq/pods-core";
-// import fs, { ensureDirSync } from "fs-extra";
+import _ from "lodash";
+import path from "path";
+import fs, { ensureDirSync } from "fs-extra";
+import { runEngineTestV5, WorkspaceOpts } from "../../engine";
+import { ObsidianStyleImportPod } from "@dendronhq/pods-core";
+import css from "css";
+import { assert } from "../../../../common-all/lib";
 
-// import _ from "lodash";
-// import path from "path";
-// import { runEngineTestV5, WorkspaceOpts } from "../../engine";
-// import { checkString } from "../../utils";
+const obsidianCSS = `.graph-view.color-fill {
+	color: red;
+	opacity: 0.5;
+}
 
-// const obsidianCSS = `.graph-view.color-fill {
-// 	color: red;
-// 	opacity: 0.5;
-// }
+/* .graph-view.color-fill-tag {
+	color: red;
+} */
 
-// /* .graph-view.color-fill-tag {
-// 	color: red;
-// } */
+/* .graph-view.color-fill-attachment {
+	color: red;
+} */
 
-// /* .graph-view.color-fill-attachment {
-// 	color: red;
-// } */
+/* .graph-view.color-arrow {
+	color: red;
+} */
 
-// /* .graph-view.color-arrow {
-// 	color: red;
-// } */
+.graph-view.color-circle {
+	color: maroon;
+}
 
-// .graph-view.color-circle {
-// 	color: maroon;
-// }
+.graph-view.color-line {
+	color: blue;
+	opacity: 0.6;
+}
 
-// .graph-view.color-line {
-// 	color: blue;
-// 	opacity: 0.6;
-// }
+.graph-view.color-text {
+	color: aqua;
+	opacity: 0.7;
+}
 
-// .graph-view.color-text {
-// 	color: aqua;
-// 	opacity: 0.7;
-// }
+.graph-view.color-fill-highlight {
+	color: purple;
+	opacity: 0.8;
+}
 
-// .graph-view.color-fill-highlight {
-// 	color: purple;
-// 	opacity: 0.8;
-// }
+.unrelated-class {
+	color: blue;
+}
 
-// .unrelated-class {
-// 	color: blue;
-// }
+/* .graph-view.color-line-highlight {
+	color: red;
+} */
 
-// /* .graph-view.color-line-highlight {
-// 	color: red;
-// } */
+/* .graph-view.color-fill-unresolved {
+	color: red;
+} */`;
 
-// /* .graph-view.color-fill-unresolved {
-// 	color: red;
-// } */`
+const setupBasic = async (opts: WorkspaceOpts) => {
+  const { wsRoot } = opts;
 
-// const setupBasic = async (opts: WorkspaceOpts) => {
-//   const { wsRoot } = opts;
+  ensureDirSync(wsRoot);
+  fs.writeFileSync(path.join(wsRoot, "obsidian.css"), obsidianCSS);
+};
 
-//   ensureDirSync(wsRoot)
-//   fs.writeFileSync(path.join(wsRoot, 'obsidian.css'), obsidianCSS)
-// };
+const checkForParsedRule = (
+  styles: css.Stylesheet,
+  selector: string,
+  property: string
+) => {
+  return !!styles.stylesheet?.rules.find((rule: css.Rule) => {
+    if (rule.type === "comment") return false;
+    if (!rule.selectors || !rule.selectors.includes(selector)) return false;
+    if (
+      !rule.declarations ||
+      rule.declarations.filter((declaration: css.Declaration) => {
+        if (declaration.type === "comment") return false;
+        if (declaration.property !== property) return false;
+        return true;
+      }).length === 0
+    )
+      return false;
+    return true;
+  });
+};
 
-// describe("obsidian import pod", () => {
-//   let exportDest: string;
+describe("obsidian import pod", () => {
+  test("all supported properties", async () => {
+    await runEngineTestV5(
+      async ({ engine, vaults, wsRoot }) => {
+        const pod = new ObsidianStyleImportPod();
+        engine.config.useFMTitle = true;
 
-//   beforeAll(() => {
-//     exportDest = tmpDir().name;
-//   });
+        const src = path.join(wsRoot, "obsidian.css");
 
-//   test("all supported properties", async () => {
-//     await runEngineTestV5(
-//       async ({ engine, vaults, wsRoot }) => {
-//         const pod = new ObsidianStyleImportPod();
-//         engine.config.useFMTitle = true;
+        // Couldn't figure out the best way to add "dest" to the pod return type, so this is a workaround
+        // @ts-ignore
+        const { errors, dest } = await pod.execute({
+          engine,
+          vaults,
+          wsRoot,
+          config: {
+            src,
+            vaultName: "vault1",
+          },
+        });
 
-//         await pod.execute({
-//           engine,
-//           vaults,
-//           wsRoot,
-//         });
+        assert(!errors || errors.length === 0, "Pod execution errors found");
 
-//         // check that graphviz file is created
-//         const [expectedFiles, actualFiles] = FileTestUtils.cmpFiles(exportDest, [
-//           "graphviz.dot",
-//         ]);
-//         expect(expectedFiles).toEqual(actualFiles);
+        // check contents of graphviz file
+        const dendronStyleFile = fs.readFileSync(dest, {
+          encoding: "utf8",
+        });
 
-//         // check contents of graphviz file
-//         const dotFile = fs.readFileSync(path.join(exportDest, "graphviz.dot"), {
-//           encoding: "utf8",
-//         });
+        const styles = css.parse(dendronStyleFile);
+        assert(
+          !!styles.stylesheet?.rules,
+          "Stylesheet parsed incorrectly or has no rules"
+        );
 
-//         // Check for:
-//         // 1. start of file -> "graph {"
-//         // 2. existence of a note -> "note_"
-//         // 3. a labeled note -> "[label=\""
-//         // 4. a connection -> "--"
-//         // 5. end of graph -> "}"
-//         await checkString(dotFile, "graph {", "note_", '[label="', "--", "}");
-//       },
-//       { expect, preSetupHook: setupBasic }
-//     );
-//   });
-// });
+        const getParsedRuleError = (selector: string, property: string) =>
+          `"${selector}" property "${property}" was not found in parsed stylesheet.`;
+
+        // Check for all currently supported rules
+        // .graph-view.color-fill
+        assert(
+          checkForParsedRule(styles, "node", "background-color"),
+          getParsedRuleError(".graph-view.color-fill", "color")
+        );
+        assert(
+          checkForParsedRule(styles, "node", "background-opacity"),
+          getParsedRuleError(".graph-view.color-fill", "opacity")
+        );
+
+        // .graph-view.color-circle
+        assert(
+          checkForParsedRule(styles, "node", "border-color"),
+          getParsedRuleError(".graph-view.color-circle", "color")
+        );
+
+        // .graph-view.color-line
+        assert(
+          checkForParsedRule(styles, "edge", "line-color"),
+          getParsedRuleError(".graph-view.color-line", "color")
+        );
+        assert(
+          checkForParsedRule(styles, "edge", "line-opacity"),
+          getParsedRuleError(".graph-view.color-line", "opacity")
+        );
+
+        // .graph-view.color-text
+        assert(
+          checkForParsedRule(styles, "node", "color"),
+          getParsedRuleError(".graph-view.color-text", "color")
+        );
+        assert(
+          checkForParsedRule(styles, "node", "text-opacity"),
+          getParsedRuleError(".graph-view.color-text", "opacity")
+        );
+
+        // .graph-view.color-fill-highlight
+        assert(
+          checkForParsedRule(styles, "node:selected", "background-color"),
+          getParsedRuleError(".graph-view.color-fill-highlight", "color")
+        );
+        assert(
+          checkForParsedRule(styles, "node:selected", "background-opacity"),
+          getParsedRuleError(".graph-view.color-fill-highlight", "opacity")
+        );
+
+        // check that non-existent rule doesn't exist as test
+        assert(
+          !checkForParsedRule(styles, "node", "fake-declaration"),
+          "Fake selector and declaration finding succeeded when it shouldn't have"
+        );
+      },
+      { expect, preSetupHook: setupBasic }
+    );
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/ObsidianStylePod.spec.ts
@@ -1,0 +1,107 @@
+// import { tmpDir } from "@dendronhq/common-server";
+// import { FileTestUtils } from "@dendronhq/common-test-utils";
+// import { ObsidianStyleImportPod } from "@dendronhq/pods-core";
+// import fs, { ensureDirSync } from "fs-extra";
+
+// import _ from "lodash";
+// import path from "path";
+// import { runEngineTestV5, WorkspaceOpts } from "../../engine";
+// import { checkString } from "../../utils";
+
+// const obsidianCSS = `.graph-view.color-fill {
+// 	color: red;
+// 	opacity: 0.5;
+// }
+
+// /* .graph-view.color-fill-tag {
+// 	color: red;
+// } */
+
+// /* .graph-view.color-fill-attachment {
+// 	color: red;
+// } */
+
+// /* .graph-view.color-arrow {
+// 	color: red;
+// } */
+
+// .graph-view.color-circle {
+// 	color: maroon;
+// }
+
+// .graph-view.color-line {
+// 	color: blue;
+// 	opacity: 0.6;
+// }
+
+// .graph-view.color-text {
+// 	color: aqua;
+// 	opacity: 0.7;
+// }
+
+// .graph-view.color-fill-highlight {
+// 	color: purple;
+// 	opacity: 0.8;
+// }
+
+// .unrelated-class {
+// 	color: blue;
+// }
+
+// /* .graph-view.color-line-highlight {
+// 	color: red;
+// } */
+
+// /* .graph-view.color-fill-unresolved {
+// 	color: red;
+// } */`
+
+// const setupBasic = async (opts: WorkspaceOpts) => {
+//   const { wsRoot } = opts;
+
+//   ensureDirSync(wsRoot)
+//   fs.writeFileSync(path.join(wsRoot, 'obsidian.css'), obsidianCSS)
+// };
+
+// describe("obsidian import pod", () => {
+//   let exportDest: string;
+
+//   beforeAll(() => {
+//     exportDest = tmpDir().name;
+//   });
+
+//   test("all supported properties", async () => {
+//     await runEngineTestV5(
+//       async ({ engine, vaults, wsRoot }) => {
+//         const pod = new ObsidianStyleImportPod();
+//         engine.config.useFMTitle = true;
+
+//         await pod.execute({
+//           engine,
+//           vaults,
+//           wsRoot,
+//         });
+
+//         // check that graphviz file is created
+//         const [expectedFiles, actualFiles] = FileTestUtils.cmpFiles(exportDest, [
+//           "graphviz.dot",
+//         ]);
+//         expect(expectedFiles).toEqual(actualFiles);
+
+//         // check contents of graphviz file
+//         const dotFile = fs.readFileSync(path.join(exportDest, "graphviz.dot"), {
+//           encoding: "utf8",
+//         });
+
+//         // Check for:
+//         // 1. start of file -> "graph {"
+//         // 2. existence of a note -> "note_"
+//         // 3. a labeled note -> "[label=\""
+//         // 4. a connection -> "--"
+//         // 5. end of graph -> "}"
+//         await checkString(dotFile, "graph {", "note_", '[label="', "--", "}");
+//       },
+//       { expect, preSetupHook: setupBasic }
+//     );
+//   });
+// });

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -14,7 +14,6 @@ const SCHEMAS = {
   //     const vault = vaults[0];
   //     const schemas = engine.schemas;
   //     const { data } = await engine.querySchema("");
-  //     debugger;
   //     const expectedNote = SchemaUtils.getSchemaModuleByFnameV4({
   //       fname: "root",
   //       schemas,
@@ -58,7 +57,7 @@ const SCHEMAS = {
         schemas,
         vault,
       });
-      const fooSchema = _.find(data, {fname: sid});
+      const fooSchema = _.find(data, { fname: sid });
       return [
         {
           actual: fooSchema,

--- a/packages/nextjs-template/components/DendronBreadCrumb.tsx
+++ b/packages/nextjs-template/components/DendronBreadCrumb.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumb } from "antd";
 import _ from "lodash";
 import React from "react";
-import { NoteUtils } from "../../common-all/lib";
+import { NoteUtils } from "@dendronhq/common-all";
 import { DendronCommonProps, verifyNoteData } from "../utils/types";
 import DendronSpinner from "./DendronSpinner";
 
@@ -11,7 +11,10 @@ export function DendronBreadCrumb(props: DendronCommonProps) {
   } else {
     const { dendronRouter, notes } = props;
     const noteActive = notes[dendronRouter.query.id];
-    const noteParents = NoteUtils.getNoteWithParents({ note: noteActive, notes });
+    const noteParents = NoteUtils.getNoteWithParents({
+      note: noteActive,
+      notes,
+    });
     return (
       <Breadcrumb style={{ margin: "16px 0" }}>
         {_.map(noteParents, (note) => {

--- a/packages/plugin-core/src/commands/ConfigureGraphStyles.ts
+++ b/packages/plugin-core/src/commands/ConfigureGraphStyles.ts
@@ -15,9 +15,10 @@ export class ConfigureGraphStylesCommand extends BasicCommand<
     return {};
   }
   async execute() {
-    if (!GraphStyleService.doesStyleFileExist()) {
-      GraphStyleService.createStyleFile();
+    const service = GraphStyleService.getInstance();
+    if (!service.doesStyleFileExist()) {
+      service.createStyleFile();
     }
-    await GraphStyleService.openStyleFile();
+    await service.openStyleFile();
   }
 }

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -108,7 +108,8 @@ export class ShowNoteGraphCommand extends BasicCommand<
         }
         case GraphViewMessageType.onRequestGraphStyle: {
           // Set graph styles
-          const styles = GraphStyleService.getParsedStyles();
+          const styleService = GraphStyleService.getInstance()
+          const styles = styleService.getParsedStyles();
           if (styles) {
             panel.webview.postMessage({
               type: "onGraphStyleLoad",

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -108,7 +108,7 @@ export class ShowNoteGraphCommand extends BasicCommand<
         }
         case GraphViewMessageType.onRequestGraphStyle: {
           // Set graph styles
-          const styleService = GraphStyleService.getInstance()
+          const styleService = GraphStyleService.getInstance();
           const styles = styleService.getParsedStyles();
           if (styles) {
             panel.webview.postMessage({
@@ -121,14 +121,6 @@ export class ShowNoteGraphCommand extends BasicCommand<
           }
           break;
         }
-        // case GraphViewMessageType.onReady: {
-        //   const profile = getDurationMilliseconds(start);
-        //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });
-        //   AnalyticsUtils.track(VSCodeEvents.TreeView_Ready, {
-        //     duration: profile,
-        //   });
-        //   break;
-        // }
         default:
           console.log("got data", msg);
           break;

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -5,14 +5,14 @@ import {
   GraphViewMessageType,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { Uri, ViewColumn, window } from "vscode";
+import vscode, { Uri, ViewColumn, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WebViewUtils } from "../views/utils";
 import { BasicCommand } from "./base";
 import { getWS } from "../workspace";
 import { VSCodeUtils } from "../utils";
 import path from "path";
-import vscode from "vscode";
+import { GraphStyleService } from "../styles";
 
 type CommandOpts = {};
 
@@ -125,14 +125,21 @@ export class ShowSchemaGraphCommand extends BasicCommand<
         //   }
         //   break;
         // }
-        // case GraphViewMessageType.onReady: {
-        //   const profile = getDurationMilliseconds(start);
-        //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });
-        //   AnalyticsUtils.track(VSCodeEvents.TreeView_Ready, {
-        //     duration: profile,
-        //   });
-        //   break;
-        // }
+        case GraphViewMessageType.onRequestGraphStyle: {
+          // Set graph styles
+          const styleService = GraphStyleService.getInstance();
+          const styles = styleService.getParsedStyles();
+          if (styles) {
+            panel.webview.postMessage({
+              type: "onGraphStyleLoad",
+              data: {
+                styles,
+              },
+              source: "vscode",
+            });
+          }
+          break;
+        }
         default:
           console.log("got data", msg);
           break;

--- a/packages/plugin-core/src/styles.ts
+++ b/packages/plugin-core/src/styles.ts
@@ -48,7 +48,7 @@ Obsidian.md style
 
 export class GraphStyleService {
   static styleFilePath() {
-    return path.join(os.homedir(), ".dendron", "styles.css");
+    return path.join(os.homedir(), ".dendron", "styles", "graph.css");
   }
 
   static doesStyleFileExist() {

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -37,6 +37,7 @@
     "test:watch": "LOG_DST=../../logs/pods-core.log jest --watch"
   },
   "devDependencies": {
+    "@types/css": "^0.0.33",
     "@types/fs-extra": "^9.0.1",
     "@types/klaw": "^3.0.1",
     "@types/lodash": "^4.14.161",
@@ -64,6 +65,7 @@
     "@octokit/graphql": "^4.6.4",
     "ajv": "^8.6.0",
     "ajv-formats": "^2.1.0",
+    "css": "^3.0.0",
     "csv-writer": "^1.6.0",
     "docs-markdown": "^1.2.0",
     "emailjs": "^3.4.0",

--- a/packages/pods-core/src/builtin/ObsidianStylePod.ts
+++ b/packages/pods-core/src/builtin/ObsidianStylePod.ts
@@ -21,12 +21,7 @@ import graphCSS from "../graph";
 
 const ID = "dendron.obsidian-graph-style";
 
-export type ObsidianStyleImportPodPlantOpts = ImportPodPlantOpts & {
-  /**
-   * Where to output the parsed styles to
-   */
-  dest: string;
-};
+export type ObsidianStyleImportPodPlantOpts = ImportPodPlantOpts;
 
 class GraphStyleUtils {
   static folderPath() {

--- a/packages/pods-core/src/builtin/ObsidianStylePod.ts
+++ b/packages/pods-core/src/builtin/ObsidianStylePod.ts
@@ -180,6 +180,8 @@ class GraphStyleUtils {
     }
 
     fs.writeFileSync(filePath, cssText);
+
+    return filePath;
   }
 }
 
@@ -202,9 +204,9 @@ export class ObsidianStyleImportPod extends ImportPod {
     const file = fs.readFileSync(src.fsPath);
     const styles = GraphStyleUtils.parseStyles(file.toString());
 
-    await GraphStyleUtils.writeStyles(styles, "import");
+    const dest = await GraphStyleUtils.writeStyles(styles, "import");
 
-    return { importedNotes: [] };
+    return { importedNotes: [], dest };
   }
 }
 

--- a/packages/pods-core/src/builtin/ObsidianStylePod.ts
+++ b/packages/pods-core/src/builtin/ObsidianStylePod.ts
@@ -1,9 +1,9 @@
 import fs from "fs-extra";
 import _ from "lodash";
 import {
-  ExportPod,
-  ExportPodPlantOpts,
-  ExportPodConfig,
+  // ExportPod,
+  // ExportPodPlantOpts,
+  // ExportPodConfig,
   ImportPod,
   ImportPodConfig,
   ImportPodPlantOpts,
@@ -15,9 +15,9 @@ import moment from "moment";
 import path from "path";
 import os from "os";
 import graphCSS from "../graph";
-import { DConfig } from "@dendronhq/engine-server";
-import { readYAML } from "@dendronhq/common-server";
-import { DendronConfig } from "@dendronhq/common-all";
+// import { DConfig } from "@dendronhq/engine-server";
+// import { readYAML } from "@dendronhq/common-server";
+// import { DendronConfig } from "@dendronhq/common-all";
 
 const ID = "dendron.obsidian-graph-style";
 
@@ -194,13 +194,8 @@ export class ObsidianStyleImportPod extends ImportPod {
 
   get config(): JSONSchemaType<ImportPodConfig> {
     return PodUtils.createImportConfig({
-      required: ["dest"],
-      properties: {
-        dest: {
-          type: "string",
-          description: "Output destination for parsed style file",
-        },
-      },
+      required: [],
+      properties: {},
     }) as JSONSchemaType<ImportPodConfig>;
   }
 

--- a/packages/pods-core/src/builtin/ObsidianStylePod.ts
+++ b/packages/pods-core/src/builtin/ObsidianStylePod.ts
@@ -1,0 +1,139 @@
+import fs from "fs-extra";
+import _ from "lodash";
+// import path from "path";
+import {
+  // ExportPod,
+  // ExportPodPlantOpts,
+  // ExportPodConfig,
+  ImportPod,
+  ImportPodConfig,
+  ImportPodPlantOpts,
+} from "../basev3";
+import { JSONSchemaType } from "ajv";
+import { PodUtils } from "../utils";
+import { parse, Rule, Declaration, Comment } from "css";
+
+const ID = "dendron.obsidian-graph-style";
+
+export type ObsidianStyleImportPodPlantOpts = ImportPodPlantOpts & {
+  /**
+   * Where to output the parsed styles to
+   */
+  dest: string;
+};
+
+class GraphStyleUtils {
+  constructor(file: Buffer) {
+    file.toString();
+  }
+
+  static _getCSSDeclarations = (decs: (Comment | Declaration)[]) => {
+    const camel = (str: string) =>
+      str.replace(/(-[a-z])/g, (x) => x.toUpperCase()).replace(/-/g, "");
+
+    const parsePx = (val: string) =>
+      /px$/.test(val) ? parseFloat(val.replace(/px$/, "")) : val;
+
+    const parsedDecs = decs.filter(
+      (d) => d.type === "declaration"
+    ) as Declaration[];
+
+    const declarations = parsedDecs
+      .map((d) => ({
+        key: camel(d.property || ""),
+        value: parsePx(d.value || ""),
+      }))
+      .reduce(
+        (
+          a: {
+            [key: string]: string | number;
+          },
+          b
+        ) => {
+          a[b.key] = b.value;
+          return a;
+        },
+        {}
+      );
+
+    return declarations;
+  };
+
+  static parseObsidianStyles(cssText: string) {
+    const styleObject = parse(cssText);
+    if (!styleObject.stylesheet) return {};
+    if (!styleObject.stylesheet.rules) return {};
+
+    const result: {
+      [key: string]: object;
+    } = {};
+
+    styleObject.stylesheet.rules.forEach((untypedRule) => {
+      if (untypedRule.type === "comment") return;
+      const rule = untypedRule as Rule;
+
+      if (!rule.selectors || !rule.declarations) return;
+      const [key] = rule.selectors;
+
+      if (key.length) {
+        result[key] = this._getCSSDeclarations(rule.declarations);
+      }
+    });
+
+    return styleObject.stylesheet.rules;
+  }
+
+  static writeDendronStyles(styles: object, dest: string) {}
+}
+
+export class ObsidianStyleImportPod extends ImportPod {
+  static id: string = ID;
+  static description: string = "import obsidian style";
+
+  get config(): JSONSchemaType<ImportPodConfig> {
+    return PodUtils.createImportConfig({
+      required: ['dest'],
+      properties: {
+        dest: {
+          type: "string",
+          description: "Output destination for parsed style file",
+        }
+      },
+    }) as JSONSchemaType<ImportPodConfig>;
+  }
+
+  async plant(opts: ObsidianStyleImportPodPlantOpts) {
+    const ctx = "ObsidianStylePod";
+    this.L.info({ ctx, opts, msg: "enter" });
+    const { src } = opts;
+
+    const file = fs.readFileSync(src.fsPath);
+    const styles = GraphStyleUtils.parseObsidianStyles(file.toString());
+
+    GraphStyleUtils.writeDendronStyles(styles, "");
+
+    return { importedNotes: [] };
+  }
+}
+
+// export class ObsidianStyleExportPod extends ExportPod {
+//   static id: string = ID;
+//   static description: string = "export notes as json";
+
+//   get config(): JSONSchemaType<ExportPodConfig> {
+//     return PodUtils.createExportConfig({
+//       required: [],
+//       properties: {},
+//     }) as ObsidianStyleSchemaType<ExportPodConfig>;
+//   }
+
+//   async plant(opts: ExportPodPlantOpts) {
+//     const { dest, notes } = opts;
+
+//     // verify dest exist
+//     const podDstPath = dest.fsPath;
+//     fs.ensureDirSync(path.dirname(podDstPath));
+
+//     return { notes };
+//   }
+// }

--- a/packages/pods-core/src/builtin/index.ts
+++ b/packages/pods-core/src/builtin/index.ts
@@ -8,3 +8,4 @@ export * from "./HTMLPod";
 export * from "./AirtablePod";
 export * from "./GithubPod";
 export * from "./GDocPod";
+export * from "./ObsidianStylePod";

--- a/packages/pods-core/src/graph.ts
+++ b/packages/pods-core/src/graph.ts
@@ -32,6 +32,16 @@ const graphCSS: GraphCSS = [
   },
   {
     obsidian: {
+      selector: '.graph-view.color-circle',
+      property: 'color',
+    },
+    dendron: {
+      selector: 'node',
+      property: 'border-color'
+    }
+  },
+  {
+    obsidian: {
       selector: '.graph-view.color-line',
       property: 'color',
     },

--- a/packages/pods-core/src/graph.ts
+++ b/packages/pods-core/src/graph.ts
@@ -1,0 +1,95 @@
+
+type GraphCSSItem = {
+  selector: string,
+  property: string,
+}
+
+type GraphCSS = {
+  obsidian: GraphCSSItem;
+  dendron: GraphCSSItem;
+}[]
+
+const graphCSS: GraphCSS = [
+  {
+    obsidian: {
+      selector: '.graph-view.color-fill',
+      property: 'color',
+    },
+    dendron: {
+      selector: 'node',
+      property: 'background-color'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-fill',
+      property: 'opacity',
+    },
+    dendron: {
+      selector: 'node',
+      property: 'background-opacity'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-line',
+      property: 'color',
+    },
+    dendron: {
+      selector: 'edge',
+      property: 'line-color'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-line',
+      property: 'opacity',
+    },
+    dendron: {
+      selector: 'edge',
+      property: 'line-opacity'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-text',
+      property: 'color',
+    },
+    dendron: {
+      selector: 'node',
+      property: 'color'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-text',
+      property: 'opacity',
+    },
+    dendron: {
+      selector: 'node',
+      property: 'text-opacity'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-fill-highlight',
+      property: 'color',
+    },
+    dendron: {
+      selector: 'node:selected',
+      property: 'background-color'
+    }
+  },
+  {
+    obsidian: {
+      selector: '.graph-view.color-fill-highlight',
+      property: 'opacity',
+    },
+    dendron: {
+      selector: 'node:selected',
+      property: 'background-opacity'
+    }
+  },
+]
+
+export default graphCSS;

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -22,6 +22,7 @@ export * from "./basev3";
 export * from "./builtin";
 export * from "./types";
 export * from "./utils";
+export * from "./graph";
 export function getAllExportPods(): PodClassEntryV4[] {
   return [
     JSONExportPod,

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -2,7 +2,7 @@ import {
   GitPunchCardExportPod,
   JSONExportPod,
   JSONImportPod,
-  JSONPublishPod
+  JSONPublishPod,
 } from "./builtin";
 import { AirtableExportPod } from "./builtin/AirtablePod";
 import { GDocImportPod } from "./builtin/GDocPod";
@@ -12,12 +12,11 @@ import { HTMLPublishPod } from "./builtin/HTMLPod";
 import {
   MarkdownExportPod,
   MarkdownImportPod,
-  MarkdownPublishPod
+  MarkdownPublishPod,
 } from "./builtin/MarkdownPod";
 import { NextjsExportPod } from "./builtin/NextjsExportPod";
 import { PodClassEntryV4 } from "./types";
 import { ObsidianStyleImportPod } from "./builtin/ObsidianStylePod";
-
 
 export * from "./basev3";
 export * from "./builtin";
@@ -30,12 +29,18 @@ export function getAllExportPods(): PodClassEntryV4[] {
     MarkdownExportPod,
     GraphvizExportPod,
     AirtableExportPod,
-    NextjsExportPod
+    NextjsExportPod,
   ];
 }
 export function getAllPublishPods(): PodClassEntryV4[] {
   return [JSONPublishPod, MarkdownPublishPod, HTMLPublishPod, GithubPublishPod];
 }
 export function getAllImportPods(): PodClassEntryV4[] {
-  return [JSONImportPod, MarkdownImportPod, GithubImportPod, GDocImportPod, ObsidianStyleImportPod];
+  return [
+    JSONImportPod,
+    MarkdownImportPod,
+    GithubImportPod,
+    GDocImportPod,
+    ObsidianStyleImportPod,
+  ];
 }

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -16,8 +16,9 @@ import {
 } from "./builtin/MarkdownPod";
 import { NextjsExportPod } from "./builtin/NextjsExportPod";
 import { PodClassEntryV4 } from "./types";
+import { ObsidianStyleImportPod } from "./builtin/ObsidianStylePod";
 
-NextjsExportPod
+
 export * from "./basev3";
 export * from "./builtin";
 export * from "./types";
@@ -36,5 +37,5 @@ export function getAllPublishPods(): PodClassEntryV4[] {
   return [JSONPublishPod, MarkdownPublishPod, HTMLPublishPod, GithubPublishPod];
 }
 export function getAllImportPods(): PodClassEntryV4[] {
-  return [JSONImportPod, MarkdownImportPod, GithubImportPod, GDocImportPod];
+  return [JSONImportPod, MarkdownImportPod, GithubImportPod, GDocImportPod, ObsidianStyleImportPod];
 }

--- a/test-workspace/dendron.code-workspace
+++ b/test-workspace/dendron.code-workspace
@@ -6,7 +6,13 @@
         },
         {
             "path": "vault"
-        }
+        },
+        {
+            "path": "../../../.dendron/styles"
+        },
+        {
+            "path": "."
+        },
     ],
     "settings": {
         "dendron.rootDir": ".",

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -55,8 +55,9 @@ dev:
     engineServerPort: 3005
 graph:
     zoomSpeed: 1
+    stylePath: import_2021-08-09-07-53-33.css
 initializeRemoteVaults: true
-dendronVersion: 0.51.2
+dendronVersion: 0.52.0
 scratch:
     name: scratch
     dateFormat: y.MM.dd.HHmmss

--- a/test-workspace/obsidian.css
+++ b/test-workspace/obsidian.css
@@ -1,5 +1,6 @@
 .graph-view.color-fill {
 	color: red;
+	opacity: 0.5;
 }
 
 /* .graph-view.color-fill-tag {
@@ -20,14 +21,21 @@
 
 .graph-view.color-line {
 	color: blue;
+	opacity: 0.6;
 }
 
 .graph-view.color-text {
 	color: aqua;
+	opacity: 0.7;
 }
 
 .graph-view.color-fill-highlight {
 	color: purple;
+	opacity: 0.8;
+}
+
+.unrelated-class {
+	color: blue;
 }
 
 /* .graph-view.color-line-highlight {

--- a/test-workspace/obsidian.css
+++ b/test-workspace/obsidian.css
@@ -15,9 +15,9 @@
 	color: red;
 } */
 
-/* .graph-view.color-circle {
-	color: red;
-} */
+.graph-view.color-circle {
+	color: maroon;
+}
 
 .graph-view.color-line {
 	color: blue;

--- a/test-workspace/obsidian.css
+++ b/test-workspace/obsidian.css
@@ -1,0 +1,39 @@
+.graph-view.color-fill {
+	color: red;
+}
+
+/* .graph-view.color-fill-tag {
+	color: red;
+} */
+
+/* .graph-view.color-fill-attachment {
+	color: red;
+} */
+
+/* .graph-view.color-arrow {
+	color: red;
+} */
+
+/* .graph-view.color-circle {
+	color: red;
+} */
+
+.graph-view.color-line {
+	color: blue;
+}
+
+.graph-view.color-text {
+	color: aqua;
+}
+
+.graph-view.color-fill-highlight {
+	color: purple;
+}
+
+/* .graph-view.color-line-highlight {
+	color: red;
+} */
+
+/* .graph-view.color-fill-unresolved {
+	color: red;
+} */

--- a/yarn.lock
+++ b/yarn.lock
@@ -10473,6 +10473,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4015,6 +4015,11 @@
   resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
   integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
+"@types/css@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/css/-/css-0.0.33.tgz#d0b49c4090c09c8e5dc01364560627e5ebb770f2"
+  integrity sha512-qjeDgh86R0LIeEM588q65yatc8Yyo/VvSIYFqq8JOIHDolhGNX0rz7k/OuxqDpnpqlefoHj8X4Ai/6hT9IWtKQ==
+
 "@types/cytoscape@^3.14.15":
   version "3.14.15"
   resolved "https://registry.yarnpkg.com/@types/cytoscape/-/cytoscape-3.14.15.tgz#ce3fc1b494f44d6bccb93a099eb005553fc2a14e"
@@ -8118,6 +8123,15 @@ css.escape@1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssnano-preset-simple@^2.0.0:
   version "2.0.0"
@@ -19468,6 +19482,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"


### PR DESCRIPTION
Changes:

- [x] Add import pod
- [x] Add basic Obsidian to Dendron parsing
- [x] Optimize parsing (limit duplicate selectors, bugfixes)
- [x] Add field to `dendron.yml` specifying which style file to apply to graph
- [x] Change `Configure Graph Styles` command to open whatever file is specified in `dendron.yml` under `graph: stylePath`