### PR TITLE
chore: update mentions to old lookup command to new one

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/tutorial.2-taking-notes.md
@@ -8,7 +8,7 @@ created: 1624333266168
 
 ### Create a Note
 
-To create a note, use `%KEYBINDING%+L` to bring up Dendron's lookup. This is a shortcut for the `Dendron: Lookup` command.
+To create a note, use `%KEYBINDING%+L` to bring up Dendron's lookup. This is a shortcut for the `Dendron: Lookup Note` command.
 
 > 💡 The lookup command is the main way to interact with Dendron. It is used for both looking up your notes and creating new notes. When you do a lookup on a note that hasn't been created, Dendron will create it for you. Remember the `%KEYBINDING%+L` shortcut.
 

--- a/packages/plugin-core/assets/dendron-ws/vault/dendron.md
+++ b/packages/plugin-core/assets/dendron-ws/vault/dendron.md
@@ -14,7 +14,7 @@ Welcome to Dendron! This guide will help get you started with your knowledge bas
 
 Here are the basics of Dendron so you can get started growing your knowledge base.
 - [ ] Create your first note. 
-    - [ ] Dendron uses the [lookup](https://www.dendron.so/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3.html#lookup-menu) command to create. So, hit CMD+L (or ctrl+L if you're on Windows) to bring up the lookup bar, type in a new note name and hit enter to create it. You can also run the lookup command through the command palette "Dendron: Lookup". 
+    - [ ] Dendron uses the [lookup](https://www.dendron.so/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3.html#lookup-menu) command to create. So, hit CMD+L (or ctrl+L if you're on Windows) to bring up the lookup bar, type in a new note name and hit enter to create it. You can also run the lookup command through the command palette "Dendron: Lookup Note". 
     - [ ] Wiki-style links are supported. If the note doesn't exist, we'll create the note for you. For example, just try [[this link]] from the editor view.
 - [ ] Find your notes. Dendron really shines when you need to look up notes quickly. For this, you use *drumroll* the lookup command (again). Just hit CMD/ctrl+L and you can search your entire set of notes.
 - [ ] To delete a note, navigate to it and use the "Dendron: Delete Node" command. As with everything else in VSCode, bring up the command palette with CMD/ctrl+shift+P and run the command.  


### PR DESCRIPTION
This PR:
- Updates mentions to `Dendron: Lookup` command to `Dendron: Lookup Note` in preparation of transitioning to lookup v3