### PR TITLE
fix: preserve keybinding comments and back up old file

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -453,6 +453,18 @@ export async function _activate(
   if (!_.isUndefined(migratedKeybindings)) {
     fs.copyFileSync(keybindingConfigPath, `${keybindingConfigPath}.old`);
     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
+    vscode.window.showInformationMessage("Keybindings for lookup has been updated.", ...["Open keybindings.json"]).then((selection) => {
+      if (selection) {
+        const uri = vscode.Uri.file(keybindingConfigPath);
+        VSCodeUtils.openFileInEditor(uri);
+      }
+    })
+    vscode.window.showInformationMessage("Old config has been backed up.", ...["Open backup"]).then((selection) => {
+      if (selection) {
+        const uri = vscode.Uri.file(`${keybindingConfigPath}.old`);
+        VSCodeUtils.openFileInEditor(uri);
+      }
+    });
   }
 
   return showWelcomeOrWhatsNew({

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -451,8 +451,8 @@ export async function _activate(
 
   const { keybindingConfigPath, migratedKeybindings } = KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
   if (!_.isUndefined(migratedKeybindings)) {
-    fs.ensureFileSync(keybindingConfigPath);
-    fs.writeFileSync(keybindingConfigPath, JSON.stringify(migratedKeybindings));
+    fs.copyFileSync(keybindingConfigPath, `${keybindingConfigPath}.old`);
+    writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
   }
 
   return showWelcomeOrWhatsNew({

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -587,7 +587,7 @@ suite("keybindings", function () {
         });
     });
 
-    test("v2 to v3 migration happens on extension activation on upgrade", (done) => {
+    test("v2 to v3 migration happens on extension activation only on upgrade", (done) => {
       const wsRoot = tmpDir().name;
       const metaKey = os.type() === "Darwin" ? "cmd" : "ctrl";
       const { userConfigDir } = VSCodeUtils.getCodeUserConfigDir();
@@ -611,7 +611,7 @@ suite("keybindings", function () {
         }
       ]`;
       fs.writeFileSync(keybindingConfigPath, config);
-
+      sinon.stub(VSCodeUtils, "getInstallStatusForExtension").returns(InstallStatus.UPGRADED);
       getWS()
         .updateGlobalState(
           GLOBAL_STATE.WORKSPACE_ACTIVATION_CONTEXT,


### PR DESCRIPTION
This PR:
- Fixes issue with lookup v3 keybinding migration so that it preserves comments and also backs up old config
- Also makes vim keybinding resolution preserve comments.
- Adds tests for this behavior

I have spent some time trying to preserve every single comment in the config, but specifically comments that users write in the `args` block of the keybinding is non-trivial to preserve, and is probably not worth the effort. I have opted for backing up the original keybinding and also showing an information message with a button to open both new and old configs instead.