### PR TITLE
fix: properly debounce picker update

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -71,7 +71,6 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       100,
       {
         leading: true,
-        maxWait: 200,
       }
     );
     quickpick.onDidChangeValue(onUpdateDebounced);


### PR DESCRIPTION
This PR:
- fixes an issue with the debounced picker value updating.
- see [[investigate debounce issue|scratch.2021.08.09.201548.investigate-debounce-issue]]