### PR TITLE
enhance: Adding caching optimization to improve startup/workspace initialization

### DIFF
--- a/packages/api-server/src/modules/workspace/index.ts
+++ b/packages/api-server/src/modules/workspace/index.ts
@@ -11,6 +11,7 @@ import {
 import { DendronEngineV2 } from "@dendronhq/engine-server";
 import { getLogger } from "../../core";
 import { getWS, putWS } from "../../utils";
+import { getDurationMilliseconds } from "@dendronhq/common-server";
 
 export class WorkspaceController {
   static singleton?: WorkspaceController;
@@ -22,6 +23,8 @@ export class WorkspaceController {
   }
 
   async init({ uri }: WorkspaceInitRequest): Promise<InitializePayload> {
+    const start = process.hrtime();
+
     let notes: NotePropsDict;
     let schemas: SchemaModuleDict;
     const ctx = "WorkspaceController:init";
@@ -39,7 +42,8 @@ export class WorkspaceController {
     notes = engine.notes;
     schemas = engine.schemas;
     await putWS({ ws: uri, engine });
-    logger.info({ ctx, msg: "finish init", uri, error });
+    const duration = getDurationMilliseconds(start);
+    logger.info({ ctx, msg: "finish init", duration, uri, error });
     if (error) {
       error = error2PlainObject(error);
     }

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -333,6 +333,11 @@ export class NoteUtils {
   static RE_FM_UPDATED_OR_CREATED =
     /^(?<beforeTimestamp>(updated|created): *)(?<timestamp>[0-9]+)$/;
 
+  /** Adds a backlink by mutating the 'to' argument in place.
+   *
+   *  @param from note that the link is pointing from.
+   *  @param to note that the link is pointing to. (mutated)
+   *  @param link backlink to add. */
   static addBacklink({
     from,
     to,
@@ -341,14 +346,13 @@ export class NoteUtils {
     from: NoteProps;
     to: NoteProps;
     link: DLink;
-  }) {
+  }): void {
     to.links.push({
       from: { fname: from.fname, vaultName: VaultUtils.getName(from.vault) },
       type: "backlink",
       position: link.position,
       value: link.value,
     });
-    // }
   }
 
   /**

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -45,9 +45,6 @@ export interface Resp<T> {
   error?: Error | null;
 }
 
-export type NotesCacheAll = {
-  [key: string]: { cache: NotesCache; cacheUpdates: NotesCacheEntryMap };
-};
 export type NotesCache = {
   version: number;
   notes: NotesCacheEntryMap;

--- a/packages/common-server/src/timingUtil.ts
+++ b/packages/common-server/src/timingUtil.ts
@@ -1,0 +1,20 @@
+const NANOS_IN_SECOND = 1000000000;
+const NANOS_IN_MILLI_SEC = 1000000;
+
+/** Return current nanoseconds. */
+export const nanos = () => {
+  let hrTime = process.hrtime();
+  return hrTime[0] * NANOS_IN_SECOND + hrTime[1];
+};
+
+/** Converts the given nano seconds to milliseconds */
+export const nanosToMillis = (nanos: number) => {
+  return nanos / NANOS_IN_MILLI_SEC;
+};
+
+/**
+ * Returns a number representing the milliseconds elapsed
+ * between 1 January 1970 00:00:00 UTC and the given date */
+export const milliseconds = () => {
+  return new Date().getTime();
+};

--- a/packages/engine-server/src/util/impl/inMemoryNoteCacheImpl.ts
+++ b/packages/engine-server/src/util/impl/inMemoryNoteCacheImpl.ts
@@ -1,0 +1,47 @@
+import { DendronError, NoteProps } from "@dendronhq/common-all";
+import { InMemoryNoteCache } from "../inMemoryNoteCache";
+
+export class InMemoryNoteCacheImpl implements InMemoryNoteCache {
+  /** Note map which maps lowercase file name to a list {@link NoteProps}
+   *  that have the matching file name */
+  private readonly mapFNameToNotes: Map<string, NoteProps[]>;
+
+  static createCache(notes: NoteProps[]) {
+    return new InMemoryNoteCacheImpl(
+      InMemoryNoteCacheImpl.initializeFileNameMap(notes)
+    );
+  }
+
+  private constructor(noteMap: Map<string, NoteProps[]>) {
+    this.mapFNameToNotes = noteMap;
+  }
+
+  private static initializeFileNameMap(notes: NoteProps[]) {
+    const map = new Map<string, NoteProps[]>();
+    notes.forEach((note) => {
+      const lowercaseName = note.fname.toLowerCase();
+      let list = map.get(lowercaseName);
+      if (list === undefined) {
+        list = [];
+      }
+      list.push(note);
+
+      map.set(lowercaseName, list);
+    });
+    return map;
+  }
+
+  getNotesByFileNameIgnoreCase(fileName: string): NoteProps[] {
+    if (fileName === undefined || fileName === null || fileName.length === 0) {
+      throw new DendronError({
+        message: `File name cannot be undefined/null/empty.`,
+      });
+    }
+
+    const list = this.mapFNameToNotes.get(fileName.toLowerCase());
+    if (list === undefined) {
+      return [];
+    }
+    return list;
+  }
+}

--- a/packages/engine-server/src/util/inMemoryNoteCache.ts
+++ b/packages/engine-server/src/util/inMemoryNoteCache.ts
@@ -1,0 +1,19 @@
+import { NoteProps } from "@dendronhq/common-all";
+import { InMemoryNoteCacheImpl } from "./impl/inMemoryNoteCacheImpl";
+
+/**
+ * In memory cache for {@link NoteProps}.
+ *
+ * Use {@link InMemoryNoteCacheFactory} to get an instance of this interface.*/
+export interface InMemoryNoteCache {
+  /** Returns list of {@link NoteProps} that have matching file name (ignoring
+   *  the file name case). Will return empty list if no notes match.  */
+  getNotesByFileNameIgnoreCase(fileName: string): NoteProps[];
+}
+
+/** Factory for {@link InMemoryNoteCache} */
+export class InMemoryNoteCacheFactory {
+  static createCache(notes: NoteProps[]): InMemoryNoteCache {
+    return InMemoryNoteCacheImpl.createCache(notes);
+  }
+}

--- a/packages/engine-server/src/util/nanosecUtil.ts
+++ b/packages/engine-server/src/util/nanosecUtil.ts
@@ -1,0 +1,13 @@
+const NANOS_IN_SECOND = 1000000000;
+const NANOS_IN_MILLI_SEC = 1000000;
+
+/** Return current nanoseconds. */
+export const nanos = () => {
+  let hrTime = process.hrtime();
+  return hrTime[0] * NANOS_IN_SECOND + hrTime[1];
+};
+
+/** Converts the given nano seconds to milliseconds */
+export const nanosToMillis = (nanos: number) => {
+  return nanos / NANOS_IN_MILLI_SEC;
+};

--- a/packages/engine-server/src/util/responseUtil.ts
+++ b/packages/engine-server/src/util/responseUtil.ts
@@ -1,0 +1,10 @@
+import { RespV2 } from "@dendronhq/common-all";
+import _ from "lodash";
+
+/** Utility for {@link RespV2} */
+export class ResponseUtil {
+  /** true when response has an error; false otherwise. */
+  static hasError<T>(resp: RespV2<T>) {
+    return !_.isNull(resp.error);
+  }
+}

--- a/packages/engine-test-utils/src/__tests__/engine-server/util/inMemoryNoteCache.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/util/inMemoryNoteCache.spec.ts
@@ -1,0 +1,83 @@
+import { InMemoryNoteCacheFactory } from "@dendronhq/engine-server/lib/util/inMemoryNoteCache";
+import { NoteProps } from "@dendronhq/common-all";
+
+/** For tests ONLY.
+ *
+ *  Utility class for making {@link NoteProps} test values. */
+class NotePropsMaker {
+  /** Create note prop with some sensible default (for tests only). */
+  static createNoteProp(opts: { id: string; fname?: string }): NoteProps {
+    const id = opts.id;
+    const fname = opts.fname ? opts.fname : `/tmp/filename-${id}`;
+
+    return {
+      id: id,
+      title: `title-val-${id}`,
+      vault: { fsPath: "vault-1" },
+      type: "note",
+      desc: "",
+      links: [],
+      anchors: {},
+      fname: fname,
+      updated: 1627283357535,
+      created: 1627283357535,
+      parent: null,
+      children: [],
+      body: `body-val-${id}`,
+      data: {},
+      contentHash: undefined,
+      tags: ["tag-1", "tag-2"],
+    };
+  }
+}
+
+describe("inMemoryNoteCache.spec.ts", () => {
+  describe("getNotesByFileNameIgnoreCase tests:", () => {
+    describe("GIVEN cache with valid note props", () => {
+      /** Two notes that have file name that differs only by case. */
+      const NOTE_1A = NotePropsMaker.createNoteProp({
+        id: "1a",
+        fname: "/tmp/one",
+      });
+      const NOTE_1B = NotePropsMaker.createNoteProp({
+        id: "1b",
+        fname: "/tmp/ONE",
+      });
+
+      /** Note that has a single file name matching */
+      const NOTE_2 = NotePropsMaker.createNoteProp({
+        id: "2",
+        fname: "/tmp/two",
+      });
+
+      const VALID_NOTES_1: NoteProps[] = [NOTE_1A, NOTE_1B, NOTE_2];
+
+      const cache = InMemoryNoteCacheFactory.createCache(VALID_NOTES_1);
+
+      it("WHEN calling for file name that has different cases in notes THEN get both", () => {
+        const notes = cache.getNotesByFileNameIgnoreCase("/tmp/onE");
+
+        expect(notes).toEqual([NOTE_1A, NOTE_1B]);
+      });
+
+      it("WHEN calling for file name that matches single note THEN get the note", () => {
+        const notes = cache.getNotesByFileNameIgnoreCase("/tmp/TWO");
+        expect(notes).toEqual([NOTE_2]);
+      });
+
+      it("WHEN calling for file name that does not exist THEN empty list", () => {
+        const notes = cache.getNotesByFileNameIgnoreCase("/tmp/i-dont-exist");
+        expect(notes.length).toEqual(0);
+      });
+
+      it("WHEN calling undefined file name THEN throw", () => {
+        // @ts-ignore
+        expect(() => cache.getNotesByFileNameIgnoreCase(undefined)).toThrow();
+      });
+
+      it("WHEN calling with empty file name THEN throw", () => {
+        expect(() => cache.getNotesByFileNameIgnoreCase("")).toThrow();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Change to cut down initialization time to about 40% of what it is before this change. Timings with org-workspace can be found at [[Start up Optimization|user.nickolay.tasks.start-up-optimization]]

[x] - Ran unit tests successfully with jest in dendron/packages/engine-test-utils
[x] - Manually started a workspace using local server , checked that existing backlinks are operational.
[x] - Wrote a test script that grabs the payload from the /initialize API call and "standardizes" to be able to be used for comparison the following is performed during "standardization"
All the 'stub' notes are removed as well as all the ids that reference stub notes (parent & child ids),
Schema updated and created times are removed. Then after standardatization does a JSON compare with previously saved standardized output. Tested the payload from org-workspace to be the same before and after this change (standardized payload)