### PR TITLE
fix: incorrect hover missing note message

### DIFF
--- a/packages/plugin-core/src/features/ReferenceHoverProvider.ts
+++ b/packages/plugin-core/src/features/ReferenceHoverProvider.ts
@@ -22,7 +22,7 @@ import {
   getReferenceAtPosition,
   isUncPath,
 } from "../utils/md";
-import { DendronWorkspace, getEngine } from "../workspace";
+import { DendronWorkspace, getEngine, getWS } from "../workspace";
 import _ from "lodash";
 import { Logger } from "../logger";
 
@@ -67,7 +67,9 @@ export default class ReferenceHoverProvider implements vscode.HoverProvider {
     const vaultName = refAtPos.vaultName
       ? ` in vault "${refAtPos.vaultName}"`
       : "";
-    return `Note ${refAtPos.ref}${vaultName} is missing, Ctrl+click or use "Dendron: Goto Note" command to create it.`;
+    const ctrlClickToCreate =
+      getWS().config.noAutoCreateOnDefinition === false ? "Ctrl+Click or " : "";
+    return `Note ${refAtPos.ref}${vaultName} is missing, ${ctrlClickToCreate}use "Dendron: Goto Note" command to create it.`;
   }
 
   /** Returns a message if this is a non-dendron URI. */

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -220,7 +220,8 @@ suite("ReferenceProvider", function () {
             await AssertUtils.assertInString({
               body: hover!.contents.join(""),
               match: [
-                `Note target is missing, Ctrl+click or use "Dendron: Goto Note" command to create it.`,
+                `Note target is missing`,
+                `use "Dendron: Goto Note" command`,
               ],
             });
             done();


### PR DESCRIPTION
The message for hovering over missing notes would recommend the user to Ctrl+click the link to create the missing note. However, this is only possible if the user has `noAutoCreateOnDefinition` config set to false. Corrected the message so that it only recommends Ctrl+click if this config is set.

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated