### PR TITLE
fix: leading slash in markdown export pod

### DIFF
--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -177,4 +177,12 @@ export const NOTE_PRESETS_V4 = {
     fname: "simple-wikilink.one",
     body: ["# Header ", "body text"].join("\n"),
   }),
+  NOTE_WITH_WIKILINK_TOP_HIERARCHY: CreateNoteFactory({
+    fname: "wikilink-top-hierarchy",
+    body: "[[wikilink-top-hierarchy-target]]",
+  }),
+  NOTE_WITH_WIKILINK_TOP_HIERARCHY_TARGET: CreateNoteFactory({
+    fname: "wikilink-top-hierarchy-target",
+    body: ["# Header ", "body text"].join("\n"),
+  }),
 };

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -541,7 +541,7 @@ export class LinkUtils {
   }: {
     link: DNoteLink;
     dest: DendronASTDest;
-    }): string | never {
+  }): string | never {
     switch (dest) {
       case DendronASTDest.MD_DENDRON: {
         if (this.isHashtagLink(link.from)) {
@@ -933,14 +933,24 @@ export class RemarkUtils {
         let dirty = false;
 
         wikiLinks.forEach((linkNode) => {
+          let newValue = linkNode.value;
+
+          // Add a leading slash to the path as some markdown parsers require it for links
+          if (!newValue.startsWith("/")) {
+            newValue = "/" + newValue;
+            dirty = true;
+          }
+
           if (linkNode.value.indexOf(".") >= 0) {
-            const newValue = _.replace(linkNode.value, /\./g, "/");
+            newValue = _.replace(newValue, /\./g, "/");
+
             if (linkNode.data.alias === linkNode.value) {
               linkNode.data.alias = newValue;
             }
-            linkNode.value = newValue;
             dirty = true;
           }
+
+          linkNode.value = newValue;
         });
         //TODO: Add support for Ref Notes and Block Links
 

--- a/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
@@ -85,7 +85,7 @@ describe("markdown import pod", () => {
 
   afterEach(() => {
     // make sure files are there
-    let [expectedFiles, actualFiles] = FileTestUtils.cmpFiles(vpath, [
+    const [expectedFiles, actualFiles] = FileTestUtils.cmpFiles(vpath, [
       "project.p1.n1.md",
       "project.p1.n2.md",
       "project.p2.n1.md",
@@ -367,7 +367,13 @@ describe("markdown export pod", () => {
 
         let [actualFiles, expectedFiles] = FileTestUtils.cmpFiles(
           path.join(exportDest, "vault1"),
-          ["root.md", "simple-wikilink.md", "simple-wikilink"]
+          [
+            "root.md",
+            "simple-wikilink.md",
+            "simple-wikilink",
+            "wikilink-top-hierarchy.md",
+            "wikilink-top-hierarchy-target.md",
+          ]
         );
         expect(actualFiles).toEqual(expectedFiles);
 
@@ -378,15 +384,28 @@ describe("markdown export pod", () => {
         expect(actualFiles).toEqual(expectedFiles);
 
         // check contents
-        const foo = fs.readFileSync(
+        let foo = fs.readFileSync(
           path.join(exportDest, "vault1", "simple-wikilink.md"),
           {
             encoding: "utf8",
           }
         );
-        debugger;
         expect(foo).toMatchSnapshot("note link reference");
-        await checkString(foo, "[One](simple-wikilink/one)");
+        await checkString(foo, "[One](/simple-wikilink/one)");
+
+        // Now do a comparison for a note reference at the top level hierarchy
+        // check contents
+        foo = fs.readFileSync(
+          path.join(exportDest, "vault1", "wikilink-top-hierarchy.md"),
+          {
+            encoding: "utf8",
+          }
+        );
+        expect(foo).toMatchSnapshot("top hierarchy note link reference");
+        await checkString(
+          foo,
+          "[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target)"
+        );
       },
       {
         expect,
@@ -396,6 +415,14 @@ describe("markdown export pod", () => {
             vault: vaults[0],
           });
           await NOTE_PRESETS_V4.NOTE_WITH_WIKILINK_SIMPLE_TARGET.create({
+            wsRoot,
+            vault: vaults[0],
+          });
+          await NOTE_PRESETS_V4.NOTE_WITH_WIKILINK_TOP_HIERARCHY.create({
+            wsRoot,
+            vault: vaults[0],
+          });
+          await NOTE_PRESETS_V4.NOTE_WITH_WIKILINK_TOP_HIERARCHY_TARGET.create({
             wsRoot,
             vault: vaults[0],
           });

--- a/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/MarkdownPod.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/MarkdownPod.spec.ts.snap
@@ -11,7 +11,13 @@ foo.ch1 body"
 exports[`markdown export pod test wikilink conversion: note link reference 1`] = `
 "# Simple Wikilink
 
-[One](simple-wikilink/one)"
+[One](/simple-wikilink/one)"
+`;
+
+exports[`markdown export pod test wikilink conversion: top hierarchy note link reference 1`] = `
+"# Wikilink Top Hierarchy
+
+[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target)"
 `;
 
 exports[`markdown publish pod basic 1`] = `


### PR DESCRIPTION
Adds a leading slash during wikilink conversion from dot notation to slash notation. Improves compat with other markdown parsers for wikilinks.