### PR TITLE
fix: accept splitType argument in lookup v2

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
@@ -61,6 +61,10 @@ export class LookupControllerV2 {
     if (lookupOpts?.effectType) {
       initialTypes.push(lookupOpts.effectType);
     }
+    // split behavior
+    if (lookupOpts?.splitType) {
+      initialTypes.push(lookupOpts.splitType);
+    }
 
     // initialize rest
     this.state = {

--- a/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
@@ -826,6 +826,33 @@ suite("Lookup, notesv2", function () {
     });
   });
 
+  describe("arguments", () => {
+    test("accepting splitType modifier as argument will pre-press button", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        postSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async () => {
+          
+          const controller = new LookupControllerV2(
+            engOpts,
+            { splitType: "horizontal" }
+          );
+          const picker = await controller.show();
+          const splitBtn = _.find(picker.buttons, (button) => {
+            return button.type === "horizontal";
+          });
+          
+          expect(splitBtn?.pressed).toBeTruthy();
+
+          picker.hide();
+          done();
+        }, 
+      });
+    });
+  });
+
   describe("onAccept:multiple", () => {
     test("existing notes", (done) => {
       runLegacyMultiWorkspaceTest({


### PR DESCRIPTION
This PR:
- Fixes Lookup V2 so that when it is given a `splitType` as argument, the controller accepts it.
- This fixes a problem where users weren't able to bind their own keyboard shortcut for lookup v2 with a horizontal split argument
- Adds test to confirm correct picker behavior.

Related: #747 