### PR TITLE
fix: update links on frontmatter tags changes

### DIFF
--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -133,14 +133,17 @@ export class NoteSyncService {
     });
     note = NoteUtils.hydrate({ noteRaw: note, noteHydrated });
 
+    // Links have to be updated even with frontmatter only changes
+    // because `tags` in frontmatter adds new links
+    const links = LinkUtils.findLinks({ note, engine: eclient });
+    note.links = links;
+
     // iif frontmatter changed, don't bother with heavy updates
     if (!fmChangeOnly) {
-      const links = LinkUtils.findLinks({ note, engine: eclient });
       const notesMap = NoteUtils.createFnameNoteMap(
         _.values(eclient.notes),
         true
       );
-      note.links = links;
       const anchors = await AnchorUtils.findAnchors({
         note,
         wsRoot: eclient.wsRoot,


### PR DESCRIPTION
Links are now updated for frontmatter changes, which is required to get the links for frontmatter tag updates.

#1143 