### PR TITLE
fix: pesky error popup when schema lookup is closed

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -183,3 +183,22 @@ export function assertInvalidState(msg: string): never {
     message: msg,
   });
 }
+
+/** Utility class for helping to correctly construct common errors. */
+export class ErrorFactory {
+  static createUnexpectedEventError({ event }: { event: any }): DendronError {
+    return new DendronError({
+      message: `unexpected event: '${this.safeStringify(event)}'`,
+    });
+  }
+
+  /** Stringify that will not throw if it fails to stringify
+   * (for example: due to circular references)  */
+  private static safeStringify(obj: any) {
+    try {
+      return JSON.stringify(obj);
+    } catch (exc) {
+      return `Failed to stringify the given object. Due to '${exc.message}'`;
+    }
+  }
+}

--- a/packages/plugin-core/src/commands/InsertNoteCommand.ts
+++ b/packages/plugin-core/src/commands/InsertNoteCommand.ts
@@ -1,4 +1,4 @@
-import { DendronError, NoteQuickInput } from "@dendronhq/common-all";
+import { ErrorFactory, NoteQuickInput } from "@dendronhq/common-all";
 import { HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { Selection, SnippetString } from "vscode";
@@ -57,7 +57,7 @@ export class InsertNoteCommand extends BasicCommand<
           } else if (event.action === "error") {
             return;
           } else {
-            throw new DendronError({ message: `unexpected event: ${event}` });
+            throw ErrorFactory.createUnexpectedEventError({ event });
           }
         },
       });

--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -1,6 +1,7 @@
 import {
   DendronError,
   DEngineClient,
+  ErrorFactory,
   NoteChangeEntry,
   RenameNoteOpts,
   VaultUtils,
@@ -154,9 +155,7 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
               msg: `changeState.hide event received.`,
             });
           } else {
-            throw new DendronError({
-              message: `unexpected event: ${JSON.stringify(event)}`,
-            });
+            throw ErrorFactory.createUnexpectedEventError({ event });
           }
         },
       });

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -1,6 +1,7 @@
 import {
   DendronError,
   ERROR_STATUS,
+  ErrorFactory,
   NoteLookupConfig,
   NoteProps,
   NoteQuickInput,
@@ -265,9 +266,7 @@ export class NoteLookupCommand extends BaseCommand<
           this.cleanUp();
           promiseResolve(undefined);
         } else {
-          const error = new DendronError({
-            message: `unexpected event: ${event}`,
-          });
+          const error = ErrorFactory.createUnexpectedEventError({ event });
           this.L.error({ error });
           this.cleanUp();
         }

--- a/packages/plugin-core/src/commands/RenameNoteV2a.ts
+++ b/packages/plugin-core/src/commands/RenameNoteV2a.ts
@@ -1,6 +1,6 @@
 import {
-  DendronError,
   DNodeUtils,
+  ErrorFactory,
   NoteChangeEntry,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -75,7 +75,7 @@ export class RenameNoteV2aCommand extends BaseCommand<
           } else if (event.action === "error") {
             return;
           } else {
-            throw new DendronError({ message: `unexpected event: ${event}` });
+            throw ErrorFactory.createUnexpectedEventError({ event });
           }
         },
       });

--- a/packages/plugin-core/src/commands/SchemaLookupCommand.ts
+++ b/packages/plugin-core/src/commands/SchemaLookupCommand.ts
@@ -2,6 +2,7 @@ import {
   DendronError,
   DVault,
   ERROR_STATUS,
+  ErrorFactory,
   SchemaModuleProps,
   SchemaQuickInput,
   SchemaUtils,
@@ -147,10 +148,19 @@ export class SchemaLookupCommand extends BaseCommand<
             const error = event.data.error as DendronError;
             this.L.error({ error });
             resolve(undefined);
-          } else {
-            const error = new DendronError({
-              message: `unexpected event: ${event}`,
+          } else if (
+            event.data &&
+            event.action === "changeState" &&
+            event.data.action === "hide"
+          ) {
+            // changeState/hide is triggered when user cancels schema lookup
+            this.L.info({
+              ctx: `SchemaLookupCommand`,
+              msg: `changeState.hide event received.`,
             });
+            resolve(undefined);
+          } else {
+            const error = ErrorFactory.createUnexpectedEventError({ event });
             this.L.error({ error });
           }
           HistoryService.instance().remove("schemaLookup", "lookupProvider");


### PR DESCRIPTION
## fix: pesky error popup when schema lookup is closed

<img width="694" alt="Screen Shot 2021-09-22 at 7 24 09 PM" src="https://user-images.githubusercontent.com/4050134/134347313-be31fe59-7b03-4fd5-8444-cfb5b0310859.png">

## Refactoring
Added ErrorFactory to correctly create common errors, the first error being `ErrorFactory.createUnexpectedEventError({ event });` which at times wasn't serialized correctly. 

## General

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
