### PR TITLE
enhance: better error message when renaming note without id

### DIFF
--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -324,6 +324,9 @@ export class DendronEngineClient implements DEngineClient {
 
   async renameNote(opts: RenameNoteOpts): Promise<RespV2<RenameNotePayload>> {
     const resp = await this.api.engineRenameNote({ ...opts, ws: this.ws });
+    if (resp.error || _.isUndefined(resp.data)) {
+      throw resp.error;
+    }
     await this.refreshNotesV2(resp.data as NoteChangeEntry[]);
     return resp;
   }

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -18,6 +18,7 @@ import {
   EngineDeleteOptsV2,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
+  error2PlainObject,
   ERROR_SEVERITY,
   ERROR_STATUS,
   FuseEngine,
@@ -505,9 +506,10 @@ export class DendronEngineV2 implements DEngine {
         data: resp,
       };
     } catch (err) {
-      return {
-        error: new DendronError({ message: "rename error", payload: err }),
-      };
+      let error = err;
+      if (err instanceof DendronError) error = error2PlainObject(err);
+      if (_.isUndefined(err.message)) err.message = "rename error";
+      return { error };
     }
   }
 


### PR DESCRIPTION
This was an [error reported on Twitter](https://twitter.com/wisdomcitynews/status/1420200694921924615), I'm not sure if there is a corresponding issue.

I believe I reproduced the issue: it occurs if some of the renamed notes don't have a frontmatter. I improved the error message to be more informative, and to also tip the user what the issue may be.

![](https://i.imgur.com/099Vkq9.png)