### PR TITLE
fix: uninstall hook force flush

### DIFF
--- a/packages/plugin-core/src/scripts/uninstallHook.ts
+++ b/packages/plugin-core/src/scripts/uninstallHook.ts
@@ -10,6 +10,9 @@ import { SegmentClient } from "@dendronhq/common-server";
  */
 async function main() {
   SegmentClient.instance().track(VSCodeEvents.Uninstall);
+
+  // Force an upload flush():
+  SegmentClient.instance().identify();
 }
 
 main();


### PR DESCRIPTION
Attempting a fix on the uninstall hook analytics by forcing a flush. 

Due to lack of a good methodology, this hasn't been tested.