### PR TITLE
fix: activation bypass for users on old vs code

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -17,6 +17,7 @@ export enum VSCodeEvents {
   ShowLapsedUserMessage = "Show_Lapsed_User_Msg",
   LapsedUserMessageAccepted = "Lapsed_User_Msg_Accepted",
   LapsedUserMessageRejected = "Show_Lapsed_User_Rejected",
+  UserOnOldVSCodeVerUnblocked = "User_On_Old_VSCode_Ver_Unblocked"
 }
 
 export enum TutorialEvents {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -6,7 +6,7 @@
   "publisher": "dendron",
   "version": "0.60.2",
   "engines": {
-    "vscode": "^1.58.0"
+    "vscode": "^1.54.0"
   },
   "categories": [
     "Other"

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -22,7 +22,7 @@ import {
 import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
-import { describe, it } from "mocha";
+import { describe, beforeEach, it } from "mocha";
 import os from "os";
 import path from "path";
 import sinon, { SinonStub } from "sinon";
@@ -54,6 +54,8 @@ import {
   setupBeforeAfter,
   stubSetupWorkspace,
 } from "../testUtilsV3";
+import semver from "semver";
+import * as vscode from "vscode";
 
 function mockUserConfigDir() {
   const dir = tmpDir().name;
@@ -695,6 +697,40 @@ suite("keybindings", function () {
             done();
           });
         });
+      });
+    });
+  });
+});
+
+suite("temporary testing of Dendron version compatibility downgrade sequence", () => {
+  describe(`GIVEN the activation sequence of Dendron`, () => {
+    describe(`WHEN VS Code Version is up to date`, () => {
+      let invokedWorkspaceTrustFn: boolean = false;
+
+      beforeEach(() => {
+        invokedWorkspaceTrustFn = semver.gte(vscode.version, "1.57.0");
+      });
+
+      it(`THEN onDidGrantWorkspaceTrust will get invoked.`, () => {
+        expect(invokedWorkspaceTrustFn).toEqual(true);
+      });
+
+      it(`AND onDidGrantWorkspaceTrust can be found in the API.`, () => {
+        vscode.workspace.onDidGrantWorkspaceTrust(() => {
+          //no-op for testing
+        });
+      });
+    });
+
+    describe(`WHEN VS Code Version is on a version less than 1.57.0`, () => {
+      let invokedWorkspaceTrustFn: boolean = false;
+      const userVersion = "1.56.1";
+      beforeEach(() => {
+        invokedWorkspaceTrustFn = semver.gte(userVersion, "1.57.0");
+      });
+
+      it(`THEN onDidGrantWorkspaceTrust will not get invoked.`, () => {
+        expect(invokedWorkspaceTrustFn).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
# fix: activation bypass for users on old vs code versions

This change attempts to unblock users who are on versions of VS Code < 1.57.0 and are stuck on a version of Dendron that will not activate for them. This change temporarily reverts the compat version to the previous value of 1.54.0.  If a user is on a VS Code version < 1.57.0, then we will not setup the `onDidGrantWorkspaceTrust` callback, which was introduced in 1.57.0 version of the API: https://code.visualstudio.com/updates/v1_57

## QA 

Not exactly a real product code test, but mimics the functionality:

```log
  temporary testing of Dendron version compatibility downgrade sequence
    GIVEN the activation sequence of Dendron
      WHEN VS Code Version is up to date
        ✓ THEN onDidGrantWorkspaceTrust will get invoked.
        ✓ AND onDidGrantWorkspaceTrust can be found in the API.
      WHEN VS Code Version is on a version less than 1.57.0
        ✓ THEN onDidGrantWorkspaceTrust will not get invoked.
```
---
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [n] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated