### PR TITLE
chore: expose copyNoteLink argument for NoteLookupCommand

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -32,6 +32,8 @@ import {
 import {
   DendronQuickPickerV2,
   DendronQuickPickState,
+  LookupEffectType,
+  LookupEffectTypeEnum,
   LookupFilterType,
   LookupNoteType,
   LookupNoteTypeEnum,
@@ -60,6 +62,7 @@ export type CommandRunOpts = {
   noteType?: LookupNoteType;
   selectionType?: LookupSelectionType;
   splitType?: LookupSplitType;
+  effectType?: LookupEffectType;
   /**
    * NOTE: currently, only one filter is supported
    */
@@ -156,7 +159,7 @@ export class NoteLookupCommand extends BaseCommand<
       ),
       extraButtons: [
         MultiSelectBtn.create(copts.multiSelect),
-        CopyNoteLinkBtn.create(),
+        CopyNoteLinkBtn.create(copts.effectType === LookupEffectTypeEnum.copyNoteLink),
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")
         ),
@@ -309,6 +312,9 @@ export class NoteLookupCommand extends BaseCommand<
       const outClean = out.filter(
         (ent) => !_.isUndefined(ent)
       ) as OnDidAcceptReturn[];
+      if (!_.isUndefined(quickpick.copyNoteLinkFunc)) {
+        await quickpick.copyNoteLinkFunc!(outClean.map((item) => item.node));
+      }
       await _.reduce(
         outClean,
         async (acc, item) => {

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -32,8 +32,6 @@ import {
 import {
   DendronQuickPickerV2,
   DendronQuickPickState,
-  LookupEffectType,
-  LookupEffectTypeEnum,
   LookupFilterType,
   LookupNoteType,
   LookupNoteTypeEnum,
@@ -59,10 +57,10 @@ export type CommandRunOpts = {
   noConfirm?: boolean;
   fuzzThreshold?: number;
   multiSelect?: boolean;
+  copyNoteLink?: boolean;
   noteType?: LookupNoteType;
   selectionType?: LookupSelectionType;
   splitType?: LookupSplitType;
-  effectType?: LookupEffectType;
   /**
    * NOTE: currently, only one filter is supported
    */
@@ -159,7 +157,7 @@ export class NoteLookupCommand extends BaseCommand<
       ),
       extraButtons: [
         MultiSelectBtn.create(copts.multiSelect),
-        CopyNoteLinkBtn.create(copts.effectType === LookupEffectTypeEnum.copyNoteLink),
+        CopyNoteLinkBtn.create(copts.copyNoteLink),
         DirectChildFilterBtn.create(
           copts.filterMiddleware?.includes("directChildOnly")
         ),

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -1,5 +1,4 @@
 import {
-  DNodePropsQuickInputV2,
   NoteUtils,
   NoteProps,
   getSlugger,
@@ -410,16 +409,10 @@ export class CopyNoteLinkBtn extends DendronBtn {
   }
 
   async onEnable({ quickPick }: ButtonHandleOpts) {
-    if (this.pressed) {
-      let items: readonly DNodePropsQuickInputV2[];
-      if (quickPick.canSelectMany) {
-        items = quickPick.selectedItems;
-      } else {
-        items = quickPick.activeItems;
-      }
-      const links = items
-        .filter((ent) => !PickerUtilsV2.isCreateNewNotePick(ent))
-        .map((note) => NoteUtils.createWikiLink({ note }));
+    quickPick.copyNoteLinkFunc = async (
+      items: NoteProps[],
+    ) => {
+      const links = items.map((note) => NoteUtils.createWikiLink({ note }));
       if (_.isEmpty(links)) {
         vscode.window.showInformationMessage(`no items selected`);
       } else {
@@ -427,6 +420,10 @@ export class CopyNoteLinkBtn extends DendronBtn {
         vscode.window.showInformationMessage(`${links.length} links copied`);
       }
     }
+  }
+
+  async onDisable({ quickPick }: ButtonHandleOpts) {
+    quickPick.copyNoteLinkFunc = undefined;
   }
 }
 

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -21,7 +21,7 @@ type ModifyPickerValueFunc = (value?: string) => {
   prefix: string;
 };
 type SelectionProcessFunc = (note: NoteProps) => Promise<NoteProps | undefined>;
-
+type CopyNoteLinkFunc = (items: NoteProps[]) => Promise<void> | undefined;
 export enum DendronQuickPickState {
   /**
    * Default state
@@ -101,6 +101,10 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    * Method to process selected text in active note.
    */
   selectionProcessFunc?: SelectionProcessFunc;
+  /**
+   * Method to copy note link
+   */
+  copyNoteLinkFunc?: CopyNoteLinkFunc;
   /**
    * Should show a subsequent picker?
    */

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1724,9 +1724,9 @@ suite("NoteLookupCommand", function () {
           await cmd.run({
             multiSelect: true,
             noConfirm: true,
-            effectType: "copyNoteLink"
+            copyNoteLink: true,
           });
-          
+
           const content = await clipboard.readText();
 
           expect(content).toEqual(

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1621,6 +1621,7 @@ suite("NoteLookupCommand", function () {
       const runOpts = {
         multiSelect: true,
         noConfirm: true,
+        effectType: opts.copyLink ? "copyNoteLink" : undefined,
       } as CommandRunOpts;
 
       if (opts.split) runOpts.splitType = LookupSplitTypeEnum.horizontal;
@@ -1633,16 +1634,6 @@ suite("NoteLookupCommand", function () {
         canSelectMany: true,
         buttons: gatherOut.quickpick.buttons,
       });
-
-      if (opts.copyLink) {
-        const { copyNoteLinkBtn } = getEffectTypeButtons(mockQuickPick.buttons);
-        sinon.stub(gatherOut.controller, "_quickpick").value(mockQuickPick);
-        sinon.stub(gatherOut.controller, "quickpick").value(mockQuickPick);
-        await gatherOut.controller.onTriggerButton(copyNoteLinkBtn);
-        const content = await clipboard.readText();
-        sinon.restore();
-        return { content };
-      }
 
       mockQuickPick.showNote = gatherOut.quickpick.showNote;
 
@@ -1723,12 +1714,20 @@ suite("NoteLookupCommand", function () {
 
           await VSCodeUtils.openNote(engine.notes["foo"]);
 
-          const { content } = await prepareCommandFunc({
+          const { cmd } = await prepareCommandFunc({
             wsRoot,
             vaults,
             engine,
             opts: { copyLink: true },
           });
+
+          await cmd.run({
+            multiSelect: true,
+            noConfirm: true,
+            effectType: "copyNoteLink"
+          });
+          
+          const content = await clipboard.readText();
 
           expect(content).toEqual(
             [


### PR DESCRIPTION
This PR:
- Adds copyNoteLink argument for NoteLookupCommand and makes it possible to pass it through custom keybindings
- Fixes copyNoteLink button effect to trigger after onAccept so that it works for new note creation as well 
- Adds tests for new behaviors