### PR TITLE
feat: consolidate dendron configs

### DIFF
--- a/packages/common-all/src/types/configs/base.ts
+++ b/packages/common-all/src/types/configs/base.ts
@@ -1,0 +1,7 @@
+export type DendronConfigValueType = string | boolean | number;
+
+export type DendronConfigEntry<DendronConfigValueType> = {
+  value?: DendronConfigValueType;
+  label: string;
+  desc: string;
+};

--- a/packages/common-all/src/types/configs/base.ts
+++ b/packages/common-all/src/types/configs/base.ts
@@ -1,5 +1,12 @@
 export type DendronConfigValueType = string | boolean | number;
 
+/**
+ * DendronConfigEntry
+ * Holds the value, label, and description of individual configuration entries.
+ *
+ * For config entries that can be an arbitrary value, only specify the label and description.
+ * For config entries that have pre-defined choices, provide the value as well as label and description specific to that value.
+ */
 export type DendronConfigEntry<DendronConfigValueType> = {
   value?: DendronConfigValueType;
   label: string;

--- a/packages/common-all/src/types/configs/commands/commands.ts
+++ b/packages/common-all/src/types/configs/commands/commands.ts
@@ -1,0 +1,17 @@
+import {
+  genDefaultInsertNoteLinkConfig,
+  InsertNoteLinkConfig,
+} from "./insertNoteLink";
+import { genDefaultLookupConfig, LookupConfig } from "./lookup";
+
+export type DendronCommandConfig = {
+  lookup: LookupConfig;
+  insertNoteLink: InsertNoteLinkConfig;
+};
+
+export function genDefaultCommandConfig(): DendronCommandConfig {
+  return {
+    lookup: genDefaultLookupConfig(),
+    insertNoteLink: genDefaultInsertNoteLinkConfig(),
+  };
+}

--- a/packages/common-all/src/types/configs/commands/commands.ts
+++ b/packages/common-all/src/types/configs/commands/commands.ts
@@ -1,14 +1,31 @@
 import {
   genDefaultInsertNoteLinkConfig,
   InsertNoteLinkConfig,
+  INSERT_NOTE_LINK,
 } from "./insertNoteLink";
-import { genDefaultLookupConfig, LookupConfig } from "./lookup";
+import { genDefaultLookupConfig, LookupConfig, LOOKUP } from "./lookup";
 
+/**
+ * Namespace for all command related configurations
+ */
 export type DendronCommandConfig = {
   lookup: LookupConfig;
   insertNoteLink: InsertNoteLinkConfig;
 };
 
+/**
+ * Constants holding all command config related {@link DendronConfigEntry}
+ */
+export const COMMANDS = {
+  LOOKUP,
+  INSERT_NOTE_LINK,
+};
+
+/**
+ * Generates default {@link DendronCommandConfig} using
+ * respective default config generators that each command config implements.
+ * @returns DendronCommandConfig
+ */
 export function genDefaultCommandConfig(): DendronCommandConfig {
   return {
     lookup: genDefaultLookupConfig(),

--- a/packages/common-all/src/types/configs/commands/insertNoteLink.ts
+++ b/packages/common-all/src/types/configs/commands/insertNoteLink.ts
@@ -1,0 +1,64 @@
+import { DendronConfigEntry } from "../base";
+
+export enum InsertNoteLinkAliasModeEnum {
+  snippet = "snippet",
+  selection = "selection",
+  title = "title",
+  prompt = "prompt",
+  none = "none",
+}
+
+export type InsertNoteLinkAliasMode = keyof typeof InsertNoteLinkAliasModeEnum;
+
+export type InsertNoteLinkConfig = {
+  aliasMode: InsertNoteLinkAliasModeEnum;
+  multiSelect: boolean;
+};
+
+export const INSERT_NOTE_LINK_ALIAS_MODES: {
+  [key: string]: DendronConfigEntry<string>;
+} = {
+  SNIPPET: {
+    value: InsertNoteLinkAliasModeEnum.snippet,
+    label: "snippet mode",
+    desc: "Insert note link as snippet string",
+  },
+  SELECTION: {
+    value: InsertNoteLinkAliasModeEnum.selection,
+    label: "selection mode",
+    desc: "Extract selection and use as link alias",
+  },
+  TITLE: {
+    value: InsertNoteLinkAliasModeEnum.title,
+    label: "title mode",
+    desc: "Use linked note's title as link alias",
+  },
+  PROMPT: {
+    value: InsertNoteLinkAliasModeEnum.prompt,
+    label: "prompt mode",
+    desc: "Prompt for input to be used as link alias",
+  },
+  NONE: {
+    value: InsertNoteLinkAliasModeEnum.none,
+    label: "no alias mode",
+    desc: "Do not add link alias",
+  },
+};
+
+export const INSERT_NOTE_LINK_MULTISELECT = (
+  value: boolean
+): DendronConfigEntry<boolean> => {
+  const valueToString = value ? "Enable" : "Disable";
+  return {
+    value,
+    label: `${valueToString} multi-select`,
+    desc: `${valueToString} multi-select when inserting note link(s)`,
+  };
+};
+
+export function genDefaultInsertNoteLinkConfig(): InsertNoteLinkConfig {
+  return {
+    aliasMode: InsertNoteLinkAliasModeEnum.none,
+    multiSelect: false,
+  };
+}

--- a/packages/common-all/src/types/configs/commands/insertNoteLink.ts
+++ b/packages/common-all/src/types/configs/commands/insertNoteLink.ts
@@ -1,5 +1,8 @@
 import { DendronConfigEntry } from "../base";
 
+/**
+ * Enum definitions of possible alias mode values
+ */
 export enum InsertNoteLinkAliasModeEnum {
   snippet = "snippet",
   selection = "selection",
@@ -8,46 +11,66 @@ export enum InsertNoteLinkAliasModeEnum {
   none = "none",
 }
 
+/**
+ * String literal types generated from {@link InsertNoteLinkAliasModeEnum}
+ */
 export type InsertNoteLinkAliasMode = keyof typeof InsertNoteLinkAliasModeEnum;
 
+/**
+ * Namespace for configuring {@link InsertNoteLinkCommand}
+ */
 export type InsertNoteLinkConfig = {
   aliasMode: InsertNoteLinkAliasModeEnum;
   multiSelect: boolean;
 };
 
-export const INSERT_NOTE_LINK_ALIAS_MODES: {
-  [key: string]: DendronConfigEntry<string>;
+/**
+ * Constants for possible alias mode choices.
+ * Each key of {@link InsertNoteLinkAliasMode} is mapped to a {@link DendronConfigEntry}
+ * which specifies the value, label, description of possible alias modes.
+ *
+ * These are used to generate user friendly descriptions in the configuration UI.
+ */
+const ALIAS_MODES: {
+  [key in InsertNoteLinkAliasMode]: DendronConfigEntry<string>;
 } = {
-  SNIPPET: {
+  snippet: {
     value: InsertNoteLinkAliasModeEnum.snippet,
     label: "snippet mode",
     desc: "Insert note link as snippet string",
   },
-  SELECTION: {
+  selection: {
     value: InsertNoteLinkAliasModeEnum.selection,
     label: "selection mode",
     desc: "Extract selection and use as link alias",
   },
-  TITLE: {
+  title: {
     value: InsertNoteLinkAliasModeEnum.title,
     label: "title mode",
     desc: "Use linked note's title as link alias",
   },
-  PROMPT: {
+  prompt: {
     value: InsertNoteLinkAliasModeEnum.prompt,
     label: "prompt mode",
     desc: "Prompt for input to be used as link alias",
   },
-  NONE: {
+  none: {
     value: InsertNoteLinkAliasModeEnum.none,
     label: "no alias mode",
     desc: "Do not add link alias",
   },
 };
 
-export const INSERT_NOTE_LINK_MULTISELECT = (
-  value: boolean
-): DendronConfigEntry<boolean> => {
+/**
+ * Given a boolean value, returns a {@link DendronConfigEntry} that holds
+ * user friendly description of the multi-select behavior.
+ *
+ * This is a function instead of an object because object keys cannot be booleans.
+ *
+ * @param value boolean
+ * @returns DendronConfigEntry<boolean>
+ */
+const MULTI_SELECT = (value: boolean): DendronConfigEntry<boolean> => {
   const valueToString = value ? "Enable" : "Disable";
   return {
     value,
@@ -56,6 +79,19 @@ export const INSERT_NOTE_LINK_MULTISELECT = (
   };
 };
 
+/**
+ * Constants / functions that produce constants for
+ * possible insert note link configurations.
+ */
+export const INSERT_NOTE_LINK = {
+  ALIAS_MODES,
+  MULTI_SELECT,
+};
+
+/**
+ * Generates default {@link InsertNoteLinkConfig}
+ * @returns InsertNoteLinkConfig
+ */
 export function genDefaultInsertNoteLinkConfig(): InsertNoteLinkConfig {
   return {
     aliasMode: InsertNoteLinkAliasModeEnum.none,

--- a/packages/common-all/src/types/configs/commands/lookup.ts
+++ b/packages/common-all/src/types/configs/commands/lookup.ts
@@ -1,0 +1,46 @@
+import { DendronConfigEntry } from "../base";
+
+export enum NoteLookupSelectionBehaviorEnum {
+  extract = "extract",
+  link = "link",
+  none = "none",
+}
+
+export type NoteLookupSelectionBehavior =
+  keyof typeof NoteLookupSelectionBehaviorEnum;
+
+type NoteLookupConfig = {
+  selection: NoteLookupSelectionBehavior;
+};
+
+export type LookupConfig = {
+  note: NoteLookupConfig;
+};
+
+export const NOTE_LOOKUP_SELECTION_BEHAVIORS: {
+  [key: string]: DendronConfigEntry<string>;
+} = {
+  EXTRACT: {
+    value: NoteLookupSelectionBehaviorEnum.extract,
+    label: "extract selection",
+    desc: "Extract selection of active editor and use it as body of new note.",
+  },
+  LINK: {
+    value: NoteLookupSelectionBehaviorEnum.link,
+    label: "selection 2 link",
+    desc: "Use selection of active editor for the basename of the lookup value.",
+  },
+  NONE: {
+    value: NoteLookupSelectionBehaviorEnum.none,
+    label: "none",
+    desc: "Do not set selection behavior",
+  },
+};
+
+export function genDefaultLookupConfig(): LookupConfig {
+  return {
+    note: {
+      selection: NoteLookupSelectionBehaviorEnum.extract,
+    },
+  };
+}

--- a/packages/common-all/src/types/configs/commands/lookup.ts
+++ b/packages/common-all/src/types/configs/commands/lookup.ts
@@ -1,46 +1,79 @@
 import { DendronConfigEntry } from "../base";
 
+/**
+ * Enum definition of possible lookup selection behavior values
+ */
 export enum NoteLookupSelectionBehaviorEnum {
   extract = "extract",
   link = "link",
   none = "none",
 }
 
+/**
+ * String literal type generated from {@link NoteLookupSelectionBehaviorEnum}
+ */
 export type NoteLookupSelectionBehavior =
   keyof typeof NoteLookupSelectionBehaviorEnum;
 
-type NoteLookupConfig = {
-  selection: NoteLookupSelectionBehavior;
-};
-
+/**
+ * Namespace for configuring lookup commands
+ */
 export type LookupConfig = {
   note: NoteLookupConfig;
 };
 
-export const NOTE_LOOKUP_SELECTION_BEHAVIORS: {
-  [key: string]: DendronConfigEntry<string>;
+/**
+ * Namespace for configuring {@link NoteLookupCommand}
+ */
+type NoteLookupConfig = {
+  selectionBehavior: NoteLookupSelectionBehavior;
+};
+
+/**
+ * Constants for possible note lookup selection behaviors.
+ * Each key holds a {@link DendronConfigEntry}
+ * which specifies the value, label, description of possible selection behaviors.
+ *
+ * These are used to generate user friendly descriptions in the configuration UI.
+ */
+const SELECTION_BEHAVIORS: {
+  [key in NoteLookupSelectionBehavior]: DendronConfigEntry<string>;
 } = {
-  EXTRACT: {
+  extract: {
     value: NoteLookupSelectionBehaviorEnum.extract,
     label: "extract selection",
     desc: "Extract selection of active editor and use it as body of new note.",
   },
-  LINK: {
+  link: {
     value: NoteLookupSelectionBehaviorEnum.link,
     label: "selection 2 link",
     desc: "Use selection of active editor for the basename of the lookup value.",
   },
-  NONE: {
+  none: {
     value: NoteLookupSelectionBehaviorEnum.none,
     label: "none",
     desc: "Do not set selection behavior",
   },
 };
 
+/**
+ * Constants / functions that produce
+ * constants for possible lookup configurations
+ */
+export const LOOKUP = {
+  NOTE: {
+    SELECTION: SELECTION_BEHAVIORS,
+  },
+};
+
+/**
+ * Generates default {@link LookupConfig}
+ * @returns LookupConfig
+ */
 export function genDefaultLookupConfig(): LookupConfig {
   return {
     note: {
-      selection: NoteLookupSelectionBehaviorEnum.extract,
+      selectionBehavior: NoteLookupSelectionBehaviorEnum.extract,
     },
   };
 }

--- a/packages/common-all/src/types/configs/commands/lookup.ts
+++ b/packages/common-all/src/types/configs/commands/lookup.ts
@@ -46,7 +46,7 @@ const SELECTION_BEHAVIORS: {
   },
   link: {
     value: NoteLookupSelectionBehaviorEnum.link,
-    label: "selection 2 link",
+    label: "selection to link",
     desc: "Use selection of active editor for the basename of the lookup value.",
   },
   none: {

--- a/packages/common-all/src/types/configs/dendronConfig.ts
+++ b/packages/common-all/src/types/configs/dendronConfig.ts
@@ -1,0 +1,22 @@
+import {
+  DendronCommandConfig,
+  genDefaultCommandConfig,
+} from "./commands/commands";
+import {
+  DendronWorkspaceConfig,
+  genDefaultWorkspaceConfig,
+} from "./workspace/workspace";
+
+export type DendronConfig = {
+  command: DendronCommandConfig;
+  workspace: DendronWorkspaceConfig;
+  // publish: DendronPublishConfig;
+  // preview: DendronPreviewConfig;
+};
+
+export function genDefaultDendronConfig(): DendronConfig {
+  return {
+    command: genDefaultCommandConfig(),
+    workspace: genDefaultWorkspaceConfig(),
+  };
+}

--- a/packages/common-all/src/types/configs/dendronConfig.ts
+++ b/packages/common-all/src/types/configs/dendronConfig.ts
@@ -1,22 +1,39 @@
 import {
   DendronCommandConfig,
   genDefaultCommandConfig,
+  COMMANDS,
 } from "./commands/commands";
 import {
   DendronWorkspaceConfig,
   genDefaultWorkspaceConfig,
+  WORKSPACE,
 } from "./workspace/workspace";
 
+/**
+ * DendronConfig
+ * This is the top level config that will hold everything.
+ */
 export type DendronConfig = {
-  command: DendronCommandConfig;
+  commands: DendronCommandConfig;
   workspace: DendronWorkspaceConfig;
-  // publish: DendronPublishConfig;
-  // preview: DendronPreviewConfig;
 };
 
+/**
+ * Constants holding all {@link DendronConfigEntry}
+ */
+export const DENDRON_CONFIG = {
+  COMMANDS,
+  WORKSPACE,
+};
+
+/**
+ * Generates a default DendronConfig using
+ * respective default config generators of each sub config groups.
+ * @returns DendronConfig
+ */
 export function genDefaultDendronConfig(): DendronConfig {
   return {
-    command: genDefaultCommandConfig(),
+    commands: genDefaultCommandConfig(),
     workspace: genDefaultWorkspaceConfig(),
   };
 }

--- a/packages/common-all/src/types/configs/workspace/journal.ts
+++ b/packages/common-all/src/types/configs/workspace/journal.ts
@@ -59,7 +59,7 @@ const ADD_BEHAVIOR: {
   },
 };
 
-// const assertion to tell the compiler that we only want these as dayOfWeekNymber.
+// const assertion to tell the compiler that we only want these as dayOfWeekNumber.
 const possibleDayOfWeekNumber = [0, 1, 2, 3, 4, 5, 6] as const;
 export type dayOfWeekNumber = typeof possibleDayOfWeekNumber[number];
 

--- a/packages/common-all/src/types/configs/workspace/journal.ts
+++ b/packages/common-all/src/types/configs/workspace/journal.ts
@@ -1,5 +1,8 @@
 import { DendronConfigEntry } from "../base";
 
+/**
+ * Enum definition of possible note add behavior values.
+ */
 export enum NoteAddBehaviorEnum {
   childOfDomain = "childOfDomain",
   childOfDomainNamespace = "childOfDomainNamespace",
@@ -7,8 +10,14 @@ export enum NoteAddBehaviorEnum {
   asOwnDomain = "asOwnDomain",
 }
 
+/**
+ * String literal type generated from {@link NoteAddBehaviorEnum}
+ */
 export type NoteAddBehavior = keyof typeof NoteAddBehaviorEnum;
 
+/**
+ * Namespace for configuring journal note behavior
+ */
 export type JournalConfig = {
   dailyDomain: string;
   dailyVault?: string;
@@ -18,49 +27,52 @@ export type JournalConfig = {
   firstDayOfWeek: number;
 };
 
-export const JOURNAL_DAILY_DOMAIN: DendronConfigEntry<string> = {
-  label: "daily domain",
-  desc: "Domain where the journal notes are created",
-};
-
-export const JOURNAL_NAME: DendronConfigEntry<string> = {
-  label: "journal name",
-  desc: "Name used for journal notes",
-};
-
-export const JOURNAL_DATE_FORMAT: DendronConfigEntry<string> = {
-  label: "date format",
-  desc: "Date format used for journal notes",
-};
-
-export const JOURNAL_ADD_BEHAVIOR: {
-  [key: string]: DendronConfigEntry<string>;
+/**
+ * Constants for possible note add behaviors.
+ * Each key of {@link NoteAddBehavior} is mapped to a {@link DendronConfigEntry}
+ * which specifies the value, label, description of possible note add behaviors.
+ *
+ * These are used to generate user friendly descriptions in the configuration.
+ */
+const ADD_BEHAVIOR: {
+  [key in NoteAddBehavior]: DendronConfigEntry<string>;
 } = {
-  CHILD_OF_DOMAIN: {
+  childOfDomain: {
     value: "childOfDomain",
     label: "child of domain",
     desc: "Note is added as the child of domain of the current hierarchy",
   },
-  CHILD_OF_DOMAIN_NAMESPACE: {
+  childOfDomainNamespace: {
     value: "childOfDomainNamespace",
     label: "child of domain namespace",
     desc: "Note is added as child of the namespace of the current domain if it has a namespace. Otherwise added as child of domain.",
   },
-  CHILD_OF_CURRENT: {
+  childOfCurrent: {
     value: "childOfCurrent",
     label: "child of current",
     desc: "Note is added as a child of the current open note",
   },
-  AS_OWN_DOMAIN: {
+  asOwnDomain: {
     value: "asOwnDomain",
     label: "as own domain",
     desc: "Note is created under the domain specified by journal name value",
   },
 };
 
-export const JOURNAL_FIRST_DAY_OF_WEEK = (
-  value: number
-): DendronConfigEntry<number> => {
+// const assertion to tell the compiler that we only want these as dayOfWeekNymber.
+const possibleDayOfWeekNumber = [0, 1, 2, 3, 4, 5, 6] as const;
+export type dayOfWeekNumber = typeof possibleDayOfWeekNumber[number];
+
+/**
+ * Given a {@link dayOfWeekNumber}, returns a {@link DendronConfigEntry} that holds
+ * user friendly description of the first day of week behavior.
+ *
+ * @param value {@link dayOfWeekNumber}
+ * @returns DendronConfigEntry
+ */
+const FIRST_DAY_OF_WEEK = (
+  value: dayOfWeekNumber
+): DendronConfigEntry<dayOfWeekNumber> => {
   const dayOfWeek = [
     "Sunday",
     "Monday",
@@ -77,6 +89,32 @@ export const JOURNAL_FIRST_DAY_OF_WEEK = (
   };
 };
 
+/**
+ * Constants / functions that produce constants for possible journal configurations.
+ * config entries that doesn't have limited choices have their values omitted.
+ * config entries that have specific choices have their choices predefined or generated.
+ */
+export const JOURNAL = {
+  DAILY_DOMAIN: {
+    label: "daily domain",
+    desc: "Domain where the journal notes are created",
+  },
+  NAME: {
+    label: "journal name",
+    desc: "Name used for journal notes",
+  },
+  DATE_FORMAT: {
+    label: "date format",
+    desc: "Date format used for journal notes",
+  },
+  ADD_BEHAVIOR,
+  FIRST_DAY_OF_WEEK,
+};
+
+/**
+ * Generates default {@link JournalConfig}
+ * @returns JouranlConfig
+ */
 export function genDefaultJournalConfig(): JournalConfig {
   return {
     dailyDomain: "daily",

--- a/packages/common-all/src/types/configs/workspace/journal.ts
+++ b/packages/common-all/src/types/configs/workspace/journal.ts
@@ -1,0 +1,88 @@
+import { DendronConfigEntry } from "../base";
+
+export enum NoteAddBehaviorEnum {
+  childOfDomain = "childOfDomain",
+  childOfDomainNamespace = "childOfDomainNamespace",
+  childOfCurrent = "childOfCurrent",
+  asOwnDomain = "asOwnDomain",
+}
+
+export type NoteAddBehavior = keyof typeof NoteAddBehaviorEnum;
+
+export type JournalConfig = {
+  dailyDomain: string;
+  dailyVault?: string;
+  name: string;
+  dateFormat: string;
+  addBehavior: NoteAddBehaviorEnum;
+  firstDayOfWeek: number;
+};
+
+export const JOURNAL_DAILY_DOMAIN: DendronConfigEntry<string> = {
+  label: "daily domain",
+  desc: "Domain where the journal notes are created",
+};
+
+export const JOURNAL_NAME: DendronConfigEntry<string> = {
+  label: "journal name",
+  desc: "Name used for journal notes",
+};
+
+export const JOURNAL_DATE_FORMAT: DendronConfigEntry<string> = {
+  label: "date format",
+  desc: "Date format used for journal notes",
+};
+
+export const JOURNAL_ADD_BEHAVIOR: {
+  [key: string]: DendronConfigEntry<string>;
+} = {
+  CHILD_OF_DOMAIN: {
+    value: "childOfDomain",
+    label: "child of domain",
+    desc: "Note is added as the child of domain of the current hierarchy",
+  },
+  CHILD_OF_DOMAIN_NAMESPACE: {
+    value: "childOfDomainNamespace",
+    label: "child of domain namespace",
+    desc: "Note is added as child of the namespace of the current domain if it has a namespace. Otherwise added as child of domain.",
+  },
+  CHILD_OF_CURRENT: {
+    value: "childOfCurrent",
+    label: "child of current",
+    desc: "Note is added as a child of the current open note",
+  },
+  AS_OWN_DOMAIN: {
+    value: "asOwnDomain",
+    label: "as own domain",
+    desc: "Note is created under the domain specified by journal name value",
+  },
+};
+
+export const JOURNAL_FIRST_DAY_OF_WEEK = (
+  value: number
+): DendronConfigEntry<number> => {
+  const dayOfWeek = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ];
+  const valueToDay = dayOfWeek[value];
+  return {
+    label: valueToDay,
+    desc: `Set start of the week to ${valueToDay}`,
+  };
+};
+
+export function genDefaultJournalConfig(): JournalConfig {
+  return {
+    dailyDomain: "daily",
+    name: "journal",
+    dateFormat: "y.MM.dd",
+    addBehavior: NoteAddBehaviorEnum.childOfDomain,
+    firstDayOfWeek: 1,
+  };
+}

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -1,0 +1,11 @@
+import { genDefaultJournalConfig, JournalConfig } from "./journal";
+
+export type DendronWorkspaceConfig = {
+  journal: JournalConfig;
+};
+
+export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
+  return {
+    journal: genDefaultJournalConfig(),
+  };
+}

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -1,7 +1,17 @@
-import { genDefaultJournalConfig, JournalConfig } from "./journal";
+import { genDefaultJournalConfig, JournalConfig, JOURNAL } from "./journal";
 
+/**
+ * Namespace for configurations that affect the workspace
+ */
 export type DendronWorkspaceConfig = {
   journal: JournalConfig;
+};
+
+/**
+ * Constants holding all workspace config related {@link DendronConfigEntry}
+ */
+export const WORKSPACE = {
+  JOURNAL,
 };
 
 export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {


### PR DESCRIPTION
# feat: consolidate dendron configs

This is a draft PR to showcase how the configurations will be organized.

## Overview


- `packages/common-all/src/types/configsdendronConfigs.ts` is where the top most level of configuration is defined.
  - As we go narrower with our namespace, we will define each namespace in a similar fashion.

- I have split up the code so that all each namespace is modularized.
  - Each namespace will define the following:
    - A type that holds all config of this namespace
      - These will be used internally, and in `dendron.yml`
    - A constant object that holds labels and descriptions of every instance of configs in this namespace
      - These are there to provide user friendly descriptions of the configs and will be used in the configuration UI
      - The value, label, and description is bundled up in the `DendronConfigEntry` type.
    - A method that returns a default config of this namespace
      - Each namespace defines this and the parent namespace will simply import and call it
    - Any other useful enum / type definitions related to the configs in the namespace

- Using `packages/common-all/src/types/configs/commands/lookup.ts` to illustrate the above points:
  - Everything here is related to configuring the lookup _command_, so it's under `DendronCommandConfig`.
  - What is defined in `LookupConfig` is what ends up in `dendron.yml`
  - Currently we let the users select what selection behavior should be for note lookup, and the possible choices are defined in `NoteLookupSelectionBehaviorEnum`, and in turn `NoteLookupSelectionBehavior` (which is generated from the enum's keys).
  - Constants in `SELECTION_BEHAVIORS` map the keys in `NoteLookupSelectionBehavior` to respective key's `DendronConfigEntry`s.
    - These will be used to generate useful messages about the lookup command configs in the configuration UI
    - If you introduce new behavior in `NoteLookupSelectionBehaviorEnum`, the compiler will catch this and warn you that you have to add a new label/description here as well. 
      - because `SELECTION_BEHAVIORS` has a type of 
        ```js
          { [key in NoteLookupSelectionBehavior]: DendronConfigEntry<string>}
        ```
  - `genDefaultLookupConfig` will define what the default `LookupConfig` should look like.
  - This will be called by it parent: `genDefaultCommandConfig`.

---

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated