### PR TITLE
fix: incorrect vault name displayed for matching hierarchy

### DIFF
--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -538,7 +538,7 @@ export class PickerUtilsV2 {
           return {
             vault: value,
             detail: HIERARCHY_MATCH_DETAIL,
-            label: VaultUtils.getName(vault),
+            label: VaultUtils.getName(value),
           };
         });
 

--- a/packages/plugin-core/src/test/suite-integ/LookupUtils.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupUtils.test.ts
@@ -1,4 +1,4 @@
-import { DVault } from "@dendronhq/common-all";
+import { DVault, VaultUtils } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import { describe } from "mocha";
@@ -130,9 +130,11 @@ suite("Lookup Utils Test", function runSuite() {
 
           expect(recs![0].vault.fsPath).toEqual(vaults[0].fsPath);
           expect(recs![0].detail).toEqual(HIERARCHY_MATCH_DETAIL);
+          expect(recs![0].label).toEqual(VaultUtils.getName(vaults[0]));
 
           expect(recs![1].vault.fsPath).toEqual(vaultCtx.fsPath);
           expect(recs![1].detail).toEqual(CONTEXT_DETAIL);
+          expect(recs![1].label).toEqual(VaultUtils.getName(vaults[1]));
 
           done();
         },


### PR DESCRIPTION
If the user was in `vault1` and there was a matching hierarchy in `vault2`, Note Lookup would display the name `vault1` for the matching hierarchy. This PR fixes this issue.

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [ ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community



### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated