### PR TITLE
enhance: conditionally bubble up create new & allow queries longer than fname when special chars are used.

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -97,6 +97,24 @@ type FuseEngineOpts = {
 };
 
 export class FuseEngine {
+  /**
+   * Characters that are specially treated by FuseJS search
+   * Reference https://fusejs.io/examples.html#extended-search
+   *
+   * Includes '*' which is not specially treated by FuseJS but we currently
+   * map '*' to ' ' which specially treated by FuseJS.
+   */
+  private static readonly SPECIAL_QUERY_CHARACTERS = [
+    "*",
+    " ",
+    "|",
+    "^",
+    "$",
+    "!",
+    "=",
+    "'",
+  ];
+
   public notesIndex: Fuse<NoteIndexProps>;
   public schemaIndex: Fuse<SchemaProps>;
 
@@ -318,19 +336,28 @@ export class FuseEngine {
     // Filter by threshold due to what appears to be a FuseJS bug
     results = this.filterByThreshold(results);
 
-    // Filter out matches that are same length as query string but are not exact.
-    //
-    // For example
-    // 'user.nickolay.journal.2021.09.03'
-    // matches
-    // 'user.nickolay.journal.2021.09.02'
-    // with a super low score of '0.03' but we don't want to display all the journal
-    // dates with the same length. Hence whenever the length of our query is equal
-    // or longer than the query results, we want to create a new note, not show those results.
-    results = results.filter(
-      (r) =>
-        r.item.fname.length > queryString.length || r.item.fname === queryString
-    );
+    if (!FuseEngine.doesContainSpecialQueryChars(queryString)) {
+      // When we use query language operators this filtering does not apply
+      // since we can query the entry with a much longer query than file name length.
+      // For example query fname="hi-world" with query="^hi world$ !bye".
+      //
+      // For cases of simple file names (do not contain special query chars):
+      // Filter out matches that are same length or less as query string but
+      // are not exact.
+      //
+      // For example
+      // 'user.nickolay.journal.2021.09.03'
+      // matches
+      // 'user.nickolay.journal.2021.09.02'
+      // with a super low score of '0.03' but we don't want to display all the journal
+      // dates with the same length. Hence whenever the length of our query is equal
+      // or longer than the query results, we want to create a new note, not show those results.
+      results = results.filter(
+        (r) =>
+          r.item.fname.length > queryString.length ||
+          r.item.fname === queryString
+      );
+    }
 
     if (onlyDirectChildren) {
       const depth = queryString.split(".").length;
@@ -342,6 +369,13 @@ export class FuseEngine {
     }
 
     return results;
+  }
+
+  /**
+   * Returns true when string contains characters that FuseJS treats as special characters.
+   * */
+  static doesContainSpecialQueryChars(str: string) {
+    return this.SPECIAL_QUERY_CHARACTERS.some((char) => str.includes(char));
   }
 }
 

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -73,6 +73,30 @@ const queryTestV1 = ({
 };
 
 describe("Fuse utility function tests", () => {
+  describe(`doesContainSpecialQueryChars`, () => {
+    test.each([
+      // Fuse doesn't treat * specially but we map * to ' ' hence we treat it as special character.
+      ["dev*ts", true],
+      ["dev vs", true],
+      ["^vs", true],
+      ["vs$", true],
+      ["vs$", true],
+      ["dev|vs", true],
+      ["!vs", true],
+      ["=vs", true],
+      ["'vs", true],
+      ["dev-vs", false],
+      ["dev_vs", false],
+    ])(
+      `WHEN input="%s" THEN result is expected to be %s`,
+      (input: string, expected: boolean) => {
+        expect(FuseEngine.doesContainSpecialQueryChars(input)).toEqual(
+          expected
+        );
+      }
+    );
+  });
+
   describe("formatQueryForFuse", () => {
     test.each([
       ["dev*vs", "dev vs"],
@@ -331,6 +355,30 @@ describe("FuseEngine tests with extracted data.", () => {
         ["devapi", ["dendron.dev.api", "dendron.dev.api.seeds"]],
         ["dendron rename", ["dendron.dev.design.commands.rename"]],
         ["rename dendron", ["dendron.dev.design.commands.rename"]],
+        [
+          "dendron.dev design.commands.rename",
+          ["dendron.dev.design.commands.rename"],
+        ],
+        [
+          "^dendron.dev.design.commands.rename",
+          ["dendron.dev.design.commands.rename"],
+        ],
+        [
+          "dendron.dev.design.commands.rename$",
+          ["dendron.dev.design.commands.rename"],
+        ],
+        [
+          "=dendron.dev.design.commands.rename",
+          ["dendron.dev.design.commands.rename"],
+        ],
+        [
+          "dendron.dev.design.commands.rename !git",
+          ["dendron.dev.design.commands.rename"],
+        ],
+        [
+          "'dendron.dev.design 'commands.rename",
+          ["dendron.dev.design.commands.rename"],
+        ],
       ])(
         "WHEN query for '%s' THEN results to contain %s",
         (qs: string, expectedFNames: string[]) => {

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -66,6 +66,23 @@ export const setupJournals: PreSetupHookFunction = async ({
   );
 };
 
+// Workspace will look like:
+// .
+// ├── dendron.code-workspace
+// ├── dendron.yml
+// ├── vault1
+// │   ├── foo.ch1.md
+// │   ├── foo.md
+// │   ├── foo.schema.yml
+// │   ├── root.md
+// │   └── root.schema.yml
+// ├── vault2
+// │   ├── bar.md
+// │   ├── root.md
+// │   └── root.schema.yml
+// └── vault3
+//     ├── root.md
+//     └── root.schema.yml
 export const setupBasicMulti: PreSetupHookFunction = async ({
   vaults,
   wsRoot,


### PR DESCRIPTION


<img width="723" alt="Screen Shot 2021-09-08 at 5 50 10 PM" src="https://user-images.githubusercontent.com/4050134/132503935-5016512e-3e69-4de7-94e8-9da91e7ffaff.png">

# Conditionally bubble up create new and allow longer queries than file name searched when special chars are used.
When special characters are not used bubble up create new entry, and allow queries that are longer than file names searched when special characters are used. For this change allows 'hi world !bye' to match 'hi.world'

# Addresses
* [[ scratch.2021.09.08.121701.lookup-bubble-up-create-new-when-no-exact-match-and-no-special-characters]]
* [[scratch.2021.09.07.213159.improve-look-up-do-not-count-special-chars-for-hiding-results]]

# Note 
As mentioned in the comments our current & previous behavior allows creation of notes that can be confusing for FuseJS to look up. For example we can create a note 'hi$world' but if we query for just dollar sign '$' FuseJS will not look up 'hi$world' since '$' will be treated as special character according to https://fusejs.io/examples.html#extended-search rules. 'hi$world' can still be matched by 'hi world'. Given that we don't know if our users have such characters in their files not disabling creation of such files in this PR but it is something for us to think about. 

# Pull Request Checklist

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
