### PR TITLE
enhance/allow-creation-of-duplicate-file-name-if-there-is-a-vault-without-such-file-name

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -144,6 +144,14 @@ export const error2PlainObject = (err: IDendronError): DendronErrorPlainObj => {
   return out as DendronErrorPlainObj;
 };
 
+export class ErrorMessages {
+  static formatShouldNeverOccurMsg(description?: string) {
+    return `${
+      description === undefined ? "" : description + " "
+    }This error should never occur! Please report a bug if you have encountered this.`;
+  }
+}
+
 /** Statically ensure that a code path is unreachable using a variable that has been exhaustively used.
  *
  * The use case for this function is that when using a switch or a chain of if/else if statements,
@@ -169,8 +177,7 @@ export const error2PlainObject = (err: IDendronError): DendronErrorPlainObj => {
  */
 export function assertUnreachable(_never?: never): never {
   throw new DendronError({
-    message:
-      "This error should never occur! Please report a bug if you have encountered this.",
+    message: ErrorMessages.formatShouldNeverOccurMsg(),
   });
 }
 

--- a/packages/engine-test-utils/src/__tests__/common-all/error.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/error.spec.ts
@@ -1,0 +1,19 @@
+import { ErrorMessages } from "@dendronhq/common-all";
+
+describe(`ErrorMessages tests:`, () => {
+  describe(`formatShouldNeverOccurMsg tests:`, () => {
+    it(`WHEN description is supplied THEN format with description`, () => {
+      expect(
+        ErrorMessages.formatShouldNeverOccurMsg("Description val.")
+      ).toEqual(
+        "Description val. This error should never occur! Please report a bug if you have encountered this."
+      );
+    });
+
+    it(`WHEN description is omitted THEN format default`, () => {
+      expect(ErrorMessages.formatShouldNeverOccurMsg()).toEqual(
+        "This error should never occur! Please report a bug if you have encountered this."
+      );
+    });
+  });
+});

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -3,6 +3,7 @@ import {
   DVault,
   ERROR_STATUS,
   ErrorFactory,
+  ErrorMessages,
   NoteLookupConfig,
   NoteProps,
   NoteQuickInput,
@@ -472,8 +473,10 @@ export class NoteLookupCommand extends BaseCommand<
       } else {
         // We should never reach this as "Create New" should not be available as option
         // to the user when there are no available vaults.
-        ErrorFactory.createInvalidStateError({
-          message: `No available vaults for file name.`,
+        throw ErrorFactory.createInvalidStateError({
+          message: ErrorMessages.formatShouldNeverOccurMsg(
+            `No available vaults for file name.`
+          ),
         });
       }
     }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -1,5 +1,6 @@
 import {
   DendronError,
+  DVault,
   ERROR_STATUS,
   ErrorFactory,
   NoteLookupConfig,
@@ -292,11 +293,7 @@ export class NoteLookupCommand extends BaseCommand<
     CommandOpts,
     "selectedItems" | "quickpick"
   >): readonly NoteQuickInput[] {
-    const maybeCreateNew = PickerUtilsV2.getCreateNewItem(selectedItems);
-    const { nonInteractive, canSelectMany } = quickpick;
-    if (nonInteractive && maybeCreateNew) {
-      return [maybeCreateNew];
-    }
+    const { canSelectMany } = quickpick;
     return canSelectMany ? selectedItems : selectedItems.slice(0, 1);
   }
 
@@ -377,9 +374,13 @@ export class NoteLookupCommand extends BaseCommand<
       Logger.info({ ctx, msg: "create stub" });
       nodeNew = engine.notes[item.id];
     } else {
-      const vault = picker.vault
-        ? picker.vault
-        : PickerUtilsV2.getOrPromptVaultForOpenEditor();
+      const vault = await this.getVaultForNewNote({ fname, picker });
+      if (vault === undefined) {
+        // Vault will be undefined when user cancelled vault selection, so we
+        // are going to cancel the creation of the note.
+        return;
+      }
+
       nodeNew = NoteUtils.create({ fname, vault });
       if (picker.selectionProcessFunc !== undefined) {
         nodeNew = (await picker.selectionProcessFunc(nodeNew)) as NoteProps;
@@ -427,6 +428,57 @@ export class NoteLookupCommand extends BaseCommand<
       wsRoot: getDWorkspace().wsRoot,
     });
     return { uri, node: nodeNew, resp };
