### PR TITLE
fix: cleanup subscribers when quickpick is hidden

### DIFF
--- a/packages/engine-server/src/history.ts
+++ b/packages/engine-server/src/history.ts
@@ -46,7 +46,8 @@ export type HistoryEventAction =
   | "upgraded"
   | APIServerEvent
   | "done"
-  | "error";
+  | "error"
+  | "changeState";
 
 export type APIServerEvent = "changedPort";
 

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -1,4 +1,5 @@
 import { DendronError, DNodeType, ERROR_STATUS } from "@dendronhq/common-all";
+import { HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { QuickInputButton } from "vscode";
 import { CancellationTokenSource } from "vscode-languageclient";
@@ -6,8 +7,8 @@ import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../utils";
 import { DendronWorkspace, getWS } from "../../workspace";
 import {
-  DendronBtn,
   ButtonCategory,
+  DendronBtn,
   getButtonCategory,
   IDendronQuickInputButton,
   VaultSelectButton,
@@ -76,6 +77,8 @@ export class LookupControllerV3 {
     buttons: DendronBtn[];
     fuzzThreshold?: number;
   }) {
+    const ctx = "LookupControllerV3:new";
+    Logger.info({ ctx, msg: "enter" });
     const { buttons, nodeType } = opts;
     this.nodeType = nodeType;
     this.state = {
@@ -139,6 +142,12 @@ export class LookupControllerV3 {
     quickpick.onDidTriggerButton(this.onTriggerButton);
     quickpick.onDidHide(() => {
       quickpick.dispose();
+      HistoryService.instance().add({
+        source: "lookupProvider",
+        action: "changeState",
+        id: provider.id,
+        data: { action: "hide" },
+      });
     });
     quickpick.title = [
       `Lookup (${this.nodeType})`,
@@ -192,9 +201,11 @@ export class LookupControllerV3 {
   }
 
   onHide() {
+    const ctx = "LookupControllerV3:onHide";
     this._quickpick?.dispose();
     this._quickpick = undefined;
     this._cancelTokenSource?.dispose();
+    Logger.info({ ctx, msg: "exit" });
   }
 
   onTriggerButton = async (btn: QuickInputButton) => {

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -141,6 +141,7 @@ export class LookupControllerV3 {
     await PickerUtilsV2.refreshPickerBehavior({ quickpick, buttons });
     quickpick.onDidTriggerButton(this.onTriggerButton);
     quickpick.onDidHide(() => {
+      Logger.debug({ ctx: "quickpick", msg: "onHide" });
       quickpick.dispose();
       HistoryService.instance().add({
         source: "lookupProvider",

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -18,7 +18,7 @@ import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
 import { DendronWorkspace } from "../../workspace";
 import { LookupControllerV3 } from "./LookupControllerV3";
-import { DendronQuickPickerV2 } from "./types";
+import { DendronQuickPickerV2, DendronQuickPickState } from "./types";
 import {
   NotePickerUtils,
   OldNewLocation,
@@ -151,6 +151,8 @@ export class NoteLookupProvider implements ILookupProviderV3 {
           providerId: this.id,
         })
       ) {
+        Logger.debug({ ctx, msg: "nextPicker:pre" });
+        picker.state = DendronQuickPickState.PENDING_NEXT_PICK;
         picker.vault = await picker.nextPicker();
         // check if we exited from selecting a vault
         if (_.isUndefined(picker.vault)) {
@@ -166,6 +168,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       // last chance to cancel
       lc.cancelToken.cancel();
       if (!this.opts.noHidePickerOnAccept) {
+        picker.state = DendronQuickPickState.FUFILLED;
         picker.hide();
       }
       const onAcceptHookResp = await Promise.all(

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -22,6 +22,21 @@ type ModifyPickerValueFunc = (value?: string) => {
 };
 type SelectionProcessFunc = (note: NoteProps) => Promise<NoteProps | undefined>;
 
+export enum DendronQuickPickState {
+  /**
+   * Default state
+   */
+  IDLE = "IDLE",
+  /**
+   * Finished taking request
+   */
+  FUFILLED = "FUFILLED",
+  /**
+   * About to show a new picker. Old picker will be hidden but we are still gathering further input
+   */
+  PENDING_NEXT_PICK = "PENDING_NEXT_PICK",
+}
+
 export type DendronQuickPickItemV2 = QuickPick<DNodePropsQuickInputV2>;
 export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   // --- Private State
@@ -33,6 +48,7 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    * Setting this true will always show ALL results that lookup returns
    */
   alwaysShowAll?: boolean;
+  state: DendronQuickPickState;
   /**
    * Buttons control modifiers for lookup
    */

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -389,6 +389,24 @@ export class PickerUtilsV2 {
     return _.find(items, { label: CREATE_NEW_LABEL });
   };
 
+  /**
+   * Check if this picker still has further pickers
+   */
+  static hasNextPicker = (
+    quickpick: DendronQuickPickerV2,
+    opts: {
+      selectedItems: readonly DNodePropsQuickInputV2[];
+      providerId: string;
+    }
+  ): quickpick is Required<DendronQuickPickerV2> => {
+    const { selectedItems, providerId } = opts;
+    const nextPicker = quickpick.nextPicker;
+    const isNewPick = PickerUtilsV2.isCreateNewNotePick(selectedItems[0]);
+    return (
+      !_.isUndefined(nextPicker) && (providerId === "lookup" ? isNewPick : true)
+    );
+  };
+
   static isCreateNewNotePickForSingle(node: DNodePropsQuickInputV2): boolean {
     if (!node) {
       return true;

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -31,7 +31,7 @@ import {
   MORE_RESULTS_LABEL,
 } from "./constants";
 import { ILookupProviderV3, OnAcceptHook } from "./LookupProviderV3";
-import { DendronQuickPickerV2 } from "./types";
+import { DendronQuickPickerV2, DendronQuickPickState } from "./types";
 
 const PAGINATE_LIMIT = 50;
 export const UPDATET_SOURCE = {
@@ -244,6 +244,7 @@ export class PickerUtilsV2 {
     const quickPick =
       window.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
     quickPick.title = title;
+    quickPick.state = DendronQuickPickState.IDLE;
     quickPick.nonInteractive = opts.nonInteractive;
     quickPick.placeholder = placeholder;
     quickPick.ignoreFocusOut = ignoreFocusOut;

--- a/test-workspace/vault/meet.journal.2021.08.17.md
+++ b/test-workspace/vault/meet.journal.2021.08.17.md
@@ -1,0 +1,8 @@
+---
+id: YnB1svB9LO3zKw0qp4f8G
+title: '2021-08-17'
+desc: ''
+updated: 1629219347222
+created: 1629219347222
+---
+

--- a/test-workspace/vault/meet.journal.2021.08.18.md
+++ b/test-workspace/vault/meet.journal.2021.08.18.md
@@ -1,0 +1,8 @@
+---
+id: NAVlqGJutIZCHqUHyufXG
+title: '2021-08-18'
+desc: ''
+updated: 1629219352525
+created: 1629219352525
+---
+

--- a/test-workspace/vault/meet.journal.2021.08.md
+++ b/test-workspace/vault/meet.journal.2021.08.md
@@ -1,0 +1,8 @@
+---
+id: gOoMt9O9btsanZ36jCXKc
+title: 08
+desc: ''
+updated: 1629219348300
+created: 1629219348300
+stub: false
+---

--- a/test-workspace/vault/meet.md
+++ b/test-workspace/vault/meet.md
@@ -1,0 +1,8 @@
+---
+id: PgHdLRIi5E31bK6TBeBB4
+title: Meet
+desc: ''
+updated: 1629219344651
+created: 1629219344651
+---
+


### PR DESCRIPTION
Currently, hiding the quickpick using `ESC` key does not clean up the `lookup` subscriber listening to quickpick events. this leads to multiple `lookup` events executing if the quickpick has been hidden using `ESC` key