### PR TITLE
chore: add config and keybinding migration for lookup v3

### DIFF
--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -1,4 +1,4 @@
-import { ScratchConfig } from "@dendronhq/common-all";
+import { LookupConfig, LookupSelectionType, ScratchConfig } from "@dendronhq/common-all";
 import {
   SegmentClient,
   TelemetryStatus,
@@ -13,29 +13,27 @@ import { Migrations } from "./types";
  * Migrations are sorted by version numbers, from greatest to least
  */
 export const ALL_MIGRATIONS: Migrations[] = [
-  // TODO: use correct version for this migration once it's confirmed when
-  //       `NoteLookupCommand` will completely replace lookup v2.
-  // {
-  //   version: "0.54.0",
-  //   changes: [
-  //     {
-  //       name: "migrate note lookup config",
-  //       func: async ({ dendronConfig, wsConfig }) => {
-  //         dendronConfig.lookup = DConfig.genDefaultConfig().lookup as LookupConfig;
-  //         const oldLookupCreateBehavior = _.get(
-  //           wsConfig.settings, 
-  //           "dendron.defaultLookupCreateBehavior",
-  //           undefined,
-  //         ) as LookupSelectionType;
-  //         if (oldLookupCreateBehavior !== undefined) {
-  //           dendronConfig.lookup.note.selectionType = oldLookupCreateBehavior;
-  //         }
+  {
+    version: "0.55.2",
+    changes: [
+      {
+        name: "migrate note lookup config",
+        func: async ({ dendronConfig, wsConfig }) => {
+          dendronConfig.lookup = DConfig.genDefaultConfig().lookup as LookupConfig;
+          const oldLookupCreateBehavior = _.get(
+            wsConfig.settings, 
+            "dendron.defaultLookupCreateBehavior",
+            undefined,
+          ) as LookupSelectionType;
+          if (oldLookupCreateBehavior !== undefined) {
+            dendronConfig.lookup.note.selectionType = oldLookupCreateBehavior;
+          }
 
-  //         return { data: { dendronConfig, wsConfig }};
-  //       },
-  //     },
-  //   ],
-  // },
+          return { data: { dendronConfig, wsConfig }};
+        },
+      },
+    ],
+  },
   {
     version: "0.51.4",
     changes: [

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -253,7 +253,7 @@ suite("Migration", function () {
       });
     });
 
-    test.only("migrate to 0.55.2 (old existing ws config to new dendron config)", (done) => {
+    test("migrate to 0.55.2 (old existing ws config to new dendron config)", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         modConfigCb: (config) => {
@@ -289,7 +289,7 @@ suite("Migration", function () {
       })
     })
 
-    test.only("migrate to 0.55.2 (implicit to new dendron config)", (done) => {
+    test("migrate to 0.55.2 (implicit to new dendron config)", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         modConfigCb: (config) => {


### PR DESCRIPTION
This PR:
- Adds migration for new lookup config namespace.
- Adds the ability to update v2 keybindings to v3 keybindings on extension activation.
- Refactors keybinding related utilities
- Adds tests for migrations
