### PR TITLE
chore: switch back to 21 character note ids & add doctor action to regenerate note ids

### DIFF
--- a/packages/common-all/src/uuid.ts
+++ b/packages/common-all/src/uuid.ts
@@ -4,16 +4,18 @@ import { customAlphabet as nanoidInsecure } from "nanoid/non-secure";
 import { alphanumeric } from "nanoid-dictionary";
 
 /** Using this length, according to [nanoid collision calculator](https://zelark.github.io/nano-id-cc/),
- * generating 1000 IDs per second, it would take around 981 years to have 1 percent chance of a single collision.
- * This is actually a higher chance than UUID (and default of nanoid), but still very safe for our purposes.
+ * generating 1000 IDs per hour, it would take around 919 years to have 1 percent chance of a single collision.
+ * This is okay for the "insecure" generator, which is used in limited cases where collisions are less likely.
  */
-const ID_LENGTH = 16;
+const SHORT_ID_LENGTH = 12;
+/** Default length for nanoids. */
+const LONG_ID_LENGTH = 21;
 
 /** Generates a random identifier.
  *
  * @returns A url-safe, random identifier.
  */
-export const genUUID = nanoid(alphanumeric, ID_LENGTH);
+export const genUUID = nanoid(alphanumeric, LONG_ID_LENGTH);
 
 /** Generates a random identifier asynchronously.
  *
@@ -21,14 +23,15 @@ export const genUUID = nanoid(alphanumeric, ID_LENGTH);
  *
  * @returns A url-safe, random identifier.
  */
-export const genUUIDasync = nanoidAsync(alphanumeric, ID_LENGTH);
+export const genUUIDasync = nanoidAsync(alphanumeric, LONG_ID_LENGTH);
 
-/** Generates a random identifier, faster but with potential cryptographic risks.
+/** Generates a shorter random identifier, faster but with potential cryptographic risks.
  *
  * Uses an insecure random generator for faster generation.
- * This increases the risk of collision attacks.
- * Only use this if performance is critical and collisions are relatively unimportant.
+ * Also shortens the length of the generated IDs to 16 characters.
+ * This increases the risk of collisions.
+ * Only use this if performance is important and collisions are relatively unimportant.
  *
  * @returns A url-safe, random identifier.
  */
-export const genUUIDInsecure = nanoidInsecure(alphanumeric, ID_LENGTH);
+export const genUUIDInsecure = nanoidInsecure(alphanumeric, SHORT_ID_LENGTH);

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -6,6 +6,8 @@ import {
   DVault,
   NoteUtils,
   DEngineClient,
+  genUUID,
+  DendronError,
 } from "@dendronhq/common-all";
 import {
   DendronASTDest,
@@ -55,6 +57,7 @@ export enum DoctorActions {
   REMOVE_STUBS = "removeStubs",
   OLD_NOTE_REF_TO_NEW = "oldNoteRefToNew",
   CREATE_MISSING_LINKED_NOTES = "createMissingLinkedNotes",
+  REGENERATE_NOTE_ID = "regenerateNoteId",
 }
 
 export { CommandOpts as DoctorCLICommandOpts };
@@ -306,6 +309,16 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         };
         break;
       }
+      case DoctorActions.REGENERATE_NOTE_ID: {
+        for (const note of notes) {
+          if (note.id === "root") continue; // Root notes are special, preserve them
+          note.id = genUUID();
+          engine.writeNote(note);
+        }
+        break;
+      }
+      default:
+        throw new DendronError({ message: "Unexpected Doctor action. If this is something Dendron should support, please create an issue on our Github repository." });
     }
     await _.reduce<any, Promise<any>>(
       notes,

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -406,8 +406,8 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
       },
     });
   });
@@ -450,8 +450,8 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
       },
     });
   });
@@ -497,8 +497,8 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
       },
     });
   });
@@ -551,8 +551,8 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
       },
     });
   });
@@ -630,8 +630,8 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
       },
     });
   });
@@ -714,8 +714,129 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
         } finally {
           gatherInputsStub.restore();
           quickPickStub.restore();
-          done();
         }
