### PR TITLE
fix: fix journal note creation

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -367,7 +367,7 @@ export class NoteLookupCommand extends BaseCommand<
   ): Promise<OnDidAcceptReturn | undefined> {
     const ctx = "acceptNewItem";
     const picker = this.controller.quickpick;
-    const fname = item.fname;
+    const fname = this.getFNameForNewItem(item);
 
     const engine = getEngine();
     let nodeNew: NoteProps;
@@ -429,6 +429,19 @@ export class NoteLookupCommand extends BaseCommand<
       wsRoot: getDWorkspace().wsRoot,
     });
     return { uri, node: nodeNew, resp };
+  }
+
+  /**
+   * TODO: align note creation file name choosing for follow a single path when accepting new item.
+   *
+   * Added to quickly fix the journal names not being created properly.
+   */
+  private getFNameForNewItem(item: NoteQuickInput) {
+    if (this.isJournalButtonPressed()) {
+      return PickerUtilsV2.getValue(this.controller.quickpick);
+    } else {
+      return item.fname;
+    }
   }
 
   private async getVaultForNewNote({
@@ -493,10 +506,7 @@ export class NoteLookupCommand extends BaseCommand<
    * e.g.) if the picker value is journal.2021.08.13.some-stuff, we don't override (title is some-stuff)
    */
   journalTitleOverride(): string | undefined {
-    const journalBtn = _.find(this.controller.state.buttons, (btn) => {
-      return btn.type === LookupNoteTypeEnum.journal;
-    });
-    if (journalBtn?.pressed) {
+    if (this.isJournalButtonPressed()) {
       const quickpick = this.controller.quickpick;
 
       // note modifier value exists, and nothing else after that.
@@ -515,5 +525,13 @@ export class NoteLookupCommand extends BaseCommand<
       }
     }
     return;
+  }
+
+  private isJournalButtonPressed() {
+    const journalBtn = _.find(this.controller.state.buttons, (btn) => {
+      return btn.type === LookupNoteTypeEnum.journal;
+    });
+    const isPressed = journalBtn?.pressed;
+    return isPressed;
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -763,6 +763,9 @@ suite("NoteLookupCommand", function () {
           const note = VSCodeUtils.getNoteFromDocument(
             VSCodeUtils.getActiveTextEditor()!.document
           );
+
+          expect(note?.fname).toEqual(noteName);
+
           const titleOverride = today.split(".").join("-");
           expect(note!.title).toEqual(titleOverride);
 


### PR DESCRIPTION
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
   - Added a test assert although it appears it even passes before the fix so its usefullness is quite low. 
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
```
WHEN cmd+shift+j to activate journal command under root
   THEN 'root.journal.2021.10.05' suggestion appears
      AND clicked enter
        THEN 'root.journal.2021.10.05' note created

WHEN cmd+shift+l to activate look up command
    AND typed 'notes.some-new-note-27' 
      AND pressed enter
         THEN 'notes.some-new-note-27' created. 

GIVEN schema book (with added children: chars)
   WHEN created new note 'book.medtations'
       AND  went to lookup 'book.meditaions.'
           THEN 'book.meditaions.chars' schema suggestion appears
               AND clicked on suggestion
                   THEN 'book.meditaions.chars' note created
```
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
