### PR TITLE
chore: change note lookup related keybindings to use v3

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -166,6 +166,8 @@
         "command": "dendron.lookupNote",
         "title": "Dendron: Lookup Note",
         "desc": "Initiate note lookup",
+        "docLink": "dendron.topic.lookup.md",
+        "docPreview": "",
         "when": "dendron:pluginActive"
       },
       {
@@ -662,13 +664,13 @@
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "mac": "cmd+L",
         "key": "ctrl+l",
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "key": "ctrl+shift+j",
         "mac": "cmd+shift+j",
         "args": {
@@ -677,7 +679,7 @@
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "key": "ctrl+shift+s",
         "mac": "cmd+shift+s",
         "args": {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -275,11 +275,6 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.lookup",
     title: `${CMD_PREFIX} Lookup`,
     group: "navigation",
-    keybindings: {
-      mac: "cmd+L",
-      key: "ctrl+l",
-      when: DendronContext.PLUGIN_ACTIVE,
-    },
     desc: "Initiate note lookup",
     docLink: "dendron.topic.lookup.md",
     docPreview: "",
@@ -293,7 +288,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     when: DendronContext.PLUGIN_ACTIVE,
   },
   LOOKUP_JOURNAL: {
-    key: "dendron.lookup",
+    key: "dendron.lookupNote",
     shortcut: true,
     title: `${CMD_PREFIX} Lookup (Journal Note)`,
     group: "navigation",
@@ -310,7 +305,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docPreview: "",
   },
   LOOKUP_SCRATCH: {
-    key: "dendron.lookup",
+    key: "dendron.lookupNote",
     shortcut: true,
     title: `${CMD_PREFIX} Lookup (Scratch Note)`,
     group: "navigation",


### PR DESCRIPTION
This PR:
  - changes `cmd/ctrl + l`, `cmd/ctrl + shift + j`, `cmd/ctrl + shift + s` to use lookup v3 instead of lookup v2.
  - lookup v2 is still accessible, but now does not have a keybinding.

_This is a pre-emptive PR in case we want to transition to lookup v3 on this week's release, and is left as a draft for that reason._