### PR TITLE
fix: don't insert title when rendering note refs in preview

### DIFF
--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -32,7 +32,7 @@ import { dendronPreview, dendronHoverPreview } from "./remark/dendronPreview";
 import { dendronPub } from "./remark/dendronPub";
 import { noteRefsV2 } from "./remark/noteRefsV2";
 import { wikiLinks } from "./remark/wikiLinks";
-import { DendronASTData, DendronASTDest } from "./types";
+import { DendronASTDest } from "./types";
 import { MDUtilsV4 } from "./utils";
 import { hashtags } from "./remark/hashtag";
 import { backlinks } from "./remark/backlinks";

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -32,7 +32,7 @@ import { dendronPreview, dendronHoverPreview } from "./remark/dendronPreview";
 import { dendronPub } from "./remark/dendronPub";
 import { noteRefsV2 } from "./remark/noteRefsV2";
 import { wikiLinks } from "./remark/wikiLinks";
-import { DendronASTDest } from "./types";
+import { DendronASTData, DendronASTDest } from "./types";
 import { MDUtilsV4 } from "./utils";
 import { hashtags } from "./remark/hashtag";
 import { backlinks } from "./remark/backlinks";
@@ -264,14 +264,16 @@ export class MDUtilsV5 {
           this.setProcData(proc, data as ProcDataFullV5);
           MDUtilsV4.setEngine(proc, data.engine!);
 
+          const isNoteRef = !_.isUndefined((data as ProcDataFullV5).noteRefLvl);
+
+          const shouldInsertTitle = isNoteRef ? false : data.config?.useFMTitle;
           // NOTE: order matters. this needs to appear before `dendronPub`
           if (data.dest === DendronASTDest.HTML) {
             proc = proc.use(backlinks).use(hierarchies);
           }
-
           // add additional plugins
           proc = proc.use(dendronPub, {
-            insertTitle: data.config?.useFMTitle,
+            insertTitle: shouldInsertTitle,
           });
           if (data.config?.useKatex) {
             proc = proc.use(math);

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/utilsv5.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/utilsv5.spec.ts.snap
@@ -12,8 +12,7 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"alpha\\">Alpha</h1>
-<p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>
@@ -39,8 +38,7 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"alpha\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#alpha\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Alpha</h1>
-<p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
@@ -66,8 +64,7 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"alpha\\">Alpha</h1>
-<p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
@@ -142,8 +142,6 @@ describe("MDUtils.proc", () => {
             resp.contents,
             // should have id for link
             `<a href="alpha-id.html"`,
-            // title should be fname,
-            "Alpha</h1>",
             // html quoted
             `<p><a href="bar.html">Bar</a></p>`
           );


### PR DESCRIPTION
This PR:
- Fixes issue with note ref rendering in preview where the note ref's title was unnecessarily inserted.