### PR TITLE
fix(commands): move header command compile noterefs

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -60,6 +60,47 @@ suite("MoveHeader", function () {
         };
       });
 
+      describe("AND WHEN note reference exists in destination", () => {
+        test("THEN selected header is moved from origin to dest", (done) => {
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async ({
+              wsRoot,
+              vaults,
+            }: {
+              wsRoot: string;
+              vaults: DVault[];
+            }) => {
+              originNote = await NoteTestUtilsV4.createNote({
+                fname: "origin",
+                wsRoot,
+                vault: vaults[0],
+                body: "## Foo header\n\n",
+              });
+              destNote = await NoteTestUtilsV4.createNote({
+                fname: "dest",
+                wsRoot,
+                vault: vaults[0],
+                body: "![[ref-note]] ",
+              });
+              await NoteTestUtilsV4.createNote({
+                fname: "ref-note",
+                wsRoot,
+                vault: vaults[0],
+                body: "[[Foo|origin#foo-header]]",
+              });
+            },
+            onInit: onInitFunc(async () => {
+              const cmd = new MoveHeaderCommand();
+              const out = await cmd.run({ dest: destNote });
+              expect(out!.origin.body.includes("## Foo header")).toBeFalsy();
+              expect(out!.dest!.body.includes("## Foo header")).toBeTruthy();
+              done();
+            }),
+          });
+        });
+      });
+
       test("THEN selected header is moved from origin to dest", (done) => {
         runLegacyMultiWorkspaceTest({
           ctx,


### PR DESCRIPTION
Move header command was set as "parser" which did not involve "compilers". This resulted in an error when using move header with a note that had dendron specific syntax (eg. note reference)


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
