### PR TITLE
feat: enable usePrettyRefs for nextJS publishing and preview

### DIFF
--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -49,6 +49,7 @@ export class DConfig {
       mermaid: true,
       useKatex: true,
       autoFoldFrontmatter: true,
+      usePrettyRefs: true,
       dev: {
         enablePreviewV2: true,
       },

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -243,7 +243,6 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         const ndata = node.data as NoteRefDataV4;
         const copts: NoteRefsOpts = {
           wikiLinkOpts: opts?.wikiLinkOpts,
-          prettyRefs: opts?.prettyRefs,
         };
         const procOpts = MDUtilsV4.getProcOpts(proc);
         const { data } = convertNoteRefASTV2({

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -16,7 +16,6 @@ import {
 import { file2Note } from "@dendronhq/common-server";
 import _ from "lodash";
 import { brk, html, paragraph, root } from "mdast-builder";
-import { ConfigUtils } from "../../config";
 import { Eat } from "remark-parse";
 import Unified, { Plugin } from "unified";
 import { Node, Parent } from "unist";
@@ -323,9 +322,23 @@ export function convertNoteRefASTV2(
     };
   }
   const { wikiLinkOpts } = compilerOpts;
-  const prettyRefs = shouldApplyPublishRules
-    ? procOpts.config.site.usePrettyRefs
-    : procOpts.config.usePrettyRefs
+  const sitePrettyRefConfig = _.isUndefined(procOpts.config?.site?.usePrettyRefs)
+    ? true
+    : procOpts.config.site.usePrettyRefs;
+  const prettyRefConfig = _.isUndefined(procOpts.config?.usePrettyRefs)
+    ? true
+    : procOpts.config.usePrettyRefs;
+  let prettyRefs = shouldApplyPublishRules
+    ? sitePrettyRefConfig
+    : prettyRefConfig
+  if (
+    prettyRefs && _.includes(
+      [DendronASTDest.MD_DENDRON, DendronASTDest.MD_REGULAR], 
+      dest
+    )
+  ) {
+    prettyRefs = false;
+  }
   if (refLvl >= MAX_REF_LVL) {
     return {
       error: new DendronError({ message: "too many nested note refs" }),

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -16,6 +16,7 @@ import {
 import { file2Note } from "@dendronhq/common-server";
 import _ from "lodash";
 import { brk, html, paragraph, root } from "mdast-builder";
+import { DConfig } from "@dendronhq/engine-server";
 import { Eat } from "remark-parse";
 import Unified, { Plugin } from "unified";
 import { Node, Parent } from "unist";
@@ -322,12 +323,8 @@ export function convertNoteRefASTV2(
     };
   }
   const { wikiLinkOpts } = compilerOpts;
-  const sitePrettyRefConfig = _.isUndefined(procOpts.config?.site?.usePrettyRefs)
-    ? true
-    : procOpts.config.site.usePrettyRefs;
-  const prettyRefConfig = _.isUndefined(procOpts.config?.usePrettyRefs)
-    ? true
-    : procOpts.config.usePrettyRefs;
+  const sitePrettyRefConfig = DConfig.getProp(procOpts.config, "site").usePrettyRefs;
+  const prettyRefConfig = DConfig.getProp(procOpts.config, "usePrettyRefs");
   let prettyRefs = shouldApplyPublishRules
     ? sitePrettyRefConfig
     : prettyRefConfig

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -16,7 +16,7 @@ import {
 import { file2Note } from "@dendronhq/common-server";
 import _ from "lodash";
 import { brk, html, paragraph, root } from "mdast-builder";
-import { DConfig } from "@dendronhq/engine-server";
+import { DConfig } from "../../config";
 import { Eat } from "remark-parse";
 import Unified, { Plugin } from "unified";
 import { Node, Parent } from "unist";

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -33,6 +33,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -119,6 +120,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -195,6 +197,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -238,6 +241,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -298,6 +302,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -27,6 +27,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -113,6 +114,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -189,6 +191,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -232,6 +235,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -292,6 +296,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -359,6 +364,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:
@@ -413,6 +419,7 @@ lookupConfirmVaultOnCreate: false
 mermaid: true
 useKatex: true
 autoFoldFrontmatter: true
+usePrettyRefs: true
 dev:
     enablePreviewV2: true
 lookup:

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -310,7 +310,7 @@ VFile {
 <div class=\\"portal-head\\">
 <div class=\\"portal-backlink\\">
 <div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
-
+<a href=\\"/notes/bar.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
 </div>
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -192,3 +192,139 @@ VFile {
   "messages": Array [],
 }
 `;
+
+exports[`dendronPub usePrettyRefs config.site.usePrettyRef: false 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p></p><p></p><p>bar body</p><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/notes/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs config.site.usePrettyRef: true 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
+
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>bar body</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/notes/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs config.usePrettyRef: false 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\">Foo</h1>
+<p></p><p></p><p>bar body</p><p></p><p></p>
+<hr>
+<h2 id=\\"children\\">Children</h2>
+<ol>
+<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs config.usePrettyRef: true 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\">Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
+<a href=\\"bar.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>bar body</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\">Children</h2>
+<ol>
+<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs usePrettyRef defaults to true in both cases 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\">Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
+<a href=\\"bar.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>bar body</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\">Children</h2>
+<ol>
+<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs usePrettyRef defaults to true in both cases 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
+
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>bar body</p>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/notes/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -947,21 +947,10 @@ VFile {
 
 # Foo Bar
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
-<a href=\\"foo\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>## Header2
+## Header2
 
 task2
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -977,21 +966,10 @@ VFile {
 
 # Foo Bar
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
-<a href=\\"foo\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>## Header2
+## Header2
 
 task2
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1005,19 +983,8 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: XVAULT_CASE" 1`] = `
 VFile {
   "contents": "# Root
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Two</span></div>
-<a href=\\"two\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>two content
+two content
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1032,15 +999,6 @@ VFile {
   "contents": "# Root
 
 <div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
-<a href=\\"foo\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><div class=\\"portal-container\\">
 <div class=\\"portal-head\\">
 <div class=\\"portal-backlink\\" >
 <div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">One</span></div>
@@ -1076,8 +1034,6 @@ Regular wikilink: [Two](foo.two)
 </div>
 
 
-</div></div>
-
 ",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -1090,19 +1046,8 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: regular" 1`] = `
 VFile {
   "contents": "# Foo
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
-<a href=\\"foo\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>foo body
+foo body
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1116,19 +1061,8 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: tags section shouldn't be i
 VFile {
   "contents": "# Foo
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
-<a href=\\"foo.ch1\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>Sint minus fuga omnis non.
+Sint minus fuga omnis non.
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1142,19 +1076,8 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: tags section shouldn't be i
 VFile {
   "contents": "# Foo
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
-<a href=\\"foo.ch1\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>Sint minus fuga omnis non.
+Sint minus fuga omnis non.
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1168,19 +1091,8 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: tags section shouldn't be i
 VFile {
   "contents": "# Foo
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
-<a href=\\"foo.ch1\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>Sint minus fuga omnis non.
+Sint minus fuga omnis non.
 
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -1194,43 +1106,12 @@ exports[`noteRefV2 common cases compile "MD_REGULAR: wildcard" 1`] = `
 VFile {
   "contents": "# Root
 
-<div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">01</span></div>
-<a href=\\"journal.2020.08.01\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>journal1
+journal1
 
+journal2
 
-</div></div><div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">02</span></div>
-<a href=\\"journal.2020.08.02\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>journal2
+journal3
 
-
-</div></div><div class=\\"portal-container\\">
-<div class=\\"portal-head\\">
-<div class=\\"portal-backlink\\" >
-<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">03</span></div>
-<a href=\\"journal.2020.08.03\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
-</div>
-</div>
-<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
-<div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>journal3
-
-
-</div></div>
 
 ",
   "cwd": "<PROJECT_ROOT>",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -273,6 +273,7 @@ describe("dendronPub", () => {
         config.site = {
           siteHierarchies: ["foo"],
           siteRootDir: "foo",
+          usePrettyRefs: true
         };
         const resp = await MDUtilsV4.procRehype({
           proc: proc(
@@ -432,10 +433,6 @@ describe("dendronPub", () => {
       "usePrettyRef defaults to true in both cases",
       async ({ engine, vaults }) => {
         const config = DConfig.genDefaultConfig();
-        config.site = {
-          siteHierarchies: ["foo"],
-          siteRootDir: "foo",
-        };
         const previewResp = await MDUtilsV5.procRehypeFull(
           {
             engine,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -8,6 +8,7 @@ import {
   DendronPubOpts,
   MDUtilsV4,
   MDUtilsV5,
+  ProcFlavor,
   ProcMode,
 } from "@dendronhq/engine-server";
 import { runEngineTestV5, testWithEngine } from "../../../engine";
@@ -303,6 +304,173 @@ describe("dendronPub", () => {
           });
         },
       }
+    );
+  });
+
+  describe("usePrettyRefs", () => {
+    testWithEngine(
+      "config.site.usePrettyRef: true",
+      async ({ engine, vaults }) => {
+        const config = DConfig.genDefaultConfig();
+        config.usePrettyRefs = false;
+        config.site = {
+          siteHierarchies: ["foo"],
+          siteRootDir: "foo",
+          usePrettyRefs: true
+        };
+        const resp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PUBLISHING }
+        ).process(`![[bar]]`);
+        expect(resp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: resp.contents as string,
+            match: ["portal-container"],
+          })
+        ).toBeTruthy();
+      },
+      { preSetupHook: ENGINE_HOOKS.setupBasic }
+    );
+
+    testWithEngine(
+      "config.site.usePrettyRef: false",
+      async ({ engine, vaults }) => {
+        const config = DConfig.genDefaultConfig();
+        config.usePrettyRefs = false;
+        config.site = {
+          siteHierarchies: ["foo"],
+          siteRootDir: "foo",
+          usePrettyRefs: false
+        };
+        const resp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PUBLISHING }
+        ).process(`![[bar]]`);
+        expect(resp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: resp.contents as string,
+            nomatch: ["portal-container"],
+          })
+        ).toBeTruthy();
+      },
+      { preSetupHook: ENGINE_HOOKS.setupBasic }
+    );
+
+    testWithEngine(
+      "config.usePrettyRef: true",
+      async ({ engine, vaults }) => {
+        const config = DConfig.genDefaultConfig();
+        config.usePrettyRefs = true;
+        config.site = {
+          siteHierarchies: ["foo"],
+          siteRootDir: "foo",
+          usePrettyRefs: false
+        };
+        const resp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PREVIEW }
+        ).process(`![[bar]]`);
+        expect(resp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: resp.contents as string,
+            match: ["portal-container"],
+          })
+        ).toBeTruthy();
+      },
+      { preSetupHook: ENGINE_HOOKS.setupBasic }
+    );
+
+    testWithEngine(
+      "config.usePrettyRef: false",
+      async ({ engine, vaults }) => {
+        const config = DConfig.genDefaultConfig();
+        config.usePrettyRefs = false;
+        config.site = {
+          siteHierarchies: ["foo"],
+          siteRootDir: "foo",
+          usePrettyRefs: false
+        };
+        const resp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PREVIEW }
+        ).process(`![[bar]]`);
+        expect(resp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: resp.contents as string,
+            nomatch: ["portal-container"],
+          })
+        ).toBeTruthy();
+      },
+      { preSetupHook: ENGINE_HOOKS.setupBasic }
+    );
+
+    testWithEngine(
+      "usePrettyRef defaults to true in both cases",
+      async ({ engine, vaults }) => {
+        const config = DConfig.genDefaultConfig();
+        config.site = {
+          siteHierarchies: ["foo"],
+          siteRootDir: "foo",
+        };
+        const previewResp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PREVIEW }
+        ).process(`![[bar]]`);
+        expect(previewResp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: previewResp.contents as string,
+            match: ["portal-container"],
+          })
+        ).toBeTruthy();
+
+        const publishResp = await MDUtilsV5.procRehypeFull(
+          {
+            engine,
+            fname: "foo",
+            vault: vaults[0],
+            config
+          },
+          { flavor: ProcFlavor.PUBLISHING }
+        ).process(`![[bar]]`);
+        expect(publishResp).toMatchSnapshot();
+        expect(
+          await AssertUtils.assertInString({
+            body: publishResp.contents as string,
+            match: ["portal-container"],
+          })
+        ).toBeTruthy();
+      },
+      { preSetupHook: ENGINE_HOOKS.setupBasic }
     );
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -158,6 +158,7 @@ suite("Extension", function () {
             },
           ],
           useFMTitle: true,
+          usePrettyRefs: true,
           useNoteTitleForLink: true,
           initializeRemoteVaults: true,
           lookup: {


### PR DESCRIPTION
This PR:
- enables `config.usePrettyRefs` and `config.site.userPrettyRefs` that overrides how note references are rendered in preview and publishing respectively.
- adds tests for both cases
- updates snapshots