### PR TITLE
fix: update vs code compat version + husky hook check

### DIFF
--- a/hooks/pre-commit.js
+++ b/hooks/pre-commit.js
@@ -1,21 +1,46 @@
 const {checkToken} = require("./common");
 const {exec} = require("./exec");
 
+const path = require('path');
+const fs = require('fs-extra');
+
 const ErrorMessages = {
-  AVOID_DIRECT_IMPORT_FROM_PACKAGES:[
+  AVOID_DIRECT_IMPORT_FROM_PACKAGES: [
     `Direct import from a package.`,
     `This check catches direct imports such as:`,
     `import { your_import1 } from "@dendronhq/common-all/path1";`,
     `import { your_import2 } from "@dendronhq/common-server/path2";`,
     `While the above imports should look as:`,
     `import { your_import1 } from "@dendronhq/common-all";`,
-    `import { your_import2 } from "@dendronhq/common-server";`
-  ].join('\n')
+    `import { your_import2 } from "@dendronhq/common-server";`,
+  ].join("\n"),
+};
+
+function checkVSCodeCompatibilityVersion() {
+  const filePath = path.resolve(process.cwd(), "packages/plugin-core/package.json");
+  if (fs.existsSync(filePath)) {
+    const content = fs.readJsonSync(filePath);
+
+    const compatVersion = content.engines["vscode"];
+    const apiVersion = content.dependencies["@types/vscode"];
+
+    if (!compatVersion.includes(apiVersion)) {
+      console.error("The vscode api version does not match the engine compatibility version! Update the compatibility version to match in plugin-core/package.json. See https://code.visualstudio.com/api/working-with-extensions/publishing-extension#visual-studio-code-compatibility");
+      console.log("api version: " + apiVersion);
+      console.log("compatibility version: " + compatVersion);
+      process.exit(1);
+    }
+  }
+  else {
+    console.log("Unable to find plugin-core/package.json! VS Code Compatibility Check skipped");
+  }
 }
 
 function main() {
+  checkVSCodeCompatibilityVersion();
+
   const gitCommand = `git diff --staged --name-only`;
-  const stagedFiles = exec(gitCommand).stdout.split('\n');
+  const stagedFiles = exec(gitCommand).stdout.split("\n");
 
   return checkToken({
     filesToCheck: stagedFiles,
@@ -24,8 +49,9 @@ function main() {
 
       [ErrorMessages.AVOID_DIRECT_IMPORT_FROM_PACKAGES]: {
         rgx: /((common-frontend|common-all|common-server|engine-server|dendron-cli|pods-core|api-server|common-test-utils|engine-test-utils|dendron-next-server)\/)/,
-        fileRgx: /\.ts[x]?$/ },
-    }
+        fileRgx: /\.ts[x]?$/,
+      },
+    },
   });
 }
 

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -6,7 +6,7 @@
   "publisher": "dendron",
   "version": "0.59.2-alpha.5",
   "engines": {
-    "vscode": "^1.54.0"
+    "vscode": "^1.58.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
```markdown
# fix: update vs code version compatibility

This changes updates the vs code compatibility version to match the vscode api version that we're using.
```

Details: It turns out that we've had a mismatch in our compatibility version (was 1.54.0, published in February 2021) and our vs code api version (1.58.0, released in June 2021). This would cause an issue where if a user has opted not to auto-update their VS Code and were on an old version, then certain API calls would fail. The error data revealed that some users were hitting an exception `workspace.onDidGrantWorkspaceTrust is not a function`, which is part of the `_activate()` initialization code.

If set properly, a user's Dendron version will not update to the newer version if their VS Code version doesn't meet the compatibility requirements.

I also added a Husky hook to check for this problem when we update the api version in the future.

---
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [n] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated