### PR TITLE
enhance: add expandAll functionality to backlink view.

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -77,6 +77,11 @@
     ],
     "commands": [
       {
+        "command": "dendron.backlinks.expandAll",
+        "title": "Expand All",
+        "icon": "$(expand-all)"
+      },
+      {
         "command": "dendron.browseNote",
         "title": "Dendron: Browse Note",
         "desc": "Browse note on github"
@@ -501,6 +506,15 @@
         "desc": "Browse the Seed Registry and Add Seeds to Current Workspace"
       }
     ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "dendron.backlinks.expandAll",
+          "when": "view == dendron.backlinks",
+          "group": "navigation"
+        }
+      ]
+    },
     "configuration": {
       "title": "dendron",
       "properties": {

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -6,18 +6,27 @@ import {
 } from "@dendronhq/common-test-utils";
 import path from "path";
 import * as vscode from "vscode";
-import { Uri } from "vscode";
+import { ProviderResult, Uri } from "vscode";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
-import BacklinksTreeDataProvider from "../../features/BacklinksTreeDataProvider";
+import BacklinksTreeDataProvider, {
+  secondLevelRefsToBacklinks,
+  Backlink,
+} from "../../features/BacklinksTreeDataProvider";
 import { VSCodeUtils } from "../../utils";
-import { DendronWorkspace } from "../../workspace";
+import { DendronWorkspace, getWS } from "../../workspace";
 import { expect, runMultiVaultTest } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import { TestConfigUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 
-const getChildren = async () => {
-  const backlinksTreeDataProvider = new BacklinksTreeDataProvider();
+type BacklinkWithChildren = Backlink & { children?: Backlink[] | undefined };
+
+/** Asking for root children (asking for children without an input) from backlinks tree
+ *  data provider will us the backlinks. */
+const getRootChildrenBacklinks = async () => {
+  const backlinksTreeDataProvider = new BacklinksTreeDataProvider(
+    getWS().config.dev?.enableLinkCandidates
+  );
   const parents = await backlinksTreeDataProvider.getChildren();
   const parentsWithChildren = [];
 
@@ -35,6 +44,72 @@ const getChildren = async () => {
     provider: backlinksTreeDataProvider,
   };
 };
+
+async function getRootChildrenBacklinksAsPlainObject() {
+  const value = await getRootChildrenBacklinks();
+
+  const cleanedOutVal = {
+    ...value,
+    out: cleanOutParentPointersFromList(value.out),
+  };
+  return toPlainObject(cleanedOutVal) as any;
+}
+
+/** Refer to {@link cleanOutParentPointers} */
+function cleanOutParentPointersFromList(
+  backlinks: BacklinkWithChildren[]
+): BacklinkWithChildren[] {
+  return backlinks.map((backlink) => {
+    return cleanOutParentPointers(backlink);
+  });
+}
+
+/** Return a copy of backlink with parent pointers cleaned out.
+ *
+ *  Need to remove parent references to avoid circular serialization error when trying
+ *  to serialize the backlinks within our tests (our existing tests serialize
+ *  the backlinks for their assertion checks). */
+function cleanOutParentPointers(
+  backlink: BacklinkWithChildren
+): BacklinkWithChildren {
+  const copy = { ...backlink };
+
+  if (copy.children) {
+    copy.children = cleanOutParentPointersFromList(copy.children);
+  }
+
+  copy.parentBacklink = undefined;
+
+  if (copy.refs) {
+    copy.refs = copy.refs.map((ref) => {
+      const refCopy = { ...ref };
+      refCopy.parentBacklink = undefined;
+      return refCopy;
+    });
+  }
+
+  return copy;
+}
+
+function backlinksToPlainObject(backlinks: Backlink[]) {
+  return toPlainObject(cleanOutParentPointersFromList(backlinks));
+}
+
+function assertAreEqual(actual: ProviderResult<Backlink>, expected: Backlink) {
+  if (actual instanceof Backlink) {
+    actual = cleanOutParentPointers(actual);
+  } else {
+    throw new Error(
+      `Actual type was '${typeof actual}'. Must be Backlink type for this assert.`
+    );
+  }
+  expected = cleanOutParentPointers(expected);
+
+  const plainActual = toPlainObject(actual);
+  const plainExpected = toPlainObject(expected);
+
+  expect(plainActual).toEqual(plainExpected);
+}
 
 suite("BacklinksTreeDataProvider", function () {
   let ctx: vscode.ExtensionContext;
@@ -65,7 +140,7 @@ suite("BacklinksTreeDataProvider", function () {
       },
       onInit: async ({ wsRoot, vaults }) => {
         await VSCodeUtils.openNote(noteWithTarget);
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           path.join(wsRoot, vaults[0].fsPath, "beta.md")
         ).path;
@@ -73,6 +148,56 @@ suite("BacklinksTreeDataProvider", function () {
           out[0].command.arguments[0].path.toLowerCase() as string
         ).toEqual(expectedPath.toLowerCase());
         expect(out.length).toEqual(1);
+        done();
+      },
+    });
+  });
+
+  test("validate get parent works", (done) => {
+    let noteWithTarget: NoteProps;
+
+    runLegacyMultiWorkspaceTest({
+      ctx,
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        noteWithTarget = await NOTE_PRESETS_V4.NOTE_WITH_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_LINK.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+      },
+      onInit: async () => {
+        await VSCodeUtils.openNote(noteWithTarget);
+        const { out: backlinks, provider } = await getRootChildrenBacklinks();
+        const parentBacklink = backlinks[0];
+
+        // Our utility method will add the children into out backlink structure.
+        // The provider will give just the backlink hence we will remove the
+        // children from the structure that will be used to assert equality.
+        const parentBacklinkForAssert = { ...parentBacklink };
+        delete parentBacklinkForAssert.children;
+
+        // Validate children added by the test setup are able to getParent()
+        expect(parentBacklink.children).toBeTruthy();
+        parentBacklink.children?.forEach((child) => {
+          const foundParent = provider.getParent(child);
+          assertAreEqual(foundParent, parentBacklinkForAssert);
+        });
+
+        // Validate backlinks created out of refs can getParent()
+        expect(parentBacklink.refs).toBeTruthy();
+        const childbacklinksFromRefs = secondLevelRefsToBacklinks(
+          parentBacklink.refs!,
+          provider.isLinkCandidateEnabled
+        );
+        expect(childbacklinksFromRefs).toBeTruthy();
+        childbacklinksFromRefs?.forEach((backlink) => {
+          const foundParent = provider.getParent(backlink);
+          assertAreEqual(foundParent, parentBacklinkForAssert);
+        });
+
         done();
       },
     });
@@ -97,7 +222,7 @@ suite("BacklinksTreeDataProvider", function () {
         // re-initialize engine from cache
         await new ReloadIndexCommand().run();
         await VSCodeUtils.openNote(noteWithTarget);
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           path.join(wsRoot, vaults[0].fsPath, "beta.md")
         ).path;
@@ -142,7 +267,7 @@ suite("BacklinksTreeDataProvider", function () {
         await new ReloadIndexCommand().execute();
         await VSCodeUtils.openNote(noteWithTarget);
 
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           path.join(wsRoot, vaults[0].fsPath, "gamma.md")
         ).path;
@@ -177,7 +302,7 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async ({ wsRoot, vaults }) => {
         const notePath = path.join(wsRoot, vaults[0].fsPath, "alpha.md");
         await VSCodeUtils.openFileInEditor(Uri.file(notePath));
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           path.join(wsRoot, vaults[1].fsPath, "beta.md")
         ).path;
@@ -219,12 +344,12 @@ suite("BacklinksTreeDataProvider", function () {
         );
 
         await VSCodeUtils.openNote(alpha);
-        const alphaOut = (toPlainObject(await getChildren()) as any).out;
+        const alphaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
         expect(alphaOut).toEqual([]);
         expect(alpha.links).toEqual([]);
 
         await VSCodeUtils.openNote(gamma);
-        const gammaOut = (toPlainObject(await getChildren()) as any).out;
+        const gammaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
         expect(gammaOut).toEqual([]);
         expect(gamma.links).toEqual([]);
         done();
@@ -263,8 +388,8 @@ suite("BacklinksTreeDataProvider", function () {
 
         await new ReloadIndexCommand().execute();
         await VSCodeUtils.openNote(alpha);
-        const { out, provider } = await getChildren();
-        const outObj = toPlainObject(out) as any;
+        const { out, provider } = await getRootChildrenBacklinks();
+        const outObj = backlinksToPlainObject(out) as any;
 
         // source should be beta.md
 
@@ -323,13 +448,13 @@ suite("BacklinksTreeDataProvider", function () {
         await new ReloadIndexCommand().execute();
         await VSCodeUtils.openNote(alpha);
 
-        const { out: alphaOut } = await getChildren();
-        const alphaOutObj = toPlainObject(alphaOut) as any;
+        const { out: alphaOut } = await getRootChildrenBacklinks();
+        const alphaOutObj = backlinksToPlainObject(alphaOut) as any;
         expect(_.isEmpty(alphaOutObj)).toBeTruthy();
 
         await VSCodeUtils.openNote(beta);
-        const { out: betaOut } = await getChildren();
-        const betaOutObj = toPlainObject(betaOut) as any;
+        const { out: betaOut } = await getRootChildrenBacklinks();
+        const betaOutObj = backlinksToPlainObject(betaOut) as any;
         expect(betaOutObj[0].children.length).toEqual(1);
         expect(betaOutObj[0].children[0].label).toEqual("Linked");
 
@@ -338,7 +463,7 @@ suite("BacklinksTreeDataProvider", function () {
     });
   });
 
-  test("mult backlink items display correctly", (done) => {
+  test("multi backlink items display correctly", (done) => {
     let alpha: NoteProps;
 
     runLegacyMultiWorkspaceTest({
@@ -372,8 +497,8 @@ suite("BacklinksTreeDataProvider", function () {
         await new ReloadIndexCommand().execute();
 
         await VSCodeUtils.openNote(alpha);
-        const { out } = await getChildren();
-        const outObj = toPlainObject(out) as any;
+        const { out } = await getRootChildrenBacklinks();
+        const outObj = backlinksToPlainObject(out) as any;
 
         // source should be beta.md
 
@@ -417,7 +542,7 @@ suite("BacklinksTreeDataProvider", function () {
       onInit: async ({ wsRoot, vaults }) => {
         const notePath = path.join(wsRoot, vaults[0].fsPath, "alpha.md");
         await VSCodeUtils.openFileInEditor(Uri.file(notePath));
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           path.join(wsRoot, vaults[1].fsPath, "beta.md")
         ).path;
@@ -448,7 +573,7 @@ suite("BacklinksTreeDataProvider", function () {
       },
       onInit: async () => {
         await VSCodeUtils.openNote(noteWithTarget);
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           NoteUtils.getFullPath({
             note: noteWithLink,
@@ -483,7 +608,7 @@ suite("BacklinksTreeDataProvider", function () {
       },
       onInit: async ({ wsRoot }) => {
         await VSCodeUtils.openNote(noteWithTarget);
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         // assert.strictEqual(
         //   out[0].command.arguments[0].path.toLowerCase() as string,
         //   NoteUtils.getPathV4({ note: noteWithLink, wsRoot })
@@ -523,7 +648,7 @@ suite("BacklinksTreeDataProvider", function () {
       },
       onInit: async ({ wsRoot }) => {
         await VSCodeUtils.openNote(noteTarget);
-        const { out } = toPlainObject(await getChildren()) as any;
+        const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           NoteUtils.getFullPath({
             note: noteWithLink,


### PR DESCRIPTION
Screenshot of the added button: 
<img width="499" alt="backlinks_view_modified" src="https://user-images.githubusercontent.com/4050134/131615572-ee767304-17ba-4adf-a38e-5043ed3ef9d6.png">

Expand Button is added in the backlink view which will fully expand all the backlinks while the button that is pre-built (collapse all) will fully collapse all the backlinks.