### PR TITLE
fix: tree view order

### DIFF
--- a/packages/common-frontend/src/utils/tree-view.tsx
+++ b/packages/common-frontend/src/utils/tree-view.tsx
@@ -106,15 +106,14 @@ export class TreeViewUtils {
     noteIds: string[];
     noteDict: NotePropsDict;
   }): string[] => {
-    return _.sortBy(noteIds, (id: string) => {
-      const note = noteDict[id];
-      if (note.custom?.nav_order) {
-        return `0${note.custom?.nav_order}`;
-      }
-      if (note.fname.startsWith(TAGS_HIERARCHY)) {
-        return `9${note.fname}`;
-      }
-      return `1${note.title}`;
-    });
+    return _.sortBy(
+      noteIds,
+      // Put tags first
+      (noteId) => !noteDict[noteId]?.fname?.startsWith(TAGS_HIERARCHY_BASE),
+      // Sort by titles
+      (noteId) => noteDict[noteId]?.title,
+      // If titles are identical, sort by last updated date
+      (noteId) => noteDict[noteId]?.updated
+    );
   };
 }

--- a/packages/dendron-next-server/pages/vscode/tree-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/tree-view.tsx
@@ -1,5 +1,5 @@
 import { BookOutlined, PlusOutlined, NumberOutlined } from "@ant-design/icons";
-import { Spin , Tree, TreeProps } from "antd";
+import { Spin, Tree, TreeProps } from "antd";
 import {
   DendronTreeViewKey,
   DMessageSource,
@@ -20,13 +20,14 @@ import {
   engineSlice,
   ideHooks,
   postVSCodeMessage,
+  TreeViewUtils as CommonTreeViewUtils,
+  ideSlice,
 } from "@dendronhq/common-frontend";
 
 import _ from "lodash";
 import { DataNode } from "rc-tree/lib/interface";
 import React, { useState } from "react";
 import { DendronProps } from "../../lib/types";
-import { ideSlice } from "@dendronhq/common-frontend/lib/features/ide/slice";
 
 type OnExpandFunc = TreeProps["onExpand"];
 type OnSelectFunc = TreeProps["onSelect"];
@@ -99,10 +100,10 @@ class TreeViewUtils {
       key: note.id,
       title,
       icon,
-      children: _.sortBy(
-        note.children,
-        (noteId) => !noteDict[noteId]?.fname?.startsWith(TAGS_HIERARCHY)
-      )
+      children: CommonTreeViewUtils.sortNotesAtLevel({
+        noteIds: note.children,
+        noteDict,
+      })
         .map((noteId) => TreeViewUtils.note2TreeDatanote({ noteId, noteDict }))
         .filter(isNotUndefined),
     };
@@ -264,7 +265,7 @@ function TreeView({
           onExpand={onExpand}
           onSelect={onSelect}
           treeData={treeData}
-         />
+        />
       ) : (
         <Spin />
       )}


### PR DESCRIPTION
Made next-server use the `common-frontend` tree sorting code,
and replaced that code to be a little simpler.

#440
