### PR TITLE
fix: add /images/ directory to logoUrl so the Dendron logo can be displayed

### DIFF
--- a/packages/nextjs-template/components/DendronLogoOrTitle.tsx
+++ b/packages/nextjs-template/components/DendronLogoOrTitle.tsx
@@ -25,7 +25,9 @@ export default function DendronLogoOrTitle() {
       >
         {engine.config?.site.logo ? (
           <Logo
-            logoUrl={"/assets/" + path.basename(engine.config?.site.logo)}
+            logoUrl={
+              "/assets/images/" + path.basename(engine.config?.site.logo)
+            }
           />
         ) : (
           <Title data={title} />


### PR DESCRIPTION
```markdown
# fix: Add /images/ directory to logoUrl so that the Dendron logo can be displayed

Very small change to the `DendronLogoOrTitle` component, to add the images directory to the logoURL base directory.

The original base directory included only `assets`. However, since all logos should be images, it makes sense to have logos stored in the `images` subdirectory.

Would be interested to know if others store their logos in the images directory, too. I'm on Discord at @nwehner. 
```