### PR TITLE
chore: add note lookupv3 default configs

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -94,6 +94,20 @@ export enum NoteAddBehavior {
   "asOwnDomain" = "asOwnDomain",
 }
 
+export enum LookupSelectionType {
+  "selection2link" = "selection2link",
+  "selectionExtract" = "selectionExtract",
+}
+
+export type NoteLookupConfig = {
+  selectionType: LookupSelectionType;
+}
+
+export type LookupConfig = {
+  note: NoteLookupConfig;
+  // schema: SchemaLookupConfig;
+}
+
 export type JournalConfig = {
   dailyDomain: string;
   /**
@@ -134,6 +148,11 @@ export type DendronConfig = {
    * Configuration related to publishing notes
    */
   site: DendronSiteConfig;
+
+  /**
+   * Configuration related to lookup v3.
+   */
+  lookup: LookupConfig;
 
   journal: JournalConfig;
 

--- a/packages/dendron-next-server/pages/workspace/config.tsx
+++ b/packages/dendron-next-server/pages/workspace/config.tsx
@@ -15,7 +15,7 @@ import {
   Switch,
   useToast,
 } from "@chakra-ui/react";
-import { NoteAddBehavior, DendronConfig } from "@dendronhq/common-all";
+import { NoteAddBehavior, DendronConfig, LookupSelectionType } from "@dendronhq/common-all";
 import { Field, FieldArray, Form, Formik } from "formik";
 import _, { get } from "lodash";
 import Head from "next/head";
@@ -34,6 +34,11 @@ const genDefaultConfig = (): DendronConfig => ({
   noLegacyNoteRef: true,
   noXVaultWikiLink: true,
   lookupConfirmVaultOnCreate: false,
+  lookup: {
+    note: {
+      selectionType: LookupSelectionType.selectionExtract,
+    }
+  },
   journal: {
     dailyDomain: "daily",
     name: "journal",

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -6,6 +6,7 @@ import {
   DendronSiteConfig,
   ERROR_STATUS,
   getStage,
+  LookupSelectionType,
   NoteAddBehavior,
 } from "@dendronhq/common-all";
 import { readYAML, writeYAML } from "@dendronhq/common-server";
@@ -50,6 +51,11 @@ export class DConfig {
       autoFoldFrontmatter: true,
       dev: {
         enablePreviewV2: true,
+      },
+      lookup: {
+        note: {
+          selectionType: LookupSelectionType.selectionExtract,
+        }
       },
       journal: {
         dailyDomain: "daily",

--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -1,4 +1,4 @@
-import { LookupConfig, LookupSelectionType, ScratchConfig } from "@dendronhq/common-all";
+import { ScratchConfig } from "@dendronhq/common-all";
 import {
   SegmentClient,
   TelemetryStatus,

--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -1,4 +1,4 @@
-import { ScratchConfig } from "@dendronhq/common-all";
+import { LookupConfig, LookupSelectionType, ScratchConfig } from "@dendronhq/common-all";
 import {
   SegmentClient,
   TelemetryStatus,
@@ -13,6 +13,29 @@ import { Migrations } from "./types";
  * Migrations are sorted by version numbers, from greatest to least
  */
 export const ALL_MIGRATIONS: Migrations[] = [
+  // TODO: use correct version for this migration once it's confirmed when
+  //       `NoteLookupCommand` will completely replace lookup v2.
+  // {
+  //   version: "0.54.0",
+  //   changes: [
+  //     {
+  //       name: "migrate note lookup config",
+  //       func: async ({ dendronConfig, wsConfig }) => {
+  //         dendronConfig.lookup = DConfig.genDefaultConfig().lookup as LookupConfig;
+  //         const oldLookupCreateBehavior = _.get(
+  //           wsConfig.settings, 
+  //           "dendron.defaultLookupCreateBehavior",
+  //           undefined,
+  //         ) as LookupSelectionType;
+  //         if (oldLookupCreateBehavior !== undefined) {
+  //           dendronConfig.lookup.note.selectionType = oldLookupCreateBehavior;
+  //         }
+
+  //         return { data: { dendronConfig, wsConfig }};
+  //       },
+  //     },
+  //   ],
+  // },
   {
     version: "0.51.4",
     changes: [

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -35,6 +35,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -118,6 +121,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -191,6 +197,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -231,6 +240,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -287,6 +299,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -29,6 +29,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -112,6 +115,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -185,6 +191,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -225,6 +234,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -281,6 +293,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -344,6 +359,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal
@@ -395,6 +413,9 @@ useKatex: true
 autoFoldFrontmatter: true
 dev:
     enablePreviewV2: true
+lookup:
+    note:
+        selectionType: selectionExtract
 journal:
     dailyDomain: daily
     name: journal

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -1,6 +1,7 @@
 import {
   DendronError,
   ERROR_STATUS,
+  NoteLookupConfig,
   NoteProps,
   NoteQuickInput,
   NoteUtils,
@@ -126,13 +127,15 @@ export class NoteLookupCommand extends BaseCommand<
   }
 
   async gatherInputs(opts?: CommandRunOpts): Promise<CommandGatherOutput> {
+    const ws = getWS();
+    const noteLookupConfig: NoteLookupConfig  = DConfig.getProp(ws.config, "lookup").note;
     const copts: CommandRunOpts = _.defaults(opts || {}, {
       multiSelect: false,
       filterMiddleware: [],
       initialValue: NotePickerUtils.getInitialValueFromOpenEditor(),
+      selectionType: noteLookupConfig.selectionType,
     } as CommandRunOpts);
     const ctx = "LookupCommand:execute";
-    const ws = getWS();
     Logger.info({ ctx, opts, msg: "enter" });
     // initialize controller and provider
     this._controller = LookupControllerV3.create({

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -123,6 +123,11 @@ suite("Extension", function () {
               useFMTitle: true,
               useNoteTitleForLink: true,
               initializeRemoteVaults: true,
+              lookup: {
+                note: {
+                  selectionType: "selectionExtract",
+                }
+              },
               journal: {
                 addBehavior: "childOfDomain",
                 dailyDomain: "daily",


### PR DESCRIPTION
This PR:
- Adds new default configuration for NoteLookupCommand.
- Change `NoteLookupCommand` to respect default configuration.
- Fixes breaking tests that are affected by the new configuration.
- Adds migration (placeholder until release version is confirmed) for new configuration.
