### PR TITLE
fix: direct child filter button trigger does not immediately update picker items

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -248,6 +248,7 @@ export class LookupControllerV3 {
         picker: quickpick,
         token: this.cancelToken.token,
         fuzzThreshold: this.fuzzThreshold,
+        forceUpdate: true,
       });
     }
   };

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -30,6 +30,10 @@ export type OnUpdatePickerItemsOpts = {
   picker: DendronQuickPickerV2;
   token: CancellationToken;
   fuzzThreshold?: number;
+  /**
+   * force update even if picker vaule didn't change
+   */
+  forceUpdate?: boolean;
 };
 
 export type OnAcceptHook = (opts: {
@@ -232,8 +236,10 @@ export class NoteLookupProvider implements ILookupProviderV3 {
 
     try {
       if (picker.value === picker.prevQuickpickValue) {
-        Logger.debug({ ctx, msg: "picker value did not change" });
-        return;
+        if (!opts.forceUpdate) {
+          Logger.debug({ ctx, msg: "picker value did not change" });
+          return;
+        }
       }
       // if empty string, show all 1st level results
       if (querystring === "") {


### PR DESCRIPTION
This PR:
- fixes issue with direct child filter button not immediately updating picker item on trigger.
- this issue was introduced with the recent fixes to lookup v3 which stopped the update if the picker value hasn't changed since last update.