### PR TITLE
fix: selection2link doesn't update note with link

### DIFF
--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -1,4 +1,9 @@
-import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import {
+  DVault,
+  NoteProps,
+  NoteUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
 import { DLogger, string2Note } from "@dendronhq/common-server";
 import {
   AnchorUtils,
@@ -123,15 +128,34 @@ export class NoteSyncService {
       return;
     }
 
+    return this.updateNoteContents({
+      oldNote: noteHydrated,
+      content,
+      fmChangeOnly,
+      fname,
+      vault,
+    });
+  }
+
+  async updateNoteContents(opts: {
+    oldNote: NoteProps;
+    content: string;
+    fmChangeOnly: boolean;
+    fname: string;
+    vault: DVault;
+  }) {
+    const ctx = "NoteSyncService:updateNoteContents";
+    const { content, fmChangeOnly, fname, vault, oldNote } = opts;
+    const { engine } = getDWorkspace();
     // note is considered dirty, apply any necessary changes here
     // call `doc.getText` to get latest note
     let note = string2Note({
-      content: doc.getText(),
+      content,
       fname,
       vault,
       calculateHash: true,
     });
-    note = NoteUtils.hydrate({ noteRaw: note, noteHydrated });
+    note = NoteUtils.hydrate({ noteRaw: note, noteHydrated: oldNote });
 
     // Links have to be updated even with frontmatter only changes
     // because `tags` in frontmatter adds new links

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1068,6 +1068,11 @@ suite("NoteLookupCommand", function () {
           // should change selection to link with alais.
           const changedText = fooNoteEditor.document.getText();
           expect(changedText.endsWith("[[foo body|foo.foo-body]]\n"));
+
+          // Note should have its links updated, since selection2link put a link in it
+          const oldNote = engine.notes["foo"];
+          expect(oldNote.links.length).toEqual(1);
+          expect(oldNote.links[0].value).toEqual("foo.foo-body");
           done();
         },
       });


### PR DESCRIPTION
# Pull Request Checklist

## Repro
1. ~~Initialize a blank workspace~~
2. Create a new note `hello`
3. Inside the note, type `bye`
4. Select `bye` and use Lookup Note with "Selection to link" and "create scratch note" options to create a scratch note
5. Rename the scratch note

The link in `hello` doesn't update with the rename.

https://www.loom.com/share/ad626921005b4e9eb91cd099ee287cfc

## Investigate

- Scratch note has no backlink after being created, the previous note's link is not updating.
- This is because the editor switches to the new note before `NoteSyncService` can update the note. `NoteSyncService` relies on having the note still open:
  ```
  // NOTE: it might be worthwile to only do this after checking that the current note is still active
  //
  // we have this logic currently and it doesn't seem to be causing issues
  // this could lead to thrashing if user makes a change and quickly changes to a dififerent active window
  // in practice, this has never been reported
  ```

## Solution

In the lookup, forced an update when inserting a link to the current note before
lookup switches to the new note.

For a more long term solution, we should look into fixing `NoteSyncService` to not depend on the note currently being open. I'll add this to my backlog.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated