### PR TITLE
fix: exclude private vault backlinks

### DIFF
--- a/packages/engine-server/src/markdown/remark/backlinks.ts
+++ b/packages/engine-server/src/markdown/remark/backlinks.ts
@@ -1,7 +1,8 @@
-import { DVaultVisibility, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { NoteUtils, VaultUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { Content, Root } from "mdast";
 import { list, listItem, paragraph } from "mdast-builder";
+import { SiteUtils } from "../../topics/site";
 import Unified, { Plugin } from "unified";
 import { Node } from "unist";
 import u from "unist-builder";
@@ -41,9 +42,24 @@ const plugin: Plugin = function (this: Unified.Processor) {
       const vaultName = backlink.from.vaultName!;
       const vault = VaultUtils.getVaultByName({
         vaults: engine.vaults,
-        vname: vaultName
+        vname: vaultName,
+      })!;
+      const note = NoteUtils.getNoteByFnameV5({
+        fname: backlink.from.fname!,
+        notes: engine.notes,
+        vault,
+        wsRoot: engine.wsRoot,
       });
-      return vault?.visibility !== DVaultVisibility.PRIVATE;
+
+      if (!note) {
+        return false;
+      }
+      const out = SiteUtils.canPublish({
+        note,
+        engine,
+        config: engine.config,
+      });
+      return out;
     });
 
     if (!_.isEmpty(backlinksToPublish)) {

--- a/test-workspace/vault2/secret.md
+++ b/test-workspace/vault2/secret.md
@@ -1,0 +1,9 @@
+---
+id: tG7Bj5kiO6UiJBVGipMkG
+title: Secret
+desc: ''
+updated: 1631003961643
+created: 1631003961643
+---
+
+[[dendron.ref.links]]

--- a/test-workspace/vault3/not-secret.md
+++ b/test-workspace/vault3/not-secret.md
@@ -1,0 +1,9 @@
+---
+id: Zq8Kz00hOPxCo4HdS5rdt
+title: Not Secret
+desc: ''
+updated: 1631003866830
+created: 1631003866830
+---
+
+[[dendron.ref.links]]


### PR DESCRIPTION
# fix: exclude private vault backlinks

This fixes issue with backlinks to private vault (`DVault` with visibility set to `private`) being generated when publishing.

Docs PR: N/A

---

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [~] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
