### PR TITLE
fix: no-op completion provider when dendron isn't active

### DIFF
--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -39,7 +39,7 @@ import {
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../utils";
 import { sentryReportingCallback } from "../utils/analytics";
-import { getDWorkspace, getExtension } from "../workspace";
+import { DendronExtension, getDWorkspace, getExtension } from "../workspace";
 
 function padWithZero(n: number): string {
   if (n > 99) return String(n);
@@ -80,6 +80,12 @@ const NOTE_AUTOCOMPLETEABLE_REGEX = new RegExp("" +
 export const provideCompletionItems = sentryReportingCallback(
   (document: TextDocument, position: Position) => {
     const ctx = "provideCompletionItems";
+
+    // No-op if we're not in a Dendron Workspace
+    if (!DendronExtension.isActive()) {
+      return;
+    }
+
     const line = document.lineAt(position).text;
     Logger.debug({ ctx, position, msg: "enter" });
 
@@ -290,6 +296,12 @@ export async function provideBlockCompletionItems(
   token?: CancellationToken
 ): Promise<CompletionItem[] | undefined> {
   const ctx = "provideBlockCompletionItems";
+
+  // No-op if we're not in a Dendron Workspace
+  if (!DendronExtension.isActive()) {
+    return;
+  }
+
   let found: RegExpMatchArray | undefined;
   // This gets triggered when the user types ^, which won't necessarily happen inside a wikilink.
   // So check that the user is actually in a wikilink before we try.


### PR DESCRIPTION
```markdown
# fix: make completion provider a no-op when dendron isn't active

This fixes a common exception being thrown in the completion provider, where an attempt to return completion provider results was occurring even in non-Dendron workspaces.

Docs PR: <URL_TO_DOCS_PR>
```
---
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [n] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [n] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated