### PR TITLE
fix: creating scratch when text is selected within a note SHOULD not match scratches just due to prefix

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -50,7 +50,7 @@ import {
 import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
-import { getEngine, getDWorkspace } from "../workspace";
+import { getDWorkspace, getEngine } from "../workspace";
 import { BaseCommand } from "./base";
 
 export type CommandRunOpts = {
@@ -181,6 +181,7 @@ export class NoteLookupCommand extends BaseCommand<
     this._provider = new NoteLookupProvider("lookup", {
       allowNewNote: true,
       noHidePickerOnAccept: false,
+      forceAsIsPickerValueUsage: copts.noteType === LookupNoteTypeEnum.scratch,
     });
     const lc = this.controller;
     if (copts.fuzzThreshold) {

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -55,6 +55,8 @@ export type ILookupProviderV3 = {
 export type ILookupProviderOptsV3 = {
   allowNewNote: boolean;
   noHidePickerOnAccept?: boolean;
+  /** Forces to use picker value as is when constructing the query string. */
+  forceAsIsPickerValueUsage?: boolean;
 };
 
 export type NoteLookupProviderSuccessResp<T = never> = {
@@ -211,7 +213,11 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     const start = process.hrtime();
 
     // just activated picker's have special behavior
-    if (picker._justActivated && !picker.nonInteractive) {
+    if (
+      picker._justActivated &&
+      !picker.nonInteractive &&
+      !this.opts.forceAsIsPickerValueUsage
+    ) {
       pickerValue = NoteLookupUtils.getQsForCurrentLevel(pickerValue);
     }
 


### PR DESCRIPTION
# Summary 
Fix scratch creation when text is selected within a note.

# Description
1. Write out a new string 
> some new string that you want to add to scratch
2. Use the create scratch note shortcut on the string. 
Expected: Just `Create New` is shown.
Actual (prior to the fix): some other scratch entries are shown. Hence, `Create New` is all the way at the bottom (can be even outside the view).

Related description of issue: [[Fix Scratch Creation|scratch.2021.08.31.091837.improve-lookup.fix-scratch-creation]]

## Prior to this change:
<img width="732" alt="pre-scratch-fix" src="https://user-images.githubusercontent.com/4050134/132195222-3c785891-4204-4f65-abb4-27575bbda3de.png">

## After the change
<img width="726" alt="after-scratch-fix" src="https://user-images.githubusercontent.com/4050134/132195251-37feecb5-4dbf-4ba2-b037-f64b50696248.png">


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [d] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature, now new feature fixing a bug.

Tried to add a test for this use case but for some reason selection does not seem to be picked up as expected in a test
tried to add 

```
  VSCodeUtils.getActiveTextEditor()!.selection =
    new vscode.Selection(7, 0,
      7, 8);
```
In a test after the note is opened and the selection is not picked up by the look up in a test. 

https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts#L721



- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows



### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [x ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

