### PR TITLE
fix: race conditions in note lookup

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -10,8 +10,8 @@ import {
   SchemaModuleProps,
   NoteUtils,
   DNodeUtils,
+  DEngineClient,
 } from ".";
-import { DEngineClient } from "../lib";
 import { DendronConfig, DVault } from "./types/workspace";
 
 export type NoteIndexProps = {

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -2,6 +2,7 @@ import { DendronError, DNodeType, ERROR_STATUS } from "@dendronhq/common-all";
 import _ from "lodash";
 import { QuickInputButton } from "vscode";
 import { CancellationTokenSource } from "vscode-languageclient";
+import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace, getWS } from "../../workspace";
 import {
@@ -123,6 +124,8 @@ export class LookupControllerV3 {
    * Wire up quickpick and initialize buttons
    */
   async prepareQuickPick(opts: PrepareQuickPickOpts) {
+    const ctx = "prepareQuickPick";
+    Logger.info({ ctx, msg: "enter" });
     const { provider } = _.defaults(opts, {
       nonInteractive: false,
     });
@@ -142,26 +145,32 @@ export class LookupControllerV3 {
       `- version: ${DendronWorkspace.version()}`,
     ].join(" ");
     provider.provide(this);
+    Logger.info({ ctx, msg: "exit" });
     return { quickpick };
   }
 
   async showQuickPick(opts: ShowQuickPickOpts) {
+    const ctx = "showQuickPick";
+    Logger.info({ ctx, msg: "enter" });
     const cancelToken = this.createCancelSource();
     const { nonInteractive, provider, quickpick } = _.defaults(opts, {
       nonInteractive: false,
     });
+    Logger.info({ ctx, msg: "onUpdatePickerItems:pre" });
     // initial call of update
     await provider.onUpdatePickerItems({
       picker: quickpick,
       token: cancelToken.token,
       fuzzThreshold: this.fuzzThreshold,
     });
+    Logger.info({ ctx, msg: "onUpdatePickerItems:post" });
     if (!nonInteractive) {
       quickpick.show();
     } else {
       quickpick.selectedItems = quickpick.items;
       await provider.onDidAccept({ quickpick, lc: this })();
     }
+    Logger.info({ ctx, msg: "exit" });
     return quickpick;
   }
 

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -144,7 +144,6 @@ export class LookupControllerV3 {
       `Lookup (${this.nodeType})`,
       `- version: ${DendronWorkspace.version()}`,
     ].join(" ");
-    provider.provide(this);
     Logger.info({ ctx, msg: "exit" });
     return { quickpick };
   }
@@ -165,6 +164,7 @@ export class LookupControllerV3 {
     });
     Logger.info({ ctx, msg: "onUpdatePickerItems:post" });
     if (!nonInteractive) {
+      provider.provide(this);
       quickpick.show();
     } else {
       quickpick.selectedItems = quickpick.items;

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -16,7 +16,7 @@ import _ from "lodash";
 import { CancellationToken, CancellationTokenSource, window } from "vscode";
 import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
-import { DendronWorkspace, getEngine } from "../../workspace";
+import { DendronWorkspace } from "../../workspace";
 import { LookupControllerV3 } from "./LookupControllerV3";
 import { DendronQuickPickerV2 } from "./types";
 import {
@@ -139,24 +139,9 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       // NOTE: if user presses <ENTER> before picker has a chance to process, this will be `[]`
       // In this case we want to calculate picker item from current value
       if (_.isEmpty(selectedItems)) {
-        const engine = getEngine();
-        const resp = await NoteLookupUtils.lookup({
-          qs: picker.value,
-          engine,
-          showDirectChildrenOnly: picker.showDirectChildrenOnly,
+        selectedItems = await NotePickerUtils.fetchPickerResultsNoInput({
+          picker,
         });
-        const note = resp[0];
-        const perfectMatch = note.fname === picker.value;
-        selectedItems = !perfectMatch
-          ? [NotePickerUtils.createNoActiveItem({} as any)]
-          : [
-              DNodeUtils.enhancePropForQuickInputV3({
-                wsRoot: DendronWorkspace.wsRoot(),
-                props: note,
-                schemas: engine.schemas,
-                vaults: DendronWorkspace.instance().vaultsv4,
-              }),
-            ];
       }
 
       if (nextPicker && isNewNotePick) {

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -13,7 +13,9 @@ export type LookupControllerState = {
   buttonsPrev: DendronBtn[];
 };
 
-export type FilterQuickPickFunction = (items: NoteQuickInput[]) => NoteQuickInput[];
+export type FilterQuickPickFunction = (
+  items: NoteQuickInput[]
+) => NoteQuickInput[];
 type ModifyPickerValueFunc = (value?: string) => {
   noteName: string;
   prefix: string;
@@ -37,7 +39,14 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   buttons: DendronBtn[];
   nonInteractive?: boolean;
   prev?: { activeItems: any; items: any };
+  /**
+   * Used by {@link DendronBtn} to store tmp state
+   */
   prevValue?: string;
+  /**
+   * Previous value in quickpick
+   */
+  prevQuickpickValue?: string;
 
   /**
    * Value before being modified

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -23,7 +23,7 @@ import { QuickPickItem, TextEditor, Uri, ViewColumn, window } from "vscode";
 import { VaultSelectionMode } from "../../commands/LookupCommand";
 import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../utils";
-import { DendronWorkspace, getWS } from "../../workspace";
+import { DendronWorkspace, getEngine, getWS } from "../../workspace";
 import { DendronBtn, getButtonCategory } from "./buttons";
 import {
   CREATE_NEW_DETAIL,
@@ -711,6 +711,34 @@ export class NotePickerUtils {
       });
     });
   };
+
+  /**
+   * Get picker results without input from the user
+   */
+  static async fetchPickerResultsNoInput({
+    picker,
+  }: {
+    picker: DendronQuickPickerV2;
+  }) {
+    const engine = getEngine();
+    const resp = await NoteLookupUtils.lookup({
+      qs: picker.value,
+      engine,
+      showDirectChildrenOnly: picker.showDirectChildrenOnly,
+    });
+    const note = resp[0];
+    const perfectMatch = note.fname === picker.value;
+    return !perfectMatch
+      ? [NotePickerUtils.createNoActiveItem({} as any)]
+      : [
+          DNodeUtils.enhancePropForQuickInputV3({
+            wsRoot: DendronWorkspace.wsRoot(),
+            props: note,
+            schemas: engine.schemas,
+            vaults: DendronWorkspace.instance().vaultsv4,
+          }),
+        ];
+  }
 
   static async fetchPickerResults(opts: {
     picker: DendronQuickPickerV2;

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -659,6 +659,11 @@ export class PickerUtilsV2 {
     delete picker.allResults;
   }
 
+  /**
+   @deprecated use {@link NoteLookupUtils.slashToDot}
+   * @param ent
+   * @returns 
+   */
   static slashToDot(ent: string) {
     return ent.replace(/\//g, ".");
   }

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -713,7 +713,7 @@ export class NotePickerUtils {
   };
 
   /**
-   * Get picker results without input from the user
+   * Get picker results with current picker value
    */
   static async fetchPickerResultsNoInput({
     picker,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -45,6 +45,7 @@ import {
 } from "../../components/lookup/buttons";
 import {
   createNoActiveItem,
+  NotePickerUtils,
   PickerUtilsV2,
 } from "../../components/lookup/utils";
 import { CONFIG } from "../../constants";
@@ -438,6 +439,30 @@ suite("NoteLookupCommand", function () {
         },
       });
     });
+
+    test("on accept, nothing selected", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults }) => {
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+          const spyFetchPickerResultsNoInput = sinon.spy(
+            NotePickerUtils,
+            "fetchPickerResultsNoInput"
+          );
+          const { quickpick, provider, controller } = await cmd.gatherInputs({
+            noConfirm: true,
+            initialValue: "foo",
+          });
+          await provider.onDidAccept({ quickpick, lc: controller })();
+          expect(spyFetchPickerResultsNoInput.calledOnce).toBeTruthy();
+          done();
+        },
+      });
+    });
   });
 
   describe("onAccept with lookupConfirmVaultOnCreate", () => {
@@ -509,27 +534,6 @@ suite("NoteLookupCommand", function () {
         },
       });
     });
-
-    // test("turned on, new note", (done) => {
-    //   runLegacyMultiWorkspaceTest({
-    //     ctx,
-    //     modConfigCb: (config) => {
-    //       config.lookupConfirmVaultOnCreate = true;
-    //       return config;
-    //     },
-    //     preSetupHook: async ({ wsRoot, vaults }) => {
-    //       await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-    //     },
-    //     onInit: async () => {
-    //       const cmd = new NoteLookupCommand();
-    //       // stubVaultPick(vaults);
-    //       const promptVaultSpy = sinon.spy(PickerUtilsV2, "promptVault");
-    //       cmd.run({ noConfirm: true, initialValue: "foo" });
-    //       expect(promptVaultSpy.calledOnce).toBeFalsy();
-    //       done();
-    //     },
-    //   });
-    // });
   });
 
   describe("modifiers", () => {


### PR DESCRIPTION
- user creates accept before picker items are finished updating. in this case, we fetch results and create a new note   
- user creates quickpick for the first time, currently results in two updates which causes quickpick list to re-order    