### PR TITLE
fix: highlighting is not displayed

### DIFF
--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -103,6 +103,7 @@ export function updateDecorations(activeEditor: TextEditor) {
       DECORATION_TYPE_TAG.delete(key);
     }
   }
+  // Clear out any old decorations left over from last pass
   const allTypes = [
     DECORATION_TYPE_TIMESTAMP,
     DECORATION_TYPE_BLOCK_ANCHOR,
@@ -112,7 +113,7 @@ export function updateDecorations(activeEditor: TextEditor) {
   ];
   for (const type of allTypes) {
     if (!allDecorations.has(type)) {
-      type.dispose();
+      activeEditor.setDecorations(type, []);
     }
   }
   return {allDecorations, allWarnings};


### PR DESCRIPTION
In some cases, highlighting would not get displayed. The issue was caused by a bug where unused decorators were being discarded rather than emptied. This would silently break highlighting as any type of highlighting that becomes unused is discarded and no longer can be displayed.