### PR TITLE
feat: user tags

### DIFF
--- a/packages/common-all/src/constants.ts
+++ b/packages/common-all/src/constants.ts
@@ -72,3 +72,7 @@ export enum RESERVED_KEYS {
 export const TAGS_HIERARCHY_BASE = "tags";
 /** Notes under this hierarchy are considered tags, for example `${TAGS_HIERARCHY}foo` is a tag note. */
 export const TAGS_HIERARCHY = `${TAGS_HIERARCHY_BASE}.`;
+
+export const USERS_HIERARCHY_BASE = "user";
+/** Notes under this hierarchy are considered users, for example `${USERS_HIERARCHY}Hamilton` is a user note. */
+export const USERS_HIERARCHY = `${USERS_HIERARCHY_BASE}.`;

--- a/packages/engine-server/src/markdown/remark/hashtag.ts
+++ b/packages/engine-server/src/markdown/remark/hashtag.ts
@@ -16,11 +16,11 @@ export const PUNCTUATION_MARKS =
   ",;:'\"<>?!`~«‹»›„“‟”’❝❞❮❯⹂〝〞〟＂‚‘‛❛❜❟［］【】…‥「」『』·؟،।॥‽⸘¡¿⁈⁉";
 
 /** Can't start with a number or period */
-const GOOD_FIRST_CHARACTER = `[^0-9#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+const GOOD_FIRST_CHARACTER = `[^0-9#@|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
 /** Can have numbers and period in the middle */
-const GOOD_MIDDLE_CHARACTER = `[^#|\\[\\]\\s${PUNCTUATION_MARKS}]`;
+const GOOD_MIDDLE_CHARACTER = `[^@#|\\[\\]\\s${PUNCTUATION_MARKS}]`;
 /** Can have numbers, but not period in the end */
-const GOOD_END_CHARACTER = `[^#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+const GOOD_END_CHARACTER = `[^@#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
 
 /** Hashtags have the form #foo, or #foo.bar, or #f123
  *

--- a/packages/engine-server/src/markdown/remark/index.ts
+++ b/packages/engine-server/src/markdown/remark/index.ts
@@ -29,3 +29,9 @@ export {
   hashtags,
   matchHashtag,
 } from "./hashtag";
+export {
+  USERTAG_REGEX,
+  USERTAG_REGEX_LOOSE,
+  userTags,
+  matchUserTag,
+} from "./userTags";

--- a/packages/engine-server/src/markdown/remark/userTags.ts
+++ b/packages/engine-server/src/markdown/remark/userTags.ts
@@ -1,0 +1,114 @@
+import _ from "lodash";
+import { DendronError, USERS_HIERARCHY } from "@dendronhq/common-all";
+import { Eat } from "remark-parse";
+import Unified, { Plugin } from "unified";
+import { DendronASTDest, DendronASTTypes, HashTag } from "../types";
+import { MDUtilsV4 } from "../utils";
+import { Element } from "hast";
+import { PUNCTUATION_MARKS } from "./hashtag";
+
+/** Can have period in the middle */
+const GOOD_MIDDLE_CHARACTER = `[^#@|\\[\\]\\s${PUNCTUATION_MARKS}]`;
+/** Can't have period in the end */
+const GOOD_END_CHARACTER = `[^#@|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+
+/** User tags have the form @Lovelace, or @Hamilton.Margaret, or @7of9.
+ *
+ * User tags are also not allowed to contain any punctuation or quotation marks, and will not include a trailing dot
+ * This allows them to be more easily mixed into text, for example:
+ *
+ * ```
+ * Please contact @Ben.Barres.
+ * ```
+ *
+ * Here, the tag is `#important` without the following comma.
+ */
+export const USERTAG_REGEX = new RegExp(
+  `^(?<tagSymbol>@)(?<tagContents>` +
+    `${GOOD_MIDDLE_CHARACTER}*` +
+    `${GOOD_END_CHARACTER}` +
+    `)`
+);
+/** Same as `USERTAG_REGEX`, except that that it doesn't have to be at the start of the string. */
+export const USERTAG_REGEX_LOOSE = new RegExp(
+  `(?<tagSymbol>@)(?<tagContents>` +
+    `${GOOD_MIDDLE_CHARACTER}*` +
+    `${GOOD_END_CHARACTER}` +
+    `)`
+);
+
+/**
+ *
+ * @param text The text to check if it matches an hashtag.
+ * @param matchLoose If true, a hashtag anywhere in the string will match. Otherwise the string must contain only the anchor.
+ * @returns The identifier for the matched hashtag, or undefined if it did not match.
+ */
+export const matchUserTag = (
+  text: string,
+  matchLoose: boolean = true
+): string | undefined => {
+  const match = (matchLoose ? USERTAG_REGEX : USERTAG_REGEX_LOOSE).exec(text);
+  if (match && match.groups) return match.groups.tagContents;
+  return undefined;
+};
+
+type PluginOpts = {};
+
+const plugin: Plugin<[PluginOpts?]> = function plugin(
+  this: Unified.Processor,
+  opts?: PluginOpts
+) {
+  attachParser(this);
+  if (this.Compiler != null) {
+    attachCompiler(this, opts);
+  }
+};
+
+function attachParser(proc: Unified.Processor) {
+  function locator(value: string, fromIndex: number) {
+    return value.indexOf("@", fromIndex);
+  }
+
+  function inlineTokenizer(eat: Eat, value: string) {
+    const match = USERTAG_REGEX.exec(value);
+    if (match && match.groups?.tagContents) {
+      return eat(match[0])({
+        type: DendronASTTypes.USERTAG,
+        value: match[0],
+        fname: `${USERS_HIERARCHY}${match.groups.tagContents}`,
+      });
+    }
+    return;
+  }
+  inlineTokenizer.locator = locator;
+
+  const Parser = proc.Parser;
+  const inlineTokenizers = Parser.prototype.inlineTokenizers;
+  const inlineMethods = Parser.prototype.inlineMethods;
+  inlineTokenizers.users = inlineTokenizer;
+  inlineMethods.splice(inlineMethods.indexOf("link"), 0, "users");
+}
+
+function attachCompiler(proc: Unified.Processor, _opts?: PluginOpts) {
+  const Compiler = proc.Compiler;
+  const visitors = Compiler.prototype.visitors;
+
+  if (visitors) {
+    visitors.usertag = (node: HashTag): string | Element => {
+      const { dest } = MDUtilsV4.getDendronData(proc);
+      const prefix = MDUtilsV4.getProcOpts(proc).wikiLinksOpts?.prefix || "";
+      switch (dest) {
+        case DendronASTDest.MD_DENDRON:
+          return node.value;
+        case DendronASTDest.MD_REGULAR:
+        case DendronASTDest.MD_ENHANCED_PREVIEW:
+          return `[${node.value}](${prefix}${node.fname})`;
+        default:
+          throw new DendronError({ message: "Unable to render user tag" });
+      }
+    };
+  }
+}
+
+export { plugin as userTags };
+export { PluginOpts as UserTagOpts };

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -61,6 +61,7 @@ import {
   HashTag,
   NoteRefNoteV4,
   NoteRefNoteV4_LEGACY,
+  UserTag,
   WikiLinkNoteV4,
   WikiLinkProps,
 } from "../types";
@@ -116,6 +117,17 @@ export function hashTag2WikiLinkNoteV4(hashtag: HashTag): WikiLinkNoteV4 {
     value: hashtag.fname,
     data: {
       alias: hashtag.value,
+    },
+  };
+}
+
+export function userTag2WikiLinkNoteV4(userTag: UserTag): WikiLinkNoteV4 {
+  return {
+    ...userTag,
+    type: DendronASTTypes.WIKI_LINK,
+    value: userTag.fname,
+    data: {
+      alias: userTag.value,
     },
   };
 }

--- a/packages/engine-server/src/markdown/types.ts
+++ b/packages/engine-server/src/markdown/types.ts
@@ -37,6 +37,7 @@ export enum DendronASTTypes {
   REF_LINK_V2 = "refLinkV2",
   BLOCK_ANCHOR = "blockAnchor",
   HASHTAG = "hashtag",
+  USERTAG = "usertag",
   // Not dendron-specific, included here for convenience
   ROOT = "root",
   HEADING = "heading",
@@ -141,6 +142,15 @@ export type HashTag = DendronASTNode & {
   /** The fname that the hashtag actually references, like `tags.foo.bar` */
   fname: string;
   /** The full test of the hashtag, like `#foo.bar` */
+  value: string;
+};
+
+/** User tags, like `@Hamilton.Margaret`, a shorthand for `[[user.Hamilton.Margaret]]` */
+export type UserTag = DendronASTNode & {
+  type: DendronASTTypes.USERTAG;
+  /** The fname that the hashtag actually references, like `user.Hamilton.Margaret` */
+  fname: string;
+  /** The full test of the hashtag, like `@Hamilton.Margaret` */
   value: string;
 };
 

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -58,6 +58,7 @@ import {
   DendronASTTypes,
 } from "./types";
 import { hashtags } from "./remark/hashtag";
+import { userTags } from "./remark/userTags";
 
 const toString = require("mdast-util-to-string");
 export { nunjucks };
@@ -333,6 +334,7 @@ export class MDUtilsV4 {
       .use(wikiLinks)
       .use(blockAnchors)
       .use(hashtags)
+      .use(userTags)
       .data("errors", errors);
     this.setDendronData(_proc, { dest: opts.dest, fname: opts.fname });
     this.setEngine(_proc, opts.engine);
@@ -401,6 +403,7 @@ export class MDUtilsV4 {
       .use(backlinks)
       .use(blockAnchors, _.merge(opts.blockAnchorsOpts))
       .use(hashtags)
+      .use(userTags)
       .use(noteRefsV2, {
         ...opts.noteRefOpts,
         wikiLinkOpts: opts.wikiLinksOpts,

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -35,6 +35,7 @@ import { wikiLinks } from "./remark/wikiLinks";
 import { DendronASTDest } from "./types";
 import { MDUtilsV4 } from "./utils";
 import { hashtags } from "./remark/hashtag";
+import { userTags } from "./remark/userTags";
 import { backlinks } from "./remark/backlinks";
 import { hierarchies } from "./remark";
 
@@ -233,6 +234,7 @@ export class MDUtilsV5 {
       .use(wikiLinks)
       .use(blockAnchors)
       .use(hashtags)
+      .use(userTags)
       .use(footnotes)
       .data("errors", errors);
 
@@ -296,8 +298,8 @@ export class MDUtilsV5 {
           if (opts.flavor === ProcFlavor.PUBLISHING) {
             proc = proc.use(dendronPub, {
               wikiLinkOpts: {
-                prefix: "/notes/"
-              }
+                prefix: "/notes/",
+              },
             });
           }
         }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/userTags.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/userTags.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`user tags rendering compile "HTML: simple" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"root\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#root\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Root</h1>
+<p><a href=\\"user.Hamilton.Margaret.html\\">@Hamilton.Margaret</a></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"bar.html\\">Bar</a></li>
+<li><a href=\\"foo.html\\">Foo</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
@@ -1,0 +1,182 @@
+import {
+  AssertUtils,
+  TestPresetEntryV4,
+  getDescendantNode,
+} from "@dendronhq/common-test-utils";
+import {
+  DendronASTDest,
+  DendronASTTypes,
+  UserTag,
+  MDUtilsV5,
+  ProcMode,
+  UnistNode,
+} from "@dendronhq/engine-server";
+import _ from "lodash";
+import { runEngineTestV5 } from "../../../engine";
+import { ENGINE_HOOKS } from "../../../presets";
+import {
+  checkVFile,
+  createProcForTest,
+  createProcTests,
+  ProcTests,
+} from "./utils";
+
+function proc() {
+  return MDUtilsV5.procRehypeParse({
+    mode: ProcMode.NO_DATA,
+  });
+}
+
+function runAllTests(opts: { name: string; testCases: ProcTests[] }) {
+  const { name, testCases } = opts;
+  describe(name, () => {
+    test.each(
+      testCases.map((ent) => [`${ent.dest}: ${ent.name}`, ent.testCase])
+    )("%p", async (_key, testCase: TestPresetEntryV4) => {
+      await runEngineTestV5(testCase.testFunc, {
+        expect,
+        preSetupHook: testCase.preSetupHook,
+      });
+    });
+  });
+}
+
+function getUserTag(node: UnistNode): UserTag {
+  return getDescendantNode<UserTag>(node, 0, 0);
+}
+
+describe("user tags", () => {
+  describe("parse", () => {
+    test("parses basic user tag", () => {
+      const resp = proc().parse("@Hamilton");
+      expect(getUserTag(resp).type).toEqual(DendronASTTypes.USERTAG);
+      expect(getUserTag(resp).fname).toEqual("user.Hamilton");
+    });
+
+    test("parses user tag with hierarchy", () => {
+      const resp = proc().parse("@Hamilton.Margaret");
+      expect(getUserTag(resp).type).toEqual(DendronASTTypes.USERTAG);
+      expect(getUserTag(resp).fname).toEqual("user.Hamilton.Margaret");
+    });
+
+    test("doesn't parse user tag inside inline code block", () => {
+      const resp = proc().parse("`@Hamilton.Margaret`");
+      expect(getUserTag(resp).type).toEqual("inlineCode");
+    });
+
+    test("doesn't parse user tag inside a link", () => {
+      const resp = proc().parse("[[@Hamilton.Margaret|some.other.note]]");
+      expect(getUserTag(resp).type).toEqual(DendronASTTypes.WIKI_LINK);
+    });
+
+    test("parses a user tag in the middle of a paragraph", () => {
+      const resp = proc().parse("Lorem ipsum @Hamilton.Margaret dolor amet.");
+      expect(getDescendantNode(resp, 0, 1).type).toEqual(
+        DendronASTTypes.USERTAG
+      );
+      expect(getDescendantNode(resp, 0, 1).value).toEqual("@Hamilton.Margaret");
+    });
+
+    test("parses user tag with numbers", () => {
+      const resp = proc().parse("@7of9");
+      expect(getUserTag(resp).type).toEqual(DendronASTTypes.USERTAG);
+      expect(getUserTag(resp).value).toEqual("@7of9");
+    });
+
+    test("doesn't parse trailing punctuation", () => {
+      const resp1 = proc().parse(
+        "Dolorem vero sed sapiente @Hamilton.Margaret. Et quam id maxime et ratione."
+      );
+      expect(getDescendantNode(resp1, 0, 1).type).toEqual(
+        DendronASTTypes.USERTAG
+      );
+      expect(getDescendantNode(resp1, 0, 1).value).toEqual(
+        "@Hamilton.Margaret"
+      );
+
+      const resp2 = proc().parse(
+        "Dolorem vero sed sapiente @Hamilton.Margaret, et quam id maxime et ratione."
+      );
+      expect(getDescendantNode(resp2, 0, 1).type).toEqual(
+        DendronASTTypes.USERTAG
+      );
+      expect(getDescendantNode(resp2, 0, 1).value).toEqual(
+        "@Hamilton.Margaret"
+      );
+    });
+
+    test("doesn't parse trailing unicode punctuation", () => {
+      const resp1 = proc().parse("この人は「@松本.行弘」です。");
+      expect(getDescendantNode(resp1, 0, 1).type).toEqual(
+        DendronASTTypes.USERTAG
+      );
+      expect(getDescendantNode(resp1, 0, 1).value).toEqual("@松本.行弘");
+    });
+  });
+
+  describe("rendering", () => {
+    const userTag = "@Hamilton.Margaret";
+
+    const SIMPLE = createProcTests({
+      name: "simple",
+      setupFunc: async ({ engine, vaults, extra }) => {
+        const proc2 = createProcForTest({
+          engine,
+          dest: extra.dest,
+          vault: vaults[0],
+        });
+        const resp = await proc2.process(userTag);
+        return { resp };
+      },
+      verifyFuncDict: {
+        [DendronASTDest.MD_DENDRON]: async ({ extra }) => {
+          const { resp } = extra;
+          return [
+            {
+              actual: await AssertUtils.assertInString({
+                body: resp.toString(),
+                match: [userTag],
+              }),
+              expected: true,
+            },
+          ];
+        },
+        [DendronASTDest.MD_REGULAR]: async ({ extra }) => {
+          const { resp } = extra;
+          return [
+            {
+              actual: await AssertUtils.assertInString({
+                body: resp.toString(),
+                match: [`[${userTag}](user.Hamilton.Margaret)`],
+              }),
+              expected: true,
+            },
+          ];
+        },
+        [DendronASTDest.MD_ENHANCED_PREVIEW]: async ({ extra }) => {
+          const { resp } = extra;
+          return [
+            {
+              actual: await AssertUtils.assertInString({
+                body: resp.toString(),
+                match: [`[${userTag}](user.Hamilton.Margaret.md)`],
+              }),
+              expected: true,
+            },
+          ];
+        },
+        [DendronASTDest.HTML]: async ({ extra }) => {
+          const { resp } = extra;
+          await checkVFile(
+            resp,
+            '<a href="user.Hamilton.Margaret.html">@Hamilton.Margaret</a>'
+          );
+        },
+      },
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    });
+
+    const ALL_TEST_CASES = [...SIMPLE];
+    runAllTests({ name: "compile", testCases: ALL_TEST_CASES });
+  });
+});

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -8,6 +8,7 @@ import {
   ProcMode,
   WikiLinkNoteV4,
   NoteRefNoteV4,
+  UserTag,
 } from "@dendronhq/engine-server";
 import {
   DecorationOptions,
@@ -113,6 +114,14 @@ export function updateDecorations(activeEditor: TextEditor) {
       }
       case DendronASTTypes.HASHTAG: {
         const out = decorateHashTag(node as HashTag);
+        if (isNotUndefined(out)) {
+          const [type, decoration] = out;
+          allDecorations.get(type).push(decoration);
+        }
+        break;
+      }
+      case DendronASTTypes.USERTAG: {
+        const out = decorateUserTag(node as UserTag);
         if (isNotUndefined(out)) {
           const [type, decoration] = out;
           allDecorations.get(type).push(decoration);
@@ -366,6 +375,22 @@ function decorateWikiLink(wikiLink: WikiLinkNoteV4, document: TextDocument) {
     decorations.push([DECORATION_TYPE_BROKEN_WIKILINK, options]);
   }
   return decorations;
+}
+
+function decorateUserTag(
+  userTag: UserTag
+): [TextEditorDecorationType, DecorationOptions] | undefined {
+  const position = userTag.position as Position;
+  if (_.isUndefined(position)) return undefined;
+
+  const userNoteFound = doesLinkedNoteExist({
+    fname: userTag.fname,
+  });
+  const type = userNoteFound
+    ? DECORATION_TYPE_WIKILINK
+    : DECORATION_TYPE_BROKEN_WIKILINK;
+
+  return [type, { range: VSCodeUtils.position2VSCodeRange(position) }];
 }
 
 function decorateReference(

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -261,6 +261,35 @@ suite("GotoNote", function () {
       });
     });
 
+    test("user tag", (done) => {
+      let note: NoteProps;
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          // Create a note with a hashtag in it
+          note = await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "test.note",
+            body: "@test.mctestface",
+          });
+        },
+        onInit: async () => {
+          // Open the note, select the hashtag, and use the command
+          await VSCodeUtils.openNote(note);
+          VSCodeUtils.getActiveTextEditorOrThrow().selection =
+            new vscode.Selection(
+              new vscode.Position(7, 1),
+              new vscode.Position(7, 1)
+            );
+          await new GotoNoteCommand().run();
+          // Make sure this took us to the tag note
+          expect(getActiveEditorBasename()).toEqual("user.test.mctestface.md");
+          done();
+        },
+      });
+    });
+
     describe("frontmatter tags", () => {
       test("single tag", (done) => {
         let note: NoteProps;

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -966,6 +966,80 @@ suite("ReferenceProvider", function () {
       });
     });
 
+    test("hashtag", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo.test",
+            body: "this is tag foo.test",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "#foo.test",
+          });
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await VSCodeUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeTruthy();
+          await AssertUtils.assertInString({
+            body: hover!.contents.join(""),
+            match: ["this is tag foo.test"],
+          });
+          done();
+        },
+      });
+    });
+
+    test("user tag", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "user.test.mctestface",
+            body: "this is user test.mctestface",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "@test.mctestface",
+          });
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await VSCodeUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeTruthy();
+          await AssertUtils.assertInString({
+            body: hover!.contents.join(""),
+            match: ["this is user test.mctestface"],
+          });
+          done();
+        },
+      });
+    });
+
     describe("frontmatter tags", () => {
       test("single tag", (done) => {
         runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -65,6 +65,8 @@ suite("windowDecorations", function () {
               "#foo",
               "[[root]]",
               "",
+              "@Hamilton.Margaret",
+              "",
               "[[with alias|root]]",
               "",
               "[[does.not.exist]]",
@@ -140,10 +142,17 @@ suite("windowDecorations", function () {
           const brokenWikilinkDecorations = allDecorations!.get(
             DECORATION_TYPE_BROKEN_WIKILINK
           );
-          expect(brokenWikilinkDecorations.length).toEqual(1);
+          expect(brokenWikilinkDecorations.length).toEqual(2);
           expect(
             isTextDecorated(
               "[[does.not.exist]]",
+              brokenWikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "@Hamilton.Margaret",
               brokenWikilinkDecorations!,
               document
             )

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -5,6 +5,7 @@ import {
   NoteProps,
   NoteUtils,
   TAGS_HIERARCHY,
+  USERS_HIERARCHY,
 } from "@dendronhq/common-all";
 import {
   DendronASTTypes,
@@ -14,6 +15,7 @@ import {
   MDUtilsV5,
   ProcMode,
   visit,
+  USERTAG_REGEX_LOOSE,
 } from "@dendronhq/engine-server";
 import { sort as sortPaths } from "cross-path-sort";
 import fs from "fs";
@@ -258,6 +260,22 @@ export const getReferenceAtPosition = (
         range: rangeForHashTag,
         label: match[0],
         ref: `${TAGS_HIERARCHY}${match.groups!.tagContents}`,
+        refText: docText,
+      };
+    }
+    // if not, it could be a user tag
+    const rangeForUserTag = document.getWordRangeAtPosition(
+      position,
+      USERTAG_REGEX_LOOSE
+    );
+    if (rangeForUserTag) {
+      const docText = document.getText(rangeForUserTag);
+      const match = docText.match(USERTAG_REGEX_LOOSE);
+      if (_.isNull(match)) return null;
+      return {
+        range: rangeForUserTag,
+        label: match[0],
+        ref: `${USERS_HIERARCHY}${match.groups!.tagContents}`,
         refText: docText,
       };
     }

--- a/test-workspace/vault/dendron.ref.users.md
+++ b/test-workspace/vault/dendron.ref.users.md
@@ -1,0 +1,13 @@
+---
+id: kCsOf22GDKfYogkogB4pa
+title: Users
+desc: ''
+updated: 1630130382349
+created: 1630130282280
+---
+
+User notes can be linked using @username.
+
+These can also have hierarchies, like @customer.Foo, which helps with organization.
+
+Some user notes may be missing, like @this.one.

--- a/test-workspace/vault/user.customer.Foo.md
+++ b/test-workspace/vault/user.customer.Foo.md
@@ -1,0 +1,9 @@
+---
+id: nMDZfnVYsSTZfRL09zz2s
+title: Foo
+desc: ''
+updated: 1630130355525
+created: 1630130346207
+---
+
+This is a another user.

--- a/test-workspace/vault/user.username.md
+++ b/test-workspace/vault/user.username.md
@@ -1,0 +1,9 @@
+---
+id: b8hXsaznBuNcYlIW8i0BQ
+title: Username
+desc: ''
+updated: 1630130365284
+created: 1630130298935
+---
+
+This is a user.


### PR DESCRIPTION
This is a work-in-progress, but usable implementation of user mentions. User notes (notes under `user.`) can be linked to by typing `@user.name`. This is very similar to hashtags.

Features:
- [x] Parsing & compiling
- [x] Goto & Hover
- [x] Editor highlighting
- [ ] Autocomplete
- [ ] Rename command automatically fixes user tags
- [ ] Notifications