### PR TITLE
enhance: add progress bar that goes away on its own instead of notification when moving notes

### DIFF
--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -10,7 +10,7 @@ import { HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import _md from "markdown-it";
 import path from "path";
-import { Uri, ViewColumn, window } from "vscode";
+import { ProgressLocation, Uri, ViewColumn, window } from "vscode";
 import { MultiSelectBtn } from "../components/lookup/buttons";
 import {
   LookupControllerV3,
@@ -209,9 +209,18 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
           return { changed: [] };
         }
       }
-      window.showInformationMessage("refactoring...");
 
-      const changed = await this.moveNotes(engine, opts.moves);
+      const changed = await window.withProgress(
+        {
+          location: ProgressLocation.Notification,
+          title: "Refactoring...",
+          cancellable: false,
+        },
+        async () => {
+          const allChanges = await this.moveNotes(engine, opts.moves);
+          return allChanges;
+        }
+      );
 
       if (opts.closeAndOpenFile) {
         // During bulk move we will only open a single file that was moved to avoid


### PR DESCRIPTION
# enhance: add progress bar that goes away on its own instead of notification when moving notes

When moving notes: This change adds a progress bar notification with `Refactoring...` message in place of a notification that didn't auto hide by itself.

<img width="591" alt="Screen Shot 2021-09-06 at 6 46 21 PM" src="https://user-images.githubusercontent.com/4050134/132212759-6de320d1-356e-4a5c-87b7-ae8c331c1fdb.png">


# Pull Request Checklist
## General

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass


#### Special Cases
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing 
 -- This change does contain a string that is visible to user. This string is previously used by other commands (eg. Refactor Hierarchy). However, I am not sure what this checkpoint is requesting to do. Where in test-workspace should we add the string?


### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description

