### PR TITLE
Updated OpenLink.ts

### DIFF
--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -46,7 +46,6 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
       this.L.error({ error });
       return { error };
     }
-
     let assetPath: string;
     if (text.indexOf("://") !== -1) {
       window.showInformationMessage(
@@ -80,6 +79,6 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
         return { error };
       });
     }
-    return { String: assetPath };
+    return { filepath: assetPath };
   }
 }

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -40,11 +40,15 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
       return { error };
     }
     let assetPath: string;
-    if (text.indexOf("://") !== -1) {
+    if (
+      text.indexOf(":/") !== -1 ||
+      text.indexOf("/") === 0 ||
+      text.indexOf(":\\") !== -1
+    ) {
       window.showInformationMessage(
-        "the selection reads as a full URI so an attempt will be made to open it"
+        "the selection reads as a full URI or filepath so an attempt will be made to open it"
       );
-      env.openExternal(Uri.parse(text));
+      env.openExternal(Uri.parse(text.replace("\\", "/"))); // make sure vscode doesn't choke on "\"s
       assetPath = text;
     } else {
       const wsRoot = getDWorkspace().wsRoot;

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -10,12 +10,13 @@ import { resolvePath, VSCodeUtils } from "../utils";
 import { isAnythingSelected } from "../utils/editor";
 import { getExtension, getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
+import { Selection, env, Uri, window } from "vscode";
 
 type CommandOpts = {};
 
 type CommandInput = {};
 
-type CommandOutput = { error?: DendronError; fsPath?: string };
+type CommandOutput = { error?: DendronError; fsPath?: string } | null;
 
 export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.OPEN_LINK.key;
@@ -25,47 +26,107 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   async execute() {
     const ctx = DENDRON_COMMANDS.OPEN_LINK;
     this.L.info({ ctx });
+
+    let text = "";
+
     if (!isAnythingSelected()) {
+      window.showInformationMessage(
+        "nothing selected, searching for valid link"
+      );
+    }
+
+    const editor = VSCodeUtils.getActiveTextEditor();
+
+    if (editor) {
+      const docText = editor.document.getText();
+      const offsetStart = editor.document.offsetAt(editor.selection.start);
+      const offsetEnd = editor.document.offsetAt(editor.selection.end);
+
+      const selectUri = true;
+      const validUriChars = "A-Za-z0-9-._~:/?#@!$&'*+,;%=";
+      const invalidUriChars = ["[^", validUriChars, "]"].join("");
+      const regex = new RegExp(invalidUriChars);
+
+      const selectedText = docText.substring(offsetStart, offsetEnd);
+
+      if (selectedText !== "" && regex.test(selectedText)) {
+        const error = DendronError.createFromStatus({
+          status: ERROR_STATUS.INVALID_STATE,
+          message: `invalid character found in selection`,
+        });
+        this.L.error({ error });
+        return { error };
+      }
+
+      const leftSplit = docText.substring(0, offsetStart).split(regex);
+      const leftText = leftSplit[leftSplit.length - 1];
+      const selectStart = offsetStart - leftText.length;
+
+      const rightSplit = docText.substring(offsetEnd, docText.length - 1);
+      const rightText = rightSplit.substring(0, regex.exec(rightSplit)?.index);
+      const selectEnd = offsetEnd + rightText.length;
+
+      if (selectEnd && selectStart) {
+        if (
+          selectStart >= 0 &&
+          selectStart < selectEnd &&
+          selectEnd <= docText.length - 1
+        ) {
+          if (selectUri) {
+            editor.selection = new Selection(
+              editor.document.positionAt(selectStart),
+              editor.document.positionAt(selectEnd)
+            );
+            editor.revealRange(editor.selection);
+          }
+          text = [leftText, rightText].join("");
+        }
+      }
+    }
+
+    if (_.isUndefined(text) || text === "") {
       const error = DendronError.createFromStatus({
         status: ERROR_STATUS.INVALID_STATE,
-        message: `nothing selected`,
+        message: `no valid path or URL selected`,
       });
       this.L.error({ error });
       return { error };
     }
-    const { text } = VSCodeUtils.getSelection();
-    if (_.isUndefined(text)) {
-      const error = DendronError.createFromStatus({
-        status: ERROR_STATUS.INVALID_STATE,
-        message: `nothing selected`,
-      });
-      this.L.error({ error });
-      return { error };
-    }
-    const wsRoot = getDWorkspace().wsRoot;
-    let assetPath: string;
-    if (text.startsWith("asset")) {
-      const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-      assetPath = path.join(vault2Path({ vault, wsRoot }), text);
+
+    if (text.indexOf("://") !== -1) {
+      window.showInformationMessage(
+        "the selection reads as a full URI so an attempt will be made to open it"
+      );
+      env.openExternal(Uri.parse(text));
+      return;
     } else {
-      assetPath = resolvePath(text, getExtension().rootWorkspace.uri.fsPath);
-    }
-    if (!fs.existsSync(assetPath)) {
-      const error = DendronError.createFromStatus({
-        status: ERROR_STATUS.INVALID_STATE,
-        message: `${assetPath} does not exist`,
+      const wsRoot = getDWorkspace().wsRoot;
+      let assetPath: string;
+
+      if (text.startsWith("asset")) {
+        const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
+        assetPath = path.join(vault2Path({ vault, wsRoot }), text);
+      } else {
+        assetPath = resolvePath(text, getExtension().rootWorkspace.uri.fsPath);
+      }
+      if (!fs.existsSync(assetPath)) {
+        const error = DendronError.createFromStatus({
+          status: ERROR_STATUS.INVALID_STATE,
+          message: `no valid path or URL selected`,
+        });
+        this.L.error({ error });
+        return { error };
+      }
+      await open(assetPath).catch((err) => {
+        const error = DendronError.createFromStatus({
+          status: ERROR_STATUS.UNKNOWN,
+          error: err,
+        });
+        this.L.error({ error });
+        return { error };
       });
-      this.L.error({ error });
-      return { error };
+
+      return { filePath: assetPath };
     }
-    await open(assetPath).catch((err) => {
-      const error = DendronError.createFromStatus({
-        status: ERROR_STATUS.UNKNOWN,
-        error: err,
-      });
-      this.L.error({ error });
-      return { error };
-    });
-    return { filePath: assetPath };
   }
 }

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -16,7 +16,7 @@ type CommandOpts = {};
 
 type CommandInput = {};
 
-type CommandOutput = { error?: DendronError; fsPath?: string } | null;
+type CommandOutput = { error?: DendronError; fsPath?: string };
 
 export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.OPEN_LINK.key;
@@ -93,15 +93,15 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
       return { error };
     }
 
+    let assetPath: string;
     if (text.indexOf("://") !== -1) {
       window.showInformationMessage(
         "the selection reads as a full URI so an attempt will be made to open it"
       );
       env.openExternal(Uri.parse(text));
-      return;
+      assetPath = resolvePath(text, getExtension().rootWorkspace.uri.fsPath);
     } else {
       const wsRoot = getDWorkspace().wsRoot;
-      let assetPath: string;
 
       if (text.startsWith("asset")) {
         const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
@@ -125,8 +125,7 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
         this.L.error({ error });
         return { error };
       });
-
-      return { filePath: assetPath };
     }
+    return { filePath: assetPath };
   }
 }

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -8,7 +8,6 @@ import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
 import { resolvePath, VSCodeUtils } from "../utils";
 import { getURLAt } from "../utils/md";
-import { isAnythingSelected } from "../utils/editor";
 import { getExtension, getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 import { env, Uri, window } from "vscode";
@@ -29,12 +28,6 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
     this.L.info({ ctx });
 
     let text = "";
-
-    if (!isAnythingSelected()) {
-      window.showInformationMessage(
-        "nothing selected, searching for valid link"
-      );
-    }
 
     text = getURLAt(VSCodeUtils.getActiveTextEditor());
 

--- a/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
@@ -20,7 +20,7 @@ suite("OpenLink", function () {
       onInit: async ({}) => {
         const cmd = new OpenLinkCommand();
         const { error } = await cmd.execute();
-        expect(error!.message).toEqual("nothing selected");
+        expect(error!.message).toEqual("no valid path or URL selected");
         done();
       },
     });

--- a/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
@@ -5,7 +5,7 @@ import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
 import { OpenLinkCommand } from "../../commands/OpenLink";
-import { expect, runSingleVaultTest } from "../testUtilsv2";
+import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import { VSCodeUtils } from "../../utils";
 import { NoteProps } from "@dendronhq/common-all";
@@ -28,10 +28,9 @@ suite("OpenLink", function () {
     });
   });
 
-  //TODO
-  test.skip("With an invalid character in the selection.", (done) => {
+  test("With an invalid character in the selection.", (done) => {
     let noteWithLink: NoteProps;
-    runSingleVaultTest({
+    runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async ({ wsRoot, vaults }) => {
         noteWithLink = await NoteTestUtilsV4.createNote({
@@ -44,8 +43,7 @@ suite("OpenLink", function () {
       onInit: async () => {
         // Open and select some text
         const editor = await VSCodeUtils.openNote(noteWithLink);
-        editor.selection = new vscode.Selection(8, 1, 8, 10);
-
+        editor.selection = new vscode.Selection(7, 1, 7, 10);
         const cmd = new OpenLinkCommand();
         const { error } = await cmd.execute();
         expect(error!.message).toEqual("no valid path or URL selected");
@@ -54,10 +52,9 @@ suite("OpenLink", function () {
     });
   });
 
-  //TODO
   test.skip("grab a URL under the cursor.", (done) => {
     let noteWithLink: NoteProps;
-    runSingleVaultTest({
+    runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async ({ wsRoot, vaults }) => {
         noteWithLink = await NoteTestUtilsV4.createNote({
@@ -72,22 +69,33 @@ suite("OpenLink", function () {
       onInit: async () => {
         // Open and select some text
         const editor = await VSCodeUtils.openNote(noteWithLink);
-        editor.selection = new vscode.Selection(9, 1, 9, 5);
+        editor.selection = new vscode.Selection(8, 1, 8, 5);
         const cmd = new OpenLinkCommand();
         const text = await cmd.run();
-        expect(text).toEqual("https://www.dendron.so/");
+        expect(text).toEqual({ filepath: "https://www.dendron.so/" });
         done();
       },
     });
   });
-  //TODO
-  test.skip("With a partially selected URL.", (done) => {
+
+  test("with a partially selected URL", (done) => {
+    let noteWithLink: NoteProps;
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async ({ wsRoot, vaults }) => {
-        ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+        noteWithLink = await NoteTestUtilsV4.createNote({
+          fname: "OpenLinkTest",
+          vault: vaults[0],
+          wsRoot,
+          body:
+            "Here we have some example text to search for URLs within\n" +
+            "check out [dendron](https://www.dendron.so/)",
+        });
       },
       onInit: async () => {
+        // Open and select some text
+        const editor = await VSCodeUtils.openNote(noteWithLink);
+        editor.selection = new vscode.Selection(8, 15, 8, 25);
         const cmd = new OpenLinkCommand();
         const { error } = await cmd.execute();
         expect(error!.message).toEqual("no valid path or URL selected");
@@ -95,6 +103,7 @@ suite("OpenLink", function () {
       },
     });
   });
+
   // TODO
   test.skip("open in diff vault", (done) => {
     runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
@@ -1,23 +1,25 @@
 import { vault2Path } from "@dendronhq/common-server";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
 import { OpenLinkCommand } from "../../commands/OpenLink";
-import { expect } from "../testUtilsv2";
+import { expect, runSingleVaultTest } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { VSCodeUtils } from "../../utils";
+import { NoteProps } from "@dendronhq/common-all";
 
 suite("OpenLink", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this);
+  const ctx = setupBeforeAfter(this, {});
 
-  test("error: nothing selected", (done) => {
+  test("error: cursor on non-link", (done) => {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: async ({ wsRoot, vaults }) => {
         ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
       },
-      onInit: async ({}) => {
+      onInit: async () => {
         const cmd = new OpenLinkCommand();
         const { error } = await cmd.execute();
         expect(error!.message).toEqual("no valid path or URL selected");
@@ -26,6 +28,73 @@ suite("OpenLink", function () {
     });
   });
 
+  //TODO
+  test.skip("With an invalid character in the selection.", (done) => {
+    let noteWithLink: NoteProps;
+    runSingleVaultTest({
+      ctx,
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        noteWithLink = await NoteTestUtilsV4.createNote({
+          fname: "OpenLinkTest",
+          vault: vaults[0],
+          wsRoot,
+          body: "Here we have some example text to search for URLs within",
+        });
+      },
+      onInit: async () => {
+        // Open and select some text
+        const editor = await VSCodeUtils.openNote(noteWithLink);
+        editor.selection = new vscode.Selection(8, 1, 8, 10);
+
+        const cmd = new OpenLinkCommand();
+        const { error } = await cmd.execute();
+        expect(error!.message).toEqual("no valid path or URL selected");
+        done();
+      },
+    });
+  });
+
+  //TODO
+  test.skip("grab a URL under the cursor.", (done) => {
+    let noteWithLink: NoteProps;
+    runSingleVaultTest({
+      ctx,
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        noteWithLink = await NoteTestUtilsV4.createNote({
+          fname: "OpenLinkTest",
+          vault: vaults[0],
+          wsRoot,
+          body:
+            "Here we have some example text to search for URLs within\n" +
+            "https://www.dendron.so/",
+        });
+      },
+      onInit: async () => {
+        // Open and select some text
+        const editor = await VSCodeUtils.openNote(noteWithLink);
+        editor.selection = new vscode.Selection(9, 1, 9, 5);
+        const cmd = new OpenLinkCommand();
+        const text = await cmd.run();
+        expect(text).toEqual("https://www.dendron.so/");
+        done();
+      },
+    });
+  });
+  //TODO
+  test.skip("With a partially selected URL.", (done) => {
+    runLegacyMultiWorkspaceTest({
+      ctx,
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+      },
+      onInit: async () => {
+        const cmd = new OpenLinkCommand();
+        const { error } = await cmd.execute();
+        expect(error!.message).toEqual("no valid path or URL selected");
+        done();
+      },
+    });
+  });
   // TODO
   test.skip("open in diff vault", (done) => {
     runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenLink.test.ts
@@ -4,6 +4,7 @@ import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
+import sinon from "sinon";
 import { OpenLinkCommand } from "../../commands/OpenLink";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
@@ -52,7 +53,7 @@ suite("OpenLink", function () {
     });
   });
 
-  test.skip("grab a URL under the cursor.", (done) => {
+  test("grab a URL under the cursor.", (done) => {
     let noteWithLink: NoteProps;
     runLegacyMultiWorkspaceTest({
       ctx,
@@ -71,8 +72,10 @@ suite("OpenLink", function () {
         const editor = await VSCodeUtils.openNote(noteWithLink);
         editor.selection = new vscode.Selection(8, 1, 8, 5);
         const cmd = new OpenLinkCommand();
+        const avoidPopUp = sinon.stub(vscode.env, "openExternal");
         const text = await cmd.run();
         expect(text).toEqual({ filepath: "https://www.dendron.so/" });
+        avoidPopUp.restore();
         done();
       },
     });

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -191,7 +191,7 @@ export const getURLAt = (editor: vscode.TextEditor | undefined): string => {
           );
           editor.revealRange(editor.selection);
         }
-        return [leftText, rightText].join("");
+        return [leftText, selectedText, rightText].join("");
       }
     }
   }

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -162,7 +162,7 @@ export const getURLAt = (editor: vscode.TextEditor | undefined): string => {
     const offsetEnd = editor.document.offsetAt(editor.selection.end);
     const selectedText = docText.substring(offsetStart, offsetEnd);
     const selectUri = true;
-    const validUriChars = "A-Za-z0-9-._~:/?#@!$&'*+,;%=";
+    const validUriChars = "A-Za-z0-9-._~:/?#@!$&'*+,;%=\\\\";
     const invalidUriChars = ["[^", validUriChars, "]"].join("");
     const regex = new RegExp(invalidUriChars);
 
@@ -174,7 +174,7 @@ export const getURLAt = (editor: vscode.TextEditor | undefined): string => {
     const leftText = leftSplit[leftSplit.length - 1];
     const selectStart = offsetStart - leftText.length;
 
-    const rightSplit = docText.substring(offsetEnd, docText.length - 1);
+    const rightSplit = docText.substring(offsetEnd, docText.length);
     const rightText = rightSplit.substring(0, regex.exec(rightSplit)?.index);
     const selectEnd = offsetEnd + rightText.length;
 
@@ -182,7 +182,7 @@ export const getURLAt = (editor: vscode.TextEditor | undefined): string => {
       if (
         selectStart >= 0 &&
         selectStart < selectEnd &&
-        selectEnd <= docText.length - 1
+        selectEnd <= docText.length
       ) {
         if (selectUri) {
           editor.selection = new Selection(


### PR DESCRIPTION
Feat: use Dendron: Open_Link to open both generic URLs and assets found in Dendron vaults.

Further, instead of needing to highlight an asset's relative path, this change allows Open_Link to open the asset path or URI found at the cursor/selection. This also amends for vs-code not handling links with different protocols than https://, http://, or vscode://, allowing users to open other programs more smoothly.