### PR TITLE
feat: Add smart vault selection to NoteLookupCommand

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -39,6 +39,7 @@ import {
   LookupSelectionTypeEnum,
   LookupSplitType,
   LookupSplitTypeEnum,
+  VaultSelectionMode,
 } from "../components/lookup/types";
 import {
   node2Uri,
@@ -64,6 +65,7 @@ export type CommandRunOpts = {
    * NOTE: currently, only one filter is supported
    */
   filterMiddleware?: LookupFilterType[];
+  vaultSelectionMode?: VaultSelectionMode;
 };
 
 /**
@@ -154,6 +156,7 @@ export class NoteLookupCommand extends BaseCommand<
         ws.config,
         "lookupConfirmVaultOnCreate"
       ),
+      vaultButtonPressed: copts.vaultSelectionMode === VaultSelectionMode.alwaysPrompt,
       extraButtons: [
         MultiSelectBtn.create(copts.multiSelect),
         CopyNoteLinkBtn.create(),

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -36,6 +36,11 @@ export type LookupControllerV3CreateOpts = {
    */
   disableVaultSelection?: boolean;
   /**
+   * if vault selection isn't disabled,
+   * press button on init if true
+   */
+  vaultButtonPressed?: boolean;
+  /**
    * Additional buttons
    */
   extraButtons?: DendronBtn[];
@@ -61,8 +66,11 @@ export class LookupControllerV3 {
         opts?.disableVaultSelection) ||
       opts?.nodeType === "schema";
     const isMultiVault = vaults.length > 1 && !disableVaultSelection;
+    const maybeVaultSelectButtonPressed = _.isUndefined(opts?.vaultButtonPressed)
+      ? isMultiVault
+      : isMultiVault && opts!.vaultButtonPressed; 
     const maybeVaultSelectButton =
-      opts?.nodeType === "note" ? [VaultSelectButton.create(isMultiVault)] : [];
+      opts?.nodeType === "note" ? [VaultSelectButton.create(maybeVaultSelectButtonPressed)] : [];
     const buttons = opts?.buttons || maybeVaultSelectButton;
     const extraButtons = opts?.extraButtons || [];
     return new LookupControllerV3({

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -134,7 +134,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     lc: LookupControllerV3;
   }) {
     return async () => {
-      const ctx = "LookupProvider:onDidAccept";
+      const ctx = "NoteLookupProvider:onDidAccept";
       const { quickpick: picker, lc } = opts;
       let selectedItems = NotePickerUtils.getSelection(picker);
       Logger.debug({
@@ -157,7 +157,8 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       ) {
         Logger.debug({ ctx, msg: "nextPicker:pre" });
         picker.state = DendronQuickPickState.PENDING_NEXT_PICK;
-        picker.vault = await picker.nextPicker();
+        
+        picker.vault = await picker.nextPicker({ note: selectedItems.slice(0, 1)[0] });
         // check if we exited from selecting a vault
         if (_.isUndefined(picker.vault)) {
           HistoryService.instance().add({
@@ -408,12 +409,19 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
       }
     );
     quickpick.onDidChangeValue(onUpdateDebounced);
-    quickpick.onDidAccept(() => {
+    quickpick.onDidAccept(async () => {
       Logger.info({
         ctx: "SchemaLookupProvider:onDidAccept",
         quickpick: quickpick.value,
       });
       onUpdateDebounced.cancel();
+      if (_.isEmpty(quickpick.selectedItems)) {
+        await onUpdatePickerItems({
+          picker: quickpick,
+          token: new CancellationTokenSource().token,
+          fuzzThreshold: lc.fuzzThreshold,
+        });
+      }
       this.onDidAccept({ quickpick, lc })();
     });
     return;
@@ -429,10 +437,28 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
     lc: LookupControllerV3;
   }) {
     return async () => {
+      const ctx = "SchemaLookupProvider:onDidAccept";
       const { quickpick: picker, lc } = opts;
-      const nextPicker = picker.nextPicker;
-      if (nextPicker) {
-        picker.vault = await nextPicker();
+      let selectedItems = NotePickerUtils.getSelection(picker);
+      Logger.debug({
+        ctx,
+        selectedItems: selectedItems.map((item) => NoteUtils.toLogObj(item)),
+      });
+      if (_.isEmpty(selectedItems)) {
+        selectedItems = await SchemaPickerUtils.fetchPickerResultsWithCurrentValue({
+          picker,
+        })
+      }
+      if (
+        PickerUtilsV2.hasNextPicker(picker, {
+          selectedItems,
+          providerId: this.id,
+        })
+      ) {
+        Logger.debug({ ctx, msg: "nextPicker:pre" });
+        picker.state = DendronQuickPickState.PENDING_NEXT_PICK;
+        
+        picker.vault = await picker.nextPicker({ note: selectedItems.slice(0, 1)[0] });
         // check if we exited from selecting a vault
         if (_.isUndefined(picker.vault)) {
           HistoryService.instance().add({
@@ -444,7 +470,6 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
           return;
         }
       }
-      const selectedItems = NotePickerUtils.getSelection(picker);
       const isMultiLevel = picker.value.split(".").length > 1;
       if (isMultiLevel) {
         window.showErrorMessage("schemas can only be one level deep");

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -158,7 +158,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         Logger.debug({ ctx, msg: "nextPicker:pre" });
         picker.state = DendronQuickPickState.PENDING_NEXT_PICK;
         
-        picker.vault = await picker.nextPicker({ note: selectedItems.slice(0, 1)[0] });
+        picker.vault = await picker.nextPicker({ note: selectedItems[0] });
         // check if we exited from selecting a vault
         if (_.isUndefined(picker.vault)) {
           HistoryService.instance().add({
@@ -458,7 +458,7 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         Logger.debug({ ctx, msg: "nextPicker:pre" });
         picker.state = DendronQuickPickState.PENDING_NEXT_PICK;
         
-        picker.vault = await picker.nextPicker({ note: selectedItems.slice(0, 1)[0] });
+        picker.vault = await picker.nextPicker({ note: selectedItems[0] });
         // check if we exited from selecting a vault
         if (_.isUndefined(picker.vault)) {
           HistoryService.instance().add({

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -104,7 +104,7 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   /**
    * Should show a subsequent picker?
    */
-  nextPicker?: () => any;
+  nextPicker?: (opts: any) => any;
   /**
    * TODO: should be required
    */

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -817,6 +817,27 @@ export class NotePickerUtils {
 }
 
 export class SchemaPickerUtils {
+  static async fetchPickerResultsWithCurrentValue({
+    picker,
+  }: {
+    picker: DendronQuickPickerV2;
+  }) {
+    const engine = getEngine();
+    const resp = await engine.querySchema(picker.value);
+    const node = SchemaUtils.getModuleRoot(resp.data[0]);
+    const perfectMatch = node.fname === picker.value;
+    return !perfectMatch
+      ? [NotePickerUtils.createNoActiveItem({} as any)]
+      : [
+          DNodeUtils.enhancePropForQuickInputV3({
+            wsRoot: DendronWorkspace.wsRoot(),
+            props: node,
+            schemas: engine.schemas,
+            vaults: DendronWorkspace.instance().vaultsv4,
+          }),
+        ];
+  }
+  
   static async fetchPickerResults(opts: {
     picker: DendronQuickPickerV2;
     qs: string;

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -8,7 +8,11 @@ import {
   Time,
 } from "@dendronhq/common-all";
 import { tmpDir, vault2Path } from "@dendronhq/common-server";
-import { FileTestUtils, NoteTestUtilsV4, NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
+import {
+  FileTestUtils,
+  NoteTestUtilsV4,
+  NOTE_PRESETS_V4,
+} from "@dendronhq/common-test-utils";
 import { HistoryService } from "@dendronhq/engine-server";
 import {
   ENGINE_HOOKS,
@@ -248,16 +252,16 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo",
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
-          const actualNote = VSCodeUtils.getNoteFromDocument(editor!.document)
+          const actualNote = VSCodeUtils.getNoteFromDocument(editor!.document);
           const expectedNote = engine.notes["foo"];
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
             moduleId: "foo",
-            schemaId: "foo"
-          })
+            schemaId: "foo",
+          });
           done();
         },
-      }); 
+      });
     });
 
     test("child query with schema", (done) => {
@@ -274,16 +278,16 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo.ch1",
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
-          const actualNote = VSCodeUtils.getNoteFromDocument(editor!.document)
+          const actualNote = VSCodeUtils.getNoteFromDocument(editor!.document);
           const expectedNote = engine.notes["foo.ch1"];
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
             moduleId: "foo",
-            schemaId: "ch1"
-          })
+            schemaId: "ch1",
+          });
           done();
         },
-      }); 
+      });
     });
 
     test("direct child filter", (done) => {
@@ -389,9 +393,11 @@ suite("NoteLookupCommand", function () {
             initialValue: "foobar",
           }))!;
           expect(opts.quickpick.selectedItems.length).toEqual(4);
-          expect(_.last(opts.quickpick.selectedItems)?.title).toEqual(
-            "Create New"
-          );
+          const lastItem = _.last(opts.quickpick.selectedItems);
+          expect(_.pick(lastItem, ["id", "fname"])).toEqual({
+            id: "Create New",
+            fname: "foobar",
+          });
           expect(
             VSCodeUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
@@ -435,7 +441,7 @@ suite("NoteLookupCommand", function () {
     test("new domain", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic, 
+        preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
@@ -447,10 +453,12 @@ suite("NoteLookupCommand", function () {
           const editor = VSCodeUtils.getActiveTextEditor()!;
           const activeNote = VSCodeUtils.getNoteFromDocument(editor.document);
           expect(activeNote).toEqual(barFromEngine);
-          expect(DNodeUtils.isRoot(engine.notes[barFromEngine.parent as string]));
+          expect(
+            DNodeUtils.isRoot(engine.notes[barFromEngine.parent as string])
+          );
           done();
-        }
-      })
+        },
+      });
     });
 
     test("regular multi-select, no pick new", (done) => {
@@ -505,9 +513,7 @@ suite("NoteLookupCommand", function () {
           expect(_.isUndefined(quickpick?.nextPicker)).toBeFalsy();
           // selected items shoudl equal
           expect(quickpick.selectedItems.length).toEqual(1);
-          expect(
-            _.pick(quickpick.selectedItems[0], ["id", "vault"])
-          ).toEqual({
+          expect(_.pick(quickpick.selectedItems[0], ["id", "vault"])).toEqual({
             id: fname,
             vault,
           });
@@ -1019,7 +1025,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          
+
           // open and create a file outside of vault.
           const extDir = tmpDir().name;
           const extPath = "outside.md";
@@ -1028,7 +1034,9 @@ suite("NoteLookupCommand", function () {
             { path: extPath, body: extBody },
           ]);
           const uri = vscode.Uri.file(path.join(extDir, extPath));
-          const editor = (await VSCodeUtils.openFileInEditor(uri)) as vscode.TextEditor;
+          const editor = (await VSCodeUtils.openFileInEditor(
+            uri
+          )) as vscode.TextEditor;
           editor.selection = new vscode.Selection(0, 0, 0, 17);
 
           await cmd.run({
@@ -1042,12 +1050,14 @@ suite("NoteLookupCommand", function () {
             newNoteEditor.document
           );
           expect(newNote?.body.trim()).toEqual("non vault content");
-          
-          const nonVaultFileEditor = await VSCodeUtils.openFileInEditor(uri) as vscode.TextEditor;
+
+          const nonVaultFileEditor = (await VSCodeUtils.openFileInEditor(
+            uri
+          )) as vscode.TextEditor;
           expect(nonVaultFileEditor.document.getText()).toEqual(extBody);
           done();
-        }
-      })
+        },
+      });
     });
 
     test("selectionExtract modifier toggle", (done) => {

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -63,7 +63,7 @@ import {
 const stubVaultPick = (vaults: DVault[]) => {
   const vault = _.find(vaults, { fsPath: "vault1" });
   return sinon
-    .stub(PickerUtilsV2, "promptVault")
+    .stub(PickerUtilsV2, "getOrPromptVaultForNewNote")
     .returns(Promise.resolve(vault));
 };
 


### PR DESCRIPTION
This PR:
- Changes `NoteLookupCommand`'s vault selection behavior to utilze the smart vault selection prompt.
- Changes vault selection behavior to:
  - if `lookupConfirmVaultOnCreate`, enable vault selection button. and:
     - vault selection button `on` label is changed to `always prompt`, and behavior is mapped to `VaultSelectionMode.alwaysPrompt`
     - vault selection button `off` label is changed to `smart`, and behavior is mapped to `VaultSelectionMode.smart`
  - if not `lookupConfirmVaultOnCreate`, behave as-is (use current vault)
- Fixes test according to changed vault selection behavior.