### PR TITLE
fix: notes added outside Dendron are missed

### DIFF
--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -45,10 +45,16 @@ export class FileWatcher {
   activate(context: vscode.ExtensionContext) {
     this.watchers.forEach(({ watcher }) => {
       context.subscriptions.push(
-        watcher.onDidCreate(sentryReportingCallback(this.onDidCreate), this)
+        watcher.onDidCreate(
+          sentryReportingCallback(this.onDidCreate.bind(this)),
+          this
+        )
       );
       context.subscriptions.push(
-        watcher.onDidDelete(sentryReportingCallback(this.onDidDelete), this)
+        watcher.onDidDelete(
+          sentryReportingCallback(this.onDidDelete.bind(this)),
+          this
+        )
       );
     });
   }

--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -59,6 +59,18 @@ export class AnalyticsUtils {
  * Wraps a callback function with a try/catch block.  In the catch, any
  * exceptions that were encountered will be uploaded to Sentry and then
  * rethrown.
+ *
+ * Warning! This function will cause the callback function to lose its `this` value.
+ * If you are passing a method to this function, you must bind the `this` value:
+ *
+ * ```ts
+ * const wrappedCallback = sentryReportingCallback(
+ *   this.callback.bind(this)
+ * );
+ * ```
+ *
+ * Otherwise, when the function is called the `this` value will be undefined.
+ *
  * @param callback the function to wrap
  * @returns the wrapped callback function
  */


### PR DESCRIPTION
Turns out, `sentryReportingCallback` drops the `this` value for wrapped functions. This becomes important for methods that use the `this` value, which was the case for the `FileWatcher`. This would cause these functions to fail immediately, and thus miss added or deleted notes.

I fixed the issue and added a warning for the future.