### PR TITLE
enhance: avoid parsing links & anchors on very long notes

### DIFF
--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -29,6 +29,10 @@ export const CONSTANTS = {
    * Initial version for first installaion
    */
   DENDRON_INIT_VERSION: "0.0.0",
+  /** Files larger than this size (in characters) don't get parsed for links,
+   * link candidates, and anchors. Currently about 1MiB, although may be larger
+   * due to unicode since it's counted in characters. */
+  DENDRON_FILE_TOO_BIG: 2 ** 20,
 };
 
 export enum ERROR_STATUS {

--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -29,10 +29,8 @@ export const CONSTANTS = {
    * Initial version for first installaion
    */
   DENDRON_INIT_VERSION: "0.0.0",
-  /** Files larger than this size (in characters) don't get parsed for links,
-   * link candidates, and anchors. Currently about 1MiB, although may be larger
-   * due to unicode since it's counted in characters. */
-  DENDRON_FILE_TOO_BIG: 2 ** 20,
+  /** Default for the `maxNoteLength` config. */
+  DENDRON_DEFAULT_MAX_NOTE_LENGTH: 204800,
 };
 
 export enum ERROR_STATUS {

--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -120,10 +120,8 @@ export class DendronCompositeError extends Error implements IDendronError {
     // Otherwise, there are no fatal errors but at least one error has
     // undefined severity. Then the composite also has undefined severity.
 
-    // Combine all error messages to display to the user. Since this is
-    // displayed in markdown in the editor, need to line breaks to separate
-    // paragraphs.
-    this.message += _.map(errors, (err) => err.message).join("\n\n");
+    // Combine all error messages to display to the user.
+    this.message += _.map(errors, (err) => err.message).join("\n");
   }
 }
 

--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -31,6 +31,7 @@ export type DendronErrorProps = {
 
 export type DendronErrorPlainObj = {
   isComposite: boolean;
+  severity?: ERROR_SEVERITY;
 } & DendronErrorProps;
 
 export type IDendronError = DendronErrorPlainObj;
@@ -92,12 +93,18 @@ export class DendronError extends Error implements IDendronError {
 export class DendronCompositeError extends Error implements IDendronError {
   public payload: DendronErrorPlainObj[];
   public message: string;
+  public severity: ERROR_SEVERITY;
   isComposite = true;
 
   constructor(errors: IDendronError[]) {
     super("multiple errors");
     this.payload = errors.map((err) => error2PlainObject(err));
-    this.message = "multiple errors";
+    const hasFatalError =
+      _.find(errors, (err) => err.severity === ERROR_SEVERITY.FATAL) !==
+      undefined;
+    this.message = hasFatalError ? "Multiple errors" : "Multiple warnings";
+    this.severity = hasFatalError ? ERROR_SEVERITY.FATAL : ERROR_SEVERITY.MINOR;
+    this.message += [":", ..._.map(errors, (err) => err.message)].join("\n");
   }
 }
 

--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -93,18 +93,37 @@ export class DendronError extends Error implements IDendronError {
 export class DendronCompositeError extends Error implements IDendronError {
   public payload: DendronErrorPlainObj[];
   public message: string;
-  public severity: ERROR_SEVERITY;
+  public severity?: ERROR_SEVERITY;
   isComposite = true;
 
   constructor(errors: IDendronError[]) {
     super("multiple errors");
     this.payload = errors.map((err) => error2PlainObject(err));
+    this.message = "Multiple errors:\n";
+
     const hasFatalError =
       _.find(errors, (err) => err.severity === ERROR_SEVERITY.FATAL) !==
       undefined;
-    this.message = hasFatalError ? "Multiple errors" : "Multiple warnings";
-    this.severity = hasFatalError ? ERROR_SEVERITY.FATAL : ERROR_SEVERITY.MINOR;
-    this.message += [":", ..._.map(errors, (err) => err.message)].join("\n");
+    const allMinorErrors =
+      _.filter(errors, (err) => err.severity !== ERROR_SEVERITY.MINOR)
+        .length === 0;
+
+    if (hasFatalError) {
+      // If there is even one fatal error, then the composite is also fatal
+      this.severity = ERROR_SEVERITY.FATAL;
+    } else if (allMinorErrors) {
+      // No fatal errors, and everything is a minor error.
+      // The composite can be safely marked as a minor error too.
+      this.message = "Multiple warnings:\n";
+      this.severity = ERROR_SEVERITY.MINOR;
+    }
+    // Otherwise, there are no fatal errors but at least one error has
+    // undefined severity. Then the composite also has undefined severity.
+
+    // Combine all error messages to display to the user. Since this is
+    // displayed in markdown in the editor, need to line breaks to separate
+    // paragraphs.
+    this.message += _.map(errors, (err) => err.message).join("\n\n");
   }
 }
 

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -287,6 +287,15 @@ export type DendronConfig = {
    * Configuration for Insert Note Index Command
    */
   insertNoteIndex?: InsertNoteIndexConfig;
+
+  /** Notes that are too large can cause serious slowdowns for Dendron. For
+   * notes longer than this many characters, some features like backlinks will
+   * be disabled to avoid slowdowns. Other functionality like note lookups will
+   * continue to function.
+   *
+   * Defaults to 204800 characters, which is about 200 KiB.
+   */
+  maxNoteLength?: number;
 };
 
 export type RandomNoteConfig = {
@@ -306,7 +315,7 @@ export type InsertNoteIndexConfig = {
    * Include marker when inserting note index.
    */
   marker?: boolean;
-}
+};
 
 export type DendronDevConfig = {
   /**

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -392,7 +392,11 @@ export class FileStorage implements DStore {
     const notesMap = NoteUtils.createFnameNoteMap(allNotes, true);
     return _.map(allNotes, (noteFrom: NoteProps) => {
       try {
-        if (noteFrom.body.length < CONSTANTS.DENDRON_FILE_TOO_BIG) {
+        if (
+          noteFrom.body.length <
+          (this.config.maxNoteLength ||
+            CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
+        ) {
           const linkCandidates = LinkUtils.findLinkCandidates({
             note: noteFrom,
             notesMap,
@@ -450,7 +454,11 @@ export class FileStorage implements DStore {
         if (n.stub) {
           return;
         }
-        if (n.body.length >= CONSTANTS.DENDRON_FILE_TOO_BIG) {
+        if (
+          n.body.length >=
+          (this.config.maxNoteLength ||
+            CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
+        ) {
           this.logger.info({
             ctx,
             msg: "Note too large, skipping",
@@ -459,9 +467,14 @@ export class FileStorage implements DStore {
           });
           errors.push(
             new DendronError({
-              message: `Note "${n.fname}" in vault "${VaultUtils.getName(
-                n.vault
-              )}" is too large, some features like backlinks may not work correctly for it.`,
+              message:
+                `Note "${n.fname}" in vault "${VaultUtils.getName(
+                  n.vault
+                )}" is longer than ${
+                  this.config.maxNoteLength ||
+                  CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH
+                } characters, some features like backlinks may not work correctly for it. ` +
+                `You may increase "maxNoteLength" in "dendron.yml" to override this warning.`,
               severity: ERROR_SEVERITY.MINOR,
             })
           );

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -459,9 +459,9 @@ export class FileStorage implements DStore {
           });
           errors.push(
             new DendronError({
-              message: `Note ${n.fname} in vault ${VaultUtils.getName(
+              message: `Note "${n.fname}" in vault "${VaultUtils.getName(
                 n.vault
-              )} is too large, some features like backlinks may not work correctly for it.`,
+              )}" is too large, some features like backlinks may not work correctly for it.`,
               severity: ERROR_SEVERITY.MINOR,
             })
           );

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -471,7 +471,11 @@ export class DendronEngineV2 implements DEngine {
             // this.history &&
             //   this.history.add({ source: "engine", action: "create", uri });
           }
-          if (ent.note.body.length < CONSTANTS.DENDRON_FILE_TOO_BIG) {
+          if (
+            ent.note.body.length <
+            (this.config.maxNoteLength ||
+              CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
+          ) {
             const links = LinkUtils.findLinks({ note: ent.note, engine: this });
             const linkCandidates = LinkUtils.findLinkCandidates({
               note: ent.note,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -1,6 +1,7 @@
 import {
   BulkAddNoteOpts,
   ConfigWriteOpts,
+  CONSTANTS,
   DendronCompositeError,
   DendronConfig,
   DendronError,
@@ -470,18 +471,20 @@ export class DendronEngineV2 implements DEngine {
             // this.history &&
             //   this.history.add({ source: "engine", action: "create", uri });
           }
-          const links = LinkUtils.findLinks({ note: ent.note, engine: this });
-          const linkCandidates = LinkUtils.findLinkCandidates({
-            note: ent.note,
-            notesMap,
-            engine: this,
-          });
-          const anchors = await AnchorUtils.findAnchors({
-            note: ent.note,
-            wsRoot: this.wsRoot,
-          });
-          ent.note.links = links.concat(linkCandidates);
-          ent.note.anchors = anchors;
+          if (ent.note.body.length < CONSTANTS.DENDRON_FILE_TOO_BIG) {
+            const links = LinkUtils.findLinks({ note: ent.note, engine: this });
+            const linkCandidates = LinkUtils.findLinkCandidates({
+              note: ent.note,
+              notesMap,
+              engine: this,
+            });
+            const anchors = await AnchorUtils.findAnchors({
+              note: ent.note,
+              wsRoot: this.wsRoot,
+            });
+            ent.note.links = links.concat(linkCandidates);
+            ent.note.anchors = anchors;
+          }
           this.notes[id] = ent.note;
         }
       })

--- a/packages/engine-test-utils/src/presets/engine-server/init.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/init.ts
@@ -16,6 +16,7 @@ import {
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
+import { TestConfigUtils } from "../../config";
 import { ENGINE_HOOKS, setupBasic } from "./utils";
 
 const SCHEMAS = {
@@ -238,7 +239,49 @@ const NOTES = {
           fname: "one",
           vault: vault1,
           wsRoot,
-          body: "# head\n[[two]]\n".repeat(100000),
+          body: "# head\n[[two]]\n".repeat(20000),
+        });
+        // The target note
+        await NoteTestUtilsV4.createNote({
+          fname: "two",
+          vault: vault3,
+          wsRoot,
+          body: "[[one]]",
+        });
+      },
+    }
+  ),
+  NOTE_TOO_LONG_CONFIG: new TestPresetEntryV4(
+    async ({ engine, initResp }) => {
+      const one = engine.notes["one"];
+      const two = engine.notes["two"];
+      return [
+        // Links in one didn't get parsed since it's too long, but two did
+        { actual: one.links.length, expected: 1 },
+        { actual: one.links[0].type, expected: "backlink" },
+        { actual: two.links.length, expected: 1 },
+        // Anchors in one didn't get parsed since it's too long
+        { actual: Object.entries(one.anchors).length, expected: 0 },
+      ];
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        console.log(wsRoot);
+        TestConfigUtils.withConfig(
+          (c) => {
+            c.maxNoteLength = 10;
+            return c;
+          },
+          { wsRoot }
+        );
+        const vault1 = vaults[0];
+        const vault3 = vaults[2];
+        // Not really a super long note, but we set the max in config to even shorter
+        await NoteTestUtilsV4.createNote({
+          fname: "one",
+          vault: vault1,
+          wsRoot,
+          body: "# head\n[[two]]\n".repeat(3),
         });
         // The target note
         await NoteTestUtilsV4.createNote({

--- a/packages/engine-test-utils/src/presets/engine-server/init.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/init.ts
@@ -216,6 +216,40 @@ const NOTES = {
       },
     }
   ),
+  NOTE_TOO_LONG: new TestPresetEntryV4(
+    async ({ engine }) => {
+      const one = engine.notes["one"];
+      const two = engine.notes["two"];
+      return [
+        // Links in one didn't get parsed since it's too long, but two did
+        { actual: one.links.length, expected: 1 },
+        { actual: one.links[0].type, expected: "backlink" },
+        { actual: two.links.length, expected: 1 },
+        // Anchors in one didn't get parsed since it's too long
+        { actual: Object.entries(one.anchors).length, expected: 0 },
+      ];
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        const vault1 = vaults[0];
+        const vault3 = vaults[2];
+        // Create a really large note with outgoing links and anchors
+        await NoteTestUtilsV4.createNote({
+          fname: "one",
+          vault: vault1,
+          wsRoot,
+          body: "# head\n[[two]]\n".repeat(100000),
+        });
+        // The target note
+        await NoteTestUtilsV4.createNote({
+          fname: "two",
+          vault: vault3,
+          wsRoot,
+          body: "[[one]]",
+        });
+      },
+    }
+  ),
   MIXED_CASE_PARENT: new TestPresetEntryV4(
     async ({ engine }) => {
       const notes = engine.notes;

--- a/packages/engine-test-utils/src/presets/engine-server/init.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/init.ts
@@ -252,7 +252,7 @@ const NOTES = {
     }
   ),
   NOTE_TOO_LONG_CONFIG: new TestPresetEntryV4(
-    async ({ engine, initResp }) => {
+    async ({ engine }) => {
       const one = engine.notes["one"];
       const two = engine.notes["two"];
       return [

--- a/test-workspace/scripts/genNote.js
+++ b/test-workspace/scripts/genNote.js
@@ -1,0 +1,3 @@
+const {generateNote} = require("./randomNote");
+
+console.log(generateNote());


### PR DESCRIPTION
When a note is too large (over 1MiB), Dendron will avoid generating backlinks and parsing anchors. This means:

1. Any outgoing links from the large note are ignored, and will not appear in backlinks
2. Any links into the large note that target an anchor will instead go to the start of the note

Other features will continue to function, the large note can be accessed with "Lookup Note", links to the large note will function, and all other notes are unaffected. The user will be warned during startup about the large note.

![](https://i.imgur.com/F0fhB1V.png)