### PR TITLE
feat: colored tags in tree view & tags at bottom

### DIFF
--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -67,5 +67,6 @@ export enum RESERVED_KEYS {
   GIT_NO_LINK = "gitNoLink",
 }
 
+export const TAGS_HIERARCHY_BASE = "tags";
 /** Notes under this hierarchy are considered tags, for example `${TAGS_HIERARCHY}foo` is a tag note. */
-export const TAGS_HIERARCHY = "tags.";
+export const TAGS_HIERARCHY = `${TAGS_HIERARCHY_BASE}.`;


### PR DESCRIPTION
Added a special symbol next to tags. All tags under `tags.` will have their symbol colored using the auto-generated color or user set color. The `tags` entry is also always moved to the bottom of the tree to keep it at a consistent position.

![](https://i.imgur.com/RwJOnY5.png)