### PR TITLE
enhance: reference a list item without its children

### DIFF
--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -2070,7 +2070,7 @@ VFile {
 }
 `;
 
-exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item" 1`] = `
+exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item without children" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
 <h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
@@ -2099,7 +2099,7 @@ VFile {
 }
 `;
 
-exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item" 2`] = `
+exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item without children" 2`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
 <h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -2012,6 +2012,64 @@ VFile {
 }
 `;
 
+exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li><a aria-hidden=\\"true\\" class=\\"block-anchor anchor-heading\\" id=\\"^block-anchor\\" href=\\"#^block-anchor\\"><svg viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Ullam optio est quia. </li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 with block anchors compile "HTML: nested list element targeting a single item" 2`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<h1 id=\\"foo-bar\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo-bar\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo Bar</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Ch1</span></div>
+<a href=\\"/undefined/foo.ch1.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><ul>
+<li><a aria-hidden=\\"true\\" class=\\"block-anchor anchor-heading\\" id=\\"^block-anchor\\" href=\\"#^block-anchor\\"><svg viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Ullam optio est quia. </li>
+</ul>
+</div></div><p></p><p></p>
+<hr>
+<h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
+<ol>
+<li><a href=\\"/undefined/foo.ch1.html\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`noteRefV2 with block anchors compile "HTML: nested list element" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1626756808041
+updated: 1630474118518
 created: 1608518909864
 ---
 
@@ -52,3 +52,16 @@ Vault2
 ![[dendron.ref.links.target#^123]]
 
 ## [[a header that's entirely a link|dendron.apples]]
+
+## Targeting a single list item without its children
+
+
+## testing with ordered list
+
+1. first ^nPm286FpKzGj
+   1. first-a  ^0NFOQ4Hi4frn
+      1. first-a-1
+1. second
+   1.  second-a ^AKRCeAVwwIX2
+
+![[#^0NFOQ4Hi4frn:#^0NFOQ4Hi4frn]]


### PR DESCRIPTION
Referencing a list item that has children will reference not only that item but it's children as well. This PR allows a single item to be referenced using the syntax `[[#^item:#^item]]`. See following example:

![](https://i.imgur.com/Ht0sY9a.png)

I think this behavior makes sense, someone referencing an item with children likely wants those children as well. A range based reference spanning all child items would create the same result, but it is less ergonomic since the user would have to move the block anchor when adding new items.

#1233