+        done();
+      },
+    });
+  });
+});
+
+suite("REGENERATE_NOTE_ID", function () {
+  const ctx = setupBeforeAfter(this);
+
+  test("file scoped", (done) => {
+    runLegacySingleWorkspaceTest({
+      ctx,
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      onInit: async ({ wsRoot, vaults, engine }) => {
+        const vault = vaults[0];
+        const oldNote = NoteUtils.getNoteOrThrow({
+          fname: "foo",
+          notes: engine.notes,
+          vault,
+          wsRoot,
+        });
+        const oldId = oldNote.id;
+        await VSCodeUtils.openNote(oldNote);
+        const cmd = new DoctorCommand();
+        const gatherInputsStub = sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.REGENERATE_NOTE_ID,
+            scope: "file",
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+
+        try {
+          quickPickStub
+            .onCall(0)
+            .returns(
+              Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+            );
+          await cmd.run();
+          const note = NoteUtils.getNoteByFnameV5({
+            fname: "foo",
+            notes: engine.notes,
+            vault,
+            wsRoot,
+          });
+          expect(note?.id).toNotEqual(oldId);
+        } finally {
+          gatherInputsStub.restore();
+          quickPickStub.restore();
+        }
+        done();
+      },
+    });
+  });
+
+  test("workspace scoped", (done) => {
+    runLegacySingleWorkspaceTest({
+      ctx,
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      onInit: async ({ wsRoot, vaults, engine }) => {
+        const vault = vaults[0];
+        const oldRootId = NoteUtils.getNoteOrThrow({
+          fname: "root",
+          notes: engine.notes,
+          vault,
+          wsRoot,
+        }).id;
+        const oldFooId = NoteUtils.getNoteOrThrow({
+          fname: "foo",
+          notes: engine.notes,
+          vault,
+          wsRoot,
+        }).id;
+        const oldBarId = NoteUtils.getNoteOrThrow({
+          fname: "foo",
+          notes: engine.notes,
+          vault,
+          wsRoot,
+        }).id;
+
+        const cmd = new DoctorCommand();
+        const gatherInputsStub = sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            action: DoctorActions.REGENERATE_NOTE_ID,
+            scope: "workspace",
+          })
+        );
+        const quickPickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+
+        try {
+          quickPickStub
+            .onCall(0)
+            .returns(
+              Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
+            );
+          await cmd.run();
+          const root = NoteUtils.getNoteByFnameV5({
+            fname: "root",
+            notes: engine.notes,
+            vault,
+            wsRoot,
+          });
+          const foo = NoteUtils.getNoteByFnameV5({
+            fname: "foo",
+            notes: engine.notes,
+            vault,
+            wsRoot,
+          });
+          const bar = NoteUtils.getNoteByFnameV5({
+            fname: "foo",
+            notes: engine.notes,
+            vault,
+            wsRoot,
+          });
+          expect(root?.id).toNotEqual(oldRootId);
+          expect(foo?.id).toNotEqual(oldFooId);
+          expect(bar?.id).toNotEqual(oldBarId);
+        } finally {
+          gatherInputsStub.restore();
+          quickPickStub.restore();
+        }
+        done();
       },
     });
   });

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -1,4 +1,4 @@
-import { DEngineClient, genUUID, NoteUtils } from "@dendronhq/common-all";
+import { DEngineClient, genUUIDInsecure, NoteUtils } from "@dendronhq/common-all";
 import {
   DendronASTDest,
   DendronASTTypes,
@@ -106,7 +106,7 @@ export function addOrGetAnchorAt(opts: {
   const line = editor.document.lineAt(position.line);
   const existingAnchor = getAnchorAt(opts);
   if (!_.isUndefined(existingAnchor)) return existingAnchor;
-  if (_.isUndefined(anchor)) anchor = genUUID();
+  if (_.isUndefined(anchor)) anchor = genUUIDInsecure();
   editBuilder.insert(line.range.end, ` ^${anchor}`);
   return `^${anchor}`;
 }

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -1,7 +1,7 @@
 import {
   DNodeUtils,
   DVault,
-  genUUID,
+  genUUIDInsecure,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -208,7 +208,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           if (config.noAddUUID) {
             assetBaseNew = `${cleanFileName(name)}${ext}`;
           } else {
-            const uuid = genUUID();
+            const uuid = genUUIDInsecure();
             assetBaseNew = `${cleanFileName(name)}-${uuid}${ext}`;
           }
           const assetPathFull = path.join(assetDir, assetBaseNew);


### PR DESCRIPTION
Note IDs use 21 character ids, the default for a nanoid.

The insecure generator, which is used in limited cases like block anchors and assets in markdown imports, use much shorter 12 character ids. This is still safe since these are used in limited cases where conflicts are unlikely, e.g. you would need over 9 billion block anchors within the same note before you have just 1% chance of a conflict.

Also adds a Doctor action which regenerates note ids. Users who wish to keep their note ids consistent can use this command to regenerate all ids. 

#1044