### PR TITLE
chore: bad `expect` in plugin tests

### DIFF
--- a/packages/common-test-utils/src/utils.ts
+++ b/packages/common-test-utils/src/utils.ts
@@ -197,14 +197,10 @@ export async function runJestHarness<TOpts>(
 
 export async function runJestHarnessV2(results: any, expect: any) {
   return _.map(await results, (ent) => {
-    try {
-      if (_.isBoolean(ent.expected) && ent.expected === true) {
-        expect(ent.actual).toBeTruthy();
-      } else {
-        expect(ent.actual).toEqual(ent.expected);
-      }
-    } catch (err) {
-      console.log(err);
+    if (_.isBoolean(ent.expected) && ent.expected === true) {
+      expect(ent.actual).toBeTruthy();
+    } else {
+      expect(ent.actual).toEqual(ent.expected);
     }
   });
 }

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -18,7 +18,7 @@ import {
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
-import { checkFile } from "../../utils";
+import { checkFileNoExpect } from "../../utils";
 
 const findCreated = (changed: NoteChangeEntry[]) => {
   const created = _.find(changed, { status: "create" });
@@ -881,13 +881,11 @@ const NOTES = {
         wsRoot,
         vault: vaults[0],
       });
-      const containsTag = checkFile(
-        {
-          fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
-          nomatch: ["#foo"],
-        },
-        "#bar"
-      );
+      const containsTag = checkFileNoExpect({
+        fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
+        match: ["#bar"],
+        nomatch: ["#foo"],
+      });
 
       return [
         {
@@ -927,13 +925,11 @@ const NOTES = {
         wsRoot,
         vault: vaults[0],
       });
-      const containsTag = checkFile(
-        {
-          fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
-          nomatch: ["tags: foo"],
-        },
-        "tags: bar"
-      );
+      const containsTag = checkFileNoExpect({
+        fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
+        match: ["tags: bar"],
+        nomatch: ["tags: foo"],
+      });
 
       return [
         {
@@ -979,13 +975,11 @@ const NOTES = {
         wsRoot,
         vault: vaults[0],
       });
-      const containsTag = checkFile(
-        {
-          fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
-          nomatch: ["foo"],
-        },
-        "bar"
-      );
+      const containsTag = checkFileNoExpect({
+        fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
+        match: ["bar"],
+        nomatch: ["foo"],
+      });
 
       return [
         {
@@ -1031,7 +1025,7 @@ const NOTES = {
         wsRoot,
         vault: vaults[0],
       });
-      const containsTag = checkFile({
+      const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         nomatch: [
           "tags: foo",
@@ -1085,7 +1079,7 @@ const NOTES = {
         wsRoot,
         vault: vaults[0],
       });
-      const containsTag = checkFile({
+      const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         nomatch: ["foo", "bar", "undefined"],
       });

--- a/packages/engine-test-utils/src/utils/index.ts
+++ b/packages/engine-test-utils/src/utils/index.ts
@@ -73,6 +73,20 @@ export async function checkNotInString(body: string, ...nomatch: string[]) {
   ).toBeTruthy();
 }
 
+/** The regular version of this only works in engine tests. If the test has to run in the plugin too, use this version. Make sure to check the return value! */
+export async function checkFileNoExpect({
+  fpath,
+  nomatch,
+  match,
+}: {
+  fpath: string;
+  nomatch?: string[];
+  match?: string[];
+}) {
+  const body = await fs.readFile(fpath, { encoding: "utf8" });
+  return AssertUtils.assertInString({ body, match, nomatch });
+}
+
 const getWorkspaceFolders = (wsRoot: string) => {
   const wsPath = path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME);
   const settings = fs.readJSONSync(wsPath) as WorkspaceSettings;


### PR DESCRIPTION
Tests in `engine-server/rename.ts` were being run in the plugin, which was then failing because the `expect` is not defined. The failed tests would print out errors, but would still pass.

I worked around the failure, another alternative would be to completely strip out the `expect` or avoid the `checkFile` functions in `rename.ts` tests. I haven't investigated why the tests were passing despite the error.