### PR TITLE
feat: support custom header path in nextjs publishing

### DIFF
--- a/packages/nextjs-template/components/DendronCustomHead.tsx
+++ b/packages/nextjs-template/components/DendronCustomHead.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Head from "next/head";
+import _ from "lodash";
+import parse from "html-react-parser";
+
+type Props = {
+  content: string
+}
+
+export default function DendronCustomHead({ content }: Props) {
+  const parsedContent = parse(content);
+  return (
+    <Head>
+      {parsedContent}
+    </Head>
+  )
+}

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@dendronhq/common-all": "^0.57.0",
     "@dendronhq/common-frontend": "^0.57.0",
+    "html-react-parser": "^1.2.8",
     "lodash": "^4.17.21",
     "next": "10.2.0",
     "next-seo": "^4.26.0",

--- a/packages/nextjs-template/pages/notes/[id].tsx
+++ b/packages/nextjs-template/pages/notes/[id].tsx
@@ -13,16 +13,17 @@ import {
 import { useRouter } from "next/router";
 import React from "react";
 import DendronSEO from "../../components/DendronSEO";
+import DendronCustomHead from "../../components/DendronCustomHead";
 import DendronSpinner from "../../components/DendronSpinner";
 import { useCombinedDispatch, useCombinedSelector } from "../../features";
 import { browserEngineSlice } from "../../features/engine";
-import { getNoteBody, getNoteMeta, getNotes } from "../../utils/build";
+import { getCustomHead, getNoteBody, getNoteMeta, getNotes } from "../../utils/build";
 import { DendronCommonProps, NoteRouterQuery } from "../../utils/types";
 
 export type NotePageProps = InferGetStaticPropsType<typeof getStaticProps> &
   DendronCommonProps;
 
-export default function Note({ note, body, ...rest }: NotePageProps) {
+export default function Note({ note, body, customHeadContent, ...rest }: NotePageProps) {
   const logger = createLogger("Note");
   const router = useRouter();
   const [bodyFromState, setBody] =
@@ -70,6 +71,7 @@ export default function Note({ note, body, ...rest }: NotePageProps) {
   return (
     <>
       <DendronSEO />
+      <DendronCustomHead content={customHeadContent}/>
       <DendronNote noteContent={noteBody} />
     </>
   );
@@ -96,10 +98,12 @@ export const getStaticProps: GetStaticProps = async (
     throw Error("id required");
   }
   const [body, note] = await Promise.all([getNoteBody(id), getNoteMeta(id)]);
+  const customHeadContent = await getCustomHead();
   return {
     props: {
       body,
       note,
+      customHeadContent,
     },
   };
 };

--- a/packages/nextjs-template/utils/build.ts
+++ b/packages/nextjs-template/utils/build.ts
@@ -46,5 +46,20 @@ export function getNoteMeta(id: string) {
 
 export function getConfig(): Promise<DendronConfig> {
   const dataDir = getDataDir();
-  return fs.readJSON(path.join(dataDir, "dendron.yml"));
+  return fs.readJSON(path.join(dataDir, "dendron.json"));
+}
+
+export function getPublicDir() {
+  return path.join(process.cwd(), "public");
+}
+
+export async function getCustomHead() {
+  const config = await getConfig();
+  const customHeadPathConfig = config.site.customHeaderPath;
+  if(_.isUndefined(customHeadPathConfig)) {
+    return null;
+  }
+  const publicDir = getPublicDir();
+  const headPath = path.join(publicDir, customHeadPathConfig);
+  return fs.readFileSync(headPath, { encoding: "utf-8" });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9539,7 +9539,7 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^4.0.0, domhandler@^4.2.0:
+domhandler@4.2.0, domhandler@^4.0.0, domhandler@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
   integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
@@ -12409,6 +12409,14 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-dom-parser@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.1.tgz#5d147fed6656c12918edbcea4a423eefe8d0e715"
+  integrity sha512-uKXISKlHzB/l9A08jrs2wseQJ9b864ZfEdmIZskj10cuP6HxCOMHSK0RdluV8NVQaWs0PwefN7d8wqG3jR0IbQ==
+  dependencies:
+    domhandler "4.2.0"
+    htmlparser2 "6.1.0"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -12438,12 +12446,22 @@ html-escaper@^3.0.3:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
   integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
 
+html-react-parser@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.2.8.tgz#6806984a5056417de38fc4b52145bd56b1b32d73"
+  integrity sha512-fPPbnMNbVuceyJARZTCu2/Ai7XbVsfncwVUl3IFpgV8BG7lv6hm+Z8NWXRgc2r1DXTf1wRnLaPDL4unbln/r+g==
+  dependencies:
+    domhandler "4.2.0"
+    html-dom-parser "1.0.1"
+    react-property "1.0.1"
+    style-to-js "1.1.0"
+
 html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
-htmlparser2@^6.0.0, htmlparser2@^6.1.0:
+htmlparser2@6.1.0, htmlparser2@^6.0.0, htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -19530,6 +19548,11 @@ react-native-get-random-values@^1.4.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
+react-property@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz#4ae4211557d0a0ae050a71aa8ad288c074bea4e6"
+  integrity sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ==
+
 react-redux@^7.2.3, react-redux@^7.2.4:
   version "7.2.4"
   resolved "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
@@ -22136,7 +22159,14 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-style-to-object@^0.3.0:
+style-to-js@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz#631cbb20fce204019b3aa1fcb5b69d951ceac4ac"
+  integrity sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==
+  dependencies:
+    style-to-object "0.3.0"
+
+style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
   integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==


### PR DESCRIPTION
# feat: support custom header path in nextjs publishing

This change adds support for the site configuration `customHeaderPath` to nextjs publishing.

Docs PR: https://wiki.dendron.so/notes/f2ed8639-a604-4a9d-b76c-41e205fb8713.html#customheaderpath

## Note
- The current way we do head tags is to use `next/head` to append necessary head tags on each components. (When we are not using that component, the appended elements will be unmounted)
- The built-in `Head` component that `next/head` provides does not currently allow `dangerouslySetInnerHTML` props (most likely because of their appending/unmount behavior).
- Specifically for third party scripts, nextjs recommends that we use their built-in `Script` component provided by `next/script`, which is available in next 11 (we are currently on 10).
- I have opted for introducing `html-react-parser` and directly parsing the `customHeaderPath` content and appending it to every note page using the `Head` component for now, but this is less than ideal.
  - The behaviour is on par with 11ty publishing, so no backwards compatibility is broken
  - but,
    - letting arbitrary html to be injected to the head isn't safe to begin with
    - we don't (nor does `html-react-parser`) make effort to sanitize the HTML or prevent XSS.
  - For these reasons, I've added a backlog item to spec out a better way to let users add custom head contents once nextjs achieves feature parity.
    - Since this feature is a relatively niche one (I have no data to back this up so correct me if I'm wrong), we should figure out a better way to do this as soon as we have the bandwidth to do so before it's exposed to more users

---

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [~] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [~] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [~] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [x] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
