### PR TITLE
enhance: allow wildcard anchors at the end of note

### DIFF
--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -546,10 +546,18 @@ function prepareNoteRefIndices<T>({
   }
 
   if (anchorEnd) {
+    const nodes = bodyAST.children.slice(start.index);
     end = findAnchor({
-      nodes: bodyAST.children.slice(start.index),
+      nodes,
       match: anchorEnd,
     });
+    if (anchorEnd === "*" && _.isNull(end)) {
+      end = {
+        type: "header",
+        index: nodes.length,
+        anchorType: "header",
+      };
+    }
     if (_.isNull(end)) {
       return {
         data: makeErrorData(anchorEnd, "End"),
@@ -771,15 +779,12 @@ function findHeader({
   match: string;
   slugger: ReturnType<typeof getSlugger>;
 }): FindAnchorResult {
-  const foundIndex = MDUtilsV4.findIndex(
-    nodes,
-    function (node: Node, idx: number) {
-      if (idx === 0 && match === "*") {
-        return false;
-      }
-      return MDUtilsV4.matchHeading(node, match, { slugger });
+  let foundIndex = MDUtilsV4.findIndex(nodes, (node: Node, idx: number) => {
+    if (idx === 0 && match === "*") {
+      return false;
     }
-  );
+    return MDUtilsV4.matchHeading(node, match, { slugger });
+  });
   if (foundIndex < 0) return null;
   return { type: "header", index: foundIndex, anchorType: "header" };
 }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -266,6 +266,60 @@ VFile {
 }
 `;
 
+exports[`noteRefV2 common cases compile "HTML: wildcard without a following header" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"reprehenderit\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#reprehenderit\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Reprehenderit</h1>
+<p>Sapiente sed accusamus eum.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 common cases compile "HTML: wildcard without a following header" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><h1 id=\\"reprehenderit\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#reprehenderit\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Reprehenderit</h1>
+<p>Sapiente sed accusamus eum.</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`noteRefV2 common cases compile "HTML: wildcard" 1`] = `
 VFile {
   "contents": "# Root

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -934,7 +934,43 @@ describe("noteRefV2", () => {
       },
     });
 
+    const WILDCARD_WITHOUT_FOLLOWING_HEADER = createProcTests({
+      name: "wildcard without a following header",
+      setupFunc: async (opts) => {
+        const { engine, vaults } = opts;
+        return processTextV2({
+          text: "![[foo.ch1#Reprehenderit:#*]]",
+          dest: opts.extra.dest,
+          engine,
+          vault: vaults[0],
+          fname: "foo",
+        });
+      },
+      preSetupHook: async (opts) => {
+        await ENGINE_HOOKS.setupBasic(opts);
+        await modifyNote(opts, "foo.ch1", (note: NoteProps) => {
+          const txt = [
+            "Sint minus fuga omnis non.",
+            "",
+            "# Reprehenderit",
+            "",
+            "Sapiente sed accusamus eum.",
+          ];
+          note.body = txt.join("\n");
+          return note;
+        });
+      },
+      verifyFuncDict: {
+        [DendronASTDest.HTML]: async ({ extra }) => {
+          const { resp } = extra;
+          await checkVFile(resp, "Sapiente sed accusamus eum.");
+          await checkNotInVFile(resp, "Sint minus fuga omnis non.");
+        },
+      },
+    });
+
     const ALL_TEST_CASES = [
+      ...WILDCARD_WITHOUT_FOLLOWING_HEADER,
       ...WITH_PUBLISHING,
       ...WITH_START_AND_END_WILDCARD_ANCHOR,
       ...WITH_START_AND_END_ANCHOR,


### PR DESCRIPTION
Allows wildcard anchors at the end of the notes to work. For example,

```
...
# foo
something
```

Here, `![[note#foo:#*]]` used to warn about not finding a header, but it will now show the region from "foo" to the end of the note. 

#1131 