### PR TITLE
enhance: improved tag color display

### DIFF
--- a/packages/dendron-11ty/raw-assets/sass/content.scss
+++ b/packages/dendron-11ty/raw-assets/sass/content.scss
@@ -24,6 +24,23 @@
     // white-space: nowrap;
   }
 
+  // For links to tag notes where we want to display a tag color.
+  // The supports media query is to skip Internet Explorer, where
+  // the `var()` is not supported (https://stackoverflow.com/a/48422293).
+  @supports not (-ms-high-contrast: none) {
+    .color-tag::before {
+      // Need these to force the browser into rendering this empty box
+      content: " ";
+      display: inline-block;
+      // The actual style of the tag color box
+      width: 0.8rem;
+      height: 0.8rem;
+      border: 1px solid $body-text-color;
+      margin: auto 0.2rem;
+      background-color: var(--tag-color); // Set when generating the link
+    }
+  }
+
   ul,
   ol {
     padding-left: 1.5em;

--- a/packages/dendron-next-server/styles/scss/content.scss
+++ b/packages/dendron-next-server/styles/scss/content.scss
@@ -24,6 +24,23 @@
     // white-space: nowrap;
   }
 
+  // For links to tag notes where we want to display a tag color.
+  // The supports media query is to skip Internet Explorer, where
+  // the `var()` is not supported (https://stackoverflow.com/a/48422293).
+  @supports not (-ms-high-contrast: none) {
+    .color-tag::before {
+      // Need these to force the browser into rendering this empty box
+      content: " ";
+      display: inline-block;
+      // The actual style of the tag color box
+      width: 0.8rem;
+      height: 0.8rem;
+      border: 1px solid $body-text-color;
+      margin: auto 0.2rem;
+      background-color: var(--tag-color); // Set when generating the link
+    }
+  }
+
   ul,
   ol {
     padding-left: 1.5em;

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -1,7 +1,6 @@
 import {
   DendronError,
   isNotUndefined,
-  makeColorTranslucent,
   NoteProps,
   NoteUtils,
   TAGS_HIERARCHY,
@@ -49,7 +48,6 @@ type PluginOpts = NoteRefsOpts & {
   noRandomlyColoredTags?: boolean;
 };
 
-const TAG_BG_TRANSLUCENCY = 0.4;
 function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
   const proc = this;
   const procData = MDUtilsV4.getDendronData(proc);
@@ -151,7 +149,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
             colorType === "configured" ||
             opts?.noRandomlyColoredTags !== false
           ) {
-            color = makeColorTranslucent(maybeColor, TAG_BG_TRANSLUCENCY);
+            color = maybeColor;
           }
         }
 
@@ -189,7 +187,8 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         }
         const alias = data.alias ? data.alias : value;
         const usePrettyLinks = engine.config.site.usePrettyLinks;
-        const maybeFileExtension = _.isBoolean(usePrettyLinks) && usePrettyLinks ? "" : ".html";
+        const maybeFileExtension =
+          _.isBoolean(usePrettyLinks) && usePrettyLinks ? "" : ".html";
         const href = `${copts?.prefix || ""}${value}${maybeFileExtension}${
           data.anchorHeader ? "#" + data.anchorHeader : ""
         }`;
@@ -203,9 +202,9 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           exists,
           hName: "a",
           hProperties: {
-            // className: classNames,
+            className: color ? "color-tag" : undefined,
+            style: color ? `--tag-color: ${color};` : undefined,
             href,
-            style: color ? `background-color: ${color};` : undefined,
           },
           hChildren: [
             {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/hashtag.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/hashtag.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`hashtag rendering colors overrides color cascading from parent 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"tags.parent.color.html\\" style=\\"background-color: #00FF1166;\\">#parent.color</a></p>
+<p><a class=\\"color-tag\\" style=\\"--tag-color: #00FF11;\\" href=\\"tags.parent.color.html\\">#parent.color</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
@@ -19,7 +19,7 @@ VFile {
 exports[`hashtag rendering colors with color 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"tags.color.html\\" style=\\"background-color: #FF003366;\\">#color</a></p>
+<p><a class=\\"color-tag\\" style=\\"--tag-color: #FF0033;\\" href=\\"tags.color.html\\">#color</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
@@ -35,7 +35,7 @@ VFile {
 exports[`hashtag rendering colors with color cascading from parent, self exists 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"tags.parent.color.html\\" style=\\"background-color: #FF003366;\\">#parent.color</a></p>
+<p><a class=\\"color-tag\\" style=\\"--tag-color: #FF0033;\\" href=\\"tags.parent.color.html\\">#parent.color</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
@@ -51,7 +51,7 @@ VFile {
 exports[`hashtag rendering colors with color cascading from parent, self missing 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"tags.parent.color.html\\" style=\\"background-color: #FF003366;\\">#parent.color</a></p>
+<p><a class=\\"color-tag\\" style=\\"--tag-color: #FF0033;\\" href=\\"tags.parent.color.html\\">#parent.color</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
@@ -67,7 +67,7 @@ VFile {
 exports[`hashtag rendering compile "HTML: simple" 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
-<p><a href=\\"tags.my-hash.tag0.html\\" style=\\"background-color: #c95efb66;\\">#my-hash.tag0</a></p>
+<p><a class=\\"color-tag\\" style=\\"--tag-color: #c95efb;\\" href=\\"tags.my-hash.tag0.html\\">#my-hash.tag0</a></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
@@ -166,7 +166,7 @@ describe("hashtag", () => {
           const { resp } = extra;
           await checkVFile(
             resp,
-            '<a href="tags.my-hash.tag0.html" style="background-color: #c95efb66;">#my-hash.tag0</a>'
+            '<a class="color-tag" style="--tag-color: #c95efb;" href="tags.my-hash.tag0.html">#my-hash.tag0</a>'
           );
         },
       },
@@ -186,7 +186,7 @@ describe("hashtag", () => {
             const resp = await proc.process(`#color`);
             await checkVFile(
               resp,
-              '<a href="tags.color.html" style="background-color: #FF003366;">#color</a>'
+              '<a class="color-tag" style="--tag-color: #FF0033;" href="tags.color.html">#color</a>'
             );
           },
           {
@@ -215,7 +215,7 @@ describe("hashtag", () => {
             const resp = await proc.process(`#parent.color`);
             await checkVFile(
               resp,
-              '<a href="tags.parent.color.html" style="background-color: #FF003366;">#parent.color</a>'
+              '<a class="color-tag" style="--tag-color: #FF0033;" href="tags.parent.color.html">#parent.color</a>'
             );
           },
           {
@@ -244,7 +244,7 @@ describe("hashtag", () => {
             const resp = await proc.process(`#parent.color`);
             await checkVFile(
               resp,
-              '<a href="tags.parent.color.html" style="background-color: #FF003366;">#parent.color</a>'
+              '<a class="color-tag" style="--tag-color: #FF0033;" href="tags.parent.color.html">#parent.color</a>'
             );
           },
           {
@@ -278,7 +278,7 @@ describe("hashtag", () => {
             const resp = await proc.process(`#parent.color`);
             await checkVFile(
               resp,
-              '<a href="tags.parent.color.html" style="background-color: #00FF1166;">#parent.color</a>'
+              '<a class="color-tag" style="--tag-color: #00FF11;" href="tags.parent.color.html">#parent.color</a>'
             );
           },
           {

--- a/packages/nextjs-template/styles/scss/content.scss
+++ b/packages/nextjs-template/styles/scss/content.scss
@@ -24,6 +24,23 @@
     // white-space: nowrap;
   }
 
+  // For links to tag notes where we want to display a tag color.
+  // The supports media query is to skip Internet Explorer, where
+  // the `var()` is not supported (https://stackoverflow.com/a/48422293).
+  @supports not (-ms-high-contrast: none) {
+    .color-tag::before {
+      // Need these to force the browser into rendering this empty box
+      content: " ";
+      display: inline-block;
+      // The actual style of the tag color box
+      width: 0.8rem;
+      height: 0.8rem;
+      border: 1px solid $body-text-color;
+      margin: auto 0.2rem;
+      background-color: var(--tag-color); // Set when generating the link
+    }
+  }
+
   ul,
   ol {
     padding-left: 1.5em;

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -165,6 +165,7 @@ export function updateDecorations(activeEditor: TextEditor) {
     DECORATION_TYPE_WIKILINK,
     DECORATION_TYPE_BROKEN_WIKILINK,
     DECORATION_TYPE_ALIAS,
+    DECORATION_TYPE_TAG,
   ];
   for (const type of allTypes) {
     if (!allDecorations.has(type)) {

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -28,7 +28,6 @@ import {
   NoteUtils,
   Position,
   VaultUtils,
-  makeColorTranslucent,
 } from "@dendronhq/common-all";
 import { DateTime } from "luxon";
 import { getConfigValue, getWS } from "../workspace";
@@ -60,8 +59,6 @@ export function delayedUpdateDecorations(
     }
   }, updateDelay);
 }
-
-const TAG_COLORING_TRANSLUCENCY = 0.4;
 
 export function updateDecorations(activeEditor: TextEditor) {
   const ctx = "updateDecorations";
@@ -161,13 +158,6 @@ export function updateDecorations(activeEditor: TextEditor) {
     activeEditor.setDecorations(type, decorations);
   }
 
-  // Clean out now-unused tag decorations
-  for (const [key, type] of DECORATION_TYPE_TAG.entries()) {
-    if (!allDecorations.has(type)) {
-      type.dispose();
-      DECORATION_TYPE_TAG.delete(key);
-    }
-  }
   // Clear out any old decorations left over from last pass
   const allTypes = [
     DECORATION_TYPE_TIMESTAMP,
@@ -243,23 +233,11 @@ function decorateBlockAnchor(blockAnchor: BlockAnchor) {
   return decoration;
 }
 
-export const DECORATION_TYPE_TAG = new DefaultMap<
-  string,
-  TextEditorDecorationType
->((fname) => {
-  const { notes } = getWS().getEngine();
-  let { color: backgroundColor } = NoteUtils.color({ fname, notes });
-  backgroundColor = makeColorTranslucent(
-    backgroundColor,
-    TAG_COLORING_TRANSLUCENCY
-  );
-  return window.createTextEditorDecorationType({
-    backgroundColor,
-    // Do not try to grow the decoration range when the user is typing,
-    // because the color for a partial hashtag `#fo` is different from `#foo`.
-    // We can't just reuse the first computed color and keep the decoration growing.
-    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
-  });
+export const DECORATION_TYPE_TAG = window.createTextEditorDecorationType({
+  // Do not try to grow the decoration range when the user is typing,
+  // because the color for a partial hashtag `#fo` is different from `#foo`.
+  // We can't just reuse the first computed color and keep the decoration growing.
+  rangeBehavior: DecorationRangeBehavior.ClosedClosed,
 });
 
 function decorateHashTag(
@@ -268,10 +246,27 @@ function decorateHashTag(
   const position = hashtag.position;
   if (_.isUndefined(position)) return; // should never happen
 
-  const type = DECORATION_TYPE_TAG.get(hashtag.fname);
+  const { color: backgroundColor } = NoteUtils.color({
+    fname: hashtag.fname,
+    notes: getWS().getEngine().notes,
+  });
+
+  const type = DECORATION_TYPE_TAG;
   const decoration: DecorationOptions = {
     range: VSCodeUtils.position2VSCodeRange(position),
+    renderOptions: {
+      before: {
+        contentText: " ",
+        width: "0.8rem",
+        height: "0.8rem",
+        margin: "auto 0.2rem",
+        border: "1px solid",
+        borderColor: new ThemeColor("foreground"),
+        backgroundColor,
+      },
+    },
   };
+
   return [type, decoration];
 }
 

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -234,7 +234,12 @@ function decorateBlockAnchor(blockAnchor: BlockAnchor) {
   return decoration;
 }
 
+const WIKILINK_DECORATION_OPTIONS = {
+  color: new ThemeColor("editorLink.activeForeground"),
+};
+
 export const DECORATION_TYPE_TAG = window.createTextEditorDecorationType({
+  ...WIKILINK_DECORATION_OPTIONS,
   // Do not try to grow the decoration range when the user is typing,
   // because the color for a partial hashtag `#fo` is different from `#foo`.
   // We can't just reuse the first computed color and keep the decoration growing.
@@ -273,7 +278,7 @@ function decorateHashTag(
 
 /** Decoration for wikilinks that point to valid notes. */
 export const DECORATION_TYPE_WIKILINK = window.createTextEditorDecorationType({
-  color: new ThemeColor("editorLink.activeForeground"),
+  ...WIKILINK_DECORATION_OPTIONS,
   rangeBehavior: DecorationRangeBehavior.ClosedClosed,
 });
 

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -130,12 +130,20 @@ suite("windowDecorations", function () {
             )
           ).toBeTruthy();
 
-          expect(DECORATION_TYPE_TAG.has("tags.foo"));
-          expect(DECORATION_TYPE_TAG.has("tags.bar"));
+          const tagDecorations = allDecorations!.get(DECORATION_TYPE_TAG);
+          expect(tagDecorations.length).toEqual(3);
+          expect(
+            isTextDecorated("#foo", tagDecorations!, document)
+          ).toBeTruthy();
+          expect(
+            isTextDecorated("#bar", tagDecorations!, document)
+          ).toBeTruthy();
 
           const aliasDecorations = allDecorations!.get(DECORATION_TYPE_ALIAS);
           expect(aliasDecorations.length).toEqual(1);
-          expect(isTextDecorated("with alias", aliasDecorations!, document));
+          expect(
+            isTextDecorated("with alias", aliasDecorations!, document)
+          ).toBeTruthy();
 
           const brokenWikilinkDecorations = allDecorations!.get(
             DECORATION_TYPE_BROKEN_WIKILINK


### PR DESCRIPTION
In both the editor and publishing, the tags now display as small squares next to the tag link. The squares are outlined with the color of the text, which improves readability for all tag colors and all themes.

For publishing, the tag colors use [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) which means users can use the tag color property (`var(--tag-color)`) in their custom themes to adjust how the color shows up. CSS custom properties work on [all browsers except Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#browser_compatibility), in which case we simply don't display the colored box.

I wasn't able to get this working in Preview V2. You can see the `.scss` file I modified under `dendron-next-server`, please let me know if there's a different file I should use for this modification.

![](https://i.imgur.com/e5zSlhM.png)

![](https://i.imgur.com/TjdCiCD.png)