### PR TITLE
fix/for-preview-links-to-navigate-within-the-same-page-in-the-note

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -612,6 +612,7 @@ export enum CalendarViewMessageType {
 export enum NoteViewMessageType {
   "onClick" = "onClick",
   "onGetActiveEditor" = "onGetActiveEditor",
+  "messageDispatcherReady" = "messageDispatcherReady",
 }
 
 export enum ThemeMessageType {

--- a/packages/plugin-core/src/commands/ShowPreviewV2.ts
+++ b/packages/plugin-core/src/commands/ShowPreviewV2.ts
@@ -2,6 +2,7 @@ import {
   assertUnreachable,
   DendronWebViewKey,
   DMessageType,
+  DNoteAnchor,
   NoteProps,
   NoteViewMessage,
   NoteViewMessageType,
@@ -22,12 +23,18 @@ type CommandOutput = any;
 
 const title = "Dendron Preview";
 
-export const extractAnchorIfExists = (link: string) => {
+export const extractHeaderAnchorIfExists = (
+  link: string
+): DNoteAnchor | undefined => {
   if (link.indexOf("#") === -1) {
     return undefined;
   } else {
     const tokens = link.split("#");
-    return tokens[tokens.length - 1];
+    const anchorValue = tokens[tokens.length - 1];
+    return {
+      type: "header",
+      value: anchorValue,
+    };
   }
 };
 
@@ -60,31 +67,37 @@ const tryGetNoteFromDocument = (
 const isLinkingWithinSameNote = (opts: {
   data: { id?: string; href?: string };
 }) => {
-  const linkToNoteId = extractNoteId(opts.data);
+  const linkToNoteId = extractNoteIdFromHref(opts.data);
+
   return linkToNoteId === opts.data.id;
 };
 
-const extractNoteId = (data: {
+export const extractNoteIdFromHref = (data: {
   id?: string;
   href?: string;
 }): string | undefined => {
   if (data.href === undefined) {
     return undefined;
   }
+  // For some cases such as markdown value='[head2](#head2)' the href isn't as nice
+  // and looks like href='http://localhost:3005/vscode/note-preview.html?ws=WS-VALUE&port=3005#head2'
+  // which currently happens when linking within the same note so we will consider it a special
+  // case of parsing for now and return the id of the current note.
+  if (data.href.includes("vscode/note-preview")) {
+    return data.id;
+  }
 
   // In normal cases such as markdown value='[[#head2]]' with
   // href='http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ.html#head2' we will
   // parse the href and extract the note id.
+  // The id within href can be without html suffix such as:
+  // * http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ#head2
+  // * http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ
+  //
+  // Regex: https://regex101.com/r/Ql3h3t/1
   const { path } = vscode.Uri.parse(data.href);
-  const noteId = path.match(/.*\/(.*).html/)?.[1];
+  const noteId = path.match(/vscode\/([a-zA-Z0-9-]*)/)?.[1];
 
-  // However, for some cases such as markdown value='[head2](#head2)' the href isn't as nice
-  // and looks like href='http://localhost:3005/vscode/note-preview.html?ws=WS-VALUE&port=3005#head2'
-  // which currently happens when linking within the same note so we will consider it a special
-  // case of parsing for now and return the id of the current note.
-  if (noteId === "note-preview") {
-    return data.id;
-  }
   return noteId;
 };
 
@@ -174,27 +187,23 @@ export class ShowPreviewV2Command extends BasicCommand<
           if (data.href) {
             // TODO find a better way to differentiate local files from web links (`data-` attribute)
             if (data.href.includes("localhost")) {
-              const noteId = extractNoteId(data);
+              const noteId = extractNoteIdFromHref(data);
+              const anchor = extractHeaderAnchorIfExists(data.href);
 
               const note: NoteProps | undefined = this.getNote(noteId);
-              if (isLinkingWithinSameNote({ data }) && note) {
-                const anchor = extractAnchorIfExists(data.href);
-                if (anchor) {
-                  await new GotoNoteCommand().execute({
-                    qs: note.fname,
-                    vault: note.vault,
-                    column: vscode.ViewColumn.One,
-                    anchor: {
-                      type: "header",
-                      value: anchor,
-                    },
-                  });
-                }
+              if (isLinkingWithinSameNote({ data }) && note && anchor) {
+                await new GotoNoteCommand().execute({
+                  qs: note.fname,
+                  vault: note.vault,
+                  column: vscode.ViewColumn.One,
+                  anchor,
+                });
               } else if (noteId && note) {
                 await new GotoNoteCommand().execute({
                   qs: note.fname,
                   vault: note.vault,
                   column: vscode.ViewColumn.One,
+                  anchor,
                 });
               }
             } else {
@@ -215,6 +224,8 @@ export class ShowPreviewV2Command extends BasicCommand<
             ShowPreviewV2Command.refresh(maybeNote);
           break;
         }
+        case NoteViewMessageType.messageDispatcherReady:
+          break;
         default:
           assertUnreachable(msg.type);
       }

--- a/packages/plugin-core/src/test/suite-integ/ShowPreviewV2.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowPreviewV2.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "mocha";
+import {
+  extractHeaderAnchorIfExists,
+  extractNoteIdFromHref,
+} from "../../commands/ShowPreviewV2";
+import { expect } from "../testUtilsv2";
+
+suite("ShowPreviewV2 utility methods", () => {
+  describe(`extractHeaderAnchorIfExists`, () => {
+    it("WHEN anchor exists THEN return it", () => {
+      const anchor = extractHeaderAnchorIfExists(
+        "http://localhost:54442/vscode/FSi3bKWQeQXYTjE1PoTB0#heading-2"
+      );
+      expect(anchor?.value).toEqual("heading-2");
+      expect(anchor?.type).toEqual("header");
+    });
+
+    it(`WHEN anchor does NOT exist THEN return undefined`, () => {
+      expect(
+        extractHeaderAnchorIfExists(
+          "http://localhost:54442/vscode/FSi3bKWQeQXYTjE1PoTB0"
+        )
+      ).toEqual(undefined);
+    });
+  });
+
+  describe(`extractNoteIdFromHref`, () => {
+    describe(`WHEN id is present with html suffix`, () => {
+      it("AND has header anchor THEN extract id", () => {
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ.html#head2",
+        });
+
+        expect(actual).toEqual("0TDNEYgYvCs3ooZEuknNZ");
+      });
+
+      it("AND does not have header anchor THEN extract id", () => {
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ.html",
+        });
+
+        expect(actual).toEqual("0TDNEYgYvCs3ooZEuknNZ");
+      });
+    });
+
+    describe(`WHEN id is present without html suffix`, () => {
+      it("AND with header anchor THEN extract id", () => {
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:3005/vscode/FSi3bKWQeQXYTjE1PoTB0#heading-2",
+        });
+
+        expect(actual).toEqual("FSi3bKWQeQXYTjE1PoTB0");
+      });
+
+      it("AND without the header anchor THEN extract id", () => {
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:3005/vscode/FSi3bKWQeQXYTjE1PoTB0",
+        });
+
+        expect(actual).toEqual("FSi3bKWQeQXYTjE1PoTB0");
+      });
+
+      it("AND is guid like", () => {
+        // This shouldnt typically happen with the way we currently generate ids but we do
+        // have some guid like ids in our test workspace right now so to make those
+        // notes happy, and in case some older id generation used guid looking identifers.
+
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:52361/vscode/56497553-c195-4ec8-bc74-6a76462d9333",
+        });
+
+        expect(actual).toEqual("56497553-c195-4ec8-bc74-6a76462d9333");
+      });
+    });
+
+    it(`WHEN id not present in href THEN default onto passed in id`, () => {
+      const actual = extractNoteIdFromHref({
+        id: "id1",
+        href: "http://localhost:3005/vscode/note-preview.html?ws=WS-VALUE&port=3005#head2",
+      });
+      expect(actual).toEqual("id1");
+    });
+  });
+});

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -32,7 +32,7 @@ site:
     siteUrl: 'https://foo.dev.dendron.so'
     usePrettyRefs: true
     githubCname: 11ty.dendron.so
-    usePrettyLinks: true 
+    usePrettyLinks: true
     siteLastModified: true
     title: Dendron
     description: >-

--- a/test-workspace/vault/dendron.links.heading-anchors-diff-page.md
+++ b/test-workspace/vault/dendron.links.heading-anchors-diff-page.md
@@ -1,0 +1,10 @@
+---
+id: bou78C3Ldc5w98Y2OX6gG
+title: Heading Anchors Diff Page
+desc: ''
+updated: 1633004671354
+created: 1633003961347
+---
+
+* [[Different page without heading anchor|dendron.links.heading-anchors]]
+* [[heading-2 in different page|dendron.links.heading-anchors#heading-2]]

--- a/test-workspace/vault/dendron.links.heading-anchors.md
+++ b/test-workspace/vault/dendron.links.heading-anchors.md
@@ -1,0 +1,40 @@
+---
+id: FSi3bKWQeQXYTjE1PoTB0
+title: Heading Anchors
+desc: ''
+updated: 1633004714929
+created: 1632988925249
+---
+
+## links 
+* Link to self: [[dendron.links.heading-anchors]] 
+* Link to different note: [[dendron.links.heading-anchors-diff-page]]
+
+## heading-1
+* Heading links within the same page:
+    * [[#heading-2]]
+    * [[heading-2|#heading-2]]
+    * [heading-2](#heading-2)
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+
+## heading-2
+* content-2


### PR DESCRIPTION
fix/for-preview-links-to-navigate-within-the-same-page-in-the-note

## General
This makes the preview links act as navigators for the note, BUT it does not currently navigate within the preview https://www.loom.com/share/24f3f11ac94442e6aacf46dea3e1593c 

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

