### PR TITLE
fix: issue with direct child filter partially omitting values in quickpick

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -189,18 +189,22 @@ export class LookupControllerV3 {
     }) as DendronBtn;
     btnTriggered.pressed = !btnTriggered.pressed;
     const btnCategory = getButtonCategory(btnTriggered);
+    let btnsToRefresh: DendronBtn[] = [];
     if (!_.includes(["effect"] as ButtonCategory[], btnCategory)) {
-      _.filter(this.state.buttons, (ent) => ent.type !== btnTriggered.type).map(
-        (ent) => {
-          if (getButtonCategory(ent) === btnCategory) {
-            ent.pressed = false;
-          }
-        }
+      btnsToRefresh = _.filter(this.state.buttons, (ent) => {
+        return (
+          ent.type !== btnTriggered.type &&
+          getButtonCategory(ent) === btnCategory
+        );
+      });
+      btnsToRefresh.map(
+        (ent) => { ent.pressed = false }
       );
-    }
+    };
+    btnsToRefresh.push(btnTriggered);
     // update button state
     PickerUtilsV2.refreshButtons({ quickpick, buttons, buttonsPrev });
     // modify button behavior
-    await PickerUtilsV2.refreshPickerBehavior({ quickpick, buttons });
+    await PickerUtilsV2.refreshPickerBehavior({ quickpick, buttons: btnsToRefresh });
   };
 }

