### PR TITLE
fix: direct children query

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -240,10 +240,14 @@ export class DNodeUtils {
   }
 
   static getDepth(node: DNodeProps): number {
-    if (node.fname === "root") {
+    return this.getFNameDepth(node.fname);
+  }
+
+  static getFNameDepth(fname: string) {
+    if (fname === "root") {
       return 0;
     }
-    return node.fname.split(".").length;
+    return fname.split(".").length;
   }
 
   static getDomain(
@@ -504,7 +508,7 @@ export class NoteUtils {
       mode: "snippet" | "title" | "value" | "none";
       value?: string;
       tabStopIndex?: number;
-    }
+    };
     useVaultPrefix?: boolean;
   }): string {
     const { note, anchor, useVaultPrefix, alias } = opts;
@@ -527,16 +531,16 @@ export class NoteUtils {
     const vaultPrefix = useVaultPrefix
       ? `${CONSTANTS.DENDRON_DELIMETER}${VaultUtils.getName(vault)}/`
       : "";
-    
+
     let aliasPrefix = "";
 
-    switch(aliasMode) {
+    switch (aliasMode) {
       case "snippet": {
         aliasPrefix = `\${${tabStopIndex}:alias}|`;
         break;
       }
       case "title": {
-        aliasPrefix = `${title}|`
+        aliasPrefix = `${title}|`;
         break;
       }
       case "value": {

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -23,6 +23,11 @@ export type NoteIndexProps = {
   stub?: boolean;
 };
 
+/** https://fusejs.io/examples.html#extended-search */
+const FuseExtendedSearchConstants = {
+  PrefixExactMatch: "^",
+};
+
 /**
  * Experimentally set.
  *
@@ -133,10 +138,18 @@ export class FuseEngine {
   /**
    * If qs = "", return root note
    * @param qs query string.
+   * @param onlyDirectChildren query for direct children only.
    * @returns
    */
-  queryNote({ qs }: { qs: string }): NoteIndexProps[] {
+  queryNote({
+    qs,
+    onlyDirectChildren,
+  }: {
+    qs: string;
+    onlyDirectChildren?: boolean;
+  }): NoteIndexProps[] {
     let items: NoteIndexProps[];
+
     if (qs === "") {
       const results = this.notesIndex.search("root");
       items = _.map(
@@ -147,12 +160,18 @@ export class FuseEngine {
       // @ts-ignore
       items = this.notesIndex._docs as NoteProps[];
     } else {
-      const fuseQueryString = FuseEngine.formatQueryForFuse({
+      const formattedQS = FuseEngine.formatQueryForFuse({
         qs,
+        onlyDirectChildren,
       });
-      let results = this.notesIndex.search(fuseQueryString);
 
-      results = this.postQueryFilter(results, fuseQueryString);
+      let results = this.notesIndex.search(formattedQS);
+
+      results = this.postQueryFilter({
+        results,
+        queryString: formattedQS,
+        onlyDirectChildren,
+      });
 
       results = FuseEngine.sortMatchingScores(results);
 
@@ -219,20 +238,34 @@ export class FuseEngine {
     });
   }
 
-  /**
-   * Fuse does not appear to see [*] as anything special.
-   * For example:
-   * `dev*vs` matches `dendron.dev.ref.vscode` with score of 0.5
-   *
-   * To compare with
-   * `dev vs` matches `dendron.dev.ref.vscode` with score of 0.001
-   *
-   * Fuse extended search https://fusejs.io/examples.html#extended-search
-   * uses spaces for AND and '|' for OR hence this function will replace '*' with spaces.
-   * We do this replacement since VSCode quick pick actually appears to respect '*'.
-   * */
-  static formatQueryForFuse({ qs }: { qs: string }): string {
-    return qs.split("*").join(" ");
+  static formatQueryForFuse({
+    qs,
+    onlyDirectChildren,
+  }: {
+    qs: string;
+    onlyDirectChildren?: boolean;
+  }): string {
+    // Fuse does not appear to see [*] as anything special.
+    // For example:
+    // `dev*vs` matches `dendron.dev.ref.vscode` with score of 0.5
+    //
+    // To compare with
+    // `dev vs` matches `dendron.dev.ref.vscode` with score of 0.001
+    //
+    // Fuse extended search https://fusejs.io/examples.html#extended-search
+    // uses spaces for AND and '|' for OR hence this function will replace '*' with spaces.
+    // We do this replacement since VSCode quick pick actually appears to respect '*'.
+    let result = qs.split("*").join(" ");
+
+    // When querying for direct children the prefix should match exactly.
+    if (
+      onlyDirectChildren &&
+      !result.startsWith(FuseExtendedSearchConstants.PrefixExactMatch)
+    ) {
+      result = FuseExtendedSearchConstants.PrefixExactMatch + result;
+    }
+
+    return result;
   }
 
   /**
@@ -273,10 +306,15 @@ export class FuseEngine {
     return scores.map((score) => groupedByScore[score.key]).flat();
   }
 
-  private postQueryFilter(
-    results: Fuse.FuseResult<NoteIndexProps>[],
-    queryString: string
-  ) {
+  private postQueryFilter({
+    results,
+    queryString,
+    onlyDirectChildren,
+  }: {
+    results: Fuse.FuseResult<NoteIndexProps>[];
+    queryString: string;
+    onlyDirectChildren?: boolean;
+  }) {
     // Filter by threshold due to what appears to be a FuseJS bug
     results = this.filterByThreshold(results);
 
@@ -287,12 +325,21 @@ export class FuseEngine {
     // matches
     // 'user.nickolay.journal.2021.09.02'
     // with a super low score of '0.03' but we don't want to display all the journal
-    // dates with the same length, whenever the length of our query is equal or more than
-    // the query results, we want to create a new note, not show those results.
+    // dates with the same length. Hence whenever the length of our query is equal
+    // or longer than the query results, we want to create a new note, not show those results.
     results = results.filter(
       (r) =>
         r.item.fname.length > queryString.length || r.item.fname === queryString
     );
+
+    if (onlyDirectChildren) {
+      const depth = queryString.split(".").length;
+      results = results
+        .filter((ent) => {
+          return DNodeUtils.getFNameDepth(ent.item.fname) === depth;
+        })
+        .filter((ent) => !ent.item.stub);
+    }
 
     return results;
   }
@@ -340,18 +387,12 @@ export class NoteLookupUtils {
     if (_.isEmpty(qsClean)) {
       return NoteLookupUtils.fetchRootResults(notes);
     }
-    const resp = await engine.queryNotes({ qs });
-    let nodes: NoteProps[];
-    if (showDirectChildrenOnly) {
-      const depth = qs.split(".").length;
-      nodes = resp.data
-        .filter((ent) => {
-          return DNodeUtils.getDepth(ent) === depth;
-        })
-        .filter((ent) => !ent.stub);
-    } else {
-      nodes = resp.data;
-    }
+    const resp = await engine.queryNotes({
+      qs,
+      onlyDirectChildren: showDirectChildrenOnly,
+    });
+    let nodes = resp.data;
+
     if (nodes.length > PAGINATE_LIMIT) {
       nodes = nodes.slice(0, PAGINATE_LIMIT);
     }

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -415,6 +415,7 @@ export type GetNotePayload = {
 };
 export type QueryNotesOpts = {
   qs: string;
+  onlyDirectChildren?: boolean;
   vault?: DVault;
   createIfNew?: boolean;
 };

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -237,8 +237,11 @@ export class DendronEngineClient implements DEngineClient {
   async queryNote(
     opts: Parameters<DEngineClient["queryNotes"]>[0]
   ): Promise<NoteProps[]> {
-    const { qs, vault } = opts;
-    let noteIndexProps = await this.fuseEngine.queryNote({ qs });
+    const { qs, onlyDirectChildren, vault } = opts;
+    let noteIndexProps = await this.fuseEngine.queryNote({
+      qs,
+      onlyDirectChildren,
+    });
     // TODO: hack
     if (!_.isUndefined(vault)) {
       noteIndexProps = noteIndexProps.filter((ent) =>

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -442,8 +442,9 @@ export class DendronEngineV2 implements DEngine {
     opts: QueryNotesOpts
   ): ReturnType<DEngineClient["queryNotes"]> {
     const ctx = "Engine:queryNotes";
-    const { qs, vault, createIfNew } = opts;
-    let items = await this.fuseEngine.queryNote({ qs });
+    const { qs, vault, createIfNew, onlyDirectChildren } = opts;
+
+    let items = await this.fuseEngine.queryNote({ qs, onlyDirectChildren });
     let item = this.notes[items[0].id];
     if (createIfNew) {
       let noteNew: NoteProps;

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -9,6 +9,7 @@ import Fuse from "fuse.js";
 type TestData = {
   fname: string;
   updated: number;
+  stub?: boolean;
 };
 
 async function testDataToNotePropsDict(
@@ -24,6 +25,7 @@ async function testDataToNotePropsDict(
       noWrite: true,
     });
 
+    note.stub = td.stub;
     note.updated = td.updated;
 
     dict[note.id] = note;
@@ -51,17 +53,21 @@ async function initializeFuseEngine(testData: TestData[]): Promise<FuseEngine> {
   return fuseEngine;
 }
 
-const queryTestV1 = (opts: {
+const queryTestV1 = ({
+  fuseEngine,
+  qs,
+  expectedFNames,
+}: {
   fuseEngine: FuseEngine;
   qs: string;
   expectedFNames: string[];
 }) => {
-  const notes = opts.fuseEngine.queryNote({ qs: opts.qs });
+  const notes = fuseEngine.queryNote({ qs });
 
-  opts.expectedFNames.forEach((expectedFname) => {
+  expectedFNames.forEach((expectedFname) => {
     const wasFound = notes.some((n) => n.fname === expectedFname);
     if (!wasFound) {
-      fail(`Did not find '${expectedFname}' when querying for '${opts.qs}'`);
+      fail(`Did not find '${expectedFname}' when querying for '${qs}'`);
     }
   });
 };
@@ -77,6 +83,23 @@ describe("Fuse utility function tests", () => {
         expect(FuseEngine.formatQueryForFuse({ qs: input })).toEqual(expected);
       }
     );
+
+    describe(`GIVEN that onlyDirectChildren is set`, () => {
+      test.each([
+        ["dev.vs.", "^dev.vs."],
+        ["^dev.vs.", "^dev.vs."],
+      ])(
+        'WHEN input="%s" THEN output is "%s"',
+        (input: string, expected: string) => {
+          expect(
+            FuseEngine.formatQueryForFuse({
+              qs: input,
+              onlyDirectChildren: true,
+            })
+          ).toEqual(expected);
+        }
+      );
+    });
   });
 
   describe("sortMatchingScores", () => {
@@ -282,34 +305,65 @@ describe("FuseEngine tests with extracted data.", () => {
 
     let fuseEngine: FuseEngine;
     beforeAll(async () => {
-      fuseEngine = await initializeFuseEngine(DATA_FILES_WITH_DEV);
+      fuseEngine = await initializeFuseEngine(
+        DATA_FILES_WITH_DEV.concat({
+          fname: "dendron.dev.i-am-a-stub",
+          updated: 1,
+          stub: true,
+        })
+      );
     });
 
-    test.each([
-      [
-        "dev*vs",
-        ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
-      ],
-      [
-        "dev vs",
-        ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
-      ],
-      [
-        "vs dev",
-        ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
-      ],
-      ["devapi", ["dendron.dev.api", "dendron.dev.api.seeds"]],
-      ["dendron rename", ["dendron.dev.design.commands.rename"]],
-      ["rename dendron", ["dendron.dev.design.commands.rename"]],
-    ])(
-      "WHEN query for '%s' THEN results to contain %s",
-      (qs: string, expectedFNames: string[]) => {
-        queryTestV1({
-          fuseEngine,
-          qs: qs,
-          expectedFNames: expectedFNames,
+    describe(`AND using default query parameters`, () => {
+      test.each([
+        [
+          "dev*vs",
+          ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
+        ],
+        [
+          "dev vs",
+          ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
+        ],
+        [
+          "vs dev",
+          ["dendron.dev.design.files-vs-folders", "dendron.dev.ref.vscode"],
+        ],
+        ["devapi", ["dendron.dev.api", "dendron.dev.api.seeds"]],
+        ["dendron rename", ["dendron.dev.design.commands.rename"]],
+        ["rename dendron", ["dendron.dev.design.commands.rename"]],
+      ])(
+        "WHEN query for '%s' THEN results to contain %s",
+        (qs: string, expectedFNames: string[]) => {
+          queryTestV1({
+            fuseEngine,
+            qs: qs,
+            expectedFNames: expectedFNames,
+          });
+        }
+      );
+    });
+
+    describe(`WHEN querying for 'dendron.dev' AND onlyDirectChildren is set.'`, () => {
+      let notes: NoteIndexProps[];
+
+      beforeEach(() => {
+        notes = fuseEngine.queryNote({
+          qs: "dendron.dev.",
+          onlyDirectChildren: true,
         });
-      }
-    );
+      });
+
+      it(`THEN match direct child 'dendron.dev.design'`, () => {
+        assertHasFName(notes, "dendron.dev.design");
+      });
+
+      it(`THEN do NOT match grandchild 'dendron.dev.design.commands'`, () => {
+        assertDoesNotHaveFName(notes, "dendron.dev.design.commands");
+      });
+
+      it(`THEN do NOT match stub child 'dendron.dev.i-am-a-stub'`, () => {
+        assertDoesNotHaveFName(notes, "dendron.dev.i-am-a-stub");
+      });
+    });
   });
 });

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -259,9 +259,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       updatedItems = await NotePickerUtils.fetchPickerResults({
         picker,
         qs: querystring,
-        depth: picker.showDirectChildrenOnly
-          ? queryOrig.split(".").length
-          : undefined,
+        onlyDirectChildren: picker.showDirectChildrenOnly,
       });
       if (token.isCancellationRequested) {
         return;

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -770,25 +770,18 @@ export class NotePickerUtils {
   static async fetchPickerResults(opts: {
     picker: DendronQuickPickerV2;
     qs: string;
-    depth?: number;
+    onlyDirectChildren?: boolean;
   }) {
     const ctx = "createPickerItemsFromEngine";
     const start = process.hrtime();
-    const { picker, qs } = opts;
+    const { picker, qs, onlyDirectChildren } = opts;
     const { engine, wsRoot, vaults } = getDWorkspace();
-    let nodes: NoteProps[];
     // if we are doing a query, reset pagination options
     PickerUtilsV2.resetPaginationOpts(picker);
-    const resp = await engine.queryNotes({ qs });
-    if (opts.depth) {
-      nodes = resp.data
-        .filter((ent) => {
-          return DNodeUtils.getDepth(ent) === opts.depth!;
-        })
-        .filter((ent) => !ent.stub);
-    } else {
-      nodes = resp.data;
-    }
+
+    const resp = await engine.queryNotes({ qs, onlyDirectChildren });
+    let nodes: NoteProps[] = resp.data;
+
     Logger.info({ ctx, msg: "post:queryNotes" });
     if (nodes.length > PAGINATE_LIMIT) {
       picker.allResults = nodes;


### PR DESCRIPTION
# fix: direct children query
Fix direct children query to only display direct children. 

# Descrption
The fix is to primarily conditionally add '^' prefix to the query, but also centralizes the depth filtering. 

# Pull Request Checklist
## Tests added
```
 Fuse utility function tests
    formatQueryForFuse
      GIVEN that onlyDirectChildren is set
        ✓ WHEN input="dev.vs." THEN output is "^dev.vs." (1ms)
        ✓ WHEN input="^dev.vs." THEN output is "^dev.vs."
        
GIVEN engine with notes containing "dev" extracted from dendron.dendron-site/vault
      WHEN querying for 'dendron.dev' AND onlyDirectChildren is set.'
        ✓ THEN match direct child 'dendron.dev.design' (1ms)
        ✓ THEN do NOT match grandchild 'dendron.dev.design.commands'
        ✓ THEN do NOT match stub child 'dendron.dev.i-am-a-stub' (1ms)
```

## Dendron File
![[scratch.2021.09.05.210359.new-lookup-direct-child-filter-will-show-results-that-are-not-direct-children]]

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

