### PR TITLE
fix: correctly render cross-vault note references in preview v2

### DIFF
--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -18,7 +18,7 @@ import mermaid from "@dendronhq/remark-mermaid";
 import rehypePrism from "@mapbox/rehype-prism";
 import _ from "lodash";
 import { Heading } from "mdast";
-import { paragraph, root, text } from "mdast-builder";
+import { blockquote, paragraph, root, text } from "mdast-builder";
 import nunjucks from "nunjucks";
 import path from "path";
 import link from "rehype-autolink-headings";
@@ -207,6 +207,10 @@ export class MDUtilsV4 {
 
   static genMDMsg(msg: string): Parent {
     return root(paragraph(text(msg)));
+  }
+
+  static genMDErrorMsg(msg: string): Parent {
+    return root(blockquote(text(msg)));
   }
 
   static getDendronData(proc: Processor) {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -270,6 +270,32 @@ VFile {
 }
 `;
 
+exports[`dendronPub note reference ok: ambiguous but duplicateNoteBehavior set 1`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Dupe</span></div>
+<a href=\\"dupe.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>dupe in vault1
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`dendronPub note reference ok: wildcard 1`] = `
 VFile {
   "contents": "# Ref

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -158,6 +158,246 @@ VFile {
 }
 `;
 
+exports[`dendronPub note reference assume vault 1`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
+<a href=\\"foo.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>foo in vault2
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference basic 1`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
+<a href=\\"foo.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference fail: ambiguous 1`] = `
+VFile {
+  "contents": "# Ref
+
+> Error rendering note reference. There are multiple notes with the name dupe. Please specify the vault prefix.
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference fail: wildcard no match 1`] = `
+VFile {
+  "contents": "# Ref
+
+> Error rendering note reference. There are no matches for /\`baz./*/\`.
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference fail: with vault prefix 1`] = `
+VFile {
+  "contents": "# Ref
+
+> Error rendering note reference for bar
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference nonexistent 1`] = `
+VFile {
+  "contents": "# Ref
+
+> Error rendering note reference. No note found with name bar
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference ok: wildcard 1`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">One</span></div>
+<a href=\\"bar.one.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>bar one
+
+
+</div></div><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Two</span></div>
+<a href=\\"bar.two.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>bar two
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference ok: wildcard 2`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">One</span></div>
+<a href=\\"bar.one.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>bar one
+
+
+</div></div><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Two</span></div>
+<a href=\\"bar.two.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>bar two
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference ok: with vault prefix 1`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
+<a href=\\"foo.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>foo in vault2
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub note reference ok: with vault prefix 2`] = `
+VFile {
+  "contents": "# Ref
+
+<div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\" >
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Foo</span></div>
+<a href=\\"foo.html\\" class=\\"portal-arrow\\">Go to text <span class=\\"right-arrow\\">→</span></a>
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div>foo in vault2
+
+
+</div></div>
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`dendronPub prefix imagePrefix 1`] = `
 VFile {
   "contents": "# Foo

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -184,7 +184,7 @@ describe("dendronPub", () => {
     });
   });
 
-  describe.only("note reference", () => {
+  describe("note reference", () => {
     test("basic", async () => {
       await runEngineTestV5(
         async ({ engine, vaults }) => {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -425,9 +425,50 @@ describe("dendronPub", () => {
       );
     });
 
+    test("ok: ambiguous but duplicateNoteBehavior set", async () => {
+      await runEngineTestV5(
+        async ({ engine, vaults }) => {
+          const out = await proc(engine, {
+            fname: "ref",
+            dest: DendronASTDest.HTML,
+            vault: vaults[0],
+            config: engine.config,
+          }).process("![[dupe]]");
+          const dupNoteVaultPayload = engine.config.site.duplicateNoteBehavior
+            ?.payload as string[];
+          await checkVFile(out, `dupe in ${dupNoteVaultPayload[0]}`);
+        },
+        {
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              fname: "ref",
+              wsRoot,
+              vault: vaults[0],
+            });
+            await NoteTestUtilsV4.createNote({
+              fname: "dupe",
+              genRandomId: true,
+              body: "dupe in vault1",
+              wsRoot,
+              vault: vaults[0],
+            });
+            await NoteTestUtilsV4.createNote({
+              fname: "dupe",
+              genRandomId: true,
+              body: "dupe in vault2",
+              wsRoot,
+              vault: vaults[1],
+            });
+          },
+          expect,
+        }
+      );
+    });
+
     test("fail: ambiguous", async () => {
       await runEngineTestV5(
         async ({ engine, vaults }) => {
+          delete engine.config.site["duplicateNoteBehavior"];
           const out = await proc(engine, {
             fname: "ref",
             dest: DendronASTDest.HTML,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -472,6 +472,7 @@ describe("dendronPub", () => {
           const out = await proc(engine, {
             fname: "ref",
             dest: DendronASTDest.HTML,
+            shouldApplyPublishRules: true,
             vault: vaults[0],
             config: engine.config,
           }).process("![[dupe]]");

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1630474118518
+updated: 1631101424735
 created: 1608518909864
 ---
 
@@ -65,3 +65,17 @@ Vault2
    1.  second-a ^AKRCeAVwwIX2
 
 ![[#^0NFOQ4Hi4frn:#^0NFOQ4Hi4frn]]
+
+## note reference error messages
+
+### no file
+
+![[void]]
+
+### wildcard no match
+
+![[void.*]]
+
+### ambiguous
+
+![[bar]]


### PR DESCRIPTION
# fix: correctly render cross-vault note references in preview v2
This fixes note ref rendering in preview v2 and publishing so that cross-vault note references without an explicit vault prefix still gets rendered if there is no ambiguity.

- Assume vault of cross-vault note references if there is no vault prefix and only one note with the same name exists.
- Render an error message if there is ambiguity (if `vault1` and `vault2` has the same note `bar`, `![[bar]]` will show an error.
  - This will first attempt to handle duplicates if `duplicateNoteBehavior` is set.
- Render an error message if a wildcard note reference has no match.
- Render note reference related error messages in a block quote to make it more visible.

docs: N/A
---

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [x] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

