### PR TITLE
chore: new BDD-light style compatible test harness & native workspace testing

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -240,3 +240,16 @@ export class PublishUtils {
     };
   }
 }
+
+/** Makes a single property within a type optional.
+ *
+ * Example:
+ * ```ts
+ * function foo(note: Optional<NoteProps, "title">) {
+ *   let title = note.title;
+ *   if (title === undefined) title = "default title";
+ *   // ...
+ * }
+ * ```
+ */
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -34,13 +34,8 @@ export class WorkspaceUtils {
       return WorkspaceType.CODE;
     }
     if (!_.isUndefined(workspaceFolders) && getStage() !== "prod") {
-      const dendronWorkspaceFolders =
-        workspaceFolders.filter((ent) => {
-          return fs.pathExistsSync(path.join(ent.uri.fsPath, "dendron.yml"));
-        }) || [];
-      if (dendronWorkspaceFolders.length > 0) {
-        return WorkspaceType.NATIVE;
-      }
+      const rootFolder = this.findWSRootInWorkspaceFolders(workspaceFolders);
+      if (rootFolder) return WorkspaceType.NATIVE;
     }
     return WorkspaceType.NONE;
   }

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -35,7 +35,12 @@ import { Duration } from "luxon";
 import path from "path";
 import semver from "semver";
 import * as vscode from "vscode";
-import { CONFIG, DendronContext, DENDRON_COMMANDS, GLOBAL_STATE } from "./constants";
+import {
+  CONFIG,
+  DendronContext,
+  DENDRON_COMMANDS,
+  GLOBAL_STATE,
+} from "./constants";
 import { Logger } from "./logger";
 import { migrateConfig } from "./migration";
 import { StateService } from "./services/stateService";
@@ -252,6 +257,12 @@ export async function _activate(
     //  needs to be initialized to setup commands
     const ws = DendronExtension.getOrCreate(context, {
       skipSetup: stage === "test",
+    });
+    // Need to recompute this for tests, because the instance of DendronExtension doesn't get re-created.
+    // Probably also needed if the user switches from one workspace to the other.
+    ws.type = WorkspaceUtils.getWorkspaceType({
+      workspaceFile: vscode.workspace.workspaceFile,
+      workspaceFolders: vscode.workspace.workspaceFolders,
     });
 
     const currentVersion = DendronExtension.version();
@@ -661,7 +672,10 @@ export async function showLapsedUserMessage(assetUri: vscode.Uri) {
         WSUtils.showWelcome(assetUri);
       } else {
         AnalyticsUtils.track(VSCodeEvents.LapsedUserMessageRejected);
-        const lapsedSurveySubmitted = await StateService.instance().getGlobalState(GLOBAL_STATE.LAPSED_USER_SURVEY_SUBMITTED);
+        const lapsedSurveySubmitted =
+          await StateService.instance().getGlobalState(
+            GLOBAL_STATE.LAPSED_USER_SURVEY_SUBMITTED
+          );
         if (lapsedSurveySubmitted === undefined) {
           SurveyUtils.showLapsedUserSurvey();
         }

--- a/packages/plugin-core/src/commands/SetupWorkspace.ts
+++ b/packages/plugin-core/src/commands/SetupWorkspace.ts
@@ -1,4 +1,4 @@
-import { CONSTANTS, DVault } from "@dendronhq/common-all";
+import { CONSTANTS, DVault, WorkspaceType } from "@dendronhq/common-all";
 import { WorkspaceService } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
@@ -23,6 +23,7 @@ type CommandOpts = {
    */
   skipConfirmation?: boolean;
   workspaceInitializer?: WorkspaceInitializer;
+  workspaceType?: WorkspaceType;
 };
 
 type CommandInput = {
@@ -153,10 +154,14 @@ export class SetupWorkspaceCommand extends BasicCommand<
       ? opts.workspaceInitializer.createVaults(opts.vault)
       : [];
 
+    // Default to CODE workspace, otherwise create a NATIVE one
+    const createCodeWorkspace =
+      opts.workspaceType === WorkspaceType.CODE ||
+      opts.workspaceType === undefined;
     await WorkspaceService.createWorkspace({
       vaults,
       wsRoot: rootDir,
-      createCodeWorkspace: true,
+      createCodeWorkspace,
     }).then(async (svc) => {
       if (opts?.workspaceInitializer?.onWorkspaceCreation) {
         await opts.workspaceInitializer.onWorkspaceCreation({

--- a/packages/plugin-core/src/commands/UpgradeSettings.ts
+++ b/packages/plugin-core/src/commands/UpgradeSettings.ts
@@ -1,7 +1,6 @@
 import { createLogger } from "@dendronhq/common-server";
 import { CodeConfigChanges } from "@dendronhq/engine-server";
 import _ from "lodash";
-import path from "path";
 import { Extension, extensions, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WorkspaceConfig } from "../settings";
@@ -23,9 +22,10 @@ export class UpgradeSettingsCommand extends BasicCommand<
   async execute(_opts: UpgradeSettingsCommandOpts) {
     const ctx = "Upgrade:execute";
     L.info({ ctx });
-    const newConfig = await WorkspaceConfig.update(
-      path.dirname(DendronExtension.workspaceFile().fsPath)
-    );
+
+    const wsRoot = DendronExtension.workspaceRoot();
+
+    const newConfig = await WorkspaceConfig.update(wsRoot!);
     this.L.info({ ctx, newConfig });
     // vscode doesn't let us uninstall extensions
     // tell user to uninstall extensions we no longer want

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
@@ -1,0 +1,78 @@
+import { WorkspaceType } from "@dendronhq/common-all";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { getDWorkspace } from "../../workspace";
+import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+import { _activate } from "../../_extension";
+import { expect } from "../testUtilsv2";
+
+suite("GIVEN testing code setupLegacyWorkspaceMulti", function () {
+  const ctx = setupBeforeAfter(this);
+
+  describeMultiWS(
+    "WHEN configured for NATIVE workspace",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+      ctx,
+      workspaceType: WorkspaceType.NATIVE,
+    },
+    () => {
+      test("THEN initializes correctly", (done) => {
+        const { engine } = getDWorkspace();
+        const testNote = engine.notes["foo"];
+        expect(testNote).toBeTruthy();
+        done();
+      });
+
+      test("THEN is of NATIVE type", (done) => {
+        const { type } = getDWorkspace();
+        expect(type).toEqual(WorkspaceType.NATIVE);
+        done();
+      });
+    }
+  );
+
+  describeMultiWS(
+    "WHEN configured for CODE workspace",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+      ctx,
+      workspaceType: WorkspaceType.CODE,
+    },
+    () => {
+      test("THEN initializes correctly", (done) => {
+        const { engine } = getDWorkspace();
+        const testNote = engine.notes["foo"];
+        expect(testNote).toBeTruthy();
+        done();
+      });
+
+      test("THEN is of CODE type", (done) => {
+        const { type } = getDWorkspace();
+        expect(type).toEqual(WorkspaceType.CODE);
+        done();
+      });
+    }
+  );
+
+  describeMultiWS(
+    "WHEN workspace type is not specified",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+      ctx,
+    },
+    () => {
+      test("THEN initializes correctly", (done) => {
+        const { engine } = getDWorkspace();
+        const testNote = engine.notes["foo"];
+        expect(testNote).toBeTruthy();
+        done();
+      });
+
+      test("THEN is of CODE type", (done) => {
+        const { type } = getDWorkspace();
+        expect(type).toEqual(WorkspaceType.CODE);
+        done();
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -198,8 +198,8 @@ export async function setupLegacyWorkspaceMulti(
     setupWsOverride: {
       skipConfirmation: true,
       emptyWs: true,
-      workspaceType: WorkspaceType.CODE,
     },
+    workspaceType: WorkspaceType.CODE,
     preSetupHook: async () => {},
     postSetupHook: async () => {},
     wsSettingsOverride: {},

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -6,6 +6,7 @@ import {
   WorkspaceFolderRaw,
   WorkspaceOpts,
   WorkspaceSettings,
+  WorkspaceType,
 } from "@dendronhq/common-all";
 import {
   assignJSONWithComment,
@@ -31,10 +32,10 @@ import {
 } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
-import { afterEach, beforeEach, describe } from "mocha";
+import { afterEach, beforeEach, before, describe } from "mocha";
 import os from "os";
 import sinon from "sinon";
-import { ExtensionContext, Uri } from "vscode";
+import { ExtensionContext, Uri, WorkspaceFolder } from "vscode";
 import {
   SetupWorkspaceCommand,
   SetupWorkspaceOpts,
@@ -59,6 +60,7 @@ import {
   stubWorkspaceFile,
   stubWorkspaceFolders,
 } from "./testUtilsv2";
+
 const TIMEOUT = 60 * 1000 * 5;
 
 export const DENDRON_REMOTE =
@@ -75,42 +77,49 @@ export type OnInitHook = (opts: WorkspaceOpts & EngineOpt) => Promise<void>;
 
 type PostSetupWorkspaceHook = (opts: WorkspaceOpts) => Promise<void>;
 
-export type SetupLegacyWorkspaceOpts = SetupCodeConfigurationV2 & {
-  ctx: ExtensionContext;
-  preActivateHook?: any;
-  postActivateHook?: any;
-  preSetupHook?: PreSetupCmdHookFunction;
-  postSetupHook?: PostSetupWorkspaceHook;
-  setupWsOverride?: Partial<SetupWorkspaceOpts>;
+type SetupWorkspaceType = {
+  /** The type of workspace to create for the test, Native (w/o dendron.code-worksace) or Code (w/ dendron.code-workspace) */
+  workspaceType?: WorkspaceType;
 };
 
-export type SetupLegacyWorkspaceMultiOpts = SetupCodeConfigurationV2 & {
-  ctx: ExtensionContext;
-  /**
-   * Runs before the workspace is initialized
-   */
-  preSetupHook?: PreSetupHookFunction;
-  /**
-   * Runs after the workspace is initialized
-   */
-  postSetupHook?: PostSetupWorkspaceHook;
-  /**
-   * Runs before the workspace is activated
-   */
-  preActivateHook?: any;
-  /**
-   * Run after workspace is activated
-   */
-  postActivateHook?: any;
-  /**
-   * By default, create workspace and vaults in a random temporary dir.
-   */
-  setupWsOverride?: Partial<SetupWorkspaceOpts>;
-  /**
-   * Overrid default Dendron settings (https://dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f48.html)
-   */
-  wsSettingsOverride?: Partial<WorkspaceSettings>;
-} & TestSetupWorkspaceOpts;
+export type SetupLegacyWorkspaceOpts = SetupCodeConfigurationV2 &
+  SetupWorkspaceType & {
+    ctx: ExtensionContext;
+    preActivateHook?: any;
+    postActivateHook?: any;
+    preSetupHook?: PreSetupCmdHookFunction;
+    postSetupHook?: PostSetupWorkspaceHook;
+    setupWsOverride?: Omit<Partial<SetupWorkspaceOpts>, "workspaceType">;
+  };
+
+export type SetupLegacyWorkspaceMultiOpts = SetupCodeConfigurationV2 &
+  SetupWorkspaceType & {
+    ctx: ExtensionContext;
+    /**
+     * Runs before the workspace is initialized
+     */
+    preSetupHook?: PreSetupHookFunction;
+    /**
+     * Runs after the workspace is initialized
+     */
+    postSetupHook?: PostSetupWorkspaceHook;
+    /**
+     * Runs before the workspace is activated
+     */
+    preActivateHook?: any;
+    /**
+     * Run after workspace is activated
+     */
+    postActivateHook?: any;
+    /**
+     * By default, create workspace and vaults in a random temporary dir.
+     */
+    setupWsOverride?: Omit<Partial<SetupWorkspaceOpts>, "workspaceType">;
+    /**
+     * Overrid default Dendron settings (https://dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f48.html)
+     */
+    wsSettingsOverride?: Partial<WorkspaceSettings>;
+  } & TestSetupWorkspaceOpts;
 
 export class EditorUtils {
   static async getURIForActiveEditor(): Promise<Uri> {
@@ -153,12 +162,13 @@ export async function setupLegacyWorkspace(
       skipConfirmation: true,
       emptyWs: true,
     },
+    workspaceType: WorkspaceType.CODE,
     preSetupHook: async () => {},
     postSetupHook: async () => {},
   });
   const wsRoot = tmpDir().name;
   fs.ensureDirSync(wsRoot);
-  stubWorkspaceFile(wsRoot);
+  if (copts.workspaceType === WorkspaceType.CODE) stubWorkspaceFile(wsRoot);
   setupCodeConfiguration(opts);
 
   await copts.preSetupHook({
@@ -170,6 +180,7 @@ export async function setupLegacyWorkspace(
     skipOpenWs: true,
     ...copts.setupWsOverride,
     workspaceInitializer: new BlankInitializer(),
+    workspaceType: copts.workspaceType,
   });
   stubWorkspaceFolders(wsRoot, vaults);
 
@@ -182,11 +193,12 @@ export async function setupLegacyWorkspace(
 
 export async function setupLegacyWorkspaceMulti(
   opts: SetupLegacyWorkspaceMultiOpts
-): Promise<any> {
+) {
   const copts = _.defaults(opts, {
     setupWsOverride: {
       skipConfirmation: true,
       emptyWs: true,
+      workspaceType: WorkspaceType.CODE,
     },
     preSetupHook: async () => {},
     postSetupHook: async () => {},
@@ -194,33 +206,42 @@ export async function setupLegacyWorkspaceMulti(
   });
   const { preSetupHook, postSetupHook, wsSettingsOverride } = copts;
 
+  let workspaceFile: Uri | undefined;
+  let workspaceFolders: readonly WorkspaceFolder[] | undefined;
+
   const { wsRoot, vaults } = await EngineTestUtilsV4.setupWS();
   new StateService(opts.ctx); // eslint-disable-line no-new
-  setupCodeConfiguration(opts);
-  // setup workspace file
-  stubWorkspace({ wsRoot, vaults });
-  const workspaceFile = DendronExtension.workspaceFile();
-  const workspaceFolders = DendronExtension.workspaceFolders();
+  if (copts.workspaceType === WorkspaceType.CODE) {
+    setupCodeConfiguration(opts);
+    stubWorkspace({ wsRoot, vaults });
 
-  // setup
-  WorkspaceConfig.write(wsRoot, vaults, {
-    overrides: wsSettingsOverride,
-    vaults,
-  });
+    workspaceFile = DendronExtension.workspaceFile();
+    workspaceFolders = DendronExtension.workspaceFolders();
+
+    WorkspaceConfig.write(wsRoot, vaults, {
+      overrides: wsSettingsOverride,
+      vaults,
+    });
+  } else {
+    stubWorkspaceFolders(wsRoot, vaults);
+  }
+
   await preSetupHook({
     wsRoot,
     vaults,
   });
   // update vscode settings
-  await DendronExtension.updateWorkspaceFile({
-    updateCb: (settings) => {
-      const folders: WorkspaceFolderRaw[] = vaults.map((ent) => ({
-        path: ent.fsPath,
-      }));
-      settings = assignJSONWithComment({ folders }, settings);
-      return settings;
-    },
-  });
+  if (copts.workspaceType === WorkspaceType.CODE) {
+    await DendronExtension.updateWorkspaceFile({
+      updateCb: (settings) => {
+        const folders: WorkspaceFolderRaw[] = vaults.map((ent) => ({
+          path: ent.fsPath,
+        }));
+        settings = assignJSONWithComment({ folders }, settings);
+        return settings;
+      },
+    });
+  }
 
   // update config
   let config = DConfig.getOrCreate(wsRoot);
@@ -266,10 +287,6 @@ export async function runLegacyMultiWorkspaceTest(
   return;
 }
 
-export function runSingleWorkspaceTest() {}
-
-export function runMultiWorkspaceTest() {}
-
 export function addDebugServerOverride() {
   return {
     configOverride: {
@@ -293,10 +310,9 @@ export function setupBeforeAfter(
     noSetInstallStatus?: boolean;
   }
 ) {
-  let ctx: ExtensionContext;
   // allows for
   _this.timeout(TIMEOUT);
-  ctx = VSCodeUtils.getOrCreateMockContext();
+  const ctx = VSCodeUtils.getOrCreateMockContext();
   beforeEach(async () => {
     // DendronWorkspace.getOrCreate(ctx);
 
@@ -399,4 +415,63 @@ export const stubVaultInput = (opts: {
 export function runTestButSkipForWindows() {
   const runTest = os.platform() === "win32" ? describe.skip : describe;
   return runTest;
+}
+
+/** Use to run tests with a multi-vault workspace. Used in the same way as regular `describe`.
+ *
+ * For example:
+ * ```ts
+ * describeMultiWS(
+ *   "WHEN workspace type is not specified",
+ *   {
+ *     preSetupHook: ENGINE_HOOKS.setupBasic,
+ *   },
+ *   () => {
+ *     test("THEN initializes correctly", (done) => {
+ *       const { engine, _wsRoot, _vaults } = getDWorkspace();
+ *       const testNote = engine.notes["foo"];
+ *       expect(testNote).toBeTruthy();
+ *       done();
+ *     });
+ *   }
+ * );
+ * ```
+ */
+export function describeMultiWS(
+  title: string,
+  opts: SetupLegacyWorkspaceMultiOpts,
+  fn: () => any
+) {
+  describe(title, () => {
+    before((done) => {
+      setupLegacyWorkspaceMulti(opts).then(() => {
+        _activate(opts.ctx);
+      });
+      onWSInit(() => {
+        done();
+      });
+    });
+
+    fn();
+  });
+}
+
+export function describeSingleWS(
+  _this: any,
+  title: string,
+  opts: SetupLegacyWorkspaceOpts,
+  fn: () => any
+) {
+  describe(title, () => {
+    before((done) => {
+      setupLegacyWorkspace(opts).then(() => {
+        _activate(opts.ctx);
+      });
+      onWSInit(() => {
+        done();
+      });
+    });
+
+    fn();
+  });
 }

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -433,28 +433,29 @@ export class LocationTestUtils {
 export const stubWorkspaceFile = (wsRoot: string) => {
   const wsPath = path.join(wsRoot, "dendron.code-workspace");
   fs.writeJSONSync(wsPath, {});
-  sinon.stub(workspace, "workspaceFile").returns(Uri.file(wsPath));
+  sinon.stub(workspace, "workspaceFile").value(Uri.file(wsPath));
   DendronExtension.workspaceFile = () => {
     return Uri.file(wsPath);
   };
 };
 
 export const stubWorkspaceFolders = (wsRoot: string, vaults: DVault[]) => {
-  sinon.stub(workspace, "workspaceFolders").returns(
-    vaults.map((v) => ({
+  const folders = vaults
+    .map((v) => ({
       name: VaultUtils.getName(v),
       index: 1,
       uri: Uri.file(path.join(wsRoot, VaultUtils.getRelPath(v))),
     }))
-  );
+    .concat([
+      {
+        name: "root",
+        index: 0,
+        uri: Uri.parse(wsRoot),
+      },
+    ]);
 
-  DendronExtension.workspaceFolders = () => {
-    return vaults.map((v) => ({
-      name: VaultUtils.getName(v),
-      index: 1,
-      uri: Uri.file(path.join(wsRoot, VaultUtils.getRelPath(v))),
-    }));
-  };
+  sinon.stub(workspace, "workspaceFolders").value(folders);
+  DendronExtension.workspaceFolders = () => folders;
 };
 
 export const stubWorkspace = ({ wsRoot, vaults }: WorkspaceOpts) => {

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -251,10 +251,10 @@ export async function setupCodeWorkspaceV2(opts: SetupCodeWorkspaceV2) {
   DendronExtension.workspaceFile = () => {
     return Uri.file(path.join(wsRoot, "dendron.code-workspace"));
   };
-  DendronExtension.workspaceFolders = () => {
-    const uri = Uri.file(path.join(wsRoot, "vault"));
-    return [{ uri, name: "vault", index: 0 }];
-  };
+  stubWorkspace({
+    wsRoot,
+    vaults: [{ fsPath: path.join(wsRoot, "vault"), name: "vault" }],
+  });
   const workspaceFile = DendronExtension.workspaceFile();
   const workspaceFolders = DendronExtension.workspaceFolders();
   await preSetupHook({

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -224,6 +224,18 @@ export class DendronExtension {
     return vscode.workspace.workspaceFolders;
   }
 
+  static workspaceRoot(): string | undefined {
+    try {
+      return path.dirname(this.workspaceFile().fsPath);
+    } catch {
+      const workspaceFolders = this.workspaceFolders();
+      if (workspaceFolders)
+        return WorkspaceUtils.findWSRootInWorkspaceFolders(workspaceFolders)
+          ?.uri.fsPath;
+    }
+    return undefined;
+  }
+
   /**
    * Currently, this is a check to see if rootDir is defined in settings
    */
@@ -233,16 +245,10 @@ export class DendronExtension {
      * the reason we don't use `vscode.*` method is because we need to stub this value during tests
      */
     try {
+      const workspaceFolders = DendronExtension.workspaceFolders();
       // ground work for standalone vaults. only activate in dev mode
-      if (context && getStage() !== "prod") {
-        const { workspaceFolders } = vscode.workspace;
-        const dendronWorkspaceFolders =
-          workspaceFolders?.filter((ent) => {
-            return fs.pathExistsSync(path.join(ent.uri.fsPath, "dendron.yml"));
-          }) || [];
-        if (dendronWorkspaceFolders.length > 0) {
-          return dendronWorkspaceFolders[0];
-        }
+      if (context && workspaceFolders && getStage() !== "prod") {
+        return WorkspaceUtils.findWSRootInWorkspaceFolders(workspaceFolders);
       }
       return (
         path.basename(DendronExtension.workspaceFile().fsPath) ===


### PR DESCRIPTION
Sorry for the messy PR, had to touch a lot of stuff to get the tests working.

Most crucially, you can see the new tests in action in `WorkspaceInit.test.ts`. This mainly tests that the harness is working correctly, but also demonstrates how to use the new test harness with a BDD-light style.

This also patches the existing `runLegacyWorkspaceMulti` and `runLegacyWorkspace` harnesses to allow native workspaces to be tested. All one needs to do is to pass a workspace type parameter.

Also fixed something that I think would be an initialization bug in `_extension.ts` where the `DendronExtension` instance doesn't have it's type recomputed between activations, which means switching from a Code to Native workspace or vice versa would result in the wrong type.