### PR TITLE
fix: single letter look up matches

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -76,7 +76,7 @@ function createFuse<T>(
     shouldSort: true,
     threshold: opts.threshold,
     distance: 15,
-    minMatchCharLength: 2,
+    minMatchCharLength: 1,
     keys: ["fname"],
     useExtendedSearch: true,
     includeScore: true,

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -206,6 +206,7 @@ describe("Fuse Engine tests with dummy data", () => {
     { fname: "note-3", updated: 4 },
     { fname: "user.tim.test", updated: 1 },
     { fname: "parent.new-note-1", updated: 1 },
+    { fname: "some.note.name.with.big-o", updated: 1 },
   ];
 
   describe(`GIVEN engine with notes: '${DATA_1.map((n) => n.fname)}'`, () => {
@@ -261,6 +262,18 @@ describe("Fuse Engine tests with dummy data", () => {
 
       it("THEN string with same size but not exact match is excluded.", () => {
         assertDoesNotHaveFName(queryResults, "note-2");
+      });
+    });
+
+    describe(`WHEN querying for 'big o'`, () => {
+      let queryResults: NoteIndexProps[];
+
+      beforeAll(() => {
+        queryResults = fuseEngine.queryNote({ qs: "big o" });
+      });
+
+      it(`THEN should match 'some.note.name.with.big-o'`, () => {
+        assertHasFName(queryResults, "some.note.name.with.big-o");
       });
     });
   });


### PR DESCRIPTION
## Summary
Fix single letter look ups.

#retention 

## Description
* Before this change: Searching for `big o` would not find `some.note.name.with.big-o` note. 
* After this change: Searching for `big o` looks up `some.note.name.with.big-o` note. 

(same applies to schema lookups, since the setting is used by both).

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