--- a/packages/plugin-core/src/components/lookup/LookupProviderV2.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV2.ts
@@ -519,7 +519,7 @@ export class LookupProviderV2 {
         const resp = await engine.queryNotes({ qs });
         if (opts.depth) {
           nodes = resp.data.filter((ent) => {
-            return DNodeUtils.getDepth(ent) > opts.depth!;
+            return DNodeUtils.getDepth(ent) === opts.depth!;
           }).filter((ent) => !ent.stub);
         } else {
           nodes = resp.data;

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -202,6 +202,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       updatedItems = await NotePickerUtils.fetchPickerResults({
         picker,
         qs: querystring,
+        depth: picker.showDirectChildrenOnly? queryOrig.split(".").length : undefined,
       });
       // }
       if (token.isCancellationRequested) {

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -288,7 +288,8 @@ export class JournalBtn extends DendronBtn {
     quickPick.modifyPickerValueFunc = undefined;
     quickPick.noteModifierValue = undefined;
     quickPick.prevValue = quickPick.value;
-    quickPick.value = quickPick.rawValue;
+    quickPick.prefix = quickPick.rawValue;
+    quickPick.value = NotePickerUtils.getPickerValue(quickPick);
   }
 }
 
@@ -322,7 +323,8 @@ export class ScratchBtn extends DendronBtn {
     quickPick.modifyPickerValueFunc = undefined;
     quickPick.noteModifierValue = undefined;
     quickPick.prevValue = quickPick.value;
-    quickPick.value = quickPick.rawValue;
+    quickPick.prefix = quickPick.rawValue;
+    quickPick.value = NotePickerUtils.getPickerValue(quickPick);
   }
 }
 export class HorizontalSplitBtn extends DendronBtn {

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -1,9 +1,9 @@
 import {
   DNodePropsQuickInputV2,
-  NoteQuickInput,
   NoteUtils,
   NoteProps,
   getSlugger,
+  NoteQuickInput,
 } from "@dendronhq/common-all";
 import { getWS } from "../../workspace";
 import _ from "lodash";
@@ -364,19 +364,15 @@ export class DirectChildFilterBtn extends DendronBtn {
   }
 
   async onEnable({ quickPick }: ButtonHandleOpts) {
-    quickPick.filterMiddleware = (items: NoteQuickInput[]) => {
-      const depth = PickerUtilsV2.slashToDot(
-        PickerUtilsV2.getValue(quickPick)
-      ).split(".").length;
-      items = PickerUtilsV2.filterByDepth(items, depth);
-      items = PickerUtilsV2.filterNonStubs(items);
-      return items;
-    };
+    quickPick.showDirectChildrenOnly = true;
+    quickPick.filterMiddleware = ((items: NoteQuickInput[]) => items);
     return;
   }
 
   async onDisable({ quickPick }: ButtonHandleOpts) {
+    quickPick.showDirectChildrenOnly = false;
     quickPick.filterMiddleware = undefined;
+    return;
   }
 }
 

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -13,7 +13,7 @@ export type LookupControllerState = {
   buttonsPrev: DendronBtn[];
 };
 
-type FilterQuickPickFunction = (items: NoteQuickInput[]) => NoteQuickInput[];
+export type FilterQuickPickFunction = (items: NoteQuickInput[]) => NoteQuickInput[];
 type ModifyPickerValueFunc = (value?: string) => {
   noteName: string;
   prefix: string;
@@ -47,9 +47,7 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   noteModifierValue?: string;
   selectionModifierValue?: string;
   onCreate?: (note: DNodeProps) => Promise<DNodeProps | undefined>;
-  /**
-   @deprecated, replace with filterResults
-   */
+
   showDirectChildrenOnly?: boolean;
   // pagiation
   offset?: number;

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -703,6 +703,7 @@ export class NotePickerUtils {
   static async fetchPickerResults(opts: {
     picker: DendronQuickPickerV2;
     qs: string;
+    depth?: number;
   }) {
     const ctx = "createPickerItemsFromEngine";
     const start = process.hrtime();
@@ -712,7 +713,14 @@ export class NotePickerUtils {
     // if we are doing a query, reset pagination options
     PickerUtilsV2.resetPaginationOpts(picker);
     const resp = await engine.queryNotes({ qs });
-    nodes = resp.data;
+    if (opts.depth) {
+      nodes = resp.data.filter((ent) => {
+        return DNodeUtils.getDepth(ent) > opts.depth!;
+      }).filter((ent) => !ent.stub);
+    } else {
+      nodes = resp.data;
+    }
+    Logger.info({ ctx, msg: "post:queryNotes" });
     if (nodes.length > PAGINATE_LIMIT) {
       picker.allResults = nodes;
       picker.offset = PAGINATE_LIMIT;

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -715,7 +715,7 @@ export class NotePickerUtils {
     const resp = await engine.queryNotes({ qs });
     if (opts.depth) {
       nodes = resp.data.filter((ent) => {
-        return DNodeUtils.getDepth(ent) > opts.depth!;
+        return DNodeUtils.getDepth(ent) === opts.depth!;
       }).filter((ent) => !ent.stub);
     } else {
       nodes = resp.data;

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -165,7 +165,7 @@ suite("NoteLookupCommand", function () {
 
   // NOTE: think these tests are wrong
   describe("updateItems", () => {
-    test("picker has value of opened note by default", (done) => {
+    test("direct child filter", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
@@ -203,7 +203,7 @@ suite("NoteLookupCommand", function () {
       });
     });
 
-    test("direct child filter", (done) => {
+    test("picker has value of opened note by default", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,

--- a/test-workspace/dendron.code-workspace
+++ b/test-workspace/dendron.code-workspace
@@ -1,6 +1,9 @@
 {
     "folders": [
         {
+            "path": "vault3"
+        },
+        {
             "path": "vault2",
             "visibility": "private"
         },

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -1,6 +1,9 @@
 version: 1
 vaults:
     -
+        fsPath: vault3
+        name: vaultThree
+    -
         fsPath: vault2
         visibility: private
     -

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -49,6 +49,8 @@ site:
             - vault2
             - vault
             - vault2
+            - vaultThree
+            - vaultThree
 dev:
     enableWebUI: true
 graph:

--- a/test-workspace/vault/egg.md
+++ b/test-workspace/vault/egg.md
@@ -1,0 +1,8 @@
+---
+id: eoNz75Pw7KzJAL4ahfcLW
+title: Egg
+desc: ''
+updated: 1628601604229
+created: 1628601604229
+---
+

--- a/test-workspace/vault/egg.one.md
+++ b/test-workspace/vault/egg.one.md
@@ -1,0 +1,8 @@
+---
+id: R01O3Jl25ryhOfP1UXVIp
+title: One
+desc: ''
+updated: 1628601607090
+created: 1628601607091
+---
+

--- a/test-workspace/vault2/egg.md
+++ b/test-workspace/vault2/egg.md
@@ -1,0 +1,8 @@
+---
+id: 6G34jAxKXPXw5FwsglpN4
+title: Egg
+desc: ''
+updated: 1628601575475
+created: 1628601575475
+---
+

--- a/test-workspace/vault2/egg.two.md
+++ b/test-workspace/vault2/egg.two.md
@@ -1,0 +1,8 @@
+---
+id: EZPsfvR1ULOz4s9nAAPAA
+title: Two
+desc: ''
+updated: 1628601580719
+created: 1628601580719
+---
+

--- a/test-workspace/vault3/egg.md
+++ b/test-workspace/vault3/egg.md
@@ -1,0 +1,9 @@
+---
+id: IWGwRWVevKx_bB5hNnD_p
+title: Egg
+desc: ''
+updated: 1628595895140
+created: 1628595886632
+stub: false
+---
+

--- a/test-workspace/vault3/egg.three.md
+++ b/test-workspace/vault3/egg.three.md
@@ -1,0 +1,8 @@
+---
+id: s3c40WZUpudglqHW
+title: Three
+desc: ''
+updated: 1628595885256
+created: 1628595885257
+---
+

--- a/test-workspace/vault3/root.md
+++ b/test-workspace/vault3/root.md
@@ -1,0 +1,10 @@
+---
+id: D44zOd8D6oqao8ps
+title: Root
+desc: ''
+updated: 1628595844563
+created: 1628595844563
+---
+# Welcome to Dendron
+
+This is the root of your dendron vault. If you decide to publish your entire vault, this will be your landing page. You are free to customize any part of this page except the frontmatter on top. 

--- a/test-workspace/vault3/root.schema.yml
+++ b/test-workspace/vault3/root.schema.yml
@@ -1,0 +1,7 @@
+version: 1
+imports: []
+schemas:
+  - id: root
+    children: []
+    title: root
+    parent: root


### PR DESCRIPTION
This PR:
- Fixes an issue in Lookup (v2) where the direct child filter would be applied _after_ pagination has happened, which allowed some values to be omitted from the selectable items.
- Adds example notes that demonstrate the fix.
