### PR TITLE
fix: wrong internal links in nextjs publishing

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -499,6 +499,11 @@ export type DendronSiteConfig = {
    */
   cognitoUserPoolId?: string;
   cognitoClientId?: string;
+
+  /**
+   * notes are published without the .html file extension
+   */
+  usePrettyLinks?: boolean;
 };
 
 export type DendronGraphConfig = {

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -188,7 +188,9 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           }
         }
         const alias = data.alias ? data.alias : value;
-        const href = `${copts?.prefix || ""}${value}.html${
+        const usePrettyLinks = engine.config.site.usePrettyLinks;
+        const maybeFileExtension = _.isBoolean(usePrettyLinks) && usePrettyLinks ? "" : ".html";
+        const href = `${copts?.prefix || ""}${value}${maybeFileExtension}${
           data.anchorHeader ? "#" + data.anchorHeader : ""
         }`;
         const exists = true;

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -658,6 +658,7 @@ function convertNoteRefHelperAST(
       if (procOpts.dest === DendronASTDest.HTML) {
         tmpProc = MDUtilsV5.procRemarkFull({
           ...MDUtilsV5.getProcData(proc),
+          insideNoteRef: true,
           fname: note.fname,
           vault: note.vault,
         });

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -113,6 +113,10 @@ export type ProcDataFullOptsV5 = {
    * Supply alternative dictionary of notes to use when resolving note ids
    */
   notes?: NotePropsDict;
+  /**
+   * Check to see if we are in a note reference.
+   */
+  insideNoteRef?: boolean;
 } & { config?: DendronConfig; wsRoot?: string };
 
 /**
@@ -128,6 +132,7 @@ export type ProcDataFullV5 = {
   // derived
   config: DendronConfig;
   notes?: NotePropsDict;
+  insideNoteRef?: boolean;
   /**
    * Keep track of current note ref level
    */

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -288,6 +288,13 @@ export class MDUtilsV5 {
           if (opts.flavor === ProcFlavor.HOVER_PREVIEW) {
             proc = proc.use(dendronHoverPreview);
           }
+          if (opts.flavor === ProcFlavor.PUBLISHING) {
+            proc = proc.use(dendronPub, {
+              wikiLinkOpts: {
+                prefix: "/notes/"
+              }
+            });
+          }
         }
         break;
       case ProcMode.IMPORT: {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/utilsv5.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/utilsv5.spec.ts.snap
@@ -33,7 +33,7 @@ VFile {
 <div class=\\"portal-head\\">
 <div class=\\"portal-backlink\\">
 <div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Alpha</span></div>
-<a href=\\"alpha-id.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+<a href=\\"/notes/alpha-id.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
 </div>
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
@@ -43,7 +43,7 @@ VFile {
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
-<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"/notes/foo.ch1.html\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
@@ -147,7 +147,15 @@ describe("MDUtils.proc", () => {
           );
         },
         [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
-        [ProcFlavor.PUBLISHING]: ProcFlavor.REGULAR,
+        [ProcFlavor.PUBLISHING]: async ({ extra }) => {
+          const { resp } = extra;
+          expect(resp).toMatchSnapshot();
+          await checkString(
+            resp.contents,
+            // should have id for link
+            `<a href="/notes/alpha-id.html"`,
+          );
+        },
       },
     },
     preSetupHook: async (opts) => {


### PR DESCRIPTION
This PR:
- Fixes internal urls / backlink / children links pointing to wrong url.
- Fixes note refs rendering backlinks and children links when it shouldn't

Tasks:
- [x] Add `usePrettyLinks` config
- [x] If `usePrettyLinks`, don't add `.html` to link
- [x] Fix issue with links not prefixed with `/notes/`
- [x] ~~Fix wrong backlink urls in rendered note refs~~ Don't render backlinks and children in note ref