### PR TITLE
fix: show all root results and their children on empty query

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -12,7 +12,7 @@ import {
   DNodeUtils,
   DEngineClient,
 } from ".";
-import { DendronConfig, DVault } from "./types";
+import { DVault } from "./types";
 
 export type NoteIndexProps = {
   id: string;
@@ -392,19 +392,12 @@ export class NoteLookupUtils {
     return lastDotIndex < 0 ? "" : qs.slice(0, lastDotIndex + 1);
   };
 
-  static fetchRootResults = (
-    notes: NotePropsDict,
-    opts?: Partial<{ config: DendronConfig }>
-  ) => {
-    const roots: NoteProps[] =
-      opts?.config?.site.siteHierarchies === ["root"]
-        ? NoteUtils.getRoots(notes)
-        : opts!.config!.site.siteHierarchies.flatMap((fname) =>
-            NoteUtils.getNotesByFname({ fname, notes })
-          );
+  static fetchRootResults = (notes: NotePropsDict) => {
+    const roots: NoteProps[] = NoteUtils.getRoots(notes);
+
     const childrenOfRoot = roots.flatMap((ent) => ent.children);
-    const nodes = _.map(childrenOfRoot, (ent) => notes[ent]).concat(roots);
-    return nodes;
+    const childrenOfRootNotes = _.map(childrenOfRoot, (ent) => notes[ent]);
+    return roots.concat(childrenOfRootNotes);
   };
 
   static async lookup({

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -432,12 +432,12 @@ export type DendronSiteConfig = {
   logo?: string;
 
   /**
-   * By default, the domain of your `siteHiearchies` page
+   * By default, the domain of your `siteHierarchies` page
    */
   siteIndex?: string;
 
   /**
-   * Hiearchies to publish
+   * Hierarchies to publish
    */
   siteHierarchies: string[];
 

--- a/packages/nextjs-template/components/DendronLookup.tsx
+++ b/packages/nextjs-template/components/DendronLookup.tsx
@@ -63,7 +63,7 @@ function AntDAutoComplete(
     logger.info({ state: "onSearch:enter", qs });
     const out =
       qs === ""
-        ? NoteLookupUtils.fetchRootResults(notes, { config: engine.config })
+        ? NoteLookupUtils.fetchRootResults(notes)
         : lookup?.queryNote({ qs });
     setResult(_.isUndefined(out) ? [] : out);
   };

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -716,9 +716,7 @@ export class NotePickerUtils {
     engine: DEngineClient;
   }) => {
     const { wsRoot, vaults } = getDWorkspace();
-    const nodes = NoteLookupUtils.fetchRootResults(engine.notes, {
-      config: engine.config,
-    });
+    const nodes = NoteLookupUtils.fetchRootResults(engine.notes);
     return nodes.map((ent) => {
       return DNodeUtils.enhancePropForQuickInput({
         wsRoot,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -215,6 +215,11 @@ suite("NoteLookupCommand", function () {
               _.find(opts.quickpick.selectedItems, { fname: "root" })
             )
           ).toBeTruthy();
+          expect(
+            !_.isUndefined(
+              _.find(opts.quickpick.selectedItems, { fname: "foo" })
+            )
+          ).toBeTruthy();
           done();
         },
       });


### PR DESCRIPTION
# Summary
Show all root elements and their immediate children on empty query.

# Description
This is in regards to @kevinslin comment when querying for empty string:
>  we want to show all domains, so `root` + all top level elements (so `root` notes and all immediate children of `root`)

However, we want to consider the previous behavior of why were we limiting the root elements to roots specified by site.siteHierarchies. Seems like for the look-up showing all the roots as this change does makes sense.

Also note that now the roots are shown first and then their immediate children (prior to this change the roots were after all the children)

Prior to this change empty query look up looked like:
<img width="720" alt="Screen Shot 2021-09-13 at 6 57 17 PM" src="https://user-images.githubusercontent.com/4050134/133082290-ba49f637-6aa0-489d-89f9-d08e47358a70.png">

After this change the empty query look up looks like:
<img width="724" alt="Screen Shot 2021-09-13 at 7 00 14 PM" src="https://user-images.githubusercontent.com/4050134/133082316-3015322b-569d-4e33-bdb5-6db6795cc124.png">


## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
    - Added assertion to existing test
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
