### PR TITLE
feat: add schema templating feature to NoteLookupCommand

### DIFF
--- a/test-workspace/vault/book.md
+++ b/test-workspace/vault/book.md
@@ -1,0 +1,9 @@
+---
+id: LMEBoLCFfFu1hWbCT6lvB
+title: Book
+desc: ''
+updated: 1628573017706
+created: 1628572997008
+---
+
+Hierarchy with book instance template.

--- a/test-workspace/vault/book.schema.yml
+++ b/test-workspace/vault/book.schema.yml
@@ -1,0 +1,12 @@
+version: 1
+imports: []
+schemas:
+  - id: book
+    children: []
+    namespace: true
+    title: book
+    parent: root
+    template:
+      id: templates.book
+      type: note
+

--- a/test-workspace/vault/templates.book.md
+++ b/test-workspace/vault/templates.book.md
@@ -1,0 +1,16 @@
+---
+id: AI5AVma55sonaoodiV9cA
+title: Book
+desc: ''
+updated: 1628572976529
+created: 1628572852436
+---
+
+## Info
+- Full title:
+- Author:
+- ISBN:
+- Publisher:
+- Status:
+
+## Notes


### PR DESCRIPTION
This PR:
- Adds the ability to apply schema templates on new note creation in `NoteLookupCommand`
- Adds basic tests for schema template
- Adds example schema and template in test-workspace