### PR TITLE
enhance: ability to set selection type to none

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -97,6 +97,7 @@ export enum NoteAddBehavior {
 export enum LookupSelectionType {
   "selection2link" = "selection2link",
   "selectionExtract" = "selectionExtract",
+  "none" = "none"
 }
 
 export type NoteLookupConfig = {
@@ -105,7 +106,6 @@ export type NoteLookupConfig = {
 
 export type LookupConfig = {
   note: NoteLookupConfig;
-  // schema: SchemaLookupConfig;
 };
 
 export type JournalConfig = {

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -132,8 +132,9 @@ export enum LookupEffectTypeEnum {
 export enum LookupSelectionTypeEnum {
   "selection2link" = "selection2link",
   "selectionExtract" = "selectionExtract",
+  "none" = "none"
 }
-export type LookupSelectionType = "selection2link" | "selectionExtract";
+export type LookupSelectionType = "selection2link" | "selectionExtract" | "none";
 
 export enum LookupSplitTypeEnum {
   "horizontal" = "horizontal",

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -3,6 +3,7 @@ import {
   DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
+  LookupSelectionType,
   NoteQuickInput,
   NoteUtils,
   Time,
@@ -886,6 +887,66 @@ suite("NoteLookupCommand", function () {
           done();
         },
       });
+    });
+
+    test("selection modifier set to none in configs", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        modConfigCb: (config: DendronConfig) => {
+          config.lookup.note.selectionType = LookupSelectionType.none;
+          return config;
+        },
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults }) => {
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+          const gatherOut = await cmd.gatherInputs({});
+          const { selection2linkBtn, selectionExtractBtn } = getSelectionTypeButtons(gatherOut.quickpick.buttons)
+          expect(selection2linkBtn.pressed).toBeFalsy();
+          expect(selectionExtractBtn.pressed).toBeFalsy();
+          done();
+        },
+      });
+    });
+    
+    test("selectionType: none in args", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults }) => {
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+          const gatherOut = await cmd.gatherInputs({
+            selectionType: LookupSelectionType.none
+          });
+          const { selection2linkBtn, selectionExtractBtn } = getSelectionTypeButtons(gatherOut.quickpick.buttons)
+          expect(selection2linkBtn.pressed).toBeFalsy();
+          expect(selectionExtractBtn.pressed).toBeFalsy();
+          done();
+        },
+      }); 
+    });
+
+    test("selectionType is selectionExtract by default", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults }) => {
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+          const gatherOut = await cmd.gatherInputs({});
+          const { selection2linkBtn, selectionExtractBtn } = getSelectionTypeButtons(gatherOut.quickpick.buttons)
+          expect(selection2linkBtn.pressed).toBeFalsy();
+          expect(selectionExtractBtn.pressed).toBeTruthy();
+          done();
+        },
+      }); 
     });
 
     test("selection2link basic", (done) => {


### PR DESCRIPTION
This PR:
- Adds a new selectionType `none`, that can be explicitly set to have no selection type modifier set on lookup.
- Adds tests


NOTE: Currently, the only way to have no selection type modifier set is to define a custom keybinding with an invalid string set for `selectionType` in the `args` block. This is not intuitive, and the ability to do this should also be available for configuration in `dendron.yml`