### PR TITLE
fix: do not show multi select button on note rename

### DIFF
--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -603,7 +603,11 @@ export class DendronExtension {
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.RENAME_NOTE.key,
         async (args: any) => {
-          await new MoveNoteCommand().run({ useSameVault: true, ...args });
+          await new MoveNoteCommand().run({
+            allowMultiselect: false,
+            useSameVault: true,
+            ...args,
+          });
         }
       )
     );


### PR DESCRIPTION
# Summary
Remove multi select option from note rename. 

# Description
Note rename only works with a single note by design, hence multi select does not make sense to be shown on it. It got inadvertly added when adding bulk move for moving notes between vaults. 

# Pull Request Checklist

## General

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
  - Two unrelated tests fail locally but they also fail on 'master' for me for a clean rebuild, hence deeming as unreleated. 
  ```
   FAIL  src/__tests__/common-server/git.spec.ts (13.174 s)
  ● GitUtils › getGithubFileUrl › ok - unix separato
  ```
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows