### PR TITLE
chore: transition lookup to v3

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -159,14 +159,6 @@
         "desc": "Rename a header, and update all links to it."
       },
       {
-        "command": "dendron.lookup",
-        "title": "Dendron: Lookup",
-        "desc": "Initiate note lookup",
-        "docLink": "dendron.topic.lookup.md",
-        "docPreview": "",
-        "when": "dendron:pluginActive"
-      },
-      {
         "command": "dendron.lookupNote",
         "title": "Dendron: Lookup Note",
         "desc": "Initiate note lookup",
@@ -666,13 +658,13 @@
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "mac": "cmd+L",
         "key": "ctrl+l",
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "key": "ctrl+shift+j",
         "mac": "cmd+shift+j",
         "args": {
@@ -681,7 +673,7 @@
         "when": "dendron:pluginActive"
       },
       {
-        "command": "dendron.lookup",
+        "command": "dendron.lookupNote",
         "key": "ctrl+shift+s",
         "mac": "cmd+shift+s",
         "args": {

--- a/packages/plugin-core/src/commands/GoDownCommand.ts
+++ b/packages/plugin-core/src/commands/GoDownCommand.ts
@@ -1,20 +1,23 @@
 import path from "path";
-import { DendronQuickPickerV2 } from "../components/lookup/types";
+// import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
 import { BasicCommand } from "./base";
-import { LookupCommand } from "./LookupCommand";
+import { NoteLookupCommand, CommandOutput as NoteLookupCommandOut } from "./NoteLookupCommand";
 
-type CommandOpts = {};
+type CommandOpts = {
+  noConfirm?: boolean;
+};
 
-type CommandOutput = DendronQuickPickerV2;
+type CommandOutput = NoteLookupCommandOut;
+
 
 export class GoDownCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.GO_DOWN_HIERARCHY.key;
   async gatherInputs(): Promise<any> {
     return {};
   }
-  async execute() {
+  async execute(opts: CommandOpts) {
     const maybeTextEditor = VSCodeUtils.getActiveTextEditor();
     let value = "";
     if (maybeTextEditor) {
@@ -24,10 +27,10 @@ export class GoDownCommand extends BasicCommand<CommandOpts, CommandOutput> {
       }
     }
 
-    const picker = (await new LookupCommand().execute({
-      flavor: "note",
-      value,
-    })) as DendronQuickPickerV2;
-    return picker;
+    const out = (await new NoteLookupCommand().run({
+      initialValue: value,
+      noConfirm: opts.noConfirm,
+    }));
+    return out!;
   }
 }

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -10,12 +10,12 @@ import {
 import _ from "lodash";
 import { Position, Selection, Uri, window, ViewColumn } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
+import { VaultSelectionMode } from "../components/lookup/types";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../utils";
 import { getReferenceAtPosition } from "../utils/md";
 import { DendronWorkspace, getWS } from "../workspace";
 import { BasicCommand } from "./base";
-import { VaultSelectionMode } from "./LookupCommand";
 
 type CommandOpts = {
   qs?: string;

--- a/packages/plugin-core/src/commands/LookupCommand.ts
+++ b/packages/plugin-core/src/commands/LookupCommand.ts
@@ -1,112 +1,112 @@
-import { VSCodeEvents } from "@dendronhq/common-all";
-import { getDurationMilliseconds } from "@dendronhq/common-server";
-import { LookupControllerV2 } from "../components/lookup/LookupControllerV2";
-import { DendronQuickPickerV2 } from "../components/lookup/types";
-import { Logger } from "../logger";
-import { VSCodeUtils } from "../utils";
-import { AnalyticsUtils } from "../utils/analytics";
-import { BasicCommand } from "./base";
+// import { VSCodeEvents } from "@dendronhq/common-all";
+// import { getDurationMilliseconds } from "@dendronhq/common-server";
+// import { LookupControllerV2 } from "../components/lookup/LookupControllerV2";
+// import { DendronQuickPickerV2 } from "../components/lookup/types";
+// import { Logger } from "../logger";
+// import { VSCodeUtils } from "../utils";
+// import { AnalyticsUtils } from "../utils/analytics";
+// import { BasicCommand } from "./base";
 
-export type LookupEffectType = "copyNoteLink" | "copyNoteRef" | "multiSelect";
-export enum LookupEffectTypeEnum {
-  "copyNoteLink" = "copyNoteLink",
-  "copyNoteRef" = "copyNoteRef",
-  "multiSelect" = "multiSelect",
-}
-export type LookupFilterType = "directChildOnly";
-export type LookupSelectionType = "selection2link" | "selectionExtract";
-export type LookupNoteType = LookupNoteTypeEnum;
-export type LookupSplitType = "horizontal";
-export enum LookupSplitTypeEnum {
-  "horizontal" = "horizontal",
-}
-export type LookupNoteExistBehavior = "open" | "overwrite";
-export enum LookupNoteTypeEnum {
-  "journal" = "journal",
-  "scratch" = "scratch",
-}
-export enum LookupSelectionTypeEnum {
-  "selection2link" = "selection2link",
-  "selectionExtract" = "selectionExtract",
-}
+// export type LookupEffectType = "copyNoteLink" | "copyNoteRef" | "multiSelect";
+// export enum LookupEffectTypeEnum {
+//   "copyNoteLink" = "copyNoteLink",
+//   "copyNoteRef" = "copyNoteRef",
+//   "multiSelect" = "multiSelect",
+// }
+// export type LookupFilterType = "directChildOnly";
+// export type LookupSelectionType = "selection2link" | "selectionExtract";
+// export type LookupNoteType = LookupNoteTypeEnum;
+// export type LookupSplitType = "horizontal";
+// export enum LookupSplitTypeEnum {
+//   "horizontal" = "horizontal",
+// }
+// export type LookupNoteExistBehavior = "open" | "overwrite";
+// export enum LookupNoteTypeEnum {
+//   "journal" = "journal",
+//   "scratch" = "scratch",
+// }
+// export enum LookupSelectionTypeEnum {
+//   "selection2link" = "selection2link",
+//   "selectionExtract" = "selectionExtract",
+// }
 
-/**
- * Mode for prompting the user on which vault should be used to
- */
-export enum VaultSelectionMode {
-  /**
-   * Never prompt the user. Useful for testing
-   */
-  auto,
+// /**
+//  * Mode for prompting the user on which vault should be used to
+//  */
+// export enum VaultSelectionMode {
+//   /**
+//    * Never prompt the user. Useful for testing
+//    */
+//   auto,
 
-  /**
-   * Tries to determine the vault automatically, but will prompt the user if
-   * there is ambiguity
-   */
-  smart,
+//   /**
+//    * Tries to determine the vault automatically, but will prompt the user if
+//    * there is ambiguity
+//    */
+//   smart,
 
-  /**
-   * Always prompt the user if there is more than one vault
-   */
-  alwaysPrompt,
-}
+//   /**
+//    * Always prompt the user if there is more than one vault
+//    */
+//   alwaysPrompt,
+// }
 
-type CommandOpts = {
-  /**
-   * When creating new note, controls
-   * behavior of selected text
-   */
-  selectionType?: LookupSelectionType;
-  filterType?: LookupFilterType;
-  /**
-   * If set, controls path of note
-   */
-  noteType?: LookupNoteType;
-  /**
-   * If set, open note in a new split
-   */
-  splitType?: LookupSplitType;
-  flavor: any;
-  noConfirm?: boolean;
-  value?: string;
-  noteExistBehavior?: LookupNoteExistBehavior;
-  effectType?: LookupEffectType;
-  vaultSelectionMode?: VaultSelectionMode;
-};
+// type CommandOpts = {
+//   /**
+//    * When creating new note, controls
+//    * behavior of selected text
+//    */
+//   selectionType?: LookupSelectionType;
+//   filterType?: LookupFilterType;
+//   /**
+//    * If set, controls path of note
+//    */
+//   noteType?: LookupNoteType;
+//   /**
+//    * If set, open note in a new split
+//    */
+//   splitType?: LookupSplitType;
+//   flavor: any;
+//   noConfirm?: boolean;
+//   value?: string;
+//   noteExistBehavior?: LookupNoteExistBehavior;
+//   effectType?: LookupEffectType;
+//   vaultSelectionMode?: VaultSelectionMode;
+// };
 
-type CommandOutput = DendronQuickPickerV2;
+// type CommandOutput = DendronQuickPickerV2;
 
-export { CommandOpts as LookupCommandOpts };
+// export { CommandOpts as LookupCommandOpts };
 
-export class LookupCommand extends BasicCommand<CommandOpts, CommandOutput> {
-  // Placeholder for telemetry purposes. More detailed telemetry exists on the lookup command.
-  key = "dendron.Lookup";
+// export class LookupCommand extends BasicCommand<CommandOpts, CommandOutput> {
+//   // Placeholder for telemetry purposes. More detailed telemetry exists on the lookup command.
+//   key = "dendron.Lookup";
 
-  async gatherInputs(): Promise<any> {
-    return {};
-  }
-  async execute(opts: CommandOpts) {
-    let profile;
-    const start = process.hrtime();
-    const ctx = "LookupCommand:execute";
-    Logger.info({ ctx, opts, msg: "enter" });
-    const controller = new LookupControllerV2({ flavor: opts.flavor }, opts);
-    profile = getDurationMilliseconds(start);
-    Logger.info({ ctx, profile, msg: "postCreateController" });
-    const resp = await VSCodeUtils.extractRangeFromActiveEditor();
-    profile = getDurationMilliseconds(start);
-    Logger.info({ ctx, profile, msg: "post:extractRange" });
-    const out = controller.show({
-      ...resp,
-      noConfirm: opts.noConfirm,
-      value: opts.value,
-    });
-    profile = getDurationMilliseconds(start);
-    AnalyticsUtils.track(VSCodeEvents.Lookup_Show, {
-      duration: profile,
-      flavor: opts.flavor,
-    });
-    Logger.info({ ctx, profile, msg: "post:show" });
-    return out;
-  }
-}
+//   async gatherInputs(): Promise<any> {
+//     return {};
+//   }
+//   async execute(opts: CommandOpts) {
+//     let profile;
+//     const start = process.hrtime();
+//     const ctx = "LookupCommand:execute";
+//     Logger.info({ ctx, opts, msg: "enter" });
+//     const controller = new LookupControllerV2({ flavor: opts.flavor }, opts);
+//     profile = getDurationMilliseconds(start);
+//     Logger.info({ ctx, profile, msg: "postCreateController" });
+//     const resp = await VSCodeUtils.extractRangeFromActiveEditor();
+//     profile = getDurationMilliseconds(start);
+//     Logger.info({ ctx, profile, msg: "post:extractRange" });
+//     const out = controller.show({
+//       ...resp,
+//       noConfirm: opts.noConfirm,
+//       value: opts.value,
+//     });
+//     profile = getDurationMilliseconds(start);
+//     AnalyticsUtils.track(VSCodeEvents.Lookup_Show, {
+//       duration: profile,
+//       flavor: opts.flavor,
+//     });
+//     Logger.info({ ctx, profile, msg: "post:show" });
+//     return out;
+//   }
+// }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -155,7 +155,6 @@ export class NoteLookupCommand extends BaseCommand<
         "lookupConfirmVaultOnCreate"
       ),
       extraButtons: [
-        //todo: mirror v2 button sequence
         MultiSelectBtn.create(copts.multiSelect),
         CopyNoteLinkBtn.create(),
         DirectChildFilterBtn.create(

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -32,6 +32,13 @@ import {
 import {
   DendronQuickPickerV2,
   DendronQuickPickState,
+  LookupFilterType,
+  LookupNoteType,
+  LookupNoteTypeEnum,
+  LookupSelectionType,
+  LookupSelectionTypeEnum,
+  LookupSplitType,
+  LookupSplitTypeEnum,
 } from "../components/lookup/types";
 import {
   node2Uri,
@@ -44,15 +51,6 @@ import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
 import { DendronWorkspace, getEngine, getWS } from "../workspace";
 import { BaseCommand } from "./base";
-import {
-  LookupFilterType,
-  LookupNoteType,
-  LookupNoteTypeEnum,
-  LookupSelectionType,
-  LookupSelectionTypeEnum,
-  LookupSplitType,
-  LookupSplitTypeEnum,
-} from "./LookupCommand";
 
 export type CommandRunOpts = {
   initialValue?: string;

--- a/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV2.ts
@@ -1,445 +1,445 @@
-import {
-  DendronError,
-  DNodePropsQuickInputV2,
-  getSlugger,
-  NoteProps,
-} from "@dendronhq/common-all";
-import { getDurationMilliseconds } from "@dendronhq/common-server";
-import _ from "lodash";
-import path from "path";
-import * as vscode from "vscode";
-import { QuickInputButton } from "vscode";
-import { CancellationTokenSource } from "vscode-languageclient";
-import {
-  LookupCommandOpts,
-  LookupNoteExistBehavior,
-  VaultSelectionMode,
-} from "../../commands/LookupCommand";
-import { CONFIG } from "../../constants";
-import { Logger } from "../../logger";
-import { EngineOpts } from "../../types";
-import { DendronClientUtilsV2, VSCodeUtils } from "../../utils";
-import { DendronWorkspace, getWS } from "../../workspace";
-import {
-  ButtonCategory,
-  ButtonType,
-  createAllButtons,
-  DendronBtn,
-  getButtonCategory,
-  IDendronQuickInputButton,
-} from "./buttons";
-import { LookupProviderV2 } from "./LookupProviderV2";
-import { DendronQuickPickerV2, LookupControllerState } from "./types";
-import { PickerUtilsV2, UPDATET_SOURCE } from "./utils";
+// import {
+//   DendronError,
+//   DNodePropsQuickInputV2,
+//   getSlugger,
+//   NoteProps,
+// } from "@dendronhq/common-all";
+// import { getDurationMilliseconds } from "@dendronhq/common-server";
+// import _ from "lodash";
+// import path from "path";
+// import * as vscode from "vscode";
+// import { QuickInputButton } from "vscode";
+// import { CancellationTokenSource } from "vscode-languageclient";
+// import {
+//   LookupCommandOpts,
+//   LookupNoteExistBehavior,
+//   VaultSelectionMode,
+// } from "../../commands/LookupCommand";
+// import { CONFIG } from "../../constants";
+// import { Logger } from "../../logger";
+// import { EngineOpts } from "../../types";
+// import { DendronClientUtilsV2, VSCodeUtils } from "../../utils";
+// import { DendronWorkspace, getWS } from "../../workspace";
+// import {
+//   ButtonCategory,
+//   ButtonType,
+//   createAllButtons,
+//   DendronBtn,
+//   getButtonCategory,
+//   IDendronQuickInputButton,
+// } from "./buttons";
+// import { LookupProviderV2 } from "./LookupProviderV2";
+// import { DendronQuickPickerV2, LookupControllerState } from "./types";
+// import { PickerUtilsV2, UPDATET_SOURCE } from "./utils";
 
-export class LookupControllerV2 {
-  public quickPick?: DendronQuickPickerV2;
-  public state: LookupControllerState;
-  public provider?: LookupProviderV2;
-  protected opts: EngineOpts;
-  protected _onDidHide?: () => void;
-  protected _cancelTokenSource?: CancellationTokenSource;
-  private vaultSelectionMode?: VaultSelectionMode;
+// export class LookupControllerV2 {
+//   public quickPick?: DendronQuickPickerV2;
+//   public state: LookupControllerState;
+//   public provider?: LookupProviderV2;
+//   protected opts: EngineOpts;
+//   protected _onDidHide?: () => void;
+//   protected _cancelTokenSource?: CancellationTokenSource;
+//   private vaultSelectionMode?: VaultSelectionMode;
 
-  constructor(
-    opts: EngineOpts,
-    lookupOpts?: Omit<LookupCommandOpts, "flavor">
-  ) {
-    // selection behaior
-    const lookupSelectionType =
-      lookupOpts?.selectionType ||
-      (DendronWorkspace.configuration().get<string>(
-        CONFIG.DEFAULT_LOOKUP_CREATE_BEHAVIOR.key
-      ) as ButtonType);
-    const noteSelectionType = lookupOpts?.noteType;
-    const initialTypes = _.isUndefined(lookupSelectionType)
-      ? []
-      : [lookupSelectionType];
-    if (noteSelectionType) {
-      initialTypes.push(noteSelectionType);
-    }
-    if (lookupOpts?.effectType) {
-      initialTypes.push(lookupOpts.effectType);
-    }
-    // split behavior
-    if (lookupOpts?.splitType) {
-      initialTypes.push(lookupOpts.splitType);
-    }
+//   constructor(
+//     opts: EngineOpts,
+//     lookupOpts?: Omit<LookupCommandOpts, "flavor">
+//   ) {
+//     // selection behaior
+//     const lookupSelectionType =
+//       lookupOpts?.selectionType ||
+//       (DendronWorkspace.configuration().get<string>(
+//         CONFIG.DEFAULT_LOOKUP_CREATE_BEHAVIOR.key
+//       ) as ButtonType);
+//     const noteSelectionType = lookupOpts?.noteType;
+//     const initialTypes = _.isUndefined(lookupSelectionType)
+//       ? []
+//       : [lookupSelectionType];
+//     if (noteSelectionType) {
+//       initialTypes.push(noteSelectionType);
+//     }
+//     if (lookupOpts?.effectType) {
+//       initialTypes.push(lookupOpts.effectType);
+//     }
+//     // split behavior
+//     if (lookupOpts?.splitType) {
+//       initialTypes.push(lookupOpts.splitType);
+//     }
 
-    // initialize rest
-    this.state = {
-      buttons: opts.flavor === "note" ? createAllButtons(initialTypes) : [],
-      buttonsPrev: [],
-    };
-    this.opts = opts;
-    this.createCancelSource();
+//     // initialize rest
+//     this.state = {
+//       buttons: opts.flavor === "note" ? createAllButtons(initialTypes) : [],
+//       buttonsPrev: [],
+//     };
+//     this.opts = opts;
+//     this.createCancelSource();
 
-    this.vaultSelectionMode = lookupOpts?.vaultSelectionMode;
-  }
+//     this.vaultSelectionMode = lookupOpts?.vaultSelectionMode;
+//   }
 
-  get cancelToken() {
-    if (_.isUndefined(this._cancelTokenSource)) {
-      throw new DendronError({ message: "no cancel token" });
-    }
-    return this._cancelTokenSource;
-  }
+//   get cancelToken() {
+//     if (_.isUndefined(this._cancelTokenSource)) {
+//       throw new DendronError({ message: "no cancel token" });
+//     }
+//     return this._cancelTokenSource;
+//   }
 
-  createCancelSource() {
-    const tokenSource = new CancellationTokenSource();
-    if (this._cancelTokenSource) {
-      this._cancelTokenSource.cancel();
-      this._cancelTokenSource.dispose();
-    }
-    this._cancelTokenSource = tokenSource;
-    return tokenSource;
-  }
+//   createCancelSource() {
+//     const tokenSource = new CancellationTokenSource();
+//     if (this._cancelTokenSource) {
+//       this._cancelTokenSource.cancel();
+//       this._cancelTokenSource.dispose();
+//     }
+//     this._cancelTokenSource = tokenSource;
+//     return tokenSource;
+//   }
 
-  // exposed for testing
-  onDidHide = (cb: () => void) => {
-    this._onDidHide = cb;
-  };
+//   // exposed for testing
+//   onDidHide = (cb: () => void) => {
+//     this._onDidHide = cb;
+//   };
 
-  onTriggerButton = async (btn: QuickInputButton) => {
-    const quickPick = this.quickPick;
-    const provider = this.provider;
-    if (!quickPick || !provider) {
-      return;
-    }
-    const resp = await VSCodeUtils.extractRangeFromActiveEditor();
-    const { document, range } = resp || {};
-    const btnType = (btn as IDendronQuickInputButton).type;
+//   onTriggerButton = async (btn: QuickInputButton) => {
+//     const quickPick = this.quickPick;
+//     const provider = this.provider;
+//     if (!quickPick || !provider) {
+//       return;
+//     }
+//     const resp = await VSCodeUtils.extractRangeFromActiveEditor();
+//     const { document, range } = resp || {};
+//     const btnType = (btn as IDendronQuickInputButton).type;
 
-    const btnTriggered = _.find(this.state.buttons, {
-      type: btnType,
-    }) as DendronBtn;
-    if (!btnTriggered) {
-      throw Error("bad button type");
-    }
-    btnTriggered.pressed = !btnTriggered.pressed;
-    const btnCategory = getButtonCategory(btnTriggered);
-    // toggle other buttons in same category off
-    if (!_.includes(["effect"] as ButtonCategory[], btnCategory)) {
-      _.filter(this.state.buttons, (ent) => ent.type !== btnTriggered.type).map(
-        (ent) => {
-          if (getButtonCategory(ent) === btnCategory) {
-            ent.pressed = false;
-          }
-        }
-      );
-    }
+//     const btnTriggered = _.find(this.state.buttons, {
+//       type: btnType,
+//     }) as DendronBtn;
+//     if (!btnTriggered) {
+//       throw Error("bad button type");
+//     }
+//     btnTriggered.pressed = !btnTriggered.pressed;
+//     const btnCategory = getButtonCategory(btnTriggered);
+//     // toggle other buttons in same category off
+//     if (!_.includes(["effect"] as ButtonCategory[], btnCategory)) {
+//       _.filter(this.state.buttons, (ent) => ent.type !== btnTriggered.type).map(
+//         (ent) => {
+//           if (getButtonCategory(ent) === btnCategory) {
+//             ent.pressed = false;
+//           }
+//         }
+//       );
+//     }
 
-    this.refreshButtons(quickPick, this.state.buttons);
-    await this.updatePickerBehavior({
-      quickPick,
-      document,
-      range,
-      provider,
-      changed: btnTriggered,
-      vaultSelectionMode: this.vaultSelectionMode,
-    });
-  };
+//     this.refreshButtons(quickPick, this.state.buttons);
+//     await this.updatePickerBehavior({
+//       quickPick,
+//       document,
+//       range,
+//       provider,
+//       changed: btnTriggered,
+//       vaultSelectionMode: this.vaultSelectionMode,
+//     });
+//   };
 
-  refreshButtons(quickpick: DendronQuickPickerV2, buttons: DendronBtn[]) {
-    this.state.buttonsPrev = quickpick.buttons.map((b: DendronBtn) =>
-      b.clone()
-    );
-    quickpick.buttons = buttons;
-  }
+//   refreshButtons(quickpick: DendronQuickPickerV2, buttons: DendronBtn[]) {
+//     this.state.buttonsPrev = quickpick.buttons.map((b: DendronBtn) =>
+//       b.clone()
+//     );
+//     quickpick.buttons = buttons;
+//   }
 
-  async show(opts?: {
-    value?: string;
-    ignoreFocusOut?: boolean;
-    document?: vscode.TextDocument;
-    range?: vscode.Range;
-    noConfirm?: boolean;
-    noteExistBehavior?: LookupNoteExistBehavior;
-  }) {
-    let profile;
-    const start = process.hrtime();
-    const ctx = "LookupControllerV2:show";
-    const cleanOpts = _.defaults(opts, {
-      ignoreFocusOut: true,
-    });
-    const { document, range } = cleanOpts;
-    Logger.info({ ctx, msg: "enter", cleanOpts });
-    // create quick pick
-    const quickPick =
-      vscode.window.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
-    const title = [`Lookup (${this.opts.flavor})`];
-    title.push(`- version: ${DendronWorkspace.version()}`);
-    quickPick.title = title.join(" ");
-    quickPick.placeholder = "eg. hello.world";
-    quickPick.ignoreFocusOut = cleanOpts.ignoreFocusOut;
-    quickPick._justActivated = !opts?.noConfirm;
-    quickPick.canSelectMany = false;
-    quickPick.matchOnDescription = false;
-    quickPick.matchOnDetail = false;
+//   async show(opts?: {
+//     value?: string;
+//     ignoreFocusOut?: boolean;
+//     document?: vscode.TextDocument;
+//     range?: vscode.Range;
+//     noConfirm?: boolean;
+//     noteExistBehavior?: LookupNoteExistBehavior;
+//   }) {
+//     let profile;
+//     const start = process.hrtime();
+//     const ctx = "LookupControllerV2:show";
+//     const cleanOpts = _.defaults(opts, {
+//       ignoreFocusOut: true,
+//     });
+//     const { document, range } = cleanOpts;
+//     Logger.info({ ctx, msg: "enter", cleanOpts });
+//     // create quick pick
+//     const quickPick =
+//       vscode.window.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
+//     const title = [`Lookup (${this.opts.flavor})`];
+//     title.push(`- version: ${DendronWorkspace.version()}`);
+//     quickPick.title = title.join(" ");
+//     quickPick.placeholder = "eg. hello.world";
+//     quickPick.ignoreFocusOut = cleanOpts.ignoreFocusOut;
+//     quickPick._justActivated = !opts?.noConfirm;
+//     quickPick.canSelectMany = false;
+//     quickPick.matchOnDescription = false;
+//     quickPick.matchOnDetail = false;
 
-    profile = getDurationMilliseconds(start);
-    const cancelToken = this.createCancelSource();
-    Logger.info({ ctx, profile, msg: "post:createQuickPick" });
+//     profile = getDurationMilliseconds(start);
+//     const cancelToken = this.createCancelSource();
+//     Logger.info({ ctx, profile, msg: "post:createQuickPick" });
 
-    const provider = new LookupProviderV2(this.opts);
-    this.provider = provider;
+//     const provider = new LookupProviderV2(this.opts);
+//     this.provider = provider;
 
-    profile = getDurationMilliseconds(start);
-    Logger.info({ ctx, profile, msg: "post:createProvider" });
+//     profile = getDurationMilliseconds(start);
+//     Logger.info({ ctx, profile, msg: "post:createProvider" });
 
-    this.refreshButtons(quickPick, this.state.buttons);
-    await this.updatePickerBehavior({
-      quickPick,
-      document,
-      range,
-      quickPickValue: cleanOpts.value,
-      provider,
-      vaultSelectionMode: this.vaultSelectionMode,
-    });
-    Logger.info({ ctx, profile, msg: "post:updatePickerBehavior" });
-    quickPick.onDidTriggerButton(this.onTriggerButton);
+//     this.refreshButtons(quickPick, this.state.buttons);
+//     await this.updatePickerBehavior({
+//       quickPick,
+//       document,
+//       range,
+//       quickPickValue: cleanOpts.value,
+//       provider,
+//       vaultSelectionMode: this.vaultSelectionMode,
+//     });
+//     Logger.info({ ctx, profile, msg: "post:updatePickerBehavior" });
+//     quickPick.onDidTriggerButton(this.onTriggerButton);
 
-    // cleanup quickpick
-    quickPick.onDidHide(() => {
-      quickPick.dispose();
-      this.quickPick = undefined;
-      this.cancelToken?.dispose();
-      if (this._onDidHide) {
-        this._onDidHide();
-      }
-    });
+//     // cleanup quickpick
+//     quickPick.onDidHide(() => {
+//       quickPick.dispose();
+//       this.quickPick = undefined;
+//       this.cancelToken?.dispose();
+//       if (this._onDidHide) {
+//         this._onDidHide();
+//       }
+//     });
 
-    provider.provide({ picker: quickPick, lc: this });
-    Logger.info({ ctx, profile, msg: "post:provide" });
-    if (opts?.noConfirm) {
-      await provider.onUpdatePickerItem(
-        quickPick,
-        this.opts,
-        "manual",
-        cancelToken.token
-      );
-      // would be empty if not set
-      quickPick.selectedItems = quickPick.items;
-      // FIXME: used for testing
-      if (quickPick.value && _.isEmpty(quickPick.items)) {
-        const items = provider.createDefaultItems({ picker: quickPick });
-        quickPick.items = items;
-        quickPick.selectedItems = items;
-      }
-      await provider.onDidAccept({
-        picker: quickPick,
-        opts: { flavor: this.opts.flavor },
-        lc: this,
-      });
-    } else {
-      quickPick.show();
-    }
-    this.quickPick = quickPick;
-    Logger.info({ ctx, profile, msg: "exit" });
-    return quickPick;
-  }
+//     provider.provide({ picker: quickPick, lc: this });
+//     Logger.info({ ctx, profile, msg: "post:provide" });
+//     if (opts?.noConfirm) {
+//       await provider.onUpdatePickerItem(
+//         quickPick,
+//         this.opts,
+//         "manual",
+//         cancelToken.token
+//       );
+//       // would be empty if not set
+//       quickPick.selectedItems = quickPick.items;
+//       // FIXME: used for testing
+//       if (quickPick.value && _.isEmpty(quickPick.items)) {
+//         const items = provider.createDefaultItems({ picker: quickPick });
+//         quickPick.items = items;
+//         quickPick.selectedItems = items;
+//       }
+//       await provider.onDidAccept({
+//         picker: quickPick,
+//         opts: { flavor: this.opts.flavor },
+//         lc: this,
+//       });
+//     } else {
+//       quickPick.show();
+//     }
+//     this.quickPick = quickPick;
+//     Logger.info({ ctx, profile, msg: "exit" });
+//     return quickPick;
+//   }
 
-  async updateBehaviorByNoteType({
-    noteResp,
-    quickPick,
-    provider,
-    quickPickValue,
-  }: {
-    noteResp?: DendronBtn;
-    quickPick: DendronQuickPickerV2;
-    provider: LookupProviderV2;
-    quickPickValue?: string;
-  }) {
-    const { selection, text } = VSCodeUtils.getSelection();
-    const buttons = this.state.buttons;
-    let suffix: string | undefined;
+//   async updateBehaviorByNoteType({
+//     noteResp,
+//     quickPick,
+//     provider,
+//     quickPickValue,
+//   }: {
+//     noteResp?: DendronBtn;
+//     quickPick: DendronQuickPickerV2;
+//     provider: LookupProviderV2;
+//     quickPickValue?: string;
+//   }) {
+//     const { selection, text } = VSCodeUtils.getSelection();
+//     const buttons = this.state.buttons;
+//     let suffix: string | undefined;
 
-    if (
-      !_.isEmpty(selection) &&
-      !_.isUndefined(text) &&
-      !_.isEmpty(text) &&
-      _.find(_.filter(buttons, { pressed: true }), {
-        type: "selection2link",
-      }) &&
-      DendronWorkspace.configuration().get<string>(
-        CONFIG.LINK_SELECT_AUTO_TITLE_BEHAVIOR.key
-      ) === "slug"
-    ) {
-      const slugger = getSlugger();
-      suffix = slugger.slug(text);
-    }
-    let onUpdateReason: any = "updatePickerBehavior:normal";
-    let onUpdateValue: string;
+//     if (
+//       !_.isEmpty(selection) &&
+//       !_.isUndefined(text) &&
+//       !_.isEmpty(text) &&
+//       _.find(_.filter(buttons, { pressed: true }), {
+//         type: "selection2link",
+//       }) &&
+//       DendronWorkspace.configuration().get<string>(
+//         CONFIG.LINK_SELECT_AUTO_TITLE_BEHAVIOR.key
+//       ) === "slug"
+//     ) {
+//       const slugger = getSlugger();
+//       suffix = slugger.slug(text);
+//     }
+//     let onUpdateReason: any = "updatePickerBehavior:normal";
+//     let onUpdateValue: string;
 
-    switch (noteResp?.type) {
-      case "journal": {
-        const { noteName } = DendronClientUtilsV2.genNoteName("JOURNAL", {
-          overrides: { domain: quickPickValue },
-        });
-        onUpdateValue = noteName;
-        onUpdateReason = "updatePickerBehavior:journal";
-        break;
-      }
-      case "scratch": {
-        const { noteName } = DendronClientUtilsV2.genNoteName("SCRATCH", {
-          overrides: { domain: quickPickValue },
-        });
-        onUpdateValue = noteName;
-        onUpdateReason = "updatePickerBehavior:scratch";
-        break;
-      }
-      default:
-        if (quickPickValue !== undefined) {
-          onUpdateValue = quickPickValue;
-        } else {
-          const editorPath =
-            vscode.window.activeTextEditor?.document.uri.fsPath;
-          if (editorPath && this.opts.flavor !== "schema") {
-            onUpdateValue = path.basename(editorPath, ".md");
-          } else {
-            onUpdateValue = "";
-          }
-        }
-        onUpdateReason = "updatePickerBehavior:normal";
-    }
-    if (!_.isUndefined(suffix)) {
-      onUpdateValue = [onUpdateValue, suffix].join(".");
-    }
-    quickPick.value = onUpdateValue;
-    const tokenSource = this.createCancelSource();
-    await provider.onUpdatePickerItem(
-      quickPick,
-      provider.opts,
-      onUpdateReason,
-      tokenSource.token
-    );
-  }
+//     switch (noteResp?.type) {
+//       case "journal": {
+//         const { noteName } = DendronClientUtilsV2.genNoteName("JOURNAL", {
+//           overrides: { domain: quickPickValue },
+//         });
+//         onUpdateValue = noteName;
+//         onUpdateReason = "updatePickerBehavior:journal";
+//         break;
+//       }
+//       case "scratch": {
+//         const { noteName } = DendronClientUtilsV2.genNoteName("SCRATCH", {
+//           overrides: { domain: quickPickValue },
+//         });
+//         onUpdateValue = noteName;
+//         onUpdateReason = "updatePickerBehavior:scratch";
+//         break;
+//       }
+//       default:
+//         if (quickPickValue !== undefined) {
+//           onUpdateValue = quickPickValue;
+//         } else {
+//           const editorPath =
+//             vscode.window.activeTextEditor?.document.uri.fsPath;
+//           if (editorPath && this.opts.flavor !== "schema") {
+//             onUpdateValue = path.basename(editorPath, ".md");
+//           } else {
+//             onUpdateValue = "";
+//           }
+//         }
+//         onUpdateReason = "updatePickerBehavior:normal";
+//     }
+//     if (!_.isUndefined(suffix)) {
+//       onUpdateValue = [onUpdateValue, suffix].join(".");
+//     }
+//     quickPick.value = onUpdateValue;
+//     const tokenSource = this.createCancelSource();
+//     await provider.onUpdatePickerItem(
+//       quickPick,
+//       provider.opts,
+//       onUpdateReason,
+//       tokenSource.token
+//     );
+//   }
 
-  async updateBehaviorByEffect({
-    quickPick,
-  }: {
-    quickPick: DendronQuickPickerV2;
-  }) {
-    const effectResp = _.filter(
-      quickPick.buttons,
-      (ent) => getButtonCategory(ent) === "effect"
-    );
-    await Promise.all(
-      effectResp.map(async (effect) => {
-        return effect.onEnable({ quickPick });
-      })
-    );
-  }
+//   async updateBehaviorByEffect({
+//     quickPick,
+//   }: {
+//     quickPick: DendronQuickPickerV2;
+//   }) {
+//     const effectResp = _.filter(
+//       quickPick.buttons,
+//       (ent) => getButtonCategory(ent) === "effect"
+//     );
+//     await Promise.all(
+//       effectResp.map(async (effect) => {
+//         return effect.onEnable({ quickPick });
+//       })
+//     );
+//   }
 
-  async updatePickerBehavior(opts: {
-    quickPick: DendronQuickPickerV2;
-    document?: vscode.TextDocument;
-    range?: vscode.Range;
-    quickPickValue?: string;
-    provider: LookupProviderV2;
-    changed?: DendronBtn;
-    vaultSelectionMode?: VaultSelectionMode;
-  }) {
-    const ctx = "updatePickerBehavior";
-    const ws = getWS();
-    const { document, range, quickPick, quickPickValue, provider, changed } =
-      opts;
-    const buttons = this.state.buttons;
-    // get all pressed buttons
-    const resp = _.filter(buttons, { pressed: true });
-    Logger.info({ ctx, activeButtons: resp });
-    const noteResp = _.find(resp, (ent) => getButtonCategory(ent) === "note");
-    // collect info
-    const selectionResp = _.find(
-      resp,
-      (ent) => getButtonCategory(ent) === "selection"
-    );
-    const filterResp = _.find(
-      resp,
-      (ent) => getButtonCategory(ent) === "filter"
-    );
-    const selection2LinkChanged = changed?.type === "selection2link";
+//   async updatePickerBehavior(opts: {
+//     quickPick: DendronQuickPickerV2;
+//     document?: vscode.TextDocument;
+//     range?: vscode.Range;
+//     quickPickValue?: string;
+//     provider: LookupProviderV2;
+//     changed?: DendronBtn;
+//     vaultSelectionMode?: VaultSelectionMode;
+//   }) {
+//     const ctx = "updatePickerBehavior";
+//     const ws = getWS();
+//     const { document, range, quickPick, quickPickValue, provider, changed } =
+//       opts;
+//     const buttons = this.state.buttons;
+//     // get all pressed buttons
+//     const resp = _.filter(buttons, { pressed: true });
+//     Logger.info({ ctx, activeButtons: resp });
+//     const noteResp = _.find(resp, (ent) => getButtonCategory(ent) === "note");
+//     // collect info
+//     const selectionResp = _.find(
+//       resp,
+//       (ent) => getButtonCategory(ent) === "selection"
+//     );
+//     const filterResp = _.find(
+//       resp,
+//       (ent) => getButtonCategory(ent) === "filter"
+//     );
+//     const selection2LinkChanged = changed?.type === "selection2link";
 
-    // handle effect resp
-    await this.updateBehaviorByEffect({ quickPick });
+//     // handle effect resp
+//     await this.updateBehaviorByEffect({ quickPick });
 
-    // handle note resp, requires updating picker value
-    if (
-      !changed ||
-      (changed && getButtonCategory(changed) === "note") ||
-      selection2LinkChanged
-    ) {
-      this.updateBehaviorByNoteType({
-        noteResp,
-        quickPick,
-        provider,
-        quickPickValue,
-      });
-    }
+//     // handle note resp, requires updating picker value
+//     if (
+//       !changed ||
+//       (changed && getButtonCategory(changed) === "note") ||
+//       selection2LinkChanged
+//     ) {
+//       this.updateBehaviorByNoteType({
+//         noteResp,
+//         quickPick,
+//         provider,
+//         quickPickValue,
+//       });
+//     }
 
-    // handle selection resp
-    quickPick.onCreate = async (note: NoteProps) => {
-      const vaultSelection = await PickerUtilsV2.getOrPromptVaultForNewNote({
-        vault: note.vault,
-        fname: note.fname,
-        vaultSelectionMode: opts.vaultSelectionMode,
-      });
+//     // handle selection resp
+//     quickPick.onCreate = async (note: NoteProps) => {
+//       const vaultSelection = await PickerUtilsV2.getOrPromptVaultForNewNote({
+//         vault: note.vault,
+//         fname: note.fname,
+//         vaultSelectionMode: opts.vaultSelectionMode,
+//       });
 
-      if (_.isUndefined(vaultSelection)) {
-        vscode.window.showInformationMessage("Note creation cancelled");
-        return undefined;
-      }
-      note.vault = vaultSelection;
+//       if (_.isUndefined(vaultSelection)) {
+//         vscode.window.showInformationMessage("Note creation cancelled");
+//         return undefined;
+//       }
+//       note.vault = vaultSelection;
 
-      switch (selectionResp?.type) {
-        case "selectionExtract": {
-          if (!_.isUndefined(document)) {
-            const body = "\n" + document.getText(range).trim();
-            note.body = body;
-            // don't delete if original file is not in workspace
-            if (!ws.workspaceService?.isPathInWorkspace(document.uri.fsPath)) {
-              return note;
-            }
-            await VSCodeUtils.deleteRange(document, range as vscode.Range);
-          }
-          return note;
-        }
-        case "selection2link": {
-          if (!_.isUndefined(document)) {
-            const editor = VSCodeUtils.getActiveTextEditor();
-            const { selection, text } = VSCodeUtils.getSelection();
-            await editor?.edit((builder) => {
-              const link = note.fname;
-              if (!_.isUndefined(selection) && !selection.isEmpty) {
-                builder.replace(selection, `[[${text}|${link}]]`);
-              }
-            });
-          }
-          return note;
-        }
-        default: {
-          quickPick.onCreate = async () => {
-            return undefined;
-          };
-          return undefined;
-        }
-      }
-    };
+//       switch (selectionResp?.type) {
+//         case "selectionExtract": {
+//           if (!_.isUndefined(document)) {
+//             const body = "\n" + document.getText(range).trim();
+//             note.body = body;
+//             // don't delete if original file is not in workspace
+//             if (!ws.workspaceService?.isPathInWorkspace(document.uri.fsPath)) {
+//               return note;
+//             }
+//             await VSCodeUtils.deleteRange(document, range as vscode.Range);
+//           }
+//           return note;
+//         }
+//         case "selection2link": {
+//           if (!_.isUndefined(document)) {
+//             const editor = VSCodeUtils.getActiveTextEditor();
+//             const { selection, text } = VSCodeUtils.getSelection();
+//             await editor?.edit((builder) => {
+//               const link = note.fname;
+//               if (!_.isUndefined(selection) && !selection.isEmpty) {
+//                 builder.replace(selection, `[[${text}|${link}]]`);
+//               }
+//             });
+//           }
+//           return note;
+//         }
+//         default: {
+//           quickPick.onCreate = async () => {
+//             return undefined;
+//           };
+//           return undefined;
+//         }
+//       }
+//     };
 
-    // handle filter resp
-    const before = quickPick.showDirectChildrenOnly;
-    if (filterResp) {
-      quickPick.showDirectChildrenOnly = true;
-    } else {
-      quickPick.showDirectChildrenOnly = false;
-    }
-    if (!_.isUndefined(before) && quickPick.showDirectChildrenOnly !== before) {
-      Logger.info({ ctx, msg: "toggle showDirectChildOnly behavior" });
-      const tokenSource = this.createCancelSource();
-      await provider.onUpdatePickerItem(
-        quickPick,
-        provider.opts,
-        UPDATET_SOURCE.UPDATE_PICKER_FILTER,
-        tokenSource.token
-      );
-    }
-  }
-}
+//     // handle filter resp
+//     const before = quickPick.showDirectChildrenOnly;
+//     if (filterResp) {
+//       quickPick.showDirectChildrenOnly = true;
+//     } else {
+//       quickPick.showDirectChildrenOnly = false;
+//     }
+//     if (!_.isUndefined(before) && quickPick.showDirectChildrenOnly !== before) {
+//       Logger.info({ ctx, msg: "toggle showDirectChildOnly behavior" });
+//       const tokenSource = this.createCancelSource();
+//       await provider.onUpdatePickerItem(
+//         quickPick,
+//         provider.opts,
+//         UPDATET_SOURCE.UPDATE_PICKER_FILTER,
+//         tokenSource.token
+//       );
+//     }
+//   }
+// }

--- a/packages/plugin-core/src/components/lookup/LookupProviderV2.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV2.ts
@@ -1,849 +1,849 @@
-import {
-  DendronError,
-  DEngineClient,
-  DNodeProps,
-  DNodePropsDict,
-  DNodePropsQuickInputV2,
-  DNodeUtils,
-  DVault,
-  getStage,
-  NoteProps,
-  NoteUtils,
-  SchemaModuleProps,
-  SchemaUtils,
-  VaultUtils,
-  VSCodeEvents,
-} from "@dendronhq/common-all";
-import { getDurationMilliseconds, vault2Path } from "@dendronhq/common-server";
-import _, { DebouncedFunc } from "lodash";
-import { CancellationToken, Uri, window } from "vscode";
-import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
-import { Logger } from "../../logger";
-import { EngineFlavor, EngineOpts } from "../../types";
-import { AnalyticsUtils } from "../../utils/analytics";
-import { DendronWorkspace, getEngine, getWS } from "../../workspace";
-import { MORE_RESULTS_LABEL } from "./constants";
-import { LookupControllerV2 } from "./LookupControllerV2";
-import { DendronQuickPickerV2 } from "./types";
-import {
-  node2Uri,
-  NotePickerUtils,
-  PickerUtilsV2,
-  showDocAndHidePicker,
-} from "./utils";
+// import {
+//   DendronError,
+//   DEngineClient,
+//   DNodeProps,
+//   DNodePropsDict,
+//   DNodePropsQuickInputV2,
+//   DNodeUtils,
+//   DVault,
+//   getStage,
+//   NoteProps,
+//   NoteUtils,
+//   SchemaModuleProps,
+//   SchemaUtils,
+//   VaultUtils,
+//   VSCodeEvents,
+// } from "@dendronhq/common-all";
+// import { getDurationMilliseconds, vault2Path } from "@dendronhq/common-server";
+// import _, { DebouncedFunc } from "lodash";
+// import { CancellationToken, Uri, window } from "vscode";
+// import { LookupNoteTypeEnum } from "../../commands/LookupCommand";
+// import { Logger } from "../../logger";
+// import { EngineFlavor, EngineOpts } from "../../types";
+// import { AnalyticsUtils } from "../../utils/analytics";
+// import { DendronWorkspace, getEngine, getWS } from "../../workspace";
+// import { MORE_RESULTS_LABEL } from "./constants";
+// import { LookupControllerV2 } from "./LookupControllerV2";
+// import { DendronQuickPickerV2 } from "./types";
+// import {
+//   node2Uri,
+//   NotePickerUtils,
+//   PickerUtilsV2,
+//   showDocAndHidePicker,
+// } from "./utils";
 
-const PAGINATE_LIMIT = 50;
-type OnDidAcceptReturn = Promise<
-  | {
-      uris: Uri[];
-      node: NoteProps | SchemaModuleProps | undefined;
-      resp?: any;
-    }
-  | undefined
->;
-type OnDidAcceptNewNodeReturn = Promise<
-  | {
-      uri: Uri;
-      node: NoteProps | SchemaModuleProps;
-      resp?: any | undefined;
-    }
-  | undefined
->;
+// const PAGINATE_LIMIT = 50;
+// type OnDidAcceptReturn = Promise<
+//   | {
+//       uris: Uri[];
+//       node: NoteProps | SchemaModuleProps | undefined;
+//       resp?: any;
+//     }
+//   | undefined
+// >;
+// type OnDidAcceptNewNodeReturn = Promise<
+//   | {
+//       uri: Uri;
+//       node: NoteProps | SchemaModuleProps;
+//       resp?: any | undefined;
+//     }
+//   | undefined
+// >;
 
-// utils
+// // utils
 
-type NoteOverride = {
-  title?: string;
-};
-function checkAndCreateNoteOverrides(opts: {
-  lc: LookupControllerV2;
-  pickerValue: string;
-}): NoteOverride {
-  const { lc, pickerValue } = opts;
-  const titleOverride = _.filter(lc.state.buttons, (ent) =>
-    _.includes(Object.values(LookupNoteTypeEnum), ent.type as any)
-  );
-  if (!_.isEmpty(titleOverride)) {
-    const button = titleOverride[0];
-    // journal or scratch
-    if (button.type === LookupNoteTypeEnum.journal) {
-      const journalName = getWS().config.journal.name;
-      const journalIndex = pickerValue.indexOf(journalName);
-      if (journalIndex < 0) {
-        return {};
-      }
-      const maybeDatePortion = pickerValue.slice(
-        journalIndex + journalName.length + 1
-      );
-      if (maybeDatePortion.match(/\d\d\d\d\.\d\d\.\d\d$/)) {
-        return {
-          title: maybeDatePortion.replace(/\./g, "-"),
-        };
-      }
-      return {};
-    }
-  }
-  return {};
-}
+// type NoteOverride = {
+//   title?: string;
+// };
+// function checkAndCreateNoteOverrides(opts: {
+//   lc: LookupControllerV2;
+//   pickerValue: string;
+// }): NoteOverride {
+//   const { lc, pickerValue } = opts;
+//   const titleOverride = _.filter(lc.state.buttons, (ent) =>
+//     _.includes(Object.values(LookupNoteTypeEnum), ent.type as any)
+//   );
+//   if (!_.isEmpty(titleOverride)) {
+//     const button = titleOverride[0];
+//     // journal or scratch
+//     if (button.type === LookupNoteTypeEnum.journal) {
+//       const journalName = getWS().config.journal.name;
+//       const journalIndex = pickerValue.indexOf(journalName);
+//       if (journalIndex < 0) {
+//         return {};
+//       }
+//       const maybeDatePortion = pickerValue.slice(
+//         journalIndex + journalName.length + 1
+//       );
+//       if (maybeDatePortion.match(/\d\d\d\d\.\d\d\.\d\d$/)) {
+//         return {
+//           title: maybeDatePortion.replace(/\./g, "-"),
+//         };
+//       }
+//       return {};
+//     }
+//   }
+//   return {};
+// }
 
-export class LookupProviderV2 {
-  public opts: EngineOpts;
-  protected onDidChangeValueDebounced?: DebouncedFunc<
-    InstanceType<typeof LookupProviderV2>["onUpdatePickerItem"]
-  >;
+// export class LookupProviderV2 {
+//   public opts: EngineOpts;
+//   protected onDidChangeValueDebounced?: DebouncedFunc<
+//     InstanceType<typeof LookupProviderV2>["onUpdatePickerItem"]
+//   >;
 
-  constructor(opts: EngineOpts) {
-    this.opts = opts;
-  }
+//   constructor(opts: EngineOpts) {
+//     this.opts = opts;
+//   }
 
-  createDefaultItems = ({ picker }: { picker: DendronQuickPickerV2 }) => {
-    const out = [];
-    if (_.find(picker.buttons, { type: "multiSelect" })?.pressed) {
-      return [];
-    } else {
-      out.push(
-        NotePickerUtils.createNoActiveItem(
-          PickerUtilsV2.getVaultForOpenEditor()
-        )
-      );
-    }
-    // if (picker.moreResults) {
-    //   out.push(createMoreResults());
-    // }
-    return out;
-  };
+//   createDefaultItems = ({ picker }: { picker: DendronQuickPickerV2 }) => {
+//     const out = [];
+//     if (_.find(picker.buttons, { type: "multiSelect" })?.pressed) {
+//       return [];
+//     } else {
+//       out.push(
+//         NotePickerUtils.createNoActiveItem(
+//           PickerUtilsV2.getVaultForOpenEditor()
+//         )
+//       );
+//     }
+//     // if (picker.moreResults) {
+//     //   out.push(createMoreResults());
+//     // }
+//     return out;
+//   };
 
-  async _onAcceptNewNote({
-    picker,
-    selectedItem,
-    overrides,
-  }: {
-    picker: DendronQuickPickerV2;
-    selectedItem: DNodePropsQuickInputV2;
-    overrides?: NoteOverride;
-  }): OnDidAcceptNewNodeReturn {
-    const ctx = "onAcceptNewNode";
-    const fname = PickerUtilsV2.getValue(picker);
-    Logger.info({ ctx, msg: "createNewPick", value: fname });
-    let nodeNew: DNodeProps;
-    let foundStub = false;
-    const ws = DendronWorkspace.instance();
-    const engine = ws.getEngine();
-    if (selectedItem?.stub) {
-      Logger.info({ ctx, msg: "create stub" });
-      nodeNew = engine.notes[selectedItem.id];
-      nodeNew.stub = false;
-      foundStub = true;
-    } else if (selectedItem?.schemaStub) {
-      Logger.info({ ctx, msg: "create schema stub" });
-      selectedItem.schemaStub = false;
-      nodeNew = selectedItem;
-    } else {
-      const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-      Logger.info({ ctx, msg: "create normal node" });
-      nodeNew = NoteUtils.create({ fname, vault });
-      const result = SchemaUtils.matchPath({
-        notePath: fname,
-        schemaModDict: engine.schemas,
-      });
-      if (result) {
-        NoteUtils.addSchema({
-          note: nodeNew,
-          schemaModule: result.schemaModule,
-          schema: result.schema,
-        });
-      }
-      Logger.info({ ctx, msg: "post:maybeAddSchema", schema: result });
-    }
-    const maybeSchema = SchemaUtils.getSchemaFromNote({
-      note: nodeNew,
-      engine,
-    });
-    const maybeTemplate =
-      maybeSchema?.schemas[nodeNew.schema?.schemaId as string].data.template;
-    if (maybeSchema && maybeTemplate) {
-      SchemaUtils.applyTemplate({
-        template: maybeTemplate,
-        note: nodeNew,
-        engine,
-      });
-    }
-    // modify note title if necessary
+//   async _onAcceptNewNote({
+//     picker,
+//     selectedItem,
+//     overrides,
+//   }: {
+//     picker: DendronQuickPickerV2;
+//     selectedItem: DNodePropsQuickInputV2;
+//     overrides?: NoteOverride;
+//   }): OnDidAcceptNewNodeReturn {
+//     const ctx = "onAcceptNewNode";
+//     const fname = PickerUtilsV2.getValue(picker);
+//     Logger.info({ ctx, msg: "createNewPick", value: fname });
+//     let nodeNew: DNodeProps;
+//     let foundStub = false;
+//     const ws = DendronWorkspace.instance();
+//     const engine = ws.getEngine();
+//     if (selectedItem?.stub) {
+//       Logger.info({ ctx, msg: "create stub" });
+//       nodeNew = engine.notes[selectedItem.id];
+//       nodeNew.stub = false;
+//       foundStub = true;
+//     } else if (selectedItem?.schemaStub) {
+//       Logger.info({ ctx, msg: "create schema stub" });
+//       selectedItem.schemaStub = false;
+//       nodeNew = selectedItem;
+//     } else {
+//       const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
+//       Logger.info({ ctx, msg: "create normal node" });
+//       nodeNew = NoteUtils.create({ fname, vault });
+//       const result = SchemaUtils.matchPath({
+//         notePath: fname,
+//         schemaModDict: engine.schemas,
+//       });
+//       if (result) {
+//         NoteUtils.addSchema({
+//           note: nodeNew,
+//           schemaModule: result.schemaModule,
+//           schema: result.schema,
+//         });
+//       }
+//       Logger.info({ ctx, msg: "post:maybeAddSchema", schema: result });
+//     }
+//     const maybeSchema = SchemaUtils.getSchemaFromNote({
+//       note: nodeNew,
+//       engine,
+//     });
+//     const maybeTemplate =
+//       maybeSchema?.schemas[nodeNew.schema?.schemaId as string].data.template;
+//     if (maybeSchema && maybeTemplate) {
+//       SchemaUtils.applyTemplate({
+//         template: maybeTemplate,
+//         note: nodeNew,
+//         engine,
+//       });
+//     }
+//     // modify note title if necessary
 
-    if (overrides && overrides.title) {
-      nodeNew.title = overrides.title;
-    }
-    Logger.info({ ctx, msg: "pre:checkNoteExist" });
-    // TODO: check for overwriting schema
-    const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-    const noteExists = NoteUtils.getNoteByFnameV5({
-      fname: nodeNew.fname,
-      vault,
-      notes: engine.notes,
-      wsRoot: DendronWorkspace.wsRoot(),
-    }) as NoteProps;
-    if (
-      noteExists &&
-      !foundStub &&
-      !selectedItem?.schemaStub &&
-      VaultUtils.isEqual(
-        nodeNew.vault,
-        noteExists.vault,
-        DendronWorkspace.wsRoot()
-      )
-    ) {
-      Logger.error({ ctx, msg: "action will overwrite existing note" });
-      throw Error("action will overwrite existing note");
-    }
-    if (picker.onCreate) {
-      Logger.info({ ctx, msg: "pre:pickerOnCreate" });
-      const out = await picker.onCreate(nodeNew);
-      if (_.isUndefined(out)) {
-        return;
-      }
-    }
-    // NOTE: this needs to be after picker.onCreate since uri can still be modified at that point
-    let uri = NoteUtils.getURI({
-      note: nodeNew,
-      wsRoot: DendronWorkspace.wsRoot(),
-    });
-    // vscode won't open a URI...
-    uri = Uri.file(uri.fsPath);
-    Logger.info({ ctx, msg: "pre:engine.write", uri });
-    const resp = await engine.writeNote(nodeNew, {
-      newNode: true,
-    });
-    if (resp.error) {
-      Logger.error({ error: resp.error });
-      throw Error();
-    }
-    return { uri, node: nodeNew, resp };
-  }
+//     if (overrides && overrides.title) {
+//       nodeNew.title = overrides.title;
+//     }
+//     Logger.info({ ctx, msg: "pre:checkNoteExist" });
+//     // TODO: check for overwriting schema
+//     const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
+//     const noteExists = NoteUtils.getNoteByFnameV5({
+//       fname: nodeNew.fname,
+//       vault,
+//       notes: engine.notes,
+//       wsRoot: DendronWorkspace.wsRoot(),
+//     }) as NoteProps;
+//     if (
+//       noteExists &&
+//       !foundStub &&
+//       !selectedItem?.schemaStub &&
+//       VaultUtils.isEqual(
+//         nodeNew.vault,
+//         noteExists.vault,
+//         DendronWorkspace.wsRoot()
+//       )
+//     ) {
+//       Logger.error({ ctx, msg: "action will overwrite existing note" });
+//       throw Error("action will overwrite existing note");
+//     }
+//     if (picker.onCreate) {
+//       Logger.info({ ctx, msg: "pre:pickerOnCreate" });
+//       const out = await picker.onCreate(nodeNew);
+//       if (_.isUndefined(out)) {
+//         return;
+//       }
+//     }
+//     // NOTE: this needs to be after picker.onCreate since uri can still be modified at that point
+//     let uri = NoteUtils.getURI({
+//       note: nodeNew,
+//       wsRoot: DendronWorkspace.wsRoot(),
+//     });
+//     // vscode won't open a URI...
+//     uri = Uri.file(uri.fsPath);
+//     Logger.info({ ctx, msg: "pre:engine.write", uri });
+//     const resp = await engine.writeNote(nodeNew, {
+//       newNode: true,
+//     });
+//     if (resp.error) {
+//       Logger.error({ error: resp.error });
+//       throw Error();
+//     }
+//     return { uri, node: nodeNew, resp };
+//   }
 
-  async _onAcceptNewSchema({
-    picker,
-    vault,
-  }: {
-    picker: DendronQuickPickerV2;
-    vault: DVault;
-  }): OnDidAcceptNewNodeReturn {
-    const ctx = "onAcceptNewSchema";
-    const fname = PickerUtilsV2.getValue(picker);
-    Logger.info({ ctx, msg: "createNewPick", value: fname });
-    const ws = DendronWorkspace.instance();
-    const engine = ws.getEngine();
-    Logger.info({ ctx, msg: "create normal node" });
-    const smodNew: SchemaModuleProps = SchemaUtils.createModuleProps({
-      fname,
-      vault,
-    });
-    const vpath = vault2Path({ vault, wsRoot: DendronWorkspace.wsRoot() });
-    const uri = Uri.file(SchemaUtils.getPath({ root: vpath, fname }));
-    const resp = await engine.writeSchema(smodNew);
-    return { uri, node: smodNew, resp };
-  }
+//   async _onAcceptNewSchema({
+//     picker,
+//     vault,
+//   }: {
+//     picker: DendronQuickPickerV2;
+//     vault: DVault;
+//   }): OnDidAcceptNewNodeReturn {
+//     const ctx = "onAcceptNewSchema";
+//     const fname = PickerUtilsV2.getValue(picker);
+//     Logger.info({ ctx, msg: "createNewPick", value: fname });
+//     const ws = DendronWorkspace.instance();
+//     const engine = ws.getEngine();
+//     Logger.info({ ctx, msg: "create normal node" });
+//     const smodNew: SchemaModuleProps = SchemaUtils.createModuleProps({
+//       fname,
+//       vault,
+//     });
+//     const vpath = vault2Path({ vault, wsRoot: DendronWorkspace.wsRoot() });
+//     const uri = Uri.file(SchemaUtils.getPath({ root: vpath, fname }));
+//     const resp = await engine.writeSchema(smodNew);
+//     return { uri, node: smodNew, resp };
+//   }
 
-  async onAcceptNewNode({
-    picker,
-    opts,
-    selectedItem,
-  }: {
-    picker: DendronQuickPickerV2;
-    opts: EngineOpts & { overrides?: NoteOverride };
-    selectedItem: DNodePropsQuickInputV2;
-  }): OnDidAcceptNewNodeReturn {
-    const ctx = "onAcceptNewNode";
-    Logger.info({ ctx });
-    const vault: DVault = PickerUtilsV2.getVaultForOpenEditor();
+//   async onAcceptNewNode({
+//     picker,
+//     opts,
+//     selectedItem,
+//   }: {
+//     picker: DendronQuickPickerV2;
+//     opts: EngineOpts & { overrides?: NoteOverride };
+//     selectedItem: DNodePropsQuickInputV2;
+//   }): OnDidAcceptNewNodeReturn {
+//     const ctx = "onAcceptNewNode";
+//     Logger.info({ ctx });
+//     const vault: DVault = PickerUtilsV2.getVaultForOpenEditor();
 
-    if (opts.flavor === "schema") {
-      return this._onAcceptNewSchema({ picker, vault });
-    } else {
-      return this._onAcceptNewNote({
-        picker,
-        selectedItem,
-        overrides: opts.overrides,
-      });
-    }
-  }
+//     if (opts.flavor === "schema") {
+//       return this._onAcceptNewSchema({ picker, vault });
+//     } else {
+//       return this._onAcceptNewNote({
+//         picker,
+//         selectedItem,
+//         overrides: opts.overrides,
+//       });
+//     }
+//   }
 
-  onDidAccept({
-    picker,
-    opts,
-    lc,
-  }: {
-    picker: DendronQuickPickerV2;
-    opts: EngineOpts;
-    lc: LookupControllerV2;
-  }) {
-    if (this.onDidChangeValueDebounced?.cancel) {
-      this.onDidChangeValueDebounced.cancel();
-    }
-    lc.cancelToken.cancel();
-    if (picker.canSelectMany) {
-      return this.onDidAcceptForMulti(picker, opts);
-    } else {
-      return this.onDidAcceptForSingle(picker, opts, lc);
-    }
-  }
+//   onDidAccept({
+//     picker,
+//     opts,
+//     lc,
+//   }: {
+//     picker: DendronQuickPickerV2;
+//     opts: EngineOpts;
+//     lc: LookupControllerV2;
+//   }) {
+//     if (this.onDidChangeValueDebounced?.cancel) {
+//       this.onDidChangeValueDebounced.cancel();
+//     }
+//     lc.cancelToken.cancel();
+//     if (picker.canSelectMany) {
+//       return this.onDidAcceptForMulti(picker, opts);
+//     } else {
+//       return this.onDidAcceptForSingle(picker, opts, lc);
+//     }
+//   }
 
-  async onDidAcceptForSingle(
-    picker: DendronQuickPickerV2,
-    opts: EngineOpts,
-    lc: LookupControllerV2
-  ): OnDidAcceptReturn {
-    const ctx = "onDidAcceptSingle";
-    const start = process.hrtime();
-    let createNewNote = false;
-    let error = false;
-    try {
-      const value = PickerUtilsV2.getValue(picker);
-      const selectedItems = PickerUtilsV2.getSelection(picker);
-      const selectedItem = selectedItems[0];
+//   async onDidAcceptForSingle(
+//     picker: DendronQuickPickerV2,
+//     opts: EngineOpts,
+//     lc: LookupControllerV2
+//   ): OnDidAcceptReturn {
+//     const ctx = "onDidAcceptSingle";
+//     const start = process.hrtime();
+//     let createNewNote = false;
+//     let error = false;
+//     try {
+//       const value = PickerUtilsV2.getValue(picker);
+//       const selectedItems = PickerUtilsV2.getSelection(picker);
+//       const selectedItem = selectedItems[0];
 
-      const noteOverrides = checkAndCreateNoteOverrides({
-        lc,
-        pickerValue: value,
-      });
+//       const noteOverrides = checkAndCreateNoteOverrides({
+//         lc,
+//         pickerValue: value,
+//       });
 
-      Logger.info({
-        ctx,
-        msg: "enter",
-        value,
-        opts,
-        noteOverrides,
-        selectedItems: selectedItems.map((ent) => NoteUtils.toLogObj(ent)),
-        activeItems: picker.activeItems.map((ent) => NoteUtils.toLogObj(ent)),
-      });
-      const resp = this.validate(picker.value, opts.flavor);
-      let uri: Uri;
-      let newNode: NoteProps | SchemaModuleProps | undefined;
-      if (resp) {
-        window.showErrorMessage(resp);
-        return;
-      }
-      if (selectedItem) {
-        if (PickerUtilsV2.isCreateNewNotePickForSingle(selectedItem)) {
-          createNewNote = true;
-          const acceptResp = await this.onAcceptNewNode({
-            picker,
-            opts: { flavor: opts.flavor, overrides: noteOverrides },
-            selectedItem,
-          });
-          if (_.isUndefined(acceptResp)) {
-            return;
-          }
-          ({ uri, node: newNode } = acceptResp);
-          // TODO: not used
-        } else if (selectedItem.label === MORE_RESULTS_LABEL) {
-          await this.paginatePickerItems({ picker });
-          return;
-        } else {
-          uri = node2Uri(selectedItem);
-          const vpath = vault2Path({
-            vault: selectedItem.vault,
-            wsRoot: DendronWorkspace.wsRoot(),
-          });
-          if (opts.flavor === "schema") {
-            const smod =
-              DendronWorkspace.instance().getEngine().schemas[selectedItem.id];
-            uri = Uri.file(
-              SchemaUtils.getPath({
-                root: vpath,
-                fname: smod.fname,
-              })
-            );
-          }
-        }
-        await showDocAndHidePicker([uri], picker);
-        return { uris: [uri], node: newNode };
-      } else {
-        // item from pressing enter
-        if (opts.flavor === "note") {
-          const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-          const maybeNote = NoteUtils.getNoteByFnameV5({
-            fname: value,
-            vault,
-            notes: getEngine().notes,
-            wsRoot: DendronWorkspace.wsRoot(),
-          });
-          if (maybeNote) {
-            uri = node2Uri(maybeNote);
-            await showDocAndHidePicker([uri], picker);
-            return { uris: [uri], node: maybeNote };
-          } else {
-            error = true;
-            throw new DendronError({ message: `note ${value} not found` });
-          }
-        }
-        return;
-      }
-    } catch (err) {
-      error = true;
-      Logger.error({ ctx, error: err });
-      throw err;
-    } finally {
-      const profile = getDurationMilliseconds(start);
-      AnalyticsUtils.track(VSCodeEvents.Lookup_Accept, {
-        duration: profile,
-        flavor: opts.flavor,
-        createNewNote,
-        error,
-      });
-    }
-  }
+//       Logger.info({
+//         ctx,
+//         msg: "enter",
+//         value,
+//         opts,
+//         noteOverrides,
+//         selectedItems: selectedItems.map((ent) => NoteUtils.toLogObj(ent)),
+//         activeItems: picker.activeItems.map((ent) => NoteUtils.toLogObj(ent)),
+//       });
+//       const resp = this.validate(picker.value, opts.flavor);
+//       let uri: Uri;
+//       let newNode: NoteProps | SchemaModuleProps | undefined;
+//       if (resp) {
+//         window.showErrorMessage(resp);
+//         return;
+//       }
+//       if (selectedItem) {
+//         if (PickerUtilsV2.isCreateNewNotePickForSingle(selectedItem)) {
+//           createNewNote = true;
+//           const acceptResp = await this.onAcceptNewNode({
+//             picker,
+//             opts: { flavor: opts.flavor, overrides: noteOverrides },
+//             selectedItem,
+//           });
+//           if (_.isUndefined(acceptResp)) {
+//             return;
+//           }
+//           ({ uri, node: newNode } = acceptResp);
+//           // TODO: not used
+//         } else if (selectedItem.label === MORE_RESULTS_LABEL) {
+//           await this.paginatePickerItems({ picker });
+//           return;
+//         } else {
+//           uri = node2Uri(selectedItem);
+//           const vpath = vault2Path({
+//             vault: selectedItem.vault,
+//             wsRoot: DendronWorkspace.wsRoot(),
+//           });
+//           if (opts.flavor === "schema") {
+//             const smod =
+//               DendronWorkspace.instance().getEngine().schemas[selectedItem.id];
+//             uri = Uri.file(
+//               SchemaUtils.getPath({
+//                 root: vpath,
+//                 fname: smod.fname,
+//               })
+//             );
+//           }
+//         }
+//         await showDocAndHidePicker([uri], picker);
+//         return { uris: [uri], node: newNode };
+//       } else {
+//         // item from pressing enter
+//         if (opts.flavor === "note") {
+//           const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
+//           const maybeNote = NoteUtils.getNoteByFnameV5({
+//             fname: value,
+//             vault,
+//             notes: getEngine().notes,
+//             wsRoot: DendronWorkspace.wsRoot(),
+//           });
+//           if (maybeNote) {
+//             uri = node2Uri(maybeNote);
+//             await showDocAndHidePicker([uri], picker);
+//             return { uris: [uri], node: maybeNote };
+//           } else {
+//             error = true;
+//             throw new DendronError({ message: `note ${value} not found` });
+//           }
+//         }
+//         return;
+//       }
+//     } catch (err) {
+//       error = true;
+//       Logger.error({ ctx, error: err });
+//       throw err;
+//     } finally {
+//       const profile = getDurationMilliseconds(start);
+//       AnalyticsUtils.track(VSCodeEvents.Lookup_Accept, {
+//         duration: profile,
+//         flavor: opts.flavor,
+//         createNewNote,
+//         error,
+//       });
+//     }
+//   }
 
-  async onDidAcceptForMulti(
-    picker: DendronQuickPickerV2,
-    opts: EngineOpts
-  ): OnDidAcceptReturn {
-    const ctx = "onDidAccept";
-    const value = PickerUtilsV2.getValue(picker);
-    Logger.info({ ctx, msg: "enter", value, opts });
-    let selectedItems = PickerUtilsV2.getSelection(picker);
-    const resp = this.validate(picker.value, opts.flavor);
-    let uris: Uri[];
-    if (resp) {
-      window.showErrorMessage(resp);
-      return;
-    }
+//   async onDidAcceptForMulti(
+//     picker: DendronQuickPickerV2,
+//     opts: EngineOpts
+//   ): OnDidAcceptReturn {
+//     const ctx = "onDidAccept";
+//     const value = PickerUtilsV2.getValue(picker);
+//     Logger.info({ ctx, msg: "enter", value, opts });
+//     let selectedItems = PickerUtilsV2.getSelection(picker);
+//     const resp = this.validate(picker.value, opts.flavor);
+//     let uris: Uri[];
+//     if (resp) {
+//       window.showErrorMessage(resp);
+//       return;
+//     }
 
-    // check if we get note by quickpick value instead of selection
-    const activeItem = picker.activeItems[0];
-    const maybeNoteFname = activeItem ? activeItem.fname : value;
-    const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-    const maybeNote = NoteUtils.getNoteByFnameV5({
-      fname: maybeNoteFname,
-      vault,
-      notes: getEngine().notes,
-      wsRoot: DendronWorkspace.wsRoot(),
-    }) as NoteProps;
-    if (_.isEmpty(selectedItems) && opts.flavor === "note") {
-      if (maybeNote) {
-        if (maybeNote.stub) {
-          selectedItems = [...picker.activeItems];
-        } else {
-          uris = [node2Uri(maybeNote)];
-          await showDocAndHidePicker(uris, picker);
-          return;
-        }
-      } else {
-        selectedItems = [];
-      }
-    }
+//     // check if we get note by quickpick value instead of selection
+//     const activeItem = picker.activeItems[0];
+//     const maybeNoteFname = activeItem ? activeItem.fname : value;
+//     const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
+//     const maybeNote = NoteUtils.getNoteByFnameV5({
+//       fname: maybeNoteFname,
+//       vault,
+//       notes: getEngine().notes,
+//       wsRoot: DendronWorkspace.wsRoot(),
+//     }) as NoteProps;
+//     if (_.isEmpty(selectedItems) && opts.flavor === "note") {
+//       if (maybeNote) {
+//         if (maybeNote.stub) {
+//           selectedItems = [...picker.activeItems];
+//         } else {
+//           uris = [node2Uri(maybeNote)];
+//           await showDocAndHidePicker(uris, picker);
+//           return;
+//         }
+//       } else {
+//         selectedItems = [];
+//       }
+//     }
 
-    // get note by selection
-    const isCreateNew =
-      _.some(selectedItems.map(PickerUtilsV2.isCreateNewNotePick)) ||
-      _.isEmpty(selectedItems);
-    if (isCreateNew && selectedItems.length > 1) {
-      window.showErrorMessage(`cannot create new note when multi-select is on`);
-      return;
-    }
-    if (isCreateNew) {
-      const newNode = await this.onAcceptNewNode({
-        picker,
-        opts,
-        selectedItem: selectedItems[0],
-      });
-      if (!newNode) {
-        return;
-      }
-      uris = [newNode.uri];
-    } else if (opts.flavor === "schema") {
-      const smods = selectedItems.map(
-        (item) => DendronWorkspace.instance().getEngine().schemas[item.id]
-      );
-      uris = smods.map((smod) =>
-        Uri.file(
-          SchemaUtils.getPath({
-            root: vault2Path({
-              vault: smod.vault,
-              wsRoot: DendronWorkspace.wsRoot(),
-            }),
-            fname: smod.fname,
-          })
-        )
-      );
-    } else {
-      uris = selectedItems.map((item) => node2Uri(item));
-    }
-    await showDocAndHidePicker(uris, picker);
-    return;
-  }
+//     // get note by selection
+//     const isCreateNew =
+//       _.some(selectedItems.map(PickerUtilsV2.isCreateNewNotePick)) ||
+//       _.isEmpty(selectedItems);
+//     if (isCreateNew && selectedItems.length > 1) {
+//       window.showErrorMessage(`cannot create new note when multi-select is on`);
+//       return;
+//     }
+//     if (isCreateNew) {
+//       const newNode = await this.onAcceptNewNode({
+//         picker,
+//         opts,
+//         selectedItem: selectedItems[0],
+//       });
+//       if (!newNode) {
+//         return;
+//       }
+//       uris = [newNode.uri];
+//     } else if (opts.flavor === "schema") {
+//       const smods = selectedItems.map(
+//         (item) => DendronWorkspace.instance().getEngine().schemas[item.id]
+//       );
+//       uris = smods.map((smod) =>
+//         Uri.file(
+//           SchemaUtils.getPath({
+//             root: vault2Path({
+//               vault: smod.vault,
+//               wsRoot: DendronWorkspace.wsRoot(),
+//             }),
+//             fname: smod.fname,
+//           })
+//         )
+//       );
+//     } else {
+//       uris = selectedItems.map((item) => node2Uri(item));
+//     }
+//     await showDocAndHidePicker(uris, picker);
+//     return;
+//   }
 
-  paginatePickerItems = async (opts: { picker: DendronQuickPickerV2 }) => {
-    const { picker } = opts;
-    const allResults = opts.picker.allResults;
-    const { offset } = picker as { offset: number };
-    const engine = getWS().getEngine();
-    const newItems = allResults!
-      .slice(offset, offset + PAGINATE_LIMIT)
-      .map((ent) =>
-        DNodeUtils.enhancePropForQuickInput({
-          wsRoot: DendronWorkspace.wsRoot(),
-          props: ent,
-          schemas: engine.schemas,
-          vaults: DendronWorkspace.instance().vaultsv4,
-        })
-      );
-    let oldItems = [...picker.items];
-    // update state
-    picker.offset = picker.offset! + PAGINATE_LIMIT;
-    // no more results
-    if (newItems.length <= picker.offset) {
-      oldItems = _.reject(oldItems, (ent) => ent.label === MORE_RESULTS_LABEL);
-      picker.moreResults = false;
-    }
-    picker.items = oldItems.concat(newItems);
-    picker.activeItems = picker.items;
-  };
+//   paginatePickerItems = async (opts: { picker: DendronQuickPickerV2 }) => {
+//     const { picker } = opts;
+//     const allResults = opts.picker.allResults;
+//     const { offset } = picker as { offset: number };
+//     const engine = getWS().getEngine();
+//     const newItems = allResults!
+//       .slice(offset, offset + PAGINATE_LIMIT)
+//       .map((ent) =>
+//         DNodeUtils.enhancePropForQuickInput({
+//           wsRoot: DendronWorkspace.wsRoot(),
+//           props: ent,
+//           schemas: engine.schemas,
+//           vaults: DendronWorkspace.instance().vaultsv4,
+//         })
+//       );
+//     let oldItems = [...picker.items];
+//     // update state
+//     picker.offset = picker.offset! + PAGINATE_LIMIT;
+//     // no more results
+//     if (newItems.length <= picker.offset) {
+//       oldItems = _.reject(oldItems, (ent) => ent.label === MORE_RESULTS_LABEL);
+//       picker.moreResults = false;
+//     }
+//     picker.items = oldItems.concat(newItems);
+//     picker.activeItems = picker.items;
+//   };
 
-  async createPickerItemsFromEngine(opts: {
-    flavor: EngineFlavor;
-    picker: DendronQuickPickerV2;
-    qs: string;
-    depth?: number;
-  }) {
-    const ctx = "createPickerItemsFromEngine";
-    const start = process.hrtime();
-    const { picker, qs } = opts;
-    const engine = getWS().getEngine();
-    Logger.info({ ctx, msg: "first query" });
-    let nodes: DNodeProps[];
-    if (opts.flavor === "note") {
-      // if we are doing a query, reset pagination options
-      PickerUtilsV2.resetPaginationOpts(picker);
-      // eslint-disable-next-line no-useless-catch
-      try {
-        const resp = await engine.queryNotes({ qs });
-        if (opts.depth) {
-          nodes = resp.data.filter((ent) => {
-            return DNodeUtils.getDepth(ent) === opts.depth!;
-          }).filter((ent) => !ent.stub);
-        } else {
-          nodes = resp.data;
-        }
-        Logger.info({ ctx, msg: "post:queryNotes" });
-      } catch (err) {
-        throw err;
-      }
-    } else {
-      const resp = await engine.querySchema(qs);
-      nodes = resp.data.map((ent) => SchemaUtils.getModuleRoot(ent));
-    }
-    if (nodes.length > PAGINATE_LIMIT) {
-      picker.allResults = nodes;
-      picker.offset = PAGINATE_LIMIT;
-      picker.moreResults = true;
-      nodes = nodes.slice(0, PAGINATE_LIMIT);
-    } else {
-      PickerUtilsV2.resetPaginationOpts(picker);
-    }
-    const updatedItems = this.createDefaultItems({ picker }).concat(
-      await Promise.all(
-        nodes.map(async (ent) =>
-          DNodeUtils.enhancePropForQuickInput({
-            wsRoot: DendronWorkspace.wsRoot(),
-            props: ent,
-            schemas: engine.schemas,
-            vaults: DendronWorkspace.instance().vaultsv4,
-          })
-        )
-      )
-    );
-    const profile = getDurationMilliseconds(start);
-    Logger.info({ ctx, msg: "engine.query", profile });
-    return updatedItems;
-  }
+//   async createPickerItemsFromEngine(opts: {
+//     flavor: EngineFlavor;
+//     picker: DendronQuickPickerV2;
+//     qs: string;
+//     depth?: number;
+//   }) {
+//     const ctx = "createPickerItemsFromEngine";
+//     const start = process.hrtime();
+//     const { picker, qs } = opts;
+//     const engine = getWS().getEngine();
+//     Logger.info({ ctx, msg: "first query" });
+//     let nodes: DNodeProps[];
+//     if (opts.flavor === "note") {
+//       // if we are doing a query, reset pagination options
+//       PickerUtilsV2.resetPaginationOpts(picker);
+//       // eslint-disable-next-line no-useless-catch
+//       try {
+//         const resp = await engine.queryNotes({ qs });
+//         if (opts.depth) {
+//           nodes = resp.data.filter((ent) => {
+//             return DNodeUtils.getDepth(ent) === opts.depth!;
+//           }).filter((ent) => !ent.stub);
+//         } else {
+//           nodes = resp.data;
+//         }
+//         Logger.info({ ctx, msg: "post:queryNotes" });
+//       } catch (err) {
+//         throw err;
+//       }
+//     } else {
+//       const resp = await engine.querySchema(qs);
+//       nodes = resp.data.map((ent) => SchemaUtils.getModuleRoot(ent));
+//     }
+//     if (nodes.length > PAGINATE_LIMIT) {
+//       picker.allResults = nodes;
+//       picker.offset = PAGINATE_LIMIT;
+//       picker.moreResults = true;
+//       nodes = nodes.slice(0, PAGINATE_LIMIT);
+//     } else {
+//       PickerUtilsV2.resetPaginationOpts(picker);
+//     }
+//     const updatedItems = this.createDefaultItems({ picker }).concat(
+//       await Promise.all(
+//         nodes.map(async (ent) =>
+//           DNodeUtils.enhancePropForQuickInput({
+//             wsRoot: DendronWorkspace.wsRoot(),
+//             props: ent,
+//             schemas: engine.schemas,
+//             vaults: DendronWorkspace.instance().vaultsv4,
+//           })
+//         )
+//       )
+//     );
+//     const profile = getDurationMilliseconds(start);
+//     Logger.info({ ctx, msg: "engine.query", profile });
+//     return updatedItems;
+//   }
 
-  onUpdatePickerItem = async (
-    picker: DendronQuickPickerV2,
-    opts: EngineOpts & { force?: boolean },
-    source: string,
-    token: CancellationToken
-    // | "updatePickerBehavior:journal"
-    // | "updatePickerBehavior:scratch"
-    // | "updatePickerBehavior:normal"
-    // | "onValueChange"
-    // | "manual"
-  ) => {
-    // ~~~ setup variables
-    const start = process.hrtime();
-    const ctx = "updatePickerItems";
-    picker.busy = true;
-    let pickerValue = picker.value;
-    // if we just started, show all results of current parent
-    if (picker._justActivated && !picker.nonInteractive) {
-      // no hiearchy, query everything
-      const lastDotIndex = pickerValue.lastIndexOf(".");
-      if (lastDotIndex < 0) {
-        pickerValue = "";
-      } else {
-        // assume query from last dot
-        pickerValue = pickerValue.slice(0, lastDotIndex + 1);
-      }
-    }
-    const querystring = PickerUtilsV2.slashToDot(pickerValue);
-    const queryOrig = PickerUtilsV2.slashToDot(picker.value);
-    const depth = queryOrig.split(".").length;
-    const ws = DendronWorkspace.instance();
-    let profile: number;
-    const queryEndsWithDot = queryOrig.endsWith(".");
-    const queryUpToLastDot =
-      queryOrig.lastIndexOf(".") >= 0
-        ? queryOrig.slice(0, queryOrig.lastIndexOf("."))
-        : undefined;
+//   onUpdatePickerItem = async (
+//     picker: DendronQuickPickerV2,
+//     opts: EngineOpts & { force?: boolean },
+//     source: string,
+//     token: CancellationToken
+//     // | "updatePickerBehavior:journal"
+//     // | "updatePickerBehavior:scratch"
+//     // | "updatePickerBehavior:normal"
+//     // | "onValueChange"
+//     // | "manual"
+//   ) => {
+//     // ~~~ setup variables
+//     const start = process.hrtime();
+//     const ctx = "updatePickerItems";
+//     picker.busy = true;
+//     let pickerValue = picker.value;
+//     // if we just started, show all results of current parent
+//     if (picker._justActivated && !picker.nonInteractive) {
+//       // no hiearchy, query everything
+//       const lastDotIndex = pickerValue.lastIndexOf(".");
+//       if (lastDotIndex < 0) {
+//         pickerValue = "";
+//       } else {
+//         // assume query from last dot
+//         pickerValue = pickerValue.slice(0, lastDotIndex + 1);
+//       }
+//     }
+//     const querystring = PickerUtilsV2.slashToDot(pickerValue);
+//     const queryOrig = PickerUtilsV2.slashToDot(picker.value);
+//     const depth = queryOrig.split(".").length;
+//     const ws = DendronWorkspace.instance();
+//     let profile: number;
+//     const queryEndsWithDot = queryOrig.endsWith(".");
+//     const queryUpToLastDot =
+//       queryOrig.lastIndexOf(".") >= 0
+//         ? queryOrig.slice(0, queryOrig.lastIndexOf("."))
+//         : undefined;
 
-    const engine = ws.getEngine();
-    Logger.info({ ctx, msg: "enter", queryOrig, source });
+//     const engine = ws.getEngine();
+//     Logger.info({ ctx, msg: "enter", queryOrig, source });
 
-    // ~~~ update results
-    try {
-      if (querystring === "") {
-        Logger.debug({ ctx, msg: "empty qs" });
-        picker.items = this.showRootResults(opts.flavor, engine);
-        return;
-      }
+//     // ~~~ update results
+//     try {
+//       if (querystring === "") {
+//         Logger.debug({ ctx, msg: "empty qs" });
+//         picker.items = this.showRootResults(opts.flavor, engine);
+//         return;
+//       }
 
-      // current items without default items present
-      const items: DNodePropsQuickInputV2[] = [...picker.items];
-      let updatedItems = PickerUtilsV2.filterDefaultItems(items);
+//       // current items without default items present
+//       const items: DNodePropsQuickInputV2[] = [...picker.items];
+//       let updatedItems = PickerUtilsV2.filterDefaultItems(items);
 
-      Logger.debug({
-        ctx,
-        pickerValue,
-        msg: "qs",
-      });
-      // check if need to cancel
-      if (token.isCancellationRequested) {
-        return;
-      }
-      updatedItems = await this.createPickerItemsFromEngine({
-        picker,
-        flavor: opts.flavor,
-        qs: querystring,
-        depth: picker.showDirectChildrenOnly ? depth : undefined,
-      });
+//       Logger.debug({
+//         ctx,
+//         pickerValue,
+//         msg: "qs",
+//       });
+//       // check if need to cancel
+//       if (token.isCancellationRequested) {
+//         return;
+//       }
+//       updatedItems = await this.createPickerItemsFromEngine({
+//         picker,
+//         flavor: opts.flavor,
+//         qs: querystring,
+//         depth: picker.showDirectChildrenOnly ? depth : undefined,
+//       });
 
-      if (token.isCancellationRequested) {
-        return;
-      }
-      // check if single item query, vscode doesn't surface single letter queries
-      if (picker.activeItems.length === 0 && querystring.length === 1) {
-        picker.items = updatedItems;
-        picker.activeItems = picker.items;
-        return;
-      }
+//       if (token.isCancellationRequested) {
+//         return;
+//       }
+//       // check if single item query, vscode doesn't surface single letter queries
+//       if (picker.activeItems.length === 0 && querystring.length === 1) {
+//         picker.items = updatedItems;
+//         picker.activeItems = picker.items;
+//         return;
+//       }
 
-      // don't use query string since this can change
-      const perfectMatch =
-        opts.flavor === "note"
-          ? _.find(updatedItems, { fname: queryOrig })
-          : _.find(updatedItems, { id: queryOrig });
-      // NOTE: we modify this later so need to track this here
-      const noUpdatedItems = updatedItems.length === 0;
+//       // don't use query string since this can change
+//       const perfectMatch =
+//         opts.flavor === "note"
+//           ? _.find(updatedItems, { fname: queryOrig })
+//           : _.find(updatedItems, { id: queryOrig });
+//       // NOTE: we modify this later so need to track this here
+//       const noUpdatedItems = updatedItems.length === 0;
 
-      // add schema suggestions
-      if (opts.flavor === "note" && !_.isUndefined(queryUpToLastDot)) {
-        const results = SchemaUtils.matchPath({
-          notePath: queryUpToLastDot,
-          schemaModDict: engine.schemas,
-        });
-        // since namespace matches everything, we don't do queries on that
-        if (results && !results.namespace) {
-          const { schema, schemaModule } = results;
-          const dirName = queryUpToLastDot;
-          const candidates = schema.children
-            .map((ent) => {
-              const mschema = schemaModule.schemas[ent];
-              if (
-                SchemaUtils.hasSimplePattern(mschema, {
-                  isNotNamespace: true,
-                })
-              ) {
-                const pattern = SchemaUtils.getPattern(mschema, {
-                  isNotNamespace: true,
-                });
-                const fname = [dirName, pattern].join(".");
-                return NoteUtils.fromSchema({
-                  schemaModule,
-                  schemaId: ent,
-                  fname,
-                  vault: PickerUtilsV2.getVaultForOpenEditor(),
-                });
-              }
-              return;
-            })
-            .filter(Boolean) as NoteProps[];
-          const candidatesToAdd = _.differenceBy(
-            candidates,
-            updatedItems,
-            (ent) => ent.fname
-          );
-          updatedItems = updatedItems.concat(
-            candidatesToAdd.map((ent) => {
-              return DNodeUtils.enhancePropForQuickInput({
-                wsRoot: DendronWorkspace.wsRoot(),
-                props: ent,
-                schemas: engine.schemas,
-                vaults: DendronWorkspace.instance().vaultsv4,
-              });
-            })
-          );
-        }
-      }
-      if (token.isCancellationRequested) {
-        return;
-      }
-      // check if new item, return if that's the case
-      if (
-        noUpdatedItems ||
-        (picker.activeItems.length === 0 && !perfectMatch && !queryEndsWithDot)
-      ) {
-        Logger.debug({ ctx, msg: "no matches" });
-        picker.items = updatedItems;
-        return;
-      }
+//       // add schema suggestions
+//       if (opts.flavor === "note" && !_.isUndefined(queryUpToLastDot)) {
+//         const results = SchemaUtils.matchPath({
+//           notePath: queryUpToLastDot,
+//           schemaModDict: engine.schemas,
+//         });
+//         // since namespace matches everything, we don't do queries on that
+//         if (results && !results.namespace) {
+//           const { schema, schemaModule } = results;
+//           const dirName = queryUpToLastDot;
+//           const candidates = schema.children
+//             .map((ent) => {
+//               const mschema = schemaModule.schemas[ent];
+//               if (
+//                 SchemaUtils.hasSimplePattern(mschema, {
+//                   isNotNamespace: true,
+//                 })
+//               ) {
+//                 const pattern = SchemaUtils.getPattern(mschema, {
+//                   isNotNamespace: true,
+//                 });
+//                 const fname = [dirName, pattern].join(".");
+//                 return NoteUtils.fromSchema({
+//                   schemaModule,
+//                   schemaId: ent,
+//                   fname,
+//                   vault: PickerUtilsV2.getVaultForOpenEditor(),
+//                 });
+//               }
+//               return;
+//             })
+//             .filter(Boolean) as NoteProps[];
+//           const candidatesToAdd = _.differenceBy(
+//             candidates,
+//             updatedItems,
+//             (ent) => ent.fname
+//           );
+//           updatedItems = updatedItems.concat(
+//             candidatesToAdd.map((ent) => {
+//               return DNodeUtils.enhancePropForQuickInput({
+//                 wsRoot: DendronWorkspace.wsRoot(),
+//                 props: ent,
+//                 schemas: engine.schemas,
+//                 vaults: DendronWorkspace.instance().vaultsv4,
+//               });
+//             })
+//           );
+//         }
+//       }
+//       if (token.isCancellationRequested) {
+//         return;
+//       }
+//       // check if new item, return if that's the case
+//       if (
+//         noUpdatedItems ||
+//         (picker.activeItems.length === 0 && !perfectMatch && !queryEndsWithDot)
+//       ) {
+//         Logger.debug({ ctx, msg: "no matches" });
+//         picker.items = updatedItems;
+//         return;
+//       }
 
-      if (perfectMatch) {
-        Logger.debug({ ctx, msg: "active = qs" });
-        picker.activeItems = [perfectMatch];
-        picker.items = updatedItems;
-        // TODO: this defaults to current vault if no note is open
-        const openedVault = PickerUtilsV2.getVaultForOpenEditor();
+//       if (perfectMatch) {
+//         Logger.debug({ ctx, msg: "active = qs" });
+//         picker.activeItems = [perfectMatch];
+//         picker.items = updatedItems;
+//         // TODO: this defaults to current vault if no note is open
+//         const openedVault = PickerUtilsV2.getVaultForOpenEditor();
 
-        if (
-          VaultUtils.isEqual(
-            openedVault,
-            perfectMatch.vault,
-            DendronWorkspace.wsRoot()
-          )
-        ) {
-          picker.items = PickerUtilsV2.filterCreateNewItem(updatedItems);
-        }
-      } else if (queryEndsWithDot) {
-        // don't show noActiveItem for dot queries
-        Logger.debug({ ctx, msg: "active != qs, end with ." });
-        picker.items = PickerUtilsV2.filterCreateNewItem(updatedItems);
-      } else {
-        // regular result
-        Logger.debug({ ctx, msg: "active != qs" });
-        picker.items = updatedItems;
-      }
-    } catch (err) {
-      window.showErrorMessage(err);
-      throw Error(err);
-    } finally {
-      profile = getDurationMilliseconds(start);
-      picker.busy = false;
-      picker._justActivated = false;
-      Logger.info({
-        ctx,
-        msg: "exit",
-        queryOrig,
-        source,
-        profile,
-        cancelled: token.isCancellationRequested,
-      });
-      AnalyticsUtils.track(VSCodeEvents.Lookup_Update, {
-        duration: profile,
-        source,
-        flavor: opts.flavor,
-      });
-      // eslint-disable-next-line
-      return picker;
-    }
-  };
+//         if (
+//           VaultUtils.isEqual(
+//             openedVault,
+//             perfectMatch.vault,
+//             DendronWorkspace.wsRoot()
+//           )
+//         ) {
+//           picker.items = PickerUtilsV2.filterCreateNewItem(updatedItems);
+//         }
+//       } else if (queryEndsWithDot) {
+//         // don't show noActiveItem for dot queries
+//         Logger.debug({ ctx, msg: "active != qs, end with ." });
+//         picker.items = PickerUtilsV2.filterCreateNewItem(updatedItems);
+//       } else {
+//         // regular result
+//         Logger.debug({ ctx, msg: "active != qs" });
+//         picker.items = updatedItems;
+//       }
+//     } catch (err) {
+//       window.showErrorMessage(err);
+//       throw Error(err);
+//     } finally {
+//       profile = getDurationMilliseconds(start);
+//       picker.busy = false;
+//       picker._justActivated = false;
+//       Logger.info({
+//         ctx,
+//         msg: "exit",
+//         queryOrig,
+//         source,
+//         profile,
+//         cancelled: token.isCancellationRequested,
+//       });
+//       AnalyticsUtils.track(VSCodeEvents.Lookup_Update, {
+//         duration: profile,
+//         source,
+//         flavor: opts.flavor,
+//       });
+//       // eslint-disable-next-line
+//       return picker;
+//     }
+//   };
 
-  provide({
-    picker,
-    lc,
-  }: {
-    picker: DendronQuickPickerV2;
-    lc: LookupControllerV2;
-  }) {
-    const { opts } = this;
-    const _this = this;
-    picker.onDidAccept(() => {
-      const ctx = "LookupProvider:onAccept";
-      // NOTE: unfortunate hack to not get prompted for testing
-      if (getStage() === "test") {
-        return;
-      }
-      this.onDidAccept({ picker, opts, lc }).catch((err) => {
-        Logger.error({
-          ctx,
-          error: new DendronError({
-            message:
-              "something went wrong. please submit a bug report to https://github.com/dendronhq/dendron/issues/new?assignees=&labels=&template=bug_report.md&title= with the output of `Dendron: Open Log`",
-            payload: err,
-          }),
-        });
-      });
-    });
+//   provide({
+//     picker,
+//     lc,
+//   }: {
+//     picker: DendronQuickPickerV2;
+//     lc: LookupControllerV2;
+//   }) {
+//     const { opts } = this;
+//     const _this = this;
+//     picker.onDidAccept(() => {
+//       const ctx = "LookupProvider:onAccept";
+//       // NOTE: unfortunate hack to not get prompted for testing
+//       if (getStage() === "test") {
+//         return;
+//       }
+//       this.onDidAccept({ picker, opts, lc }).catch((err) => {
+//         Logger.error({
+//           ctx,
+//           error: new DendronError({
+//             message:
+//               "something went wrong. please submit a bug report to https://github.com/dendronhq/dendron/issues/new?assignees=&labels=&template=bug_report.md&title= with the output of `Dendron: Open Log`",
+//             payload: err,
+//           }),
+//         });
+//       });
+//     });
 
-    // create debounced update method
-    this.onDidChangeValueDebounced = _.debounce(
-      _.bind(this.onUpdatePickerItem, _this),
-      60,
-      { leading: true, maxWait: 120 }
-    ) as DebouncedFunc<typeof _this.onUpdatePickerItem>;
+//     // create debounced update method
+//     this.onDidChangeValueDebounced = _.debounce(
+//       _.bind(this.onUpdatePickerItem, _this),
+//       60,
+//       { leading: true, maxWait: 120 }
+//     ) as DebouncedFunc<typeof _this.onUpdatePickerItem>;
 
-    // picker.onDidChangeSelection(() => {
-    //   Logger.info({ctx: "onDidChangeSelection", picker: PickerUtilsV2.dumpPicker(picker)})
-    // });
-    // picker.onDidChangeActive(()=> {
-    //   Logger.info({ctx: "onDidChangeActive", picker: PickerUtilsV2.dumpPicker(picker)})
-    // })
+//     // picker.onDidChangeSelection(() => {
+//     //   Logger.info({ctx: "onDidChangeSelection", picker: PickerUtilsV2.dumpPicker(picker)})
+//     // });
+//     // picker.onDidChangeActive(()=> {
+//     //   Logger.info({ctx: "onDidChangeActive", picker: PickerUtilsV2.dumpPicker(picker)})
+//     // })
 
-    picker.onDidChangeValue(() => {
-      if (_.isUndefined(this.onDidChangeValueDebounced)) {
-        throw new DendronError({ message: "onAccept already called" });
-      }
+//     picker.onDidChangeValue(() => {
+//       if (_.isUndefined(this.onDidChangeValueDebounced)) {
+//         throw new DendronError({ message: "onAccept already called" });
+//       }
 
-      this.onDidChangeValueDebounced(
-        picker,
-        opts,
-        "onValueChange",
-        lc.createCancelSource().token
-      );
-    });
-  }
+//       this.onDidChangeValueDebounced(
+//         picker,
+//         opts,
+//         "onValueChange",
+//         lc.createCancelSource().token
+//       );
+//     });
+//   }
 
-  showRootResults(
-    flavor: EngineFlavor,
-    engine: DEngineClient
-  ): DNodePropsQuickInputV2[] {
-    let nodeDict: DNodePropsDict;
-    let nodes: DNodeProps[];
-    if (flavor === "note") {
-      nodeDict = engine.notes;
-      const roots = NoteUtils.getRoots(nodeDict);
-      const childrenOfRoot = roots.flatMap((ent) => ent.children);
-      nodes = _.map(childrenOfRoot, (ent) => nodeDict[ent]).concat(roots);
-    } else {
-      nodeDict = _.mapValues(engine.schemas, (ent) => ent.root);
-      nodes = _.map(_.values(engine.schemas), (ent: SchemaModuleProps) => {
-        return SchemaUtils.getModuleRoot(ent);
-      });
-    }
-    return nodes.map((ent) => {
-      return DNodeUtils.enhancePropForQuickInput({
-        wsRoot: DendronWorkspace.wsRoot(),
-        props: ent,
-        schemas: engine.schemas,
-        vaults: DendronWorkspace.instance().vaultsv4,
-      });
-    });
-  }
+//   showRootResults(
+//     flavor: EngineFlavor,
+//     engine: DEngineClient
+//   ): DNodePropsQuickInputV2[] {
+//     let nodeDict: DNodePropsDict;
+//     let nodes: DNodeProps[];
+//     if (flavor === "note") {
+//       nodeDict = engine.notes;
+//       const roots = NoteUtils.getRoots(nodeDict);
+//       const childrenOfRoot = roots.flatMap((ent) => ent.children);
+//       nodes = _.map(childrenOfRoot, (ent) => nodeDict[ent]).concat(roots);
+//     } else {
+//       nodeDict = _.mapValues(engine.schemas, (ent) => ent.root);
+//       nodes = _.map(_.values(engine.schemas), (ent: SchemaModuleProps) => {
+//         return SchemaUtils.getModuleRoot(ent);
+//       });
+//     }
+//     return nodes.map((ent) => {
+//       return DNodeUtils.enhancePropForQuickInput({
+//         wsRoot: DendronWorkspace.wsRoot(),
+//         props: ent,
+//         schemas: engine.schemas,
+//         vaults: DendronWorkspace.instance().vaultsv4,
+//       });
+//     });
+//   }
 
-  validate(value: string, flavor: EngineFlavor): string | undefined {
-    if (flavor === "schema") {
-      if (value.split(".").length > 1) {
-        return "schemas can only be one level deep";
-      }
-    }
-    return;
-  }
-}
+//   validate(value: string, flavor: EngineFlavor): string | undefined {
+//     if (flavor === "schema") {
+//       if (value.split(".").length > 1) {
+//         return "schemas can only be one level deep";
+//       }
+//     }
+//     return;
+//   }
+// }

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -9,16 +9,16 @@ import { getWS } from "../../workspace";
 import _ from "lodash";
 import * as vscode from "vscode";
 import { QuickInputButton, ThemeIcon } from "vscode";
-import {
+import { clipboard, DendronClientUtilsV2, VSCodeUtils } from "../../utils";
+import { 
+  DendronQuickPickerV2,
   LookupEffectType,
   LookupFilterType,
   LookupNoteType,
   LookupNoteTypeEnum,
   LookupSelectionType,
   LookupSplitType,
-} from "../../commands/LookupCommand";
-import { clipboard, DendronClientUtilsV2, VSCodeUtils } from "../../utils";
-import { DendronQuickPickerV2 } from "./types";
+} from "./types";
 import { NotePickerUtils, PickerUtilsV2 } from "./utils";
 
 export type ButtonType =
@@ -35,7 +35,7 @@ export type ButtonCategory =
   | "split"
   | "filter"
   | "effect"
-  | "other"; //TODO: better category name?
+  | "other"; 
 
 export type ButtonHandleOpts = { quickPick: DendronQuickPickerV2 };
 

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -110,3 +110,49 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    */
   showNote?: (uri: Uri) => Promise<TextEditor>;
 };
+
+
+export type LookupFilterType = "directChildOnly";
+
+export enum LookupNoteTypeEnum {
+  "journal" = "journal",
+  "scratch" = "scratch",
+}
+export type LookupNoteType = LookupNoteTypeEnum;
+
+export enum LookupEffectTypeEnum {
+  "copyNoteLink" = "copyNoteLink",
+  "copyNoteRef" = "copyNoteRef",
+  "multiSelect" = "multiSelect",
+}
+export enum LookupSelectionTypeEnum {
+  "selection2link" = "selection2link",
+  "selectionExtract" = "selectionExtract",
+}
+export type LookupSelectionType = "selection2link" | "selectionExtract";
+
+export enum LookupSplitTypeEnum {
+  "horizontal" = "horizontal",
+}
+export type LookupSplitType = "horizontal";
+
+export type LookupEffectType = "copyNoteLink" | "copyNoteRef" | "multiSelect";
+export type LookupNoteExistBehavior = "open" | "overwrite";
+
+export enum VaultSelectionMode {
+  /**
+   * Never prompt the user. Useful for testing
+   */
+  auto,
+
+  /**
+   * Tries to determine the vault automatically, but will prompt the user if
+   * there is ambiguity
+   */
+  smart,
+
+  /**
+   * Always prompt the user if there is more than one vault
+   */
+  alwaysPrompt,
+}

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -20,7 +20,6 @@ import { getDurationMilliseconds, vault2Path } from "@dendronhq/common-server";
 import _ from "lodash";
 import path from "path";
 import { QuickPickItem, TextEditor, Uri, ViewColumn, window } from "vscode";
-import { VaultSelectionMode } from "../../commands/LookupCommand";
 import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace, getEngine, getWS } from "../../workspace";
@@ -31,7 +30,7 @@ import {
   MORE_RESULTS_LABEL,
 } from "./constants";
 import { ILookupProviderV3, OnAcceptHook } from "./LookupProviderV3";
-import { DendronQuickPickerV2, DendronQuickPickState } from "./types";
+import { VaultSelectionMode, DendronQuickPickerV2, DendronQuickPickState } from "./types";
 
 const PAGINATE_LIMIT = 50;
 export const UPDATET_SOURCE = {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -277,8 +277,23 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     desc: "Convert link candidate into backlink",
   },
   // --- Lookup
-  LOOKUP: {
-    key: "dendron.lookup",
+  // LOOKUP: {
+  //   // @deprecated
+  //   key: "dendron.lookup",
+  //   title: `${CMD_PREFIX} Lookup`,
+  //   group: "navigation",
+  //    keybindings: {
+  //      mac: "cmd+L",
+  //      key: "ctrl+l",
+  //      when: DendronContext.PLUGIN_ACTIVE,
+  //    },
+  //   desc: "Initiate note lookup",
+  //   docLink: "dendron.topic.lookup.md",
+  //   docPreview: "",
+  //   when: DendronContext.PLUGIN_ACTIVE,
+  // },
+  LOOKUP_NOTE: {
+    key: "dendron.lookupNote",
     title: `${CMD_PREFIX} Lookup`,
     group: "navigation",
     keybindings: {
@@ -291,15 +306,8 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docPreview: "",
     when: DendronContext.PLUGIN_ACTIVE,
   },
-  LOOKUP_NOTE: {
-    key: "dendron.lookupNote",
-    title: `${CMD_PREFIX} Lookup Note`,
-    group: "navigation",
-    desc: "Initiate note lookup",
-    when: DendronContext.PLUGIN_ACTIVE,
-  },
   LOOKUP_JOURNAL: {
-    key: "dendron.lookup",
+    key: "dendron.lookupNote",
     shortcut: true,
     title: `${CMD_PREFIX} Lookup (Journal Note)`,
     group: "navigation",
@@ -316,7 +324,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docPreview: "",
   },
   LOOKUP_SCRATCH: {
-    key: "dendron.lookup",
+    key: "dendron.lookupNote",
     shortcut: true,
     title: `${CMD_PREFIX} Lookup (Scratch Note)`,
     group: "navigation",

--- a/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
@@ -3,7 +3,7 @@ import { NodeTestPresetsV2 } from "@dendronhq/common-test-utils";
 import path from "path";
 import * as vscode from "vscode";
 import { GoDownCommand } from "../../commands/GoDownCommand";
-import { DendronQuickPickerV2 } from "../../components/lookup/types";
+// import { DendronQuickPickerV2 } from "../../components/lookup/types";
 import { VSCodeUtils } from "../../utils";
 import { onWSInit, setupDendronWorkspace } from "../testUtils";
 import { expect } from "../testUtilsv2";
@@ -19,20 +19,16 @@ suite("notes", function () {
     },
   });
 
-  // TODO: currently this opens a quickpick
-  test.skip("basic", (done) => {
+  test("basic", (done) => {
     onWSInit(async () => {
       const notePath = path.join(vaultPath, "foo.md");
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-      const quickpick =
-        (await new GoDownCommand().run()) as DendronQuickPickerV2;
-      quickpick.onDidChangeValue(() => {});
-      quickpick.onDidChangeSelection(() => {});
-      quickpick.onDidChangeActive(() => {
-        const item = quickpick.activeItems[0];
-        expect(item.id).toEqual("foo.ch1");
-        done();
-      });
+      await new GoDownCommand().run({noConfirm: true});
+      const editor = VSCodeUtils.getActiveTextEditor();
+      const activeNote = VSCodeUtils.getNoteFromDocument(editor!.document);
+      expect(activeNote?.fname).toEqual("foo.ch1");
+
+      done();
     });
     setupDendronWorkspace(root.name, ctx, {
       lsp: true,

--- a/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts
@@ -1,1253 +1,1253 @@
-import {
-  DNodePropsQuickInputV2,
-  DNodeUtils,
-  NoteProps,
-  NoteUtils,
-  SchemaModuleProps,
-  SchemaUtils,
-  WorkspaceOpts,
-} from "@dendronhq/common-all";
-import { tmpDir, vault2Path } from "@dendronhq/common-server";
-import {
-  FileTestUtils,
-  NOTE_PRESETS_V4,
-  runJestHarnessV2,
-  TestPresetEntryV4,
-} from "@dendronhq/common-test-utils";
-import { DendronEngineV2 } from "@dendronhq/engine-server";
-import {
-  ENGINE_HOOKS,
-  ENGINE_QUERY_PRESETS,
-  ENGINE_WRITE_PRESETS,
-} from "@dendronhq/engine-test-utils";
-import fs from "fs-extra";
-import _ from "lodash";
-import { describe } from "mocha";
-import path from "path";
-import sinon from "sinon";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
-import { CancellationTokenSource } from "vscode-languageclient";
-import {
-  LookupCommand,
-  LookupNoteTypeEnum,
-} from "../../commands/LookupCommand";
-import { createAllButtons } from "../../components/lookup/buttons";
-import { LookupControllerV2 } from "../../components/lookup/LookupControllerV2";
-import { LookupProviderV2 } from "../../components/lookup/LookupProviderV2";
-import { NotePickerUtils, PickerUtilsV2 } from "../../components/lookup/utils";
-import { CONFIG } from "../../constants";
-import { EngineFlavor, EngineOpts } from "../../types";
-import { VSCodeUtils } from "../../utils";
-import { DendronWorkspace, getWS } from "../../workspace";
-import { createMockQuickPick } from "../testUtils";
-import { expect, getNoteFromTextEditor } from "../testUtilsv2";
-import {
-  createEngineFactory,
-  EditorUtils,
-  runLegacyMultiWorkspaceTest,
-  runLegacySingleWorkspaceTest,
-  setupBeforeAfter,
-  withConfig,
-} from "../testUtilsV3";
+// import {
+//   DNodePropsQuickInputV2,
+//   DNodeUtils,
+//   NoteProps,
+//   NoteUtils,
+//   SchemaModuleProps,
+//   SchemaUtils,
+//   WorkspaceOpts,
+// } from "@dendronhq/common-all";
+// import { tmpDir, vault2Path } from "@dendronhq/common-server";
+// import {
+//   FileTestUtils,
+//   NOTE_PRESETS_V4,
+//   runJestHarnessV2,
+//   TestPresetEntryV4,
+// } from "@dendronhq/common-test-utils";
+// import { DendronEngineV2 } from "@dendronhq/engine-server";
+// import {
+//   ENGINE_HOOKS,
+//   ENGINE_QUERY_PRESETS,
+//   ENGINE_WRITE_PRESETS,
+// } from "@dendronhq/engine-test-utils";
+// import fs from "fs-extra";
+// import _ from "lodash";
+// import { describe } from "mocha";
+// import path from "path";
+// import sinon from "sinon";
+// // // You can import and use all API from the 'vscode' module
+// // // as well as import your extension to test it
+// import * as vscode from "vscode";
+// import { CancellationTokenSource } from "vscode-languageclient";
+// import {
+//   LookupCommand,
+//   LookupNoteTypeEnum,
+// } from "../../commands/LookupCommand";
+// import { createAllButtons } from "../../components/lookup/buttons";
+// import { LookupControllerV2 } from "../../components/lookup/LookupControllerV2";
+// import { LookupProviderV2 } from "../../components/lookup/LookupProviderV2";
+// import { NotePickerUtils, PickerUtilsV2 } from "../../components/lookup/utils";
+// import { CONFIG } from "../../constants";
+// import { EngineFlavor, EngineOpts } from "../../types";
+// import { VSCodeUtils } from "../../utils";
+// import { DendronWorkspace, getWS } from "../../workspace";
+// import { createMockQuickPick } from "../testUtils";
+// import { expect, getNoteFromTextEditor } from "../testUtilsv2";
+// import {
+//   createEngineFactory,
+//   EditorUtils,
+//   runLegacyMultiWorkspaceTest,
+//   runLegacySingleWorkspaceTest,
+//   setupBeforeAfter,
+//   withConfig,
+// } from "../testUtilsV3";
 
-const { createNoActiveItem } = NotePickerUtils;
+// const { createNoActiveItem } = NotePickerUtils;
 
-const createEngineForSchemaUpdateItems = createEngineFactory({
-  querySchema: (_opts: WorkspaceOpts) => {
-    const querySchema: DendronEngineV2["querySchema"] = async (qs) => {
-      const engOpts: EngineOpts = { flavor: "schema" };
-      const ws = DendronWorkspace.instance();
-      const client = ws.getEngine();
-      const lc = new LookupControllerV2(engOpts);
-      const lp = new LookupProviderV2(engOpts);
-      const quickpick = await lc.show();
-      quickpick.value = qs;
-      await lp.onUpdatePickerItem(
-        quickpick,
-        engOpts,
-        "manual",
-        lc.cancelToken.token
-      );
-      const schemaModules = _.map(
-        lc.quickPick?.items,
-        (ent) => client.schemas[ent.id]
-      ).filter((ent) => !_.isUndefined(ent));
-      return {
-        data: schemaModules,
-        error: null,
-      };
-    };
-    return querySchema;
-  },
-});
-
-const createEngineForNoteUpdateItems = createEngineFactory({
-  queryNotes: (_opts: WorkspaceOpts) => {
-    const queryNotes: DendronEngineV2["queryNotes"] = async (opts) => {
-      return new Promise(async (resolve) => {
-        const engOpts: EngineOpts = { flavor: "note" };
-        const ws = DendronWorkspace.instance();
-        const client = ws.getEngine();
-        const lc = new LookupControllerV2(engOpts);
-        const lp = new LookupProviderV2(engOpts);
-        const quickpick = await lc.show();
-        quickpick.value = opts.qs;
-        const newPicker = await lp.onUpdatePickerItem(
-          quickpick,
-          { ...engOpts, force: true },
-          "manual",
-          lc.cancelToken.token
-        );
-        let data = _.map(
-          newPicker?.items,
-          (ent) => client.notes[ent.id]
-        ).filter((ent) => !_.isUndefined(ent));
-        if (opts.vault) {
-          // NOTE: this is a hack
-          data = data.filter(
-            (ent) =>
-              path.basename(ent.vault.fsPath) ===
-              path.basename(opts.vault?.fsPath as string)
-          );
-        }
-        resolve({ data, error: null });
-
-        // return {
-        //   data,
-        //   error: null,
-        // };
-      });
-    };
-    return queryNotes;
-  },
-});
-
-const lookupHelper = async (flavor: EngineFlavor) => {
-  const engOpts: EngineOpts = { flavor };
-  const lc = new LookupControllerV2(engOpts);
-  const lp = new LookupProviderV2(engOpts);
-  const picker = await lc.show();
-  return { lc, lp, picker };
-};
-
-const lookupHelperForNote = async () => {
-  const engOpts: EngineOpts = { flavor: "note" };
-  const lc = new LookupControllerV2(engOpts);
-  const lp = new LookupProviderV2(engOpts);
-  const picker = createMockQuickPick({});
-
-  return { lc, lp, picker };
-};
-
-const schemaAcceptHelper = async (qs: string) => {
-  const engOpts: EngineOpts = { flavor: "schema" };
-  const ws = DendronWorkspace.instance();
-  const client = ws.getEngine();
-  const schemaModule = client.schemas[qs];
-  const schemaInput = SchemaUtils.enhanceForQuickInput({
-    props: schemaModule,
-    vaults: DendronWorkspace.instance().config.vaults,
-  });
-  const quickpick = createMockQuickPick({
-    value: qs,
-    selectedItems: [schemaInput],
-  });
-  const lc = new LookupControllerV2(engOpts);
-  const lp = new LookupProviderV2(engOpts);
-  const resp = await lp.onDidAccept({
-    picker: quickpick,
-    opts: engOpts,
-    lc,
-  });
-  return resp?.uris;
-};
-
-const createEngineForSchemaAcceptQuery = createEngineFactory({
-  writeSchema: (_opts: WorkspaceOpts) => {
-    const func: DendronEngineV2["writeSchema"] = async (schema) => {
-      const engOpts: EngineOpts = { flavor: "schema" };
-      const quickpick = createMockQuickPick({
-        value: schema.fname,
-        selectedItems: [NotePickerUtils.createNoActiveItem(schema.vault)],
-      });
-      const lc = new LookupControllerV2(engOpts);
-      const lp = new LookupProviderV2(engOpts);
-      await lp.onDidAccept({
-        picker: quickpick,
-        opts: engOpts,
-        lc,
-      });
-      await quickpick.hide();
-    };
-    return func;
-  },
-  querySchema: (_opts: WorkspaceOpts) => {
-    const querySchema: DendronEngineV2["querySchema"] = async (qs) => {
-      const uris = await schemaAcceptHelper(qs);
-      const schemas = uris?.map((ent) => {
-        return SchemaUtils.getSchemaModuleByFnameV4({
-          fname: path.basename(ent.fsPath, ".schema.yml"),
-          schemas: getWS().getEngine().schemas,
-          vault: { fsPath: path.dirname(ent.fsPath) },
-          wsRoot: _opts.wsRoot,
-        });
-      }) as SchemaModuleProps[];
-      return {
-        error: null,
-        data: schemas,
-      };
-    };
-    return querySchema;
-  },
-});
-
-const createEngineForNoteAcceptNewItem = createEngineFactory({
-  writeNote: (_opts: WorkspaceOpts) => {
-    const func: DendronEngineV2["writeNote"] = async (note) => {
-      const engOpts: EngineOpts = { flavor: "note" };
-      const quickpick = createMockQuickPick({
-        value: note.fname,
-        selectedItems: [createNoActiveItem(note.vault)],
-      });
-      const lc = new LookupControllerV2(engOpts);
-      const lp = new LookupProviderV2(engOpts);
-      const resp = await lp.onDidAccept({
-        picker: quickpick,
-        opts: engOpts,
-        lc,
-      });
-      if (_.isUndefined(resp)) {
-        throw Error("resp is undefined");
-      }
-      return resp.resp;
-    };
-    return func;
-  },
-  queryNotes: (_opts: WorkspaceOpts) => {
-    const queryNotes: DendronEngineV2["queryNotes"] = async (opts) => {
-      return getWS().getEngine().queryNotes(opts);
-    };
-    return queryNotes;
-  },
-});
-
-suite("Lookup, schemas", function () {
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {});
-
-  describe("updateItems", () => {
-    _.map(
-      ENGINE_QUERY_PRESETS["SCHEMAS"],
-      (TestCase: TestPresetEntryV4, name) => {
-        test(name, (done) => {
-          const { testFunc, preSetupHook } = TestCase;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            postSetupHook: async ({ wsRoot, vaults }) => {
-              await preSetupHook({
-                wsRoot,
-                vaults,
-              });
-            },
-            onInit: async ({ vaults, wsRoot }) => {
-              const engineMock = createEngineForSchemaUpdateItems({
-                wsRoot,
-                vaults,
-              });
-              const results = await testFunc({
-                engine: engineMock,
-                vaults,
-                wsRoot,
-                initResp: {} as any,
-              });
-              await runJestHarnessV2(results, expect);
-              done();
-            },
-          });
-        });
-      }
-    );
-  });
-
-  describe("onAccept", () => {
-    _.map(
-      _.pick(ENGINE_QUERY_PRESETS["SCHEMAS"], "SIMPLE"),
-      (TestCase: TestPresetEntryV4, name) => {
-        test(name, (done) => {
-          const { testFunc, preSetupHook } = TestCase;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            postSetupHook: async ({ wsRoot, vaults }) => {
-              await preSetupHook({
-                wsRoot,
-                vaults,
-              });
-            },
-            onInit: async ({ vaults, wsRoot }) => {
-              const engineMock = createEngineForSchemaAcceptQuery({
-                wsRoot,
-                vaults,
-              });
-              const results = await testFunc({
-                engine: engineMock,
-                vaults,
-                wsRoot,
-                initResp: {} as any,
-              });
-              await runJestHarnessV2(results, expect);
-              done();
-            },
-          });
-        });
-      }
-    );
-
-    _.map(
-      _.pick(ENGINE_WRITE_PRESETS.SCHEMAS, "ADD_NEW_MODULE_NO_CHILD"),
-      (TestCase: TestPresetEntryV4, name) => {
-        test(name, (done) => {
-          const { testFunc, preSetupHook } = TestCase;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            postSetupHook: async ({ wsRoot, vaults }) => {
-              await preSetupHook({
-                wsRoot,
-                vaults,
-              });
-            },
-            onInit: async ({ vaults, wsRoot }) => {
-              const engineMock = createEngineForSchemaAcceptQuery({
-                wsRoot,
-                vaults,
-              });
-              const results = await testFunc({
-                engine: engineMock,
-                vaults,
-                wsRoot,
-                initResp: {} as any,
-              });
-              await runJestHarnessV2(results, expect);
-              done();
-            },
-          });
-        });
-      }
-    );
-  });
-});
-
-suite("Lookup, notesv2", function () {
-  const engOpts: EngineOpts = { flavor: "note" };
-
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
-    afterHook: async () => {
-      sinon.restore();
-    },
-  });
-
-  // TODO: flaky test, can run by itself
-  describe.skip("updateItems", () => {
-    _.forEach(
-      ENGINE_QUERY_PRESETS["NOTES"],
-      (TestCase: TestPresetEntryV4, name) => {
-        test(name, (done) => {
-          const { testFunc, preSetupHook } = TestCase;
-          runLegacySingleWorkspaceTest({
-            ctx,
-            postSetupHook: async ({ wsRoot, vaults }) => {
-              await preSetupHook({
-                wsRoot,
-                vaults,
-              });
-            },
-            onInit: async ({ vaults, wsRoot }) => {
-              const engineMock = createEngineForNoteUpdateItems({
-                wsRoot,
-                vaults,
-              });
-              const results = await testFunc({
-                engine: engineMock,
-                vaults,
-                wsRoot,
-                initResp: {} as any,
-                extra: { vscode: true },
-              });
-              await runJestHarnessV2(results, expect);
-              done();
-            },
-          });
-        });
-      }
-    );
-
-    // migrated
-    test("opened note", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-        },
-        onInit: async () => {
-          const engOpts: EngineOpts = { flavor: "note" };
-          const lc = new LookupControllerV2(engOpts);
-          const lp = new LookupProviderV2(engOpts);
-          const root = DendronWorkspace.wsRoot();
-          await VSCodeUtils.openFileInEditor(
-            vscode.Uri.file(path.join(root, "vault1", "foo.md"))
-          );
-          const quickpick = await lc.show();
-          quickpick.onDidChangeActive(() => {
-            expect(lc.quickPick?.activeItems.length).toEqual(1);
-            expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
-            done();
-          });
-          await lp.onUpdatePickerItem(
-            quickpick,
-            engOpts,
-            "manual",
-            lc.cancelToken.token
-          );
-        },
-      });
-    });
-
-    // migrated
-    test("remove stub status after creation", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NOTE_PRESETS_V4.NOTE_SIMPLE_CHILD.create({
-            vault: vaults[0],
-            wsRoot,
-          });
-        },
-        onInit: async () => {
-          const engOpts: EngineOpts = { flavor: "note" };
-          const lc = new LookupControllerV2(engOpts);
-          const lp = new LookupProviderV2(engOpts);
-
-          const quickpick = await lc.show();
-          let note = _.find(quickpick.items, {
-            fname: "foo",
-          }) as DNodePropsQuickInputV2;
-          expect(note.stub).toBeTruthy();
-          quickpick.selectedItems = [note];
-          await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          lc.onDidHide(async () => {
-            expect(
-              path.basename(
-                VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-              )
-            ).toEqual("foo.md");
-            const lc2 = new LookupControllerV2(engOpts);
-            const quickpick2 = await lc2.show();
-            note = _.find(quickpick2.items, {
-              fname: "foo",
-            }) as DNodePropsQuickInputV2;
-            expect(note.stub).toBeFalsy();
-            done();
-          });
-          quickpick.hide();
-        },
-      });
-    });
-
-    // skip
-    test("schema suggestion", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-          const vpath = vault2Path({ vault: vaults[0], wsRoot });
-          fs.removeSync(path.join(vpath, "foo.ch1.md"));
-        },
-        onInit: async () => {
-          const { lc, lp, picker: quickpick } = await lookupHelper("note");
-          quickpick.value = "foo.";
-          await lp.onUpdatePickerItem(
-            quickpick,
-            { flavor: "note" },
-            "manual",
-            lc.cancelToken.token
-          );
-          const schemaItem = _.pick(
-            _.find(quickpick.items, { fname: "foo.ch1" }),
-            ["fname", "schemaStub"]
-          );
-          await runJestHarnessV2(
-            [
-              {
-                actual: schemaItem,
-                expected: {
-                  fname: "foo.ch1",
-                  schemaStub: true,
-                },
-              },
-            ],
-            expect
-          );
-          done();
-        },
-      });
-    });
-
-    test("filter by depth", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-          await NOTE_PRESETS_V4.NOTE_SIMPLE_GRANDCHILD.create({
-            wsRoot,
-            vault: vaults[0],
-          });
-        },
-        onInit: async () => {
-          const { picker: quickpick, lp, lc } = await lookupHelper("note");
-          quickpick.value = "foo.";
-          quickpick.showDirectChildrenOnly = true;
-          await lp.onUpdatePickerItem(
-            quickpick,
-            { flavor: "note" },
-            "manual",
-            lc.cancelToken.token
-          );
-          expect(quickpick.items.length).toEqual(4);
-          expect(_.find(quickpick.items, { fname: "foo.ch1.gch1" })).toEqual(
-            undefined
-          );
-          done();
-        },
-      });
-    });
-  });
-
-  describe("onAccept with modifiers", () => {
-    test("with lookupPrompt on current vault", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        onInit: async ({ wsRoot, vaults }) => {
-          const engOpts: EngineOpts = { flavor: "note" };
-          withConfig(
-            (config) => {
-              config.lookupConfirmVaultOnCreate = true;
-              return config;
-            },
-            { wsRoot }
-          );
-
-          const vault = vaults[0];
-          const { lc, lp, picker } = await lookupHelperForNote();
-          await lc.updatePickerBehavior({ quickPick: picker, provider: lp });
-
-          picker.value = "alpha";
-          sinon.stub(picker, "selectedItems").get(() => {
-            return [createNoActiveItem(vault)];
-          });
-          sinon
-            .stub(PickerUtilsV2, "promptVault")
-            .returns(Promise.resolve(vaults[0]));
-
-          await lp.onDidAccept({
-            picker,
-            opts: engOpts,
-            lc,
-          });
-          expect(
-            (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
-              path.join("vault1", "alpha.md")
-            )
-          ).toBeTruthy();
-          done();
-        },
-      });
-    });
-
-    test("with lookupPrompt on other vault", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        onInit: async ({ wsRoot, vaults }) => {
-          const engOpts: EngineOpts = { flavor: "note" };
-          withConfig(
-            (config) => {
-              config.lookupConfirmVaultOnCreate = true;
-              return config;
-            },
-            { wsRoot }
-          );
-
-          const vault = vaults[0];
-          const { lc, lp, picker } = await lookupHelperForNote();
-          await lc.updatePickerBehavior({ quickPick: picker, provider: lp });
-
-          picker.value = "alpha";
-          sinon.stub(picker, "selectedItems").get(() => {
-            return [createNoActiveItem(vault)];
-          });
-          sinon
-            .stub(PickerUtilsV2, "getOrPromptVaultForNewNote")
-            .returns(Promise.resolve(vaults[1]));
-
-          await lp.onDidAccept({
-            picker,
-            opts: engOpts,
-            lc,
-          });
-          expect(
-            (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
-              path.join("vault2", "alpha.md")
-            )
-          ).toBeTruthy();
-          done();
-        },
-      });
-    });
-
-    test("scratch config in yml ", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        wsSettingsOverride: {
-          settings: {
-            [CONFIG.DEFAULT_JOURNAL_NAME.key]: "scratch",
-          },
-        },
-        modConfigCb: (config) => {
-          config.scratch!.name = "testScratch";
-          return config;
-        },
-        preSetupHook: ENGINE_HOOKS.setupBasic,
-        onInit: async () => {
-          const cmd = new LookupCommand();
-          const note = getWS().getEngine().notes["foo"];
-          await VSCodeUtils.openNote(note);
-          await cmd.run({
-            noConfirm: true,
-            noteType: LookupNoteTypeEnum.scratch,
-            flavor: "note",
-          });
-          expect(
-            path
-              .basename(
-                VSCodeUtils.getActiveTextEditorOrThrow().document.uri.fsPath
-              )
-              .startsWith("testScratch")
-          ).toBeTruthy();
-          done();
-        },
-      });
-    });
-  });
-
-  // TODO: don't skip
-  describe("onAccept", () => {
-    _.map(
-      _.pick(ENGINE_WRITE_PRESETS["NOTES"], "NEW_DOMAIN"),
-      (TestCase: TestPresetEntryV4, name) => {
-        test(name, (done) => {
-          const { testFunc, preSetupHook } = TestCase;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            postSetupHook: async ({ wsRoot, vaults }) => {
-              await preSetupHook({
-                wsRoot,
-                vaults,
-              });
-            },
-            onInit: async ({ vaults, wsRoot }) => {
-              const engineMock = createEngineForNoteAcceptNewItem({
-                wsRoot,
-                vaults,
-              });
-              const results = await testFunc({
-                engine: engineMock,
-                vaults,
-                wsRoot,
-                initResp: {} as any,
-              });
-              await runJestHarnessV2(results, expect);
-              done();
-            },
-          });
-        });
-      }
-    );
-
-    test("with override", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic,
-        onInit: async () => {
-          const cmd = new LookupCommand();
-          const note = getWS().getEngine().notes["foo"];
-          await VSCodeUtils.openNote(note);
-          await cmd.run({
-            noConfirm: true,
-            value: "gamma",
-            noteType: LookupNoteTypeEnum.journal,
-            flavor: "note",
-          });
-          expect(
-            path
-              .basename(
-                VSCodeUtils.getActiveTextEditorOrThrow().document.uri.fsPath
-              )
-              .startsWith("gamma.journal")
-          ).toBeTruthy();
-          done();
-        },
-      });
-    });
-
-    test("existing note", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
-        },
-        onInit: async ({ vaults, wsRoot }) => {
-          const { lp, lc } = await lookupHelper("note");
-          const ws = DendronWorkspace.instance();
-          const client = ws.getEngine();
-          const note = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes: client.notes,
-            vault: vaults[0],
-            wsRoot: DendronWorkspace.wsRoot(),
-          }) as NoteProps;
-          const item = DNodeUtils.enhancePropForQuickInput({
-            wsRoot,
-            props: note,
-            schemas: client.schemas,
-            vaults: DendronWorkspace.instance().config.vaults,
-          });
-          const quickpick = createMockQuickPick({
-            value: "foo",
-            selectedItems: [item],
-          });
-          await lp.onDidAccept({
-            picker: quickpick,
-            opts: { flavor: "note" },
-            lc,
-          });
-
-          await runJestHarnessV2(
-            [
-              {
-                actual: DNodeUtils.fname(
-                  VSCodeUtils.getActiveTextEditor()?.document.uri
-                    .fsPath as string
-                ),
-                expected: "foo",
-              },
-              {
-                actual: _.pick(getNoteFromTextEditor(), "title"),
-                expected: {
-                  title: "Foo",
-                },
-              },
-            ],
-            expect
-          );
-          done();
-        },
-      });
-    });
-
-    test("lookup new node with schema template", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
-        },
-        onInit: async ({ vaults }) => {
-          const { lp, lc } = await lookupHelper("note");
-          const picker = createMockQuickPick({
-            value: "bar.ch1",
-            selectedItems: [createNoActiveItem(vaults[0])],
-          });
-          const engOpts: EngineOpts = { flavor: "note" };
-          await lp.onUpdatePickerItem(
-            picker,
-            engOpts,
-            "manual",
-            new CancellationTokenSource().token
-          );
-          await lp.onDidAccept({ picker, opts: engOpts, lc });
-          const node = getNoteFromTextEditor();
-          await runJestHarnessV2(
-            [
-              {
-                actual: _.trim(node.body),
-                expected: "ch1 template",
-              },
-            ],
-            expect
-          );
-          done();
-        },
-      });
-    });
-
-    test("lookup new node with schema template on namespace", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupSchemaPresetWithNamespaceTemplate({
-            wsRoot,
-            vaults,
-          });
-        },
-        onInit: async ({ vaults }) => {
-          const { lp, lc } = await lookupHelper("note");
-          const picker = createMockQuickPick({
-            value: "daily.journal.2020.08.10",
-            selectedItems: [createNoActiveItem(vaults[0])],
-          });
-          await lp.onUpdatePickerItem(
-            picker,
-            engOpts,
-            "manual",
-            new CancellationTokenSource().token
-          );
-          await lp.onDidAccept({ picker, opts: engOpts, lc });
-          const node = getNoteFromTextEditor();
-          await runJestHarnessV2(
-            [
-              {
-                actual: _.trim(node.body),
-                expected: "Template text",
-              },
-            ],
-            expect
-          );
-          done();
-        },
-      });
-    });
-  });
-
-  describe("arguments", () => {
-    test("accepting splitType modifier as argument will pre-press button", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-        },
-        onInit: async () => {
-          
-          const controller = new LookupControllerV2(
-            engOpts,
-            { splitType: "horizontal" }
-          );
-          const picker = await controller.show();
-          const splitBtn = _.find(picker.buttons, (button) => {
-            return button.type === "horizontal";
-          });
-          
-          expect(splitBtn?.pressed).toBeTruthy();
-
-          picker.hide();
-          done();
-        }, 
-      });
-    });
-  });
-
-  describe("onAccept:multiple", () => {
-    test("existing notes", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-        },
-        onInit: async ({ wsRoot }) => {
-          const { lc, lp } = await lookupHelper(engOpts.flavor);
-          const client = getWS().getEngine();
-          const notes = ["foo", "foo.ch1"].map((fname) => client.notes[fname]);
-          const items = notes.map((note) =>
-            DNodeUtils.enhancePropForQuickInput({
-              wsRoot,
-              props: note,
-              schemas: client.schemas,
-              vaults: DendronWorkspace.instance().config.vaults,
-            })
-          );
-          const quickpick = createMockQuickPick({
-            value: "foo",
-            selectedItems: items,
-          });
-          quickpick.canSelectMany = true;
-          await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          const openWindows = vscode.workspace.textDocuments.map((ent) =>
-            path.basename(ent.uri.fsPath, ".md")
-          );
-          await runJestHarnessV2(
-            [
-              {
-                actual: _.every(
-                  notes.map((n) => _.includes(openWindows, n.fname))
-                ),
-                expected: true,
-              },
-            ],
-            expect
-          );
-          done();
-        },
-      });
-    });
-  });
-});
-
-suite("selectionExtract", function () {
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {});
-
-  describe("extraction from file not in known vault", () => {
-    test("basic", (done) => {
-      runLegacySingleWorkspaceTest({
-        ctx,
-        onInit: async ({ vaults }) => {
-          // open and create a file outside of vault.
-          const extDir = tmpDir().name;
-          const extPath = "outside.md";
-          const extBody = "non vault content";
-          await FileTestUtils.createFiles(extDir, [
-            { path: extPath, body: extBody },
-          ]);
-          const uri = vscode.Uri.file(path.join(extDir, extPath));
-          const editor = (await VSCodeUtils.openFileInEditor(
-            uri
-          )) as vscode.TextEditor;
-
-          // select content from above file and do a lookup.
-          const vault = vaults[0];
-          const picker = createMockQuickPick({
-            selectedItems: [createNoActiveItem(vault)],
-            buttons: createAllButtons(["selectionExtract"]),
-          });
-
-          const { lc, lp } = await lookupHelperForNote();
-
-          await lc.updatePickerBehavior({
-            quickPick: picker,
-            provider: lp,
-            document: editor.document,
-            range: new vscode.Range(0, 0, 0, 17),
-            quickPickValue: "from-outside",
-          });
-
-          const engOpts: EngineOpts = { flavor: "note" };
-
-          lp.onDidAccept({
-            picker,
-            opts: engOpts,
-            lc,
-          });
-
-          // original note content should not be altered.
-          const newEditor = (await VSCodeUtils.openFileInEditor(
-            uri
-          )) as vscode.TextEditor;
-
-          expect(newEditor.document.getText()).toEqual(extBody);
-
-          done();
-        },
-      });
-    });
-  });
-});
-
-// suite.skip("selection2Link", function () {
-//   let root: DirResult;
-//   let ctx: vscode.ExtensionContext;
-//   let lookupOpts: LookupCommandOpts = {
-//     noteType: "scratch",
-//     selectionType: "selection2link",
-//     noConfirm: true,
-//     flavor: "note",
-//   };
-//   let vaultDir: string;
-//   this.timeout(TIMEOUT);
-
-//   beforeEach(function () {
-//     root = tmpDir();
-//     ctx = VSCodeUtils.getOrCreateMockContext();
-//     DendronWorkspace.getOrCreate(ctx);
-//   });
-
-//   afterEach(function () {
-//     HistoryService.instance().clearSubscriptions();
-//   });
-
-//   test("slug title", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultDir, "foo.md"));
-//       const editor = (await VSCodeUtils.openFileInEditor(
-//         uri
-//       )) as vscode.TextEditor;
-//       editor.selection = new vscode.Selection(7, 0, 7, 12);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("scratch"));
-//       assert.ok(getActiveEditorBasename().endsWith("foo-body.md"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       useCb: (_vaultDir) => {
-//         vaultDir = _vaultDir;
-//         return NodeTestPresetsV2.createOneNoteOneSchemaPresetWithBody({
-//           vaultDir,
-//         });
-//       },
-//     });
-//   });
-
-//   test("no slug title", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultDir, "foo.md"));
-//       const editor = (await VSCodeUtils.openFileInEditor(
-//         uri
-//       )) as vscode.TextEditor;
-//       editor.selection = new vscode.Selection(7, 0, 7, 12);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("scratch"));
-//       assert.ok(!getActiveEditorBasename().endsWith("foo-body.md"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG.LINK_SELECT_AUTO_TITLE_BEHAVIOR.key]: "none",
-//       },
-//       useCb: (_vaultDir) => {
-//         vaultDir = _vaultDir;
-//         return NodeTestPresetsV2.createOneNoteOneSchemaPresetWithBody({
-//           vaultDir,
-//         });
-//       },
-//     });
-//   });
+// const createEngineForSchemaUpdateItems = createEngineFactory({
+//   querySchema: (_opts: WorkspaceOpts) => {
+//     const querySchema: DendronEngineV2["querySchema"] = async (qs) => {
+//       const engOpts: EngineOpts = { flavor: "schema" };
+//       const ws = DendronWorkspace.instance();
+//       const client = ws.getEngine();
+//       const lc = new LookupControllerV2(engOpts);
+//       const lp = new LookupProviderV2(engOpts);
+//       const quickpick = await lc.show();
+//       quickpick.value = qs;
+//       await lp.onUpdatePickerItem(
+//         quickpick,
+//         engOpts,
+//         "manual",
+//         lc.cancelToken.token
+//       );
+//       const schemaModules = _.map(
+//         lc.quickPick?.items,
+//         (ent) => client.schemas[ent.id]
+//       ).filter((ent) => !_.isUndefined(ent));
+//       return {
+//         data: schemaModules,
+//         error: null,
+//       };
+//     };
+//     return querySchema;
+//   },
 // });
 
-// suite.skip("scratch notes", function () {
-//   let root: DirResult;
-//   let ctx: vscode.ExtensionContext;
-//   let noteType = "SCRATCH";
-//   let lookupOpts: LookupCommandOpts = {
-//     noteType: "scratch",
-//     selectionType: "selection2link",
-//     noConfirm: true,
-//     flavor: "note",
-//   };
-//   this.timeout(TIMEOUT);
-
-//   beforeEach(function () {
-//     root = tmpDir();
-//     ctx = VSCodeUtils.getOrCreateMockContext();
-//     DendronWorkspace.getOrCreate(ctx);
-//   });
-
-//   afterEach(function () {
-//     HistoryService.instance().clearSubscriptions();
-//   });
-
-//   test("basic", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("scratch"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
-
-//   test("add: childOfCurrent", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.scratch"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "childOfCurrent",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
-
-//   test("add: childOfDomain", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.scratch"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "childOfDomain",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
-// });
-
-// suite.skip("effect buttons", function () {
-//   let ctx: vscode.ExtensionContext;
-//   this.timeout(TIMEOUT);
-
-//   describe("copy note link", function () {
-//     beforeEach(function () {
-//       ctx = VSCodeUtils.getOrCreateMockContext();
-//       DendronWorkspace.getOrCreate(ctx);
-//     });
-
-//     test("basic", function (done) {
-//       setupCase2({ ctx }).then(async ({}) => {
+// const createEngineForNoteUpdateItems = createEngineFactory({
+//   queryNotes: (_opts: WorkspaceOpts) => {
+//     const queryNotes: DendronEngineV2["queryNotes"] = async (opts) => {
+//       return new Promise(async (resolve) => {
 //         const engOpts: EngineOpts = { flavor: "note" };
+//         const ws = DendronWorkspace.instance();
+//         const client = ws.getEngine();
 //         const lc = new LookupControllerV2(engOpts);
-//         await lc.show();
-//         const client = DendronWorkspace.instance().getEngine();
-//         const notes = ["foo", "foo.ch1"].map((fname) => client.notes[fname]);
-//         const items = notes.map((note) =>
-//           DNodeUtils.enhancePropForQuickInput({
+//         const lp = new LookupProviderV2(engOpts);
+//         const quickpick = await lc.show();
+//         quickpick.value = opts.qs;
+//         const newPicker = await lp.onUpdatePickerItem(
+//           quickpick,
+//           { ...engOpts, force: true },
+//           "manual",
+//           lc.cancelToken.token
+//         );
+//         let data = _.map(
+//           newPicker?.items,
+//           (ent) => client.notes[ent.id]
+//         ).filter((ent) => !_.isUndefined(ent));
+//         if (opts.vault) {
+//           // NOTE: this is a hack
+//           data = data.filter(
+//             (ent) =>
+//               path.basename(ent.vault.fsPath) ===
+//               path.basename(opts.vault?.fsPath as string)
+//           );
+//         }
+//         resolve({ data, error: null });
+
+//         // return {
+//         //   data,
+//         //   error: null,
+//         // };
+//       });
+//     };
+//     return queryNotes;
+//   },
+// });
+
+// const lookupHelper = async (flavor: EngineFlavor) => {
+//   const engOpts: EngineOpts = { flavor };
+//   const lc = new LookupControllerV2(engOpts);
+//   const lp = new LookupProviderV2(engOpts);
+//   const picker = await lc.show();
+//   return { lc, lp, picker };
+// };
+
+// const lookupHelperForNote = async () => {
+//   const engOpts: EngineOpts = { flavor: "note" };
+//   const lc = new LookupControllerV2(engOpts);
+//   const lp = new LookupProviderV2(engOpts);
+//   const picker = createMockQuickPick({});
+
+//   return { lc, lp, picker };
+// };
+
+// const schemaAcceptHelper = async (qs: string) => {
+//   const engOpts: EngineOpts = { flavor: "schema" };
+//   const ws = DendronWorkspace.instance();
+//   const client = ws.getEngine();
+//   const schemaModule = client.schemas[qs];
+//   const schemaInput = SchemaUtils.enhanceForQuickInput({
+//     props: schemaModule,
+//     vaults: DendronWorkspace.instance().config.vaults,
+//   });
+//   const quickpick = createMockQuickPick({
+//     value: qs,
+//     selectedItems: [schemaInput],
+//   });
+//   const lc = new LookupControllerV2(engOpts);
+//   const lp = new LookupProviderV2(engOpts);
+//   const resp = await lp.onDidAccept({
+//     picker: quickpick,
+//     opts: engOpts,
+//     lc,
+//   });
+//   return resp?.uris;
+// };
+
+// const createEngineForSchemaAcceptQuery = createEngineFactory({
+//   writeSchema: (_opts: WorkspaceOpts) => {
+//     const func: DendronEngineV2["writeSchema"] = async (schema) => {
+//       const engOpts: EngineOpts = { flavor: "schema" };
+//       const quickpick = createMockQuickPick({
+//         value: schema.fname,
+//         selectedItems: [NotePickerUtils.createNoActiveItem(schema.vault)],
+//       });
+//       const lc = new LookupControllerV2(engOpts);
+//       const lp = new LookupProviderV2(engOpts);
+//       await lp.onDidAccept({
+//         picker: quickpick,
+//         opts: engOpts,
+//         lc,
+//       });
+//       await quickpick.hide();
+//     };
+//     return func;
+//   },
+//   querySchema: (_opts: WorkspaceOpts) => {
+//     const querySchema: DendronEngineV2["querySchema"] = async (qs) => {
+//       const uris = await schemaAcceptHelper(qs);
+//       const schemas = uris?.map((ent) => {
+//         return SchemaUtils.getSchemaModuleByFnameV4({
+//           fname: path.basename(ent.fsPath, ".schema.yml"),
+//           schemas: getWS().getEngine().schemas,
+//           vault: { fsPath: path.dirname(ent.fsPath) },
+//           wsRoot: _opts.wsRoot,
+//         });
+//       }) as SchemaModuleProps[];
+//       return {
+//         error: null,
+//         data: schemas,
+//       };
+//     };
+//     return querySchema;
+//   },
+// });
+
+// const createEngineForNoteAcceptNewItem = createEngineFactory({
+//   writeNote: (_opts: WorkspaceOpts) => {
+//     const func: DendronEngineV2["writeNote"] = async (note) => {
+//       const engOpts: EngineOpts = { flavor: "note" };
+//       const quickpick = createMockQuickPick({
+//         value: note.fname,
+//         selectedItems: [createNoActiveItem(note.vault)],
+//       });
+//       const lc = new LookupControllerV2(engOpts);
+//       const lp = new LookupProviderV2(engOpts);
+//       const resp = await lp.onDidAccept({
+//         picker: quickpick,
+//         opts: engOpts,
+//         lc,
+//       });
+//       if (_.isUndefined(resp)) {
+//         throw Error("resp is undefined");
+//       }
+//       return resp.resp;
+//     };
+//     return func;
+//   },
+//   queryNotes: (_opts: WorkspaceOpts) => {
+//     const queryNotes: DendronEngineV2["queryNotes"] = async (opts) => {
+//       return getWS().getEngine().queryNotes(opts);
+//     };
+//     return queryNotes;
+//   },
+// });
+
+// suite("Lookup, schemas", function () {
+//   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {});
+
+//   describe("updateItems", () => {
+//     _.map(
+//       ENGINE_QUERY_PRESETS["SCHEMAS"],
+//       (TestCase: TestPresetEntryV4, name) => {
+//         test(name, (done) => {
+//           const { testFunc, preSetupHook } = TestCase;
+//           runLegacyMultiWorkspaceTest({
+//             ctx,
+//             postSetupHook: async ({ wsRoot, vaults }) => {
+//               await preSetupHook({
+//                 wsRoot,
+//                 vaults,
+//               });
+//             },
+//             onInit: async ({ vaults, wsRoot }) => {
+//               const engineMock = createEngineForSchemaUpdateItems({
+//                 wsRoot,
+//                 vaults,
+//               });
+//               const results = await testFunc({
+//                 engine: engineMock,
+//                 vaults,
+//                 wsRoot,
+//                 initResp: {} as any,
+//               });
+//               await runJestHarnessV2(results, expect);
+//               done();
+//             },
+//           });
+//         });
+//       }
+//     );
+//   });
+
+//   describe("onAccept", () => {
+//     _.map(
+//       _.pick(ENGINE_QUERY_PRESETS["SCHEMAS"], "SIMPLE"),
+//       (TestCase: TestPresetEntryV4, name) => {
+//         test(name, (done) => {
+//           const { testFunc, preSetupHook } = TestCase;
+//           runLegacyMultiWorkspaceTest({
+//             ctx,
+//             postSetupHook: async ({ wsRoot, vaults }) => {
+//               await preSetupHook({
+//                 wsRoot,
+//                 vaults,
+//               });
+//             },
+//             onInit: async ({ vaults, wsRoot }) => {
+//               const engineMock = createEngineForSchemaAcceptQuery({
+//                 wsRoot,
+//                 vaults,
+//               });
+//               const results = await testFunc({
+//                 engine: engineMock,
+//                 vaults,
+//                 wsRoot,
+//                 initResp: {} as any,
+//               });
+//               await runJestHarnessV2(results, expect);
+//               done();
+//             },
+//           });
+//         });
+//       }
+//     );
+
+//     _.map(
+//       _.pick(ENGINE_WRITE_PRESETS.SCHEMAS, "ADD_NEW_MODULE_NO_CHILD"),
+//       (TestCase: TestPresetEntryV4, name) => {
+//         test(name, (done) => {
+//           const { testFunc, preSetupHook } = TestCase;
+//           runLegacyMultiWorkspaceTest({
+//             ctx,
+//             postSetupHook: async ({ wsRoot, vaults }) => {
+//               await preSetupHook({
+//                 wsRoot,
+//                 vaults,
+//               });
+//             },
+//             onInit: async ({ vaults, wsRoot }) => {
+//               const engineMock = createEngineForSchemaAcceptQuery({
+//                 wsRoot,
+//                 vaults,
+//               });
+//               const results = await testFunc({
+//                 engine: engineMock,
+//                 vaults,
+//                 wsRoot,
+//                 initResp: {} as any,
+//               });
+//               await runJestHarnessV2(results, expect);
+//               done();
+//             },
+//           });
+//         });
+//       }
+//     );
+//   });
+// });
+
+// suite("Lookup, notesv2", function () {
+//   const engOpts: EngineOpts = { flavor: "note" };
+
+//   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
+//     afterHook: async () => {
+//       sinon.restore();
+//     },
+//   });
+
+//   // TODO: flaky test, can run by itself
+//   describe.skip("updateItems", () => {
+//     _.forEach(
+//       ENGINE_QUERY_PRESETS["NOTES"],
+//       (TestCase: TestPresetEntryV4, name) => {
+//         test(name, (done) => {
+//           const { testFunc, preSetupHook } = TestCase;
+//           runLegacySingleWorkspaceTest({
+//             ctx,
+//             postSetupHook: async ({ wsRoot, vaults }) => {
+//               await preSetupHook({
+//                 wsRoot,
+//                 vaults,
+//               });
+//             },
+//             onInit: async ({ vaults, wsRoot }) => {
+//               const engineMock = createEngineForNoteUpdateItems({
+//                 wsRoot,
+//                 vaults,
+//               });
+//               const results = await testFunc({
+//                 engine: engineMock,
+//                 vaults,
+//                 wsRoot,
+//                 initResp: {} as any,
+//                 extra: { vscode: true },
+//               });
+//               await runJestHarnessV2(results, expect);
+//               done();
+//             },
+//           });
+//         });
+//       }
+//     );
+
+//     // migrated
+//     test("opened note", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         preSetupHook: async ({ wsRoot, vaults }) => {
+//           ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+//         },
+//         onInit: async () => {
+//           const engOpts: EngineOpts = { flavor: "note" };
+//           const lc = new LookupControllerV2(engOpts);
+//           const lp = new LookupProviderV2(engOpts);
+//           const root = DendronWorkspace.wsRoot();
+//           await VSCodeUtils.openFileInEditor(
+//             vscode.Uri.file(path.join(root, "vault1", "foo.md"))
+//           );
+//           const quickpick = await lc.show();
+//           quickpick.onDidChangeActive(() => {
+//             expect(lc.quickPick?.activeItems.length).toEqual(1);
+//             expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
+//             done();
+//           });
+//           await lp.onUpdatePickerItem(
+//             quickpick,
+//             engOpts,
+//             "manual",
+//             lc.cancelToken.token
+//           );
+//         },
+//       });
+//     });
+
+//     // migrated
+//     test("remove stub status after creation", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         preSetupHook: async ({ wsRoot, vaults }) => {
+//           await NOTE_PRESETS_V4.NOTE_SIMPLE_CHILD.create({
+//             vault: vaults[0],
+//             wsRoot,
+//           });
+//         },
+//         onInit: async () => {
+//           const engOpts: EngineOpts = { flavor: "note" };
+//           const lc = new LookupControllerV2(engOpts);
+//           const lp = new LookupProviderV2(engOpts);
+
+//           const quickpick = await lc.show();
+//           let note = _.find(quickpick.items, {
+//             fname: "foo",
+//           }) as DNodePropsQuickInputV2;
+//           expect(note.stub).toBeTruthy();
+//           quickpick.selectedItems = [note];
+//           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
+//           lc.onDidHide(async () => {
+//             expect(
+//               path.basename(
+//                 VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+//               )
+//             ).toEqual("foo.md");
+//             const lc2 = new LookupControllerV2(engOpts);
+//             const quickpick2 = await lc2.show();
+//             note = _.find(quickpick2.items, {
+//               fname: "foo",
+//             }) as DNodePropsQuickInputV2;
+//             expect(note.stub).toBeFalsy();
+//             done();
+//           });
+//           quickpick.hide();
+//         },
+//       });
+//     });
+
+//     // skip
+//     test("schema suggestion", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+//           const vpath = vault2Path({ vault: vaults[0], wsRoot });
+//           fs.removeSync(path.join(vpath, "foo.ch1.md"));
+//         },
+//         onInit: async () => {
+//           const { lc, lp, picker: quickpick } = await lookupHelper("note");
+//           quickpick.value = "foo.";
+//           await lp.onUpdatePickerItem(
+//             quickpick,
+//             { flavor: "note" },
+//             "manual",
+//             lc.cancelToken.token
+//           );
+//           const schemaItem = _.pick(
+//             _.find(quickpick.items, { fname: "foo.ch1" }),
+//             ["fname", "schemaStub"]
+//           );
+//           await runJestHarnessV2(
+//             [
+//               {
+//                 actual: schemaItem,
+//                 expected: {
+//                   fname: "foo.ch1",
+//                   schemaStub: true,
+//                 },
+//               },
+//             ],
+//             expect
+//           );
+//           done();
+//         },
+//       });
+//     });
+
+//     test("filter by depth", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         preSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+//           await NOTE_PRESETS_V4.NOTE_SIMPLE_GRANDCHILD.create({
+//             wsRoot,
+//             vault: vaults[0],
+//           });
+//         },
+//         onInit: async () => {
+//           const { picker: quickpick, lp, lc } = await lookupHelper("note");
+//           quickpick.value = "foo.";
+//           quickpick.showDirectChildrenOnly = true;
+//           await lp.onUpdatePickerItem(
+//             quickpick,
+//             { flavor: "note" },
+//             "manual",
+//             lc.cancelToken.token
+//           );
+//           expect(quickpick.items.length).toEqual(4);
+//           expect(_.find(quickpick.items, { fname: "foo.ch1.gch1" })).toEqual(
+//             undefined
+//           );
+//           done();
+//         },
+//       });
+//     });
+//   });
+
+//   describe("onAccept with modifiers", () => {
+//     test("with lookupPrompt on current vault", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         onInit: async ({ wsRoot, vaults }) => {
+//           const engOpts: EngineOpts = { flavor: "note" };
+//           withConfig(
+//             (config) => {
+//               config.lookupConfirmVaultOnCreate = true;
+//               return config;
+//             },
+//             { wsRoot }
+//           );
+
+//           const vault = vaults[0];
+//           const { lc, lp, picker } = await lookupHelperForNote();
+//           await lc.updatePickerBehavior({ quickPick: picker, provider: lp });
+
+//           picker.value = "alpha";
+//           sinon.stub(picker, "selectedItems").get(() => {
+//             return [createNoActiveItem(vault)];
+//           });
+//           sinon
+//             .stub(PickerUtilsV2, "promptVault")
+//             .returns(Promise.resolve(vaults[0]));
+
+//           await lp.onDidAccept({
+//             picker,
+//             opts: engOpts,
+//             lc,
+//           });
+//           expect(
+//             (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
+//               path.join("vault1", "alpha.md")
+//             )
+//           ).toBeTruthy();
+//           done();
+//         },
+//       });
+//     });
+
+//     test("with lookupPrompt on other vault", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         onInit: async ({ wsRoot, vaults }) => {
+//           const engOpts: EngineOpts = { flavor: "note" };
+//           withConfig(
+//             (config) => {
+//               config.lookupConfirmVaultOnCreate = true;
+//               return config;
+//             },
+//             { wsRoot }
+//           );
+
+//           const vault = vaults[0];
+//           const { lc, lp, picker } = await lookupHelperForNote();
+//           await lc.updatePickerBehavior({ quickPick: picker, provider: lp });
+
+//           picker.value = "alpha";
+//           sinon.stub(picker, "selectedItems").get(() => {
+//             return [createNoActiveItem(vault)];
+//           });
+//           sinon
+//             .stub(PickerUtilsV2, "getOrPromptVaultForNewNote")
+//             .returns(Promise.resolve(vaults[1]));
+
+//           await lp.onDidAccept({
+//             picker,
+//             opts: engOpts,
+//             lc,
+//           });
+//           expect(
+//             (await EditorUtils.getURIForActiveEditor()).fsPath.endsWith(
+//               path.join("vault2", "alpha.md")
+//             )
+//           ).toBeTruthy();
+//           done();
+//         },
+//       });
+//     });
+
+//     test("scratch config in yml ", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         wsSettingsOverride: {
+//           settings: {
+//             [CONFIG.DEFAULT_JOURNAL_NAME.key]: "scratch",
+//           },
+//         },
+//         modConfigCb: (config) => {
+//           config.scratch!.name = "testScratch";
+//           return config;
+//         },
+//         preSetupHook: ENGINE_HOOKS.setupBasic,
+//         onInit: async () => {
+//           const cmd = new LookupCommand();
+//           const note = getWS().getEngine().notes["foo"];
+//           await VSCodeUtils.openNote(note);
+//           await cmd.run({
+//             noConfirm: true,
+//             noteType: LookupNoteTypeEnum.scratch,
+//             flavor: "note",
+//           });
+//           expect(
+//             path
+//               .basename(
+//                 VSCodeUtils.getActiveTextEditorOrThrow().document.uri.fsPath
+//               )
+//               .startsWith("testScratch")
+//           ).toBeTruthy();
+//           done();
+//         },
+//       });
+//     });
+//   });
+
+//   // TODO: don't skip
+//   describe("onAccept", () => {
+//     _.map(
+//       _.pick(ENGINE_WRITE_PRESETS["NOTES"], "NEW_DOMAIN"),
+//       (TestCase: TestPresetEntryV4, name) => {
+//         test(name, (done) => {
+//           const { testFunc, preSetupHook } = TestCase;
+//           runLegacyMultiWorkspaceTest({
+//             ctx,
+//             postSetupHook: async ({ wsRoot, vaults }) => {
+//               await preSetupHook({
+//                 wsRoot,
+//                 vaults,
+//               });
+//             },
+//             onInit: async ({ vaults, wsRoot }) => {
+//               const engineMock = createEngineForNoteAcceptNewItem({
+//                 wsRoot,
+//                 vaults,
+//               });
+//               const results = await testFunc({
+//                 engine: engineMock,
+//                 vaults,
+//                 wsRoot,
+//                 initResp: {} as any,
+//               });
+//               await runJestHarnessV2(results, expect);
+//               done();
+//             },
+//           });
+//         });
+//       }
+//     );
+
+//     test("with override", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         preSetupHook: ENGINE_HOOKS.setupBasic,
+//         onInit: async () => {
+//           const cmd = new LookupCommand();
+//           const note = getWS().getEngine().notes["foo"];
+//           await VSCodeUtils.openNote(note);
+//           await cmd.run({
+//             noConfirm: true,
+//             value: "gamma",
+//             noteType: LookupNoteTypeEnum.journal,
+//             flavor: "note",
+//           });
+//           expect(
+//             path
+//               .basename(
+//                 VSCodeUtils.getActiveTextEditorOrThrow().document.uri.fsPath
+//               )
+//               .startsWith("gamma.journal")
+//           ).toBeTruthy();
+//           done();
+//         },
+//       });
+//     });
+
+//     test("existing note", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
+//         },
+//         onInit: async ({ vaults, wsRoot }) => {
+//           const { lp, lc } = await lookupHelper("note");
+//           const ws = DendronWorkspace.instance();
+//           const client = ws.getEngine();
+//           const note = NoteUtils.getNoteByFnameV5({
+//             fname: "foo",
+//             notes: client.notes,
+//             vault: vaults[0],
+//             wsRoot: DendronWorkspace.wsRoot(),
+//           }) as NoteProps;
+//           const item = DNodeUtils.enhancePropForQuickInput({
+//             wsRoot,
 //             props: note,
 //             schemas: client.schemas,
 //             vaults: DendronWorkspace.instance().config.vaults,
-//           })
-//         );
-//         lc.quickPick = createMockQuickPick({
-//           value: "foo",
-//           selectedItems: items,
-//         });
-//         (_.find(lc.state.buttons, {
-//           type: "multiSelect",
-//         }) as MultiSelectBtn).pressed = true;
-//         await lc.onTriggerButton(CopyNoteLinkBtn.create(true));
-//         assert.strictEqual(
-//           clipboardy.readSync(),
-//           "[[Foo|foo]]\n[[Ch1|foo.ch1]]"
-//         );
-//         done();
+//           });
+//           const quickpick = createMockQuickPick({
+//             value: "foo",
+//             selectedItems: [item],
+//           });
+//           await lp.onDidAccept({
+//             picker: quickpick,
+//             opts: { flavor: "note" },
+//             lc,
+//           });
+
+//           await runJestHarnessV2(
+//             [
+//               {
+//                 actual: DNodeUtils.fname(
+//                   VSCodeUtils.getActiveTextEditor()?.document.uri
+//                     .fsPath as string
+//                 ),
+//                 expected: "foo",
+//               },
+//               {
+//                 actual: _.pick(getNoteFromTextEditor(), "title"),
+//                 expected: {
+//                   title: "Foo",
+//                 },
+//               },
+//             ],
+//             expect
+//           );
+//           done();
+//         },
+//       });
+//     });
+
+//     test("lookup new node with schema template", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
+//         },
+//         onInit: async ({ vaults }) => {
+//           const { lp, lc } = await lookupHelper("note");
+//           const picker = createMockQuickPick({
+//             value: "bar.ch1",
+//             selectedItems: [createNoActiveItem(vaults[0])],
+//           });
+//           const engOpts: EngineOpts = { flavor: "note" };
+//           await lp.onUpdatePickerItem(
+//             picker,
+//             engOpts,
+//             "manual",
+//             new CancellationTokenSource().token
+//           );
+//           await lp.onDidAccept({ picker, opts: engOpts, lc });
+//           const node = getNoteFromTextEditor();
+//           await runJestHarnessV2(
+//             [
+//               {
+//                 actual: _.trim(node.body),
+//                 expected: "ch1 template",
+//               },
+//             ],
+//             expect
+//           );
+//           done();
+//         },
+//       });
+//     });
+
+//     test("lookup new node with schema template on namespace", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupSchemaPresetWithNamespaceTemplate({
+//             wsRoot,
+//             vaults,
+//           });
+//         },
+//         onInit: async ({ vaults }) => {
+//           const { lp, lc } = await lookupHelper("note");
+//           const picker = createMockQuickPick({
+//             value: "daily.journal.2020.08.10",
+//             selectedItems: [createNoActiveItem(vaults[0])],
+//           });
+//           await lp.onUpdatePickerItem(
+//             picker,
+//             engOpts,
+//             "manual",
+//             new CancellationTokenSource().token
+//           );
+//           await lp.onDidAccept({ picker, opts: engOpts, lc });
+//           const node = getNoteFromTextEditor();
+//           await runJestHarnessV2(
+//             [
+//               {
+//                 actual: _.trim(node.body),
+//                 expected: "Template text",
+//               },
+//             ],
+//             expect
+//           );
+//           done();
+//         },
+//       });
+//     });
+//   });
+
+//   describe("arguments", () => {
+//     test("accepting splitType modifier as argument will pre-press button", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+//         },
+//         onInit: async () => {
+          
+//           const controller = new LookupControllerV2(
+//             engOpts,
+//             { splitType: "horizontal" }
+//           );
+//           const picker = await controller.show();
+//           const splitBtn = _.find(picker.buttons, (button) => {
+//             return button.type === "horizontal";
+//           });
+          
+//           expect(splitBtn?.pressed).toBeTruthy();
+
+//           picker.hide();
+//           done();
+//         }, 
+//       });
+//     });
+//   });
+
+//   describe("onAccept:multiple", () => {
+//     test("existing notes", (done) => {
+//       runLegacyMultiWorkspaceTest({
+//         ctx,
+//         postSetupHook: async ({ wsRoot, vaults }) => {
+//           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+//         },
+//         onInit: async ({ wsRoot }) => {
+//           const { lc, lp } = await lookupHelper(engOpts.flavor);
+//           const client = getWS().getEngine();
+//           const notes = ["foo", "foo.ch1"].map((fname) => client.notes[fname]);
+//           const items = notes.map((note) =>
+//             DNodeUtils.enhancePropForQuickInput({
+//               wsRoot,
+//               props: note,
+//               schemas: client.schemas,
+//               vaults: DendronWorkspace.instance().config.vaults,
+//             })
+//           );
+//           const quickpick = createMockQuickPick({
+//             value: "foo",
+//             selectedItems: items,
+//           });
+//           quickpick.canSelectMany = true;
+//           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
+//           const openWindows = vscode.workspace.textDocuments.map((ent) =>
+//             path.basename(ent.uri.fsPath, ".md")
+//           );
+//           await runJestHarnessV2(
+//             [
+//               {
+//                 actual: _.every(
+//                   notes.map((n) => _.includes(openWindows, n.fname))
+//                 ),
+//                 expected: true,
+//               },
+//             ],
+//             expect
+//           );
+//           done();
+//         },
 //       });
 //     });
 //   });
 // });
 
-// suite.skip("journal notes", function () {
-//   let root: DirResult;
-//   let ctx: vscode.ExtensionContext;
-//   let noteType = "JOURNAL";
-//   let lookupOpts: LookupCommandOpts = {
-//     noteType: "journal",
-//     noConfirm: true,
-//     flavor: "note",
-//   };
-//   this.timeout(TIMEOUT);
+// suite("selectionExtract", function () {
+//   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {});
 
-//   beforeEach(function () {
-//     root = tmpDir();
-//     ctx = VSCodeUtils.getOrCreateMockContext();
-//     DendronWorkspace.getOrCreate(ctx);
-//   });
+//   describe("extraction from file not in known vault", () => {
+//     test("basic", (done) => {
+//       runLegacySingleWorkspaceTest({
+//         ctx,
+//         onInit: async ({ vaults }) => {
+//           // open and create a file outside of vault.
+//           const extDir = tmpDir().name;
+//           const extPath = "outside.md";
+//           const extBody = "non vault content";
+//           await FileTestUtils.createFiles(extDir, [
+//             { path: extPath, body: extBody },
+//           ]);
+//           const uri = vscode.Uri.file(path.join(extDir, extPath));
+//           const editor = (await VSCodeUtils.openFileInEditor(
+//             uri
+//           )) as vscode.TextEditor;
 
-//   afterEach(function () {
-//     HistoryService.instance().clearSubscriptions();
-//   });
+//           // select content from above file and do a lookup.
+//           const vault = vaults[0];
+//           const picker = createMockQuickPick({
+//             selectedItems: [createNoActiveItem(vault)],
+//             buttons: createAllButtons(["selectionExtract"]),
+//           });
 
-//   test("basic", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.journal"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
+//           const { lc, lp } = await lookupHelperForNote();
 
-//   test.skip("add: childOfDomainNamespace", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.scratch"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "childOfDomainNamespace",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
+//           await lc.updatePickerBehavior({
+//             quickPick: picker,
+//             provider: lp,
+//             document: editor.document,
+//             range: new vscode.Range(0, 0, 0, 17),
+//             quickPickValue: "from-outside",
+//           });
 
-//   test.skip("add: diff name", function (_done) {});
+//           const engOpts: EngineOpts = { flavor: "note" };
 
-//   // test creating a daily journal with no note open
-//   test("add: asOwnDomain", function (done) {
-//     onWSInit(async () => {
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("journal"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "asOwnDomain",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
+//           lp.onDidAccept({
+//             picker,
+//             opts: engOpts,
+//             lc,
+//           });
 
-//   test("add: childOfCurrent", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.journal"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       lsp: true,
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "childOfCurrent",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
-//     });
-//   });
+//           // original note content should not be altered.
+//           const newEditor = (await VSCodeUtils.openFileInEditor(
+//             uri
+//           )) as vscode.TextEditor;
 
-//   test("add: childOfDomain", function (done) {
-//     onWSInit(async () => {
-//       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
-//       await vscode.window.showTextDocument(uri);
-//       await new LookupCommand().execute(lookupOpts);
-//       assert.ok(getActiveEditorBasename().startsWith("foo.journal"));
-//       done();
-//     });
-//     setupDendronWorkspace(root.name, ctx, {
-//       configOverride: {
-//         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
-//           "childOfDomain",
-//       },
-//       useCb: createOneNoteOneSchemaPresetCallback,
+//           expect(newEditor.document.getText()).toEqual(extBody);
+
+//           done();
+//         },
+//       });
 //     });
 //   });
 // });
+
+// // suite.skip("selection2Link", function () {
+// //   let root: DirResult;
+// //   let ctx: vscode.ExtensionContext;
+// //   let lookupOpts: LookupCommandOpts = {
+// //     noteType: "scratch",
+// //     selectionType: "selection2link",
+// //     noConfirm: true,
+// //     flavor: "note",
+// //   };
+// //   let vaultDir: string;
+// //   this.timeout(TIMEOUT);
+
+// //   beforeEach(function () {
+// //     root = tmpDir();
+// //     ctx = VSCodeUtils.getOrCreateMockContext();
+// //     DendronWorkspace.getOrCreate(ctx);
+// //   });
+
+// //   afterEach(function () {
+// //     HistoryService.instance().clearSubscriptions();
+// //   });
+
+// //   test("slug title", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultDir, "foo.md"));
+// //       const editor = (await VSCodeUtils.openFileInEditor(
+// //         uri
+// //       )) as vscode.TextEditor;
+// //       editor.selection = new vscode.Selection(7, 0, 7, 12);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("scratch"));
+// //       assert.ok(getActiveEditorBasename().endsWith("foo-body.md"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       useCb: (_vaultDir) => {
+// //         vaultDir = _vaultDir;
+// //         return NodeTestPresetsV2.createOneNoteOneSchemaPresetWithBody({
+// //           vaultDir,
+// //         });
+// //       },
+// //     });
+// //   });
+
+// //   test("no slug title", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultDir, "foo.md"));
+// //       const editor = (await VSCodeUtils.openFileInEditor(
+// //         uri
+// //       )) as vscode.TextEditor;
+// //       editor.selection = new vscode.Selection(7, 0, 7, 12);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("scratch"));
+// //       assert.ok(!getActiveEditorBasename().endsWith("foo-body.md"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG.LINK_SELECT_AUTO_TITLE_BEHAVIOR.key]: "none",
+// //       },
+// //       useCb: (_vaultDir) => {
+// //         vaultDir = _vaultDir;
+// //         return NodeTestPresetsV2.createOneNoteOneSchemaPresetWithBody({
+// //           vaultDir,
+// //         });
+// //       },
+// //     });
+// //   });
+// // });
+
+// // suite.skip("scratch notes", function () {
+// //   let root: DirResult;
+// //   let ctx: vscode.ExtensionContext;
+// //   let noteType = "SCRATCH";
+// //   let lookupOpts: LookupCommandOpts = {
+// //     noteType: "scratch",
+// //     selectionType: "selection2link",
+// //     noConfirm: true,
+// //     flavor: "note",
+// //   };
+// //   this.timeout(TIMEOUT);
+
+// //   beforeEach(function () {
+// //     root = tmpDir();
+// //     ctx = VSCodeUtils.getOrCreateMockContext();
+// //     DendronWorkspace.getOrCreate(ctx);
+// //   });
+
+// //   afterEach(function () {
+// //     HistoryService.instance().clearSubscriptions();
+// //   });
+
+// //   test("basic", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("scratch"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test("add: childOfCurrent", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.scratch"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "childOfCurrent",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test("add: childOfDomain", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.scratch"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "childOfDomain",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+// // });
+
+// // suite.skip("effect buttons", function () {
+// //   let ctx: vscode.ExtensionContext;
+// //   this.timeout(TIMEOUT);
+
+// //   describe("copy note link", function () {
+// //     beforeEach(function () {
+// //       ctx = VSCodeUtils.getOrCreateMockContext();
+// //       DendronWorkspace.getOrCreate(ctx);
+// //     });
+
+// //     test("basic", function (done) {
+// //       setupCase2({ ctx }).then(async ({}) => {
+// //         const engOpts: EngineOpts = { flavor: "note" };
+// //         const lc = new LookupControllerV2(engOpts);
+// //         await lc.show();
+// //         const client = DendronWorkspace.instance().getEngine();
+// //         const notes = ["foo", "foo.ch1"].map((fname) => client.notes[fname]);
+// //         const items = notes.map((note) =>
+// //           DNodeUtils.enhancePropForQuickInput({
+// //             props: note,
+// //             schemas: client.schemas,
+// //             vaults: DendronWorkspace.instance().config.vaults,
+// //           })
+// //         );
+// //         lc.quickPick = createMockQuickPick({
+// //           value: "foo",
+// //           selectedItems: items,
+// //         });
+// //         (_.find(lc.state.buttons, {
+// //           type: "multiSelect",
+// //         }) as MultiSelectBtn).pressed = true;
+// //         await lc.onTriggerButton(CopyNoteLinkBtn.create(true));
+// //         assert.strictEqual(
+// //           clipboardy.readSync(),
+// //           "[[Foo|foo]]\n[[Ch1|foo.ch1]]"
+// //         );
+// //         done();
+// //       });
+// //     });
+// //   });
+// // });
+
+// // suite.skip("journal notes", function () {
+// //   let root: DirResult;
+// //   let ctx: vscode.ExtensionContext;
+// //   let noteType = "JOURNAL";
+// //   let lookupOpts: LookupCommandOpts = {
+// //     noteType: "journal",
+// //     noConfirm: true,
+// //     flavor: "note",
+// //   };
+// //   this.timeout(TIMEOUT);
+
+// //   beforeEach(function () {
+// //     root = tmpDir();
+// //     ctx = VSCodeUtils.getOrCreateMockContext();
+// //     DendronWorkspace.getOrCreate(ctx);
+// //   });
+
+// //   afterEach(function () {
+// //     HistoryService.instance().clearSubscriptions();
+// //   });
+
+// //   test("basic", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.journal"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test.skip("add: childOfDomainNamespace", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.scratch"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "childOfDomainNamespace",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test.skip("add: diff name", function (_done) {});
+
+// //   // test creating a daily journal with no note open
+// //   test("add: asOwnDomain", function (done) {
+// //     onWSInit(async () => {
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("journal"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "asOwnDomain",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test("add: childOfCurrent", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.ch1.journal"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       lsp: true,
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "childOfCurrent",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+
+// //   test("add: childOfDomain", function (done) {
+// //     onWSInit(async () => {
+// //       const uri = vscode.Uri.file(path.join(vaultPath, "foo.ch1.md"));
+// //       await vscode.window.showTextDocument(uri);
+// //       await new LookupCommand().execute(lookupOpts);
+// //       assert.ok(getActiveEditorBasename().startsWith("foo.journal"));
+// //       done();
+// //     });
+// //     setupDendronWorkspace(root.name, ctx, {
+// //       configOverride: {
+// //         [CONFIG[`DEFAULT_${noteType}_ADD_BEHAVIOR` as ConfigKey].key]:
+// //           "childOfDomain",
+// //       },
+// //       useCb: createOneNoteOneSchemaPresetCallback,
+// //     });
+// //   });
+// // });

--- a/packages/plugin-core/src/test/suite-integ/LookupCommandMulti.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupCommandMulti.test.ts
@@ -1,324 +1,324 @@
-import { DNodeUtils, DVault, NoteProps } from "@dendronhq/common-all";
-import { file2Note } from "@dendronhq/common-server";
-import { NodeTestPresetsV2, PLUGIN_CORE } from "@dendronhq/common-test-utils";
-import fs from "fs-extra";
-import _ from "lodash";
-import { describe } from "mocha";
-import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
-import { CancellationToken } from "vscode-languageclient";
-import { LookupControllerV2 } from "../../components/lookup/LookupControllerV2";
-import { LookupProviderV2 } from "../../components/lookup/LookupProviderV2";
-import { DendronQuickPickerV2 } from "../../components/lookup/types";
-import { NotePickerUtils } from "../../components/lookup/utils";
-import { EngineOpts } from "../../types";
-import { VSCodeUtils } from "../../utils";
-import { DendronWorkspace } from "../../workspace";
-import { _activate } from "../../_extension";
-import { createMockQuickPick, onWSInit, TIMEOUT } from "../testUtils";
-import {
-  expect,
-  getNoteFromTextEditor,
-  setupCodeWorkspaceMultiVaultV2,
-} from "../testUtilsv2";
-import { setupBeforeAfter } from "../testUtilsV3";
+// import { DNodeUtils, DVault, NoteProps } from "@dendronhq/common-all";
+// import { file2Note } from "@dendronhq/common-server";
+// import { NodeTestPresetsV2, PLUGIN_CORE } from "@dendronhq/common-test-utils";
+// import fs from "fs-extra";
+// import _ from "lodash";
+// import { describe } from "mocha";
+// import path from "path";
+// // // You can import and use all API from the 'vscode' module
+// // // as well as import your extension to test it
+// import * as vscode from "vscode";
+// import { CancellationToken } from "vscode-languageclient";
+// import { LookupControllerV2 } from "../../components/lookup/LookupControllerV2";
+// import { LookupProviderV2 } from "../../components/lookup/LookupProviderV2";
+// import { DendronQuickPickerV2 } from "../../components/lookup/types";
+// import { NotePickerUtils } from "../../components/lookup/utils";
+// import { EngineOpts } from "../../types";
+// import { VSCodeUtils } from "../../utils";
+// import { DendronWorkspace } from "../../workspace";
+// import { _activate } from "../../_extension";
+// import { createMockQuickPick, onWSInit, TIMEOUT } from "../testUtils";
+// import {
+//   expect,
+//   getNoteFromTextEditor,
+//   setupCodeWorkspaceMultiVaultV2,
+// } from "../testUtilsv2";
+// import { setupBeforeAfter } from "../testUtilsV3";
 
-const { LOOKUP_SINGLE_TEST_PRESET } = PLUGIN_CORE;
-const { createNoActiveItem } = NotePickerUtils;
+// const { LOOKUP_SINGLE_TEST_PRESET } = PLUGIN_CORE;
+// const { createNoActiveItem } = NotePickerUtils;
 
-// suite("Lookup Schema, Multi/", function () {
+// // suite("Lookup Schema, Multi/", function () {
+// //   let ctx: vscode.ExtensionContext;
+// //   this.timeout(TIMEOUT);
+
+// //   beforeEach(function () {
+// //     ctx = VSCodeUtils.getOrCreateMockContext();
+// //     DendronWorkspace.getOrCreate(ctx);
+// //     VSCodeUtils.closeAllEditors();
+// //   });
+
+// //   afterEach(function () {
+// //     HistoryService.instance().clearSubscriptions();
+// //     VSCodeUtils.closeAllEditors();
+// //   });
+
+// //   test.skip("basics", function (done) {
+// //     runMultiVaultTest({
+// //       ctx,
+// //       onInit: async ({ vaults, wsRoot }) => {
+// //         const engine = DendronWorkspace.instance().getEngine();
+// //         await SCHEMAS.WRITE.BASICS.postSetupHook({ wsRoot, vaults, engine });
+// //         await runMochaHarness(SCHEMAS.WRITE.BASICS.results, { engine });
+// //         done();
+// //       },
+// //     });
+// //   });
+// // });
+
+// suite.skip("Lookup notes, multi", function () {
+//   let wsRoot: string;
+//   let vaults: DVault[];
 //   let ctx: vscode.ExtensionContext;
+//   const engOpts: EngineOpts = { flavor: "note" };
+//   let token: CancellationToken;
 //   this.timeout(TIMEOUT);
 
-//   beforeEach(function () {
-//     ctx = VSCodeUtils.getOrCreateMockContext();
-//     DendronWorkspace.getOrCreate(ctx);
-//     VSCodeUtils.closeAllEditors();
+//   ctx = setupBeforeAfter(this, {
+//     beforeHook: () => {
+//       token = new vscode.CancellationTokenSource().token;
+//     },
 //   });
 
-//   afterEach(function () {
-//     HistoryService.instance().clearSubscriptions();
-//     VSCodeUtils.closeAllEditors();
-//   });
+//   const runUpdateItemTest = async (opts: {
+//     beforeActivateCb?: (opts: {
+//       vaults: DVault[];
+//       wsRoot: string;
+//     }) => Promise<void>;
+//     onInitCb: (opts: {
+//       lc: LookupControllerV2;
+//       lp: LookupProviderV2;
+//       quickpick: DendronQuickPickerV2;
+//     }) => Promise<void>;
+//   }) => {
+//     const { onInitCb } = opts;
+//     onInitForUpdateItems({ onInitCb });
+//     const { wsRoot: _wsRoot, vaults: _vaults } =
+//       await setupCodeWorkspaceMultiVaultV2({ ctx });
+//     wsRoot = _wsRoot;
+//     vaults = _vaults;
+//     await VSCodeUtils.closeAllEditors();
+//     if (opts.beforeActivateCb) {
+//       await opts.beforeActivateCb({ wsRoot, vaults });
+//     }
+//     await _activate(ctx);
+//   };
 
-//   test.skip("basics", function (done) {
-//     runMultiVaultTest({
+//   const runAcceptItemTest = async (opts: {
+//     beforeActivateCb?: (opts: {
+//       vaults: DVault[];
+//       wsRoot: string;
+//     }) => Promise<void>;
+//     onInitCb: (opts: {
+//       lc: LookupControllerV2;
+//       lp: LookupProviderV2;
+//     }) => Promise<void>;
+//   }) => {
+//     console.log("runAcceptItemTest:enter");
+//     const { onInitCb } = opts;
+//     onInitForAcceptItems({ onInitCb });
+//     const {
+//       wsRoot: _wsRoot,
+//       vaults: _vaults,
+//       workspaceFolders,
+//     } = await setupCodeWorkspaceMultiVaultV2({
 //       ctx,
-//       onInit: async ({ vaults, wsRoot }) => {
-//         const engine = DendronWorkspace.instance().getEngine();
-//         await SCHEMAS.WRITE.BASICS.postSetupHook({ wsRoot, vaults, engine });
-//         await runMochaHarness(SCHEMAS.WRITE.BASICS.results, { engine });
-//         done();
+//       configOverride: {
+//         //"dendron.serverPort": 3005
 //       },
+//     });
+//     console.log(
+//       "runAcceptItemTest:setupCodeWorkspaceV2",
+//       JSON.stringify({ vaults, workspaceFolders })
+//     );
+//     wsRoot = _wsRoot;
+//     vaults = _vaults;
+//     if (opts.beforeActivateCb) {
+//       await opts.beforeActivateCb({ wsRoot, vaults });
+//     }
+//     console.log("runAcceptItemTest:pre_activate");
+//     await _activate(ctx);
+//     console.log("runAcceptItemTest:post_activate");
+//   };
+
+//   const onInitForUpdateItems = async (opts: {
+//     onInitCb: (opts: {
+//       lc: LookupControllerV2;
+//       lp: LookupProviderV2;
+//       quickpick: DendronQuickPickerV2;
+//     }) => Promise<void>;
+//   }) => {
+//     onWSInit(async () => {
+//       const { onInitCb } = opts;
+//       const engOpts: EngineOpts = { flavor: "note" };
+//       const lc = new LookupControllerV2(engOpts);
+//       const lp = new LookupProviderV2(engOpts);
+//       const quickpick = await lc.show();
+//       await onInitCb({ lp, quickpick, lc });
+//     });
+//   };
+
+//   const onInitForAcceptItems = async (opts: {
+//     onInitCb: (opts: {
+//       lc: LookupControllerV2;
+//       lp: LookupProviderV2;
+//     }) => Promise<void>;
+//   }) => {
+//     onWSInit(async () => {
+//       const { onInitCb } = opts;
+//       const engOpts: EngineOpts = { flavor: "note" };
+//       const lc = new LookupControllerV2(engOpts);
+//       const lp = new LookupProviderV2(engOpts);
+//       await onInitCb({ lp, lc });
+//     });
+//   };
+
+//   describe("updateItems", () => {
+//     test("empty qs", (done) => {
+//       runUpdateItemTest({
+//         onInitCb: async ({ quickpick, lp, lc }) => {
+//           quickpick.value = "";
+//           await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
+//           expect(lc.quickPick?.items.length).toEqual(4);
+//           done();
+//         },
+//       });
+//     });
+
+//     test("opened note", (done) => {
+//       runUpdateItemTest({
+//         onInitCb: async ({ quickpick, lp, lc }) => {
+//           await VSCodeUtils.openFileInEditor(
+//             vscode.Uri.file(path.join(vaults[0].fsPath, "foo.md"))
+//           );
+//           quickpick.value = "";
+//           await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
+//           quickpick.onDidChangeActive(() => {
+//             expect(lc.quickPick?.activeItems.length).toEqual(1);
+//             expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
+//             done();
+//           });
+//         },
+//       });
+//     });
+
+//     test("schema suggestion", (done) => {
+//       runUpdateItemTest({
+//         onInitCb: async ({ quickpick, lp }) => {
+//           quickpick.value = "foo.";
+//           await lp.onUpdatePickerItem(
+//             quickpick,
+//             { flavor: "note" },
+//             "manual",
+//             token
+//           );
+//           expect(quickpick.items.length).toEqual(4);
+//           expect(
+//             _.pick(_.find(quickpick.items, { fname: "foo.ch1" }), [
+//               "fname",
+//               "schemaStub",
+//             ])
+//           ).toEqual({
+//             fname: "foo.ch1",
+//             schemaStub: true,
+//           });
+//           done();
+//         },
+//         beforeActivateCb: async ({ vaults }) => {
+//           fs.removeSync(path.join(vaults[0].fsPath, "foo.ch1.md"));
+//         },
+//       });
+//     });
+//   });
+
+//   describe("accept items", () => {
+//     test("exiting item", (done) => {
+//       runAcceptItemTest({
+//         onInitCb: async ({ lp, lc }) => {
+//           const ws = DendronWorkspace.instance();
+//           const client = ws.getEngine();
+//           const note = client.notes["foo"];
+//           const item = DNodeUtils.enhancePropForQuickInput({
+//             wsRoot: DendronWorkspace.wsRoot(),
+//             props: note,
+//             schemas: client.schemas,
+//             vaults: DendronWorkspace.instance().config.vaults,
+//           });
+//           const quickpick = createMockQuickPick({
+//             value: "foo",
+//             selectedItems: [item],
+//           });
+//           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
+//           await NodeTestPresetsV2.runMochaHarness({
+//             opts: {
+//               activeFileName: DNodeUtils.fname(
+//                 VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+//               ),
+//               activeNote: getNoteFromTextEditor(),
+//             },
+//             results:
+//               LOOKUP_SINGLE_TEST_PRESET.ACCEPT_ITEMS.EXISTING_ITEM.results,
+//           });
+//           done();
+//         },
+//       });
+//     });
+
+//     test("new item", (done) => {
+//       runAcceptItemTest({
+//         onInitCb: async ({ lp, lc }) => {
+//           console.log("onInitCb:enter");
+//           const ws = DendronWorkspace.instance();
+//           const client = ws.getEngine();
+//           const note = client.notes["foo"];
+//           await VSCodeUtils.openFileInEditor(
+//             vscode.Uri.file(path.join(note.vault.fsPath, note.fname + ".md"))
+//           );
+//           const quickpick = createMockQuickPick({
+//             value: "bond",
+//             selectedItems: [createNoActiveItem(vaults[0])],
+//           });
+//           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
+//           expect(
+//             DNodeUtils.fname(
+//               VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+//             )
+//           ).toEqual("bond");
+//           const txtPath = vscode.window.activeTextEditor?.document.uri
+//             .fsPath as string;
+//           const vault = { fsPath: path.dirname(txtPath) };
+//           const node = file2Note(txtPath, vault);
+//           expect(node.title).toEqual("Bond");
+//           console.log("onInitCb:exit");
+//           done();
+//         },
+//       });
+//     });
+
+//     test("new item in other", (done) => {
+//       runAcceptItemTest({
+//         onInitCb: async ({ lp, lc }) => {
+//           console.log("onInitCb:enter");
+//           const ws = DendronWorkspace.instance();
+//           const vaults = DendronWorkspace.instance().vaultsv4;
+//           const client = ws.getEngine();
+//           const note = _.find(client.notes, (ent) => {
+//             return (
+//               ent.vault.fsPath === vaults[1].fsPath && ent.fname === "root"
+//             );
+//           }) as NoteProps;
+//           await VSCodeUtils.openFileInEditor(
+//             vscode.Uri.file(path.join(note.vault.fsPath, note.fname + ".md"))
+//           );
+//           const quickpick = createMockQuickPick({
+//             value: "bond",
+//             selectedItems: [createNoActiveItem(vaults[0])],
+//           });
+//           await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
+//           expect(
+//             DNodeUtils.fname(
+//               VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
+//             )
+//           ).toEqual("bond");
+//           const txtPath = vscode.window.activeTextEditor?.document.uri
+//             .fsPath as string;
+//           const vault = { fsPath: path.dirname(txtPath) };
+//           const node = file2Note(txtPath, vault);
+//           expect(node.title).toEqual("Bond");
+//           console.log("onInitCb:exit");
+//           done();
+//         },
+//       });
 //     });
 //   });
 // });
-
-suite.skip("Lookup notes, multi", function () {
-  let wsRoot: string;
-  let vaults: DVault[];
-  let ctx: vscode.ExtensionContext;
-  const engOpts: EngineOpts = { flavor: "note" };
-  let token: CancellationToken;
-  this.timeout(TIMEOUT);
-
-  ctx = setupBeforeAfter(this, {
-    beforeHook: () => {
-      token = new vscode.CancellationTokenSource().token;
-    },
-  });
-
-  const runUpdateItemTest = async (opts: {
-    beforeActivateCb?: (opts: {
-      vaults: DVault[];
-      wsRoot: string;
-    }) => Promise<void>;
-    onInitCb: (opts: {
-      lc: LookupControllerV2;
-      lp: LookupProviderV2;
-      quickpick: DendronQuickPickerV2;
-    }) => Promise<void>;
-  }) => {
-    const { onInitCb } = opts;
-    onInitForUpdateItems({ onInitCb });
-    const { wsRoot: _wsRoot, vaults: _vaults } =
-      await setupCodeWorkspaceMultiVaultV2({ ctx });
-    wsRoot = _wsRoot;
-    vaults = _vaults;
-    await VSCodeUtils.closeAllEditors();
-    if (opts.beforeActivateCb) {
-      await opts.beforeActivateCb({ wsRoot, vaults });
-    }
-    await _activate(ctx);
-  };
-
-  const runAcceptItemTest = async (opts: {
-    beforeActivateCb?: (opts: {
-      vaults: DVault[];
-      wsRoot: string;
-    }) => Promise<void>;
-    onInitCb: (opts: {
-      lc: LookupControllerV2;
-      lp: LookupProviderV2;
-    }) => Promise<void>;
-  }) => {
-    console.log("runAcceptItemTest:enter");
-    const { onInitCb } = opts;
-    onInitForAcceptItems({ onInitCb });
-    const {
-      wsRoot: _wsRoot,
-      vaults: _vaults,
-      workspaceFolders,
-    } = await setupCodeWorkspaceMultiVaultV2({
-      ctx,
-      configOverride: {
-        //"dendron.serverPort": 3005
-      },
-    });
-    console.log(
-      "runAcceptItemTest:setupCodeWorkspaceV2",
-      JSON.stringify({ vaults, workspaceFolders })
-    );
-    wsRoot = _wsRoot;
-    vaults = _vaults;
-    if (opts.beforeActivateCb) {
-      await opts.beforeActivateCb({ wsRoot, vaults });
-    }
-    console.log("runAcceptItemTest:pre_activate");
-    await _activate(ctx);
-    console.log("runAcceptItemTest:post_activate");
-  };
-
-  const onInitForUpdateItems = async (opts: {
-    onInitCb: (opts: {
-      lc: LookupControllerV2;
-      lp: LookupProviderV2;
-      quickpick: DendronQuickPickerV2;
-    }) => Promise<void>;
-  }) => {
-    onWSInit(async () => {
-      const { onInitCb } = opts;
-      const engOpts: EngineOpts = { flavor: "note" };
-      const lc = new LookupControllerV2(engOpts);
-      const lp = new LookupProviderV2(engOpts);
-      const quickpick = await lc.show();
-      await onInitCb({ lp, quickpick, lc });
-    });
-  };
-
-  const onInitForAcceptItems = async (opts: {
-    onInitCb: (opts: {
-      lc: LookupControllerV2;
-      lp: LookupProviderV2;
-    }) => Promise<void>;
-  }) => {
-    onWSInit(async () => {
-      const { onInitCb } = opts;
-      const engOpts: EngineOpts = { flavor: "note" };
-      const lc = new LookupControllerV2(engOpts);
-      const lp = new LookupProviderV2(engOpts);
-      await onInitCb({ lp, lc });
-    });
-  };
-
-  describe("updateItems", () => {
-    test("empty qs", (done) => {
-      runUpdateItemTest({
-        onInitCb: async ({ quickpick, lp, lc }) => {
-          quickpick.value = "";
-          await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
-          expect(lc.quickPick?.items.length).toEqual(4);
-          done();
-        },
-      });
-    });
-
-    test("opened note", (done) => {
-      runUpdateItemTest({
-        onInitCb: async ({ quickpick, lp, lc }) => {
-          await VSCodeUtils.openFileInEditor(
-            vscode.Uri.file(path.join(vaults[0].fsPath, "foo.md"))
-          );
-          quickpick.value = "";
-          await lp.onUpdatePickerItem(quickpick, engOpts, "manual", token);
-          quickpick.onDidChangeActive(() => {
-            expect(lc.quickPick?.activeItems.length).toEqual(1);
-            expect(lc.quickPick?.activeItems[0].fname).toEqual("foo");
-            done();
-          });
-        },
-      });
-    });
-
-    test("schema suggestion", (done) => {
-      runUpdateItemTest({
-        onInitCb: async ({ quickpick, lp }) => {
-          quickpick.value = "foo.";
-          await lp.onUpdatePickerItem(
-            quickpick,
-            { flavor: "note" },
-            "manual",
-            token
-          );
-          expect(quickpick.items.length).toEqual(4);
-          expect(
-            _.pick(_.find(quickpick.items, { fname: "foo.ch1" }), [
-              "fname",
-              "schemaStub",
-            ])
-          ).toEqual({
-            fname: "foo.ch1",
-            schemaStub: true,
-          });
-          done();
-        },
-        beforeActivateCb: async ({ vaults }) => {
-          fs.removeSync(path.join(vaults[0].fsPath, "foo.ch1.md"));
-        },
-      });
-    });
-  });
-
-  describe("accept items", () => {
-    test("exiting item", (done) => {
-      runAcceptItemTest({
-        onInitCb: async ({ lp, lc }) => {
-          const ws = DendronWorkspace.instance();
-          const client = ws.getEngine();
-          const note = client.notes["foo"];
-          const item = DNodeUtils.enhancePropForQuickInput({
-            wsRoot: DendronWorkspace.wsRoot(),
-            props: note,
-            schemas: client.schemas,
-            vaults: DendronWorkspace.instance().config.vaults,
-          });
-          const quickpick = createMockQuickPick({
-            value: "foo",
-            selectedItems: [item],
-          });
-          await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          await NodeTestPresetsV2.runMochaHarness({
-            opts: {
-              activeFileName: DNodeUtils.fname(
-                VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-              ),
-              activeNote: getNoteFromTextEditor(),
-            },
-            results:
-              LOOKUP_SINGLE_TEST_PRESET.ACCEPT_ITEMS.EXISTING_ITEM.results,
-          });
-          done();
-        },
-      });
-    });
-
-    test("new item", (done) => {
-      runAcceptItemTest({
-        onInitCb: async ({ lp, lc }) => {
-          console.log("onInitCb:enter");
-          const ws = DendronWorkspace.instance();
-          const client = ws.getEngine();
-          const note = client.notes["foo"];
-          await VSCodeUtils.openFileInEditor(
-            vscode.Uri.file(path.join(note.vault.fsPath, note.fname + ".md"))
-          );
-          const quickpick = createMockQuickPick({
-            value: "bond",
-            selectedItems: [createNoActiveItem(vaults[0])],
-          });
-          await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          expect(
-            DNodeUtils.fname(
-              VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-            )
-          ).toEqual("bond");
-          const txtPath = vscode.window.activeTextEditor?.document.uri
-            .fsPath as string;
-          const vault = { fsPath: path.dirname(txtPath) };
-          const node = file2Note(txtPath, vault);
-          expect(node.title).toEqual("Bond");
-          console.log("onInitCb:exit");
-          done();
-        },
-      });
-    });
-
-    test("new item in other", (done) => {
-      runAcceptItemTest({
-        onInitCb: async ({ lp, lc }) => {
-          console.log("onInitCb:enter");
-          const ws = DendronWorkspace.instance();
-          const vaults = DendronWorkspace.instance().vaultsv4;
-          const client = ws.getEngine();
-          const note = _.find(client.notes, (ent) => {
-            return (
-              ent.vault.fsPath === vaults[1].fsPath && ent.fname === "root"
-            );
-          }) as NoteProps;
-          await VSCodeUtils.openFileInEditor(
-            vscode.Uri.file(path.join(note.vault.fsPath, note.fname + ".md"))
-          );
-          const quickpick = createMockQuickPick({
-            value: "bond",
-            selectedItems: [createNoActiveItem(vaults[0])],
-          });
-          await lp.onDidAccept({ picker: quickpick, opts: engOpts, lc });
-          expect(
-            DNodeUtils.fname(
-              VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath as string
-            )
-          ).toEqual("bond");
-          const txtPath = vscode.window.activeTextEditor?.document.uri
-            .fsPath as string;
-          const vault = { fsPath: path.dirname(txtPath) };
-          const node = file2Note(txtPath, vault);
-          expect(node.title).toEqual("Bond");
-          console.log("onInitCb:exit");
-          done();
-        },
-      });
-    });
-  });
-});

--- a/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
@@ -7,10 +7,8 @@ import { ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import { describe } from "mocha";
 import * as vscode from "vscode";
-import {
-  LookupCommand,
-  LookupNoteTypeEnum,
-} from "../../commands/LookupCommand";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { LookupNoteTypeEnum } from "../../components/lookup/types";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace, getWS } from "../../workspace";
 import { TIMEOUT } from "../testUtils";
@@ -44,9 +42,8 @@ suite("Scratch Notes", function () {
             wsRoot: DendronWorkspace.wsRoot(),
           });
           await VSCodeUtils.openNote(note!);
-          await new LookupCommand().execute({
+          await new NoteLookupCommand().run({
             noteType: LookupNoteTypeEnum.journal,
-            flavor: "note",
             noConfirm: true,
           });
           const newNote = getNoteFromTextEditor();
@@ -76,9 +73,8 @@ suite("Scratch Notes", function () {
             wsRoot: DendronWorkspace.wsRoot(),
           });
           await VSCodeUtils.openNote(note!);
-          await new LookupCommand().execute({
+          await new NoteLookupCommand().run({
             noteType: LookupNoteTypeEnum.journal,
-            flavor: "note",
             noConfirm: true,
           });
           const newNote = getNoteFromTextEditor();

--- a/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
@@ -2,11 +2,8 @@ import { NoteAddBehavior, NoteUtils } from "@dendronhq/common-all";
 import { NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { describe } from "mocha";
 import * as vscode from "vscode";
-import {
-  LookupCommand,
-  LookupNoteTypeEnum,
-  VaultSelectionMode,
-} from "../../commands/LookupCommand";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { LookupNoteTypeEnum, LookupSelectionTypeEnum } from "../../components/lookup/types";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace, getWS } from "../../workspace";
 import { TIMEOUT } from "../testUtils";
@@ -45,10 +42,9 @@ suite("Scratch Notes", function () {
           const editor = await VSCodeUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);
           editor.selection = SIMPLE_SELECTION;
-          await new LookupCommand().execute({
-            selectionType: "selection2link",
+          await new NoteLookupCommand().run({
+            selectionType: LookupSelectionTypeEnum.selection2link,
             noteType: LookupNoteTypeEnum.scratch,
-            flavor: "note",
             noConfirm: true,
           });
           const scratchNote = getNoteFromTextEditor();
@@ -77,10 +73,9 @@ suite("Scratch Notes", function () {
             NOTE_PRESETS_V4.NOTE_DOMAIN_NAMESPACE_CHILD;
           const editor = await getNoteFromFname({ fname, vault });
           editor.selection = new vscode.Selection(...selection);
-          await new LookupCommand().execute({
-            selectionType: "selection2link",
+          await new NoteLookupCommand().run({
+            selectionType: LookupSelectionTypeEnum.selection2link, 
             noteType: LookupNoteTypeEnum.scratch,
-            flavor: "note",
             noConfirm: true,
           });
           const scratchNote = getNoteFromTextEditor();
@@ -114,12 +109,10 @@ suite("Scratch Notes", function () {
           const editor = await VSCodeUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);
           editor.selection = SIMPLE_SELECTION;
-          await new LookupCommand().execute({
-            selectionType: "selection2link",
+          await new NoteLookupCommand().run({
+            selectionType: LookupSelectionTypeEnum.selection2link,
             noteType: LookupNoteTypeEnum.scratch,
-            flavor: "note",
             noConfirm: true,
-            vaultSelectionMode: VaultSelectionMode.auto,
           });
           const scratchNote = getNoteFromTextEditor();
           expect(scratchNote.fname.startsWith("scratch")).toBeTruthy();
@@ -147,10 +140,9 @@ suite("Scratch Notes", function () {
             NOTE_PRESETS_V4.NOTE_DOMAIN_NAMESPACE_CHILD;
           const editor = await getNoteFromFname({ fname, vault });
           editor.selection = new vscode.Selection(...selection);
-          await new LookupCommand().execute({
-            selectionType: "selection2link",
+          await new NoteLookupCommand().run({
+            selectionType: LookupSelectionTypeEnum.selection2link,
             noteType: LookupNoteTypeEnum.scratch,
-            flavor: "note",
             noConfirm: true,
           });
           const scratchNote = getNoteFromTextEditor();

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -28,7 +28,8 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionTypeEnum,
   LookupSplitTypeEnum,
-} from "../../commands/LookupCommand";
+  LookupEffectTypeEnum,
+} from "../../components/lookup/types";
 import {
   CommandOutput,
   CommandRunOpts,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -28,7 +28,6 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionTypeEnum,
   LookupSplitTypeEnum,
-  LookupEffectTypeEnum,
 } from "../../components/lookup/types";
 import {
   CommandOutput,

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -31,7 +31,6 @@ import path from "path";
 import * as vscode from "vscode";
 import { ALL_COMMANDS } from "./commands";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
-// import { LookupCommand, VaultSelectionMode } from "./commands/LookupCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";
 import { ReloadIndexCommand } from "./commands/ReloadIndex";
 import { SetupWorkspaceCommand } from "./commands/SetupWorkspace";
@@ -584,27 +583,6 @@ export class DendronWorkspace {
         })
       );
     });
-
-    // ----
-
-    // this.context.subscriptions.push(
-    //   vscode.commands.registerCommand(
-    //     DENDRON_COMMANDS.LOOKUP.key,
-    //     async (args: any) => {
-    //       const confirmVaultSetting =
-    //         DendronWorkspace.instance().config["lookupConfirmVaultOnCreate"];
-    //       const selectionMode =
-    //         confirmVaultSetting === false || _.isUndefined(confirmVaultSetting)
-    //           ? VaultSelectionMode.smart
-    //           : VaultSelectionMode.alwaysPrompt;
-    //       new LookupCommand().run({
-    //         ...args,
-    //         flavor: "note",
-    //         vaultSelectionMode: selectionMode,
-    //       });
-    //     }
-    //   )
-    // );
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -31,7 +31,7 @@ import path from "path";
 import * as vscode from "vscode";
 import { ALL_COMMANDS } from "./commands";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
-import { LookupCommand, VaultSelectionMode } from "./commands/LookupCommand";
+// import { LookupCommand, VaultSelectionMode } from "./commands/LookupCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";
 import { ReloadIndexCommand } from "./commands/ReloadIndex";
 import { SetupWorkspaceCommand } from "./commands/SetupWorkspace";
@@ -587,24 +587,24 @@ export class DendronWorkspace {
 
     // ----
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand(
-        DENDRON_COMMANDS.LOOKUP.key,
-        async (args: any) => {
-          const confirmVaultSetting =
-            DendronWorkspace.instance().config["lookupConfirmVaultOnCreate"];
-          const selectionMode =
-            confirmVaultSetting === false || _.isUndefined(confirmVaultSetting)
-              ? VaultSelectionMode.smart
-              : VaultSelectionMode.alwaysPrompt;
-          new LookupCommand().run({
-            ...args,
-            flavor: "note",
-            vaultSelectionMode: selectionMode,
-          });
-        }
-      )
-    );
+    // this.context.subscriptions.push(
+    //   vscode.commands.registerCommand(
+    //     DENDRON_COMMANDS.LOOKUP.key,
+    //     async (args: any) => {
+    //       const confirmVaultSetting =
+    //         DendronWorkspace.instance().config["lookupConfirmVaultOnCreate"];
+    //       const selectionMode =
+    //         confirmVaultSetting === false || _.isUndefined(confirmVaultSetting)
+    //           ? VaultSelectionMode.smart
+    //           : VaultSelectionMode.alwaysPrompt;
+    //       new LookupCommand().run({
+    //         ...args,
+    //         flavor: "note",
+    //         vaultSelectionMode: selectionMode,
+    //       });
+    //     }
+    //   )
+    // );
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(


### PR DESCRIPTION
This PR:
- Moves exports from v2 related files to respective v3 component modules
- Cleans up all stale imports that reference parts of lookup v2
- Refactor GoDownCommand to use lookup v3
- Refactor LookupJournal / LookupScratch tests to use lookup v3
- Deregister lookup v2 command and related keybindings

NOTE: Test suites related to `LookupCommand`, and the v2 lookup command components are still left but commented out. Once all the test suites are re-written to test respective parts of lookup v3, the components and tests that are commented out will be removed