### PR TITLE
feat: re-engage lapsed users with prompt

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -523,10 +523,9 @@ async function showWelcomeOrWhatsNew({
       break;
   }
 
-  //TODO: Re-enable lapsed user message after a one-week grace period of having
-  //users activate their dendron workspaces
-  // eslint-disable-next-line no-constant-condition
-  if (false && shouldDisplayLapsedUserMsg()) {
+  // Show lapsed users (users who have installed Dendron but haven't initialied
+  // a workspace) a reminder prompt to re-engage them.
+  if (shouldDisplayLapsedUserMsg()) {
     showLapsedUserMessage();
   }
 }
@@ -579,7 +578,11 @@ export function shouldDisplayLapsedUserMsg(): boolean {
           Duration.fromObject({ seconds: metaData.lapsedUserMsgSendTime })
         ));
 
-  // If the user has never initialized and it's time to refresh the lapsed user
-  // message
-  return !metaData.firstWsInitialize && refreshMsg;
+  // If the user has never initialized, has never activated a dendron workspace,
+  // and it's time to refresh the lapsed user message
+  return (
+    !metaData.dendronWorkspaceActivated &&
+    !metaData.firstWsInitialize &&
+    refreshMsg
+  );
 }


### PR DESCRIPTION
Part 2 of lapsed user change, part 1 is https://github.com/dendronhq/dendron/pull/1002/files

For any user that has never sent an initialize workspace event AND has not opened a Dendron workspace in the past ~3 weeks (since we released the code in https://github.com/dendronhq/dendron/pull/1002/files), then we'll prompt a modal dialog asking them to launch the tutorial experience.