### PR TITLE
chore: well-typed sentry wrapper

### DIFF
--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -62,9 +62,9 @@ export class AnalyticsUtils {
  * @param callback the function to wrap
  * @returns the wrapped callback function
  */
-export function sentryReportingCallback(
-  callback: (...args: any[]) => any
-): (...args: any[]) => any {
+export function sentryReportingCallback<A extends any[], R>(
+  callback: (...args: A) => R
+): (...args: A) => R {
   return (...args) => {
     try {
       return callback(...args);


### PR DESCRIPTION
This PR makes the `sentryReportingCallback` well typed. The wrapper will now automatically match the type of the function it's wrapping, giving us type errors if the types don't match. Thanks to type inference, no additional work is needed.