### PR TITLE
fix: resolve relative links on markdown import

### DIFF
--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -958,9 +958,20 @@ export class RemarkUtils {
           ...selectAll(DendronASTTypes.LINK, root),
         ];
         assetReferences.forEach((asset) => {
-          const key = _.replace(asset.url as string, /[\\|/]/g, "");
+          const key = _.replace(asset.url as string, /[\\|/|.]/g, "");
           const value = assetHashMap.get(key);
-          if (value) asset.url = value;
+          if (value) {
+            asset.url = value;
+          } else {
+            // for realative links
+            const prefix = _.replace(
+              note.fname.substring(0, note.fname.lastIndexOf(".")),
+              /[\\|/|.]/g,
+              ""
+            );
+            const value = assetHashMap.get(prefix.concat(key));
+            if (value) asset.url = value;
+          }
           changes.push({
             note,
             status: "update",

--- a/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
@@ -450,9 +450,16 @@ describe("markdown import pod", () => {
             encoding: "utf8",
           }
         );
+        const fileBody2Content = fs.readFileSync(
+          path.join(vpath, "project.p4.n1.md"),
+          {
+            encoding: "utf8",
+          }
+        );
         expect(fileBody.match("test.txt")).toBeTruthy();
         const assetPath = path.join("assets", "test.txt").replace(/[\\]/g, "/");
         expect(fileBodyContent).toContain(`[test-pdf](/${assetPath})`);
+        expect(fileBody2Content).toContain(`[test-pdf](/${assetPath})`);
         expect(assetsDir.length).toEqual(3);
       },
       {
@@ -462,6 +469,10 @@ describe("markdown import pod", () => {
           fs.writeFileSync(
             path.join(importSrc, "project", "p2", "n1.md"),
             "[test-pdf](/project/p4/test.txt)"
+          );
+          fs.writeFileSync(
+            path.join(importSrc, "project", "p4", "n1.md"),
+            "[test-pdf](./test.txt)"
           );
         },
       }

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -216,7 +216,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           const assetPathRel = path
             .join(assetDirName, assetBaseNew)
             .replace(/[\\]/g, "/");
-          const key = _.replace(_item.path as string, /[\\|/]/g, "");
+          const key = _.replace(_item.path as string, /[\\|/|.]/g, "");
           assetHashMap.set(key, `/${assetPathRel}`);
 
           fs.copyFileSync(path.join(src, _item.path), assetPathFull);


### PR DESCRIPTION
```markdown
# fix(pods): markdown import to resolve relative asset references 
```
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [n] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [n] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [n] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [~] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [x] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [~] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [~] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated