### PR TITLE
feat(calendar-view): allow journal settings deviating from defaults

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -584,7 +584,7 @@ export enum ThemeMessageType {
 }
 
 export type OnDidChangeActiveTextEditorData = {
-  note: NoteProps;
+  note: NoteProps | undefined;
   /**
    * Sync all notes
    */

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -43,12 +43,14 @@
     "@types/lodash": "^4.14.161",
     "@types/node": "^14.11.2",
     "@types/react": "^17.0.5",
+    "@types/redux-logger": "^3.0.9",
     "antd": "4.15.4",
     "lodash": "^4.17.20",
     "querystring": "^0.2.1",
     "react": "17.0.1",
     "react-dom": "^17.0.2",
-    "react-redux": "^7.2.3"
+    "react-redux": "^7.2.3",
+    "redux-logger": "^3.0.6"
   },
   "nohoist": [
     "**/common-all",

--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -33,7 +33,7 @@ export const ideSlice = createSlice({
     },
   } as InitialState,
   reducers: {
-    setNoteActive: (state, action: PayloadAction<NoteProps>) => {
+    setNoteActive: (state, action: PayloadAction<NoteProps | undefined>) => {
       state.noteActive = action.payload;
     },
     setTheme: (state, action: PayloadAction<Theme>) => {

--- a/packages/common-frontend/src/features/index.ts
+++ b/packages/common-frontend/src/features/index.ts
@@ -1,9 +1,22 @@
+import { getStage } from "@dendronhq/common-all";
 import { engineSlice } from "./engine/slice";
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import { ideSlice } from "./ide/slice";
 
 export * from "./engine";
 export * from "./ide";
+
+const middleware = [...getDefaultMiddleware()];
+
+if (getStage() === `dev`) {
+  const { createLogger } = require(`redux-logger`);
+
+  const logger = createLogger({
+    collapsed: true,
+  });
+
+  middleware.push(logger);
+}
 
 const engine = engineSlice.reducer;
 const ide = ideSlice.reducer;
@@ -13,6 +26,7 @@ const store = configureStore({
     engine,
     ide,
   },
+  middleware,
 });
 
 export { store as combinedStore };

--- a/packages/dendron-next-server/pages/_app.tsx
+++ b/packages/dendron-next-server/pages/_app.tsx
@@ -100,7 +100,7 @@ function AppVSCode({ Component, pageProps }: any) {
         });
         await ideDispatch(engineSlice.initNotes({ port, ws }));
       }
-      if (syncChangedNote) {
+      if (syncChangedNote && note) {
         await ideDispatch(engineSlice.syncNote({ port, ws, note }));
       }
       logger.info({ ctx, msg: "syncEngine:post" });

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -136,7 +136,7 @@ function CalendarView({ engine, ide }: DendronProps) {
     (date, mode) => {
       const format =
         (mode || activeMode) === "month"
-          ? journalDateFormat || "y.MM.dd"
+          ? journalDateFormat
           : journalMonthDateFormat;
       return date.toFormat(format);
     },

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -295,12 +295,16 @@ function CalendarView({ engine, ide }: DendronProps) {
 
 function areEqual(prevProps: DendronProps, nextProps: DendronProps) {
   const logger = createLogger("calendarViewContainer");
+
+  const didNotesLengthChanged =
+    Object.keys(prevProps.engine.notes || {}).length !==
+    Object.keys(nextProps.engine.notes || {}).length;
+
   const isDiff = _.some([
     // active note changed
     prevProps.ide.noteActive?.id !== nextProps.ide.noteActive?.id,
     // engine initialized for first time
-    _.isUndefined(prevProps.engine.notes) ||
-      (_.isEmpty(prevProps.engine.notes) && !_.isEmpty(nextProps.engine.notes)),
+    _.isUndefined(prevProps.engine.notes) || didNotesLengthChanged,
     // engine just went from pending to loading
     prevProps.engine.loading === "pending" &&
       nextProps.engine.loading === "idle",

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -275,11 +275,6 @@ function CalendarView({ engine, ide }: DendronProps) {
       `only "journal.addBehavior = "childOfDomain" is supported currently`
     );
   }
-  if (engine.config?.journal.dailyDomain !== "daily") {
-    return genError(
-      `only "journal.dailyDomain = "daily" is supported currently`
-    );
-  }
   if (engine.config?.journal.name !== "journal") {
     return genError(`only "journal.name = "name" is supported currently`);
   }

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -158,12 +158,12 @@ function CalendarView({ engine, ide }: DendronProps) {
         type: CalendarViewMessageType.onSelect,
         data: {
           id: selectedNote?.id,
-          fname: `daily.journal.${dateKey}`,
+          fname: `${dailyJournalDomain}.${defaultJournalName}.${dateKey}`,
         },
         source: DMessageSource.webClient,
       });
     },
-    [groupedDailyNotes, getDateKey]
+    [groupedDailyNotes, getDateKey, dailyJournalDomain, defaultJournalName]
   );
 
   const onPanelChange = useCallback<

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -163,16 +163,14 @@ function CalendarView({ engine, ide }: DendronProps) {
         ? _.first(groupedDailyNotes[dateKey])
         : undefined;
 
-      if (selectedNote) {
-        postVSCodeMessage({
-          type: CalendarViewMessageType.onSelect,
-          data: {
-            id: selectedNote?.id,
-            fname: `${journalDailyDomain}.${journalName}.${dateKey}`,
-          },
-          source: DMessageSource.webClient,
-        });
-      }
+      postVSCodeMessage({
+        type: CalendarViewMessageType.onSelect,
+        data: {
+          id: selectedNote?.id,
+          fname: `${journalDailyDomain}.${journalName}.${dateKey}`,
+        },
+        source: DMessageSource.webClient,
+      });
     },
     [groupedDailyNotes, getDateKey, journalDailyDomain, journalName]
   );

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -93,6 +93,7 @@ function CalendarView({ engine, ide }: DendronProps) {
   // const locale = "en-us";
 
   if (journalDateFormat) {
+    // correct possible user mistake that very likely is meant to be day of the month, padded to 2 (dd) and not localized date with abbreviated month (DD)
     journalDateFormat = journalDateFormat.replace(/DD/, "dd");
   }
 

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -105,13 +105,13 @@ function CalendarView({ engine, ide }: DendronProps) {
     });
 
     const dailyNotes = vaultNotes.filter((note) =>
-      note.fname.startsWith(`${journalDailyDomain}.`)
+      note.fname.startsWith(`${journalDailyDomain}.${journalName}`)
     );
     const result = _.groupBy(dailyNotes, (note) => {
       return getMaybeDatePortion(note, journalName);
     });
     return result;
-  }, [notes, journalName, currentVault?.fsPath]);
+  }, [notes, journalName, journalDailyDomain, currentVault?.fsPath]);
 
   const activeDate = useMemo(() => {
     if (noteActive) {
@@ -274,9 +274,6 @@ function CalendarView({ engine, ide }: DendronProps) {
     return genError(
       `only "journal.addBehavior = "childOfDomain" is supported currently`
     );
-  }
-  if (engine.config?.journal.name !== "journal") {
-    return genError(`only "journal.name = "name" is supported currently`);
   }
 
   return (

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -266,21 +266,6 @@ function CalendarView({ engine, ide }: DendronProps) {
     return <Spin />;
   }
 
-  const genError = (msg: string) => {
-    const suffix = "Please update your dendron.yml configuration";
-    return (
-      <>
-        `{msg} {suffix}`
-      </>
-    );
-  };
-
-  if (engine.config?.journal.addBehavior !== "childOfDomain") {
-    return genError(
-      `only "journal.addBehavior = "childOfDomain" is supported currently`
-    );
-  }
-
   return (
     <>
       <Calendar

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -81,19 +81,19 @@ function CalendarView({ engine, ide }: DendronProps) {
 
   const maxDots: number = 5;
   const wordsPerDot: number = 250;
-  const dailyJournalDomain = config?.journal.dailyDomain || "daily";
-  const defaultJournalName = config?.journal.name || "journal";
+  const journalDailyDomain = config?.journal.dailyDomain || "daily";
+  const journalName = config?.journal.name || "journal";
 
   // luxon token format lookup https://github.com/moment/luxon/blob/master/docs/formatting.md#table-of-tokens
-  let defaultJournalDateFormat = config?.journal.dateFormat || "y.MM.dd";
-  const defaultJournalMonthDateFormat = "y.MM"; // TODO compute format for currentMode="year" from config
+  let journalDateFormat = config?.journal.dateFormat || "y.MM.dd";
+  const journalMonthDateFormat = "y.MM"; // TODO compute format for currentMode="year" from config
 
   // Currently luxon does not support setting first day of the week (https://github.com/moment/luxon/issues/373)
   // const dayOfWeek = config?.journal.firstDayOfWeek;
   // const locale = "en-us";
 
-  if (defaultJournalDateFormat) {
-    defaultJournalDateFormat = defaultJournalDateFormat.replace(/DD/, "dd");
+  if (journalDateFormat) {
+    journalDateFormat = journalDateFormat.replace(/DD/, "dd");
   }
 
   const groupedDailyNotes = useMemo(() => {
@@ -105,20 +105,17 @@ function CalendarView({ engine, ide }: DendronProps) {
     });
 
     const dailyNotes = vaultNotes.filter((note) =>
-      note.fname.startsWith(`${dailyJournalDomain}.`)
+      note.fname.startsWith(`${journalDailyDomain}.`)
     );
     const result = _.groupBy(dailyNotes, (note) => {
-      return getMaybeDatePortion(note, defaultJournalName);
+      return getMaybeDatePortion(note, journalName);
     });
     return result;
-  }, [notes, defaultJournalName, currentVault?.fsPath]);
+  }, [notes, journalName, currentVault?.fsPath]);
 
   const activeDate = useMemo(() => {
     if (noteActive) {
-      const maybeDatePortion = getMaybeDatePortion(
-        noteActive,
-        defaultJournalName
-      );
+      const maybeDatePortion = getMaybeDatePortion(noteActive, journalName);
 
       // check if daily file is `y.MM` instead of `y.MM.dd` to apply proper format string.
       // unlike moment luxon marks the date as invalid if date and dateformat do not match
@@ -127,7 +124,7 @@ function CalendarView({ engine, ide }: DendronProps) {
       return maybeDatePortion && _.first(groupedDailyNotes[maybeDatePortion])
         ? Time.DateTime.fromFormat(
             maybeDatePortion,
-            isMonthly ? defaultJournalMonthDateFormat : defaultJournalDateFormat
+            isMonthly ? journalMonthDateFormat : journalDateFormat
           )
         : undefined;
     }
@@ -139,11 +136,11 @@ function CalendarView({ engine, ide }: DendronProps) {
     (date, mode) => {
       const format =
         (mode || activeMode) === "month"
-          ? defaultJournalDateFormat || "y.MM.dd"
-          : defaultJournalMonthDateFormat;
+          ? journalDateFormat || "y.MM.dd"
+          : journalMonthDateFormat;
       return date.toFormat(format);
     },
-    [activeMode, defaultJournalDateFormat]
+    [activeMode, journalDateFormat]
   );
 
   const onSelect = useCallback<
@@ -158,12 +155,12 @@ function CalendarView({ engine, ide }: DendronProps) {
         type: CalendarViewMessageType.onSelect,
         data: {
           id: selectedNote?.id,
-          fname: `${dailyJournalDomain}.${defaultJournalName}.${dateKey}`,
+          fname: `${journalDailyDomain}.${journalName}.${dateKey}`,
         },
         source: DMessageSource.webClient,
       });
     },
-    [groupedDailyNotes, getDateKey, dailyJournalDomain, defaultJournalName]
+    [groupedDailyNotes, getDateKey, journalDailyDomain, journalName]
   );
 
   const onPanelChange = useCallback<

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -9,7 +9,6 @@ import {
   engineSlice,
   postVSCodeMessage,
 } from "@dendronhq/common-frontend";
-import { DConfig } from "@dendronhq/engine-server";
 import {
   CalendarProps as AntdCalendarProps,
   Spin,
@@ -65,7 +64,13 @@ const {
     dateFormat: DEFAULT_JOURNAL_FORMAT,
     name: DEFAULT_JOURNAL_NAME,
   },
-} = DConfig.genDefaultConfig();
+} = {
+  journal: {
+    dailyDomain: "daily",
+    name: "journal",
+    dateFormat: "y.MM.dd",
+  },
+};
 
 function CalendarView({ engine, ide }: DendronProps) {
   // --- init

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -65,6 +65,7 @@ const {
     name: DEFAULT_JOURNAL_NAME,
   },
 } = {
+  // TODO replace with `DConfig.getDefaultConfig() from @dendronhq/engine-server`
   journal: {
     dailyDomain: "daily",
     name: "journal",

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -9,6 +9,7 @@ import {
   engineSlice,
   postVSCodeMessage,
 } from "@dendronhq/common-frontend";
+import { DConfig } from "@dendronhq/engine-server";
 import {
   CalendarProps as AntdCalendarProps,
   Spin,
@@ -58,6 +59,13 @@ function getMaybeDatePortion({ fname }: NoteProps, journalName: string) {
 
 const today = luxonGenerateConfig.getNow();
 const { EngineSliceUtils } = engineSlice;
+const {
+  journal: {
+    dailyDomain: DEFAULT_JOURNAL_DAILY_DOMAIN,
+    dateFormat: DEFAULT_JOURNAL_FORMAT,
+    name: DEFAULT_JOURNAL_NAME,
+  },
+} = DConfig.genDefaultConfig();
 
 function CalendarView({ engine, ide }: DendronProps) {
   // --- init
@@ -81,11 +89,12 @@ function CalendarView({ engine, ide }: DendronProps) {
 
   const maxDots: number = 5;
   const wordsPerDot: number = 250;
-  const journalDailyDomain = config?.journal.dailyDomain || "daily";
-  const journalName = config?.journal.name || "journal";
+  const journalDailyDomain =
+    config?.journal.dailyDomain || DEFAULT_JOURNAL_DAILY_DOMAIN;
+  const journalName = config?.journal.name || DEFAULT_JOURNAL_NAME;
 
   // luxon token format lookup https://github.com/moment/luxon/blob/master/docs/formatting.md#table-of-tokens
-  let journalDateFormat = config?.journal.dateFormat || "y.MM.dd";
+  let journalDateFormat = config?.journal.dateFormat || DEFAULT_JOURNAL_FORMAT;
   const journalMonthDateFormat = "y.MM"; // TODO compute format for currentMode="year" from config
 
   // Currently luxon does not support setting first day of the week (https://github.com/moment/luxon/issues/373)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,6 +4389,13 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/redux-logger@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz#9193b3d51bb6ab98d25514ba7764e4f98a64d3ec"
+  integrity sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==
+  dependencies:
+    redux "^4.0.0"
+
 "@types/remark-abbr@^1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@types/remark-abbr/-/remark-abbr-1.4.0.tgz#2acf550b702306eaaca08d297dd69f2a6b56923d"
@@ -8368,6 +8375,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
 
 deep-equal@^1.0.1:
   version "1.1.1"
@@ -18067,6 +18079,13 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
+  dependencies:
+    deep-diff "^0.3.5"
 
 redux-thunk@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This is a follow up issue from https://github.com/dendronhq/dendron/pull/1065#pullrequestreview-721482799

- It includes:
  - [x] journal.dateFormat: change year, month, and day component (tokens from https://github.com/moment/luxon/blob/master/docs/formatting.md#table-of-tokens should work)
  - [x] journal.dailyDomain: change to non default value
  - [x] journal.name: change to non default value 
  - ~~[ ] journal.addBehavior: change to other add behavior and see if it works~~
  - adds `redux-logger` to have redux actions visible inside vscode (redux devtools don't work there)
- fixes:
  - issue with `syncNote` which gets called with `note` being `undefined`.
  - calendar-view's memo `isEqual` function to rather consider `engine.notes.length`
   