+  }
+
+  private async getVaultForNewNote({
+    fname,
+    picker,
+  }: {
+    fname: string;
+    picker: DendronQuickPickerV2;
+  }) {
+    const engine = getEngine();
+
+    const vaultsWithMatchingFile = new Set(
+      NoteUtils.getNotesByFname({ fname, notes: engine.notes }).map(
+        (n) => n.vault.fsPath
+      )
+    );
+
+    // Try to get the default vault value.
+    let vault: DVault | undefined = picker.vault
+      ? picker.vault
+      : PickerUtilsV2.getVaultForOpenEditor();
+
+    // If our current context does not have vault or if our current context vault
+    // already has a matching file name we want to ask the user for a different vault.
+    if (vault === undefined || vaultsWithMatchingFile.has(vault.fsPath)) {
+      // Available vaults are vaults that do not have the desired file name.
+      const availVaults = engine.vaults.filter(
+        (v) => !vaultsWithMatchingFile.has(v.fsPath)
+      );
+
+      if (availVaults.length > 1) {
+        const promptedVault = await PickerUtilsV2.promptVault(availVaults);
+        if (promptedVault === undefined) {
+          // User must have cancelled vault selection.
+          vault = undefined;
+        } else {
+          vault = promptedVault;
+        }
+      } else if (availVaults.length === 1) {
+        // There is only a single vault that is available so we dont have to ask the user.
+        vault = availVaults[0];
+      } else {
+        // We should never reach this as "Create New" should not be available as option
+        // to the user when there are no available vaults.
+        ErrorFactory.createInvalidStateError({
+          message: `No available vaults for file name.`,
+        });
+      }
+    }
+
+    return vault;
   }
 
   /**

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -497,9 +497,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, wsRoot }) => {
           const vault = _.find(vaults, { fsPath: "vault2" });
           const cmd = new NoteLookupCommand();
-          sinon
-            .stub(PickerUtilsV2, "getOrPromptVaultForOpenEditor")
-            .returns(vault!);
+          sinon.stub(PickerUtilsV2, "getVaultForOpenEditor").returns(vault!);
 
           const opts = (await cmd.run({
             noConfirm: true,
@@ -548,8 +546,9 @@ suite("NoteLookupCommand", function () {
           }))!;
           // should have next pick
           expect(_.isUndefined(quickpick?.nextPicker)).toBeFalsy();
-          // selected items shoudl equal
-          expect(quickpick.selectedItems.length).toEqual(1);
+          // One item for our file name and the other for 'CreateNew' since there
+          // are multiple vaults in this test.
+          expect(quickpick.selectedItems.length).toEqual(2);
           expect(_.pick(quickpick.selectedItems[0], ["id", "vault"])).toEqual({
             id: fname,
             vault,


### PR DESCRIPTION
# enhance/allow-creation-of-duplicate-file-name-if-there-is-a-vault-without-such-file-name


# Note
**Note there was a weird scenario where note was created in different vault but was not indexed correctly**, reload fixed the issue. It looked like: 
<img width="862" alt="Screen_Shot_2021-09-29_at_3 01 59_PM" src="https://user-images.githubusercontent.com/4050134/135231858-aefc592c-3eb9-4beb-adb9-68a615daad63.png">
However, not able to reproduce this right now. 

## General


### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
https://www.loom.com/share/cd2b8ee8cf6e47fdafde6fee20dfd85b

- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
