### PR TITLE
fix: highlight same file wikilinks, wildcard references, links with anchors

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -81,7 +81,7 @@ suite("windowDecorations", function () {
         },
         onInit: async ({ vaults, engine, wsRoot }) => {
           const note = NoteUtils.getNoteByFnameV5({
-            fname: "bar",
+            fname: FNAME,
             notes: engine.notes,
             vault: vaults[0],
             wsRoot,
@@ -161,6 +161,125 @@ suite("windowDecorations", function () {
           ).toBeTruthy();
           expect(
             isTextDecorated("#foo", brokenWikilinkDecorations!, document)
+          ).toBeTruthy();
+
+          done();
+        },
+      });
+    });
+
+    test("highlighting same file wikilinks", (done) => {
+      const FNAME = "bar";
+
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ vaults, wsRoot }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: FNAME,
+            body: [
+              "Ut incidunt id commodi. ^anchor-1",
+              "",
+              "[[#^anchor-1]]",
+              "[[#^anchor-not-exists]]",
+              "![[#^anchor-1]]",
+              "![[#^anchor-not-exists]]",
+              "![[#^anchor-1:#*]]",
+              "![[#^anchor-not-exists]]",
+            ].join("\n"),
+            vault: vaults[0],
+            wsRoot,
+          });
+        },
+        onInit: async ({ vaults, engine, wsRoot }) => {
+          const note = NoteUtils.getNoteByFnameV5({
+            fname: FNAME,
+            notes: engine.notes,
+            vault: vaults[0],
+            wsRoot,
+          });
+          const editor = await VSCodeUtils.openNote(note!);
+          const document = editor.document;
+          const { allDecorations } = updateDecorations(editor);
+
+          const wikilinkDecorations = allDecorations!.get(
+            DECORATION_TYPE.wikiLink
+          );
+          expect(wikilinkDecorations.length).toEqual(3);
+          expect(
+            isTextDecorated("[[#^anchor-1]]", wikilinkDecorations!, document)
+          ).toBeTruthy();
+          expect(
+            isTextDecorated("![[#^anchor-1]]", wikilinkDecorations!, document)
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "![[#^anchor-1:#*]]",
+              wikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+
+          const brokenWikilinkDecorations = allDecorations!.get(
+            DECORATION_TYPE.brokenWikilink
+          );
+          expect(brokenWikilinkDecorations.length).toEqual(3);
+          expect(
+            isTextDecorated(
+              "[[#^anchor-not-exists]]",
+              brokenWikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "![[#^anchor-not-exists]]",
+              brokenWikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "![[#^anchor-not-exists]]",
+              brokenWikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+
+          done();
+        },
+      });
+    });
+
+    test("highlighting wildcard references", (done) => {
+      const FNAME = "bar";
+
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ vaults, wsRoot }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: FNAME,
+            body: ["![[foo.bar.*]]"].join("\n"),
+            vault: vaults[0],
+            wsRoot,
+          });
+        },
+        onInit: async ({ vaults, engine, wsRoot }) => {
+          const note = NoteUtils.getNoteByFnameV5({
+            fname: FNAME,
+            notes: engine.notes,
+            vault: vaults[0],
+            wsRoot,
+          });
+          const editor = await VSCodeUtils.openNote(note!);
+          const document = editor.document;
+          const { allDecorations } = updateDecorations(editor);
+
+          const wikilinkDecorations = allDecorations!.get(
+            DECORATION_TYPE.wikiLink
+          );
+          expect(wikilinkDecorations.length).toEqual(1);
+          expect(
+            isTextDecorated("![[foo.bar.*]]", wikilinkDecorations!, document)
           ).toBeTruthy();
 
           done();


### PR DESCRIPTION
Same file wikilinks and references (`[[#foo]]`) and wildcard references (`![[foo.*]]`) are now highlighted as correct links (although no checks are performed for wildcard references).

Wikilinks and references with anchors (`[[note#foo]]` or `![[note#foo:#bar]]`) are now highlighted as broken if the anchor is broken (for example, `note` has no header `# foo`).


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated