### PR TITLE
fix: Frontmatter tags display similar to Children

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -6,10 +6,9 @@ import {
   TAGS_HIERARCHY,
 } from "@dendronhq/common-all";
 import _ from "lodash";
-import { Content, Image, Root } from "mdast";
-import { heading, paragraph, text } from "mdast-builder";
+import type { Image, Root } from "mdast";
+import { paragraph } from "mdast-builder";
 import {
-  frontmatterTag2WikiLinkNoteV4,
   addError,
   getNoteOrError,
   hashTag2WikiLinkNoteV4,
@@ -84,19 +83,6 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           0,
           u(DendronASTTypes.HEADING, { depth: 1 }, [u("text", note.title)])
         );
-      }
-      // Add frontmatter tags, if any, ahead of time. This way wikilink compiler will pick them up and render them.
-      if (
-        config?.site?.showFrontMatterTags !== false &&
-        note?.tags &&
-        note.tags.length > 0
-      ) {
-        root.children.push(heading(2, text("Tags")) as Content);
-        const tagLinks = _.map(
-          _.isString(note.tags) ? [note.tags] : note.tags,
-          frontmatterTag2WikiLinkNoteV4
-        );
-        root.children.push(paragraph(tagLinks) as Content);
       }
     }
     visitParents(tree, (node, ancestors) => {

--- a/packages/engine-server/src/markdown/remark/hierarchies.ts
+++ b/packages/engine-server/src/markdown/remark/hierarchies.ts
@@ -1,7 +1,7 @@
 import { NoteUtils, VaultUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { Content, Root } from "mdast";
-import { list, listItem, paragraph } from "mdast-builder";
+import { heading, list, listItem, paragraph, text } from "mdast-builder";
 import Unified, { Plugin } from "unified";
 import { Node } from "unist";
 import u from "unist-builder";
@@ -9,12 +9,14 @@ import { SiteUtils } from "../../topics/site";
 import { HierarchyUtils } from "../../utils";
 import { DendronASTDest, WikiLinkNoteV4, DendronASTTypes } from "../types";
 import { MDUtilsV4 } from "../utils";
+import { frontmatterTag2WikiLinkNoteV4 } from "./utils";
 
 type PluginOpts = {
   hierarchyDisplayTitle?: string;
   hierarchyDisplay?: boolean;
 };
 
+/** Adds the "Children" and "Tags" items to the end of the note. */
 const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
   const proc = this;
   const hierarchyDisplayTitle = opts?.hierarchyDisplayTitle || "Children";
@@ -43,58 +45,89 @@ const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
       vault: vault!,
       wsRoot: engine.wsRoot,
     });
-    if (_.isUndefined(note)) {
-      return;
-    }
-    // don't include if collection present
-    if (note.children.length <= 0 || note.custom?.has_collection) {
-      return;
-    }
-    if (
-      _.isBoolean(note.custom?.hierarchyDisplay) &&
-      !note.custom.hierarchyDisplay
-    ) {
-      return;
-    }
-    const children = HierarchyUtils.getChildren({
-      skipLevels: note.custom?.skipLevels || 0,
-      note,
-      notes: engine.notes,
-    })
-      .filter((note) => SiteUtils.canPublish({ note, engine, config }))
-      .filter(
-        (note) =>
-          _.isUndefined(note.custom?.nav_exclude) || !note.custom?.nav_exclude
-      );
 
-    if (!_.isEmpty(children)) {
+    let addedBreak = false;
+    function addBreak() {
+      if (addedBreak) return;
       root.children.push({
         type: "thematicBreak",
       });
-      root.children.push(
-        u(DendronASTTypes.HEADING, { depth: 2 }, [
-          u("text", hierarchyDisplayTitle),
-        ])
-      );
-      root.children.push(
-        list(
-          "ordered",
-          _.sortBy(children, ["custom.nav_order", "title"]).map((note) => {
-            return listItem(
-              paragraph({
-                type: DendronASTTypes.WIKI_LINK,
-                value: note.fname,
-                data: {
-                  alias: note.title,
-                  vaultName: VaultUtils.getName(note.vault),
-                },
-                children: [],
-              } as WikiLinkNoteV4)
-            );
-          })
-        ) as Content
-      );
+      addedBreak = true;
     }
+
+    /** Add frontmatter tags, if any, ahead of time. This way wikilink compiler will pick them up and render them. */
+    function addTags() {
+      if (
+        config?.site?.showFrontMatterTags !== false &&
+        note?.tags &&
+        note.tags.length > 0
+      ) {
+        addBreak();
+        root.children.push(heading(2, text("Tags")) as Content);
+        const tags = _.isString(note.tags) ? [note.tags] : note.tags;
+        const tagLinks = _.sortBy(
+          _.map(tags, (tag) =>
+            listItem(paragraph(frontmatterTag2WikiLinkNoteV4(tag)))
+          ),
+          ["custom.nav_order", "title"]
+        );
+        root.children.push(list("ordered", tagLinks) as Content);
+      }
+    }
+
+    function addChildren() {
+      // don't include if collection present
+      if (!note || note.children.length <= 0 || note?.custom?.has_collection) {
+        return;
+      }
+      if (
+        _.isBoolean(note.custom?.hierarchyDisplay) &&
+        !note.custom.hierarchyDisplay
+      ) {
+        return;
+      }
+      const children = HierarchyUtils.getChildren({
+        skipLevels: note.custom?.skipLevels || 0,
+        note,
+        notes: engine.notes,
+      })
+        .filter((note) => SiteUtils.canPublish({ note, engine, config }))
+        .filter(
+          (note) =>
+            _.isUndefined(note.custom?.nav_exclude) || !note.custom?.nav_exclude
+        );
+
+      if (!_.isEmpty(children)) {
+        addBreak();
+        root.children.push(
+          u(DendronASTTypes.HEADING, { depth: 2 }, [
+            u("text", hierarchyDisplayTitle),
+          ])
+        );
+        root.children.push(
+          list(
+            "ordered",
+            _.sortBy(children, ["custom.nav_order", "title"]).map((note) => {
+              return listItem(
+                paragraph({
+                  type: DendronASTTypes.WIKI_LINK,
+                  value: note.fname,
+                  data: {
+                    alias: note.title,
+                    vaultName: VaultUtils.getName(note.vault),
+                  },
+                  children: [],
+                } as WikiLinkNoteV4)
+              );
+            })
+          ) as Content
+        );
+      }
+    }
+
+    // Will appear on page in this order
+    addChildren();
+    addTags();
 
     // end transformer
   }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -34,9 +34,12 @@ VFile {
 
 has fm tags
 
+* * *
+
 ## Tags
 
-[first](tags.first.html)[second](tags.second.html)
+1. [first](tags.first.html)
+2. [second](tags.second.html)
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -52,9 +55,11 @@ VFile {
 
 has fm tags
 
+* * *
+
 ## Tags
 
-[first](tags.first.html)
+1. [first](tags.first.html)
 
 ",
   "cwd": "<PROJECT_ROOT>",


### PR DESCRIPTION
The main change is that the tags are now displayed in a list (respecting user defined order if it exists), and the separator is added even if there are no children (the second image wouldn't have had it before).

![](https://i.imgur.com/2ltJBRm.png)

![](https://i.imgur.com/lHgbC2J.png)


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated