### PR TITLE
fix: fix move note to have exact match

### DIFF
--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -101,7 +101,11 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
       lookupCreateOpts.buttons = [];
     }
     const lc = LookupControllerV3.create(lookupCreateOpts);
-    const provider = new NoteLookupProvider("move", { allowNewNote: true });
+
+    const provider = new NoteLookupProvider("move", {
+      allowNewNote: true,
+      forceAsIsPickerValueUsage: true,
+    });
     provider.registerOnAcceptHook(ProviderAcceptHooks.oldNewLocationHook);
     const initialValue = path.basename(
       VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath || "",

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -213,7 +213,10 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     let pickerValue = picker.value;
     const start = process.hrtime();
 
-    // just activated picker's have special behavior
+    // Just activated picker's have special behavior:
+    //
+    // We slice the postfix off until the first dot to show all results at the same
+    // level so that when a user types `foo.one`, they will see all results in `foo.*`
     if (
       picker._justActivated &&
       !picker.nonInteractive &&


### PR DESCRIPTION
## Summary
Fix move & rename notes to use the exact string provided by the customer .

## 
Fix the issue: https://www.loom.com/share/4e4cacd1de284415a12eef1afa318e0c

Reference note: [[Move Note Lookup Issue|scratch.2021.09.08.115911.move-note-lookup-issue]]
## General

### Quality Assurance
- [d] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
   - Tried to add a test for the input but all the existing tests for move note use `execute` instead of `run`/`gatherInput`, hence for now didn't add a test which tests note rename input gathering. 
   
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

