### PR TITLE
fix: stop calendar from auto expanding when the last note is closed

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -595,6 +595,7 @@ export enum GraphViewMessageType {
 export enum CalendarViewMessageType {
   "onSelect" = "onSelect",
   "onGetActiveEditor" = "onGetActiveEditor",
+  "messageDispatcherReady" = "messageDispatcherReady",
 }
 
 export enum NoteViewMessageType {

--- a/packages/plugin-core/src/views/CalendarView.ts
+++ b/packages/plugin-core/src/views/CalendarView.ts
@@ -110,6 +110,10 @@ export class CalendarView implements vscode.WebviewViewProvider {
         this.onActiveTextEditorChangeHandler(); // initial call
         break;
       }
+      case CalendarViewMessageType.messageDispatcherReady:
+        // Exception was thrown on this event, hence including it in the case statement
+        // but as far as it seems there isn't much we need to do for Calendar to work.
+        break;
       default:
         assertUnreachable(msg.type);
         break;
@@ -142,7 +146,11 @@ export class CalendarView implements vscode.WebviewViewProvider {
 
   public refresh(note?: NoteProps) {
     if (this._view) {
-      this._view.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
+      // When the last note is closed the note will be undefined and we do not
+      // want to auto expand the calendar if there are no notes.
+      if (note) {
+        this._view.show?.(true);
+      }
       this._view.webview.postMessage({
         type: DMessageType.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
         data: {


### PR DESCRIPTION
### Summary
Calendar should not auto expand when the last note is closed.


[[1185-The calendar panel expands automatically when the last editor is closed|dendron.github.issues.1185-The calendar panel expands automatically when the last editor is closed]]

https://github.com/dendronhq/dendron/issues/1185


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
