### PR TITLE
fix: patch `getOrCreate` to inherit from default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ packages/plugin-core/dendron.server.log
 dendron.server
 dendron.server.log.old
 test-workspace-*-profile
+Session.vim

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -55,7 +55,7 @@ export class DConfig {
       lookup: {
         note: {
           selectionType: LookupSelectionType.selectionExtract,
-        }
+        },
       },
       journal: {
         dailyDomain: "daily",
@@ -95,12 +95,14 @@ export class DConfig {
     defaults?: Partial<DendronConfig>
   ): DendronConfig {
     const configPath = DConfig.configPath(dendronRoot);
-    let config: DendronConfig;
+    let config: DendronConfig = { ...defaults, ...DConfig.genDefaultConfig() };
     if (!fs.existsSync(configPath)) {
-      config = { ...defaults, ...DConfig.genDefaultConfig() };
       writeYAML(configPath, config);
     } else {
-      config = readYAML(configPath) as DendronConfig;
+      config = {
+        ...config,
+        ...readYAML(configPath),
+      } as DendronConfig;
     }
     return config;
   }


### PR DESCRIPTION
Like `getProp` also inherits from default values this commit makes the
behavior consistent.

The reason this came up was because calendar-view broke with `dendron.yml` not having a `journal` field.

Inheriting from the default values when getting the config object makes
the `journal` config values available for example in
`CreateDailyJournal.ts` where the error happend.