### PR TITLE
chore: make initial survey always prompt

### DIFF
--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -367,54 +367,49 @@ export class LapsedUserPlugDiscordSurvey extends DendronQuickPickSurvey {
 
 export class SurveyUtils {
   /**
-   * Flip a coin to randomly prompt initial survey.
    * Asks three questions about background, use case, and prior tools used.
-   * @param forcePrompt skip flipping a coin and force prompting.
    */
-  static async maybePromptInitialSurvey(opts: { forcePrompt?: boolean }) {
-    const shouldPrompt = opts.forcePrompt ? true : !!Math.floor(Math.random() * 2);
-    if (shouldPrompt) {
-      AnalyticsUtils.track(SurveyEvents.InitialSurveyPrompted);
-      vscode.window
-        .showInformationMessage(
-          "Welcome to Dendron! 🌱",
-          { modal: true , detail: "Would you like to tell us a bit about yourself? This info will be used to provide a better onboarding experience. It will take less than a minute to complete."},
-          { title: "Proceed" },
-          { title: "Skip Survey"},
-        )
-        .then(async (resp) => {
-          if (resp?.title === "Proceed") {
-            const backgroundSurvey = BackgroundSurvey.create();
-            const useCaseSurvey = UseCaseSurvey.create();
-            const priorToolSurvey = PriorToolsSurvey.create();
+  static async showInitialSurvey() {
+    AnalyticsUtils.track(SurveyEvents.InitialSurveyPrompted);
+    vscode.window
+      .showInformationMessage(
+        "Welcome to Dendron! 🌱",
+        { modal: true , detail: "Would you like to tell us a bit about yourself? This info will be used to provide a better onboarding experience. It will take less than a minute to complete."},
+        { title: "Proceed" },
+        { title: "Skip Survey"},
+      )
+      .then(async (resp) => {
+        if (resp?.title === "Proceed") {
+          const backgroundSurvey = BackgroundSurvey.create();
+          const useCaseSurvey = UseCaseSurvey.create();
+          const priorToolSurvey = PriorToolsSurvey.create();
 
-            const backgroundResults = await backgroundSurvey.show(1, 3);
-            const useCaseResults = await useCaseSurvey.show(2, 3);
-            const priorToolsResults = await priorToolSurvey.show(3, 3);
+          const backgroundResults = await backgroundSurvey.show(1, 3);
+          const useCaseResults = await useCaseSurvey.show(2, 3);
+          const priorToolsResults = await priorToolSurvey.show(3, 3);
 
-            const answerCount = [
-              backgroundResults,
-              useCaseResults,
-              priorToolsResults,
-            ].filter((value) => !_.isUndefined(value)).length;
-            AnalyticsUtils.track(SurveyEvents.InitialSurveyAccepted, {
-              answerCount,
-            });
-            await StateService.instance().updateGlobalState(
-              GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED,
-              "submitted"
-            );
-            vscode.window.showInformationMessage("Survey submitted! Thanks for helping us make Dendron better 🌱");
-          } else {
-            vscode.window.showInformationMessage("Survey cancelled.");
-            AnalyticsUtils.track(SurveyEvents.InitialSurveyRejected);
-          }
-        })
-        // @ts-ignore
-        .catch((error: any) => {
-          Logger.error({msg: error});
-        });
-    }
+          const answerCount = [
+            backgroundResults,
+            useCaseResults,
+            priorToolsResults,
+          ].filter((value) => !_.isUndefined(value)).length;
+          AnalyticsUtils.track(SurveyEvents.InitialSurveyAccepted, {
+            answerCount,
+          });
+          await StateService.instance().updateGlobalState(
+            GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED,
+            "submitted"
+          );
+          vscode.window.showInformationMessage("Survey submitted! Thanks for helping us make Dendron better 🌱");
+        } else {
+          vscode.window.showInformationMessage("Survey cancelled.");
+          AnalyticsUtils.track(SurveyEvents.InitialSurveyRejected);
+        }
+      })
+      // @ts-ignore
+      .catch((error: any) => {
+        Logger.error({msg: error});
+      });
   }
 
   static async showLapsedUserSurvey() {

--- a/packages/plugin-core/src/test/suite-integ/Survey.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Survey.test.ts
@@ -12,15 +12,15 @@ import * as vscode from "vscode";
 
 suite("SurveyUtils", function () {
   const ctx = setupBeforeAfter(this);
-  describe("maybePromptInitialSurvey", () => {
+  describe("showInitialSurvey", () => {
     describe("GIVEN: INITIAL_SURVEY_SUBMITTED is not set", () => {
-      test("THEN: maybePromptInitialSurvey is called", (done) => {
+      test("THEN: showInitialSurvey is called", (done) => {
         runLegacyMultiWorkspaceTest({
           ctx,
           preSetupHook: async() => {},
           onInit: async () => {
             sinon.stub(StateService.instance(), "getGlobalState").resolves(undefined);
-            const surveySpy = sinon.spy(SurveyUtils, "maybePromptInitialSurvey")
+            const surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey")
             const tutorialInitializer = new TutorialInitializer();
             const ws = getDWorkspace();
             await tutorialInitializer.onWorkspaceOpen({ws});
@@ -32,13 +32,13 @@ suite("SurveyUtils", function () {
     });
 
     describe("GIVEN: INITIAL_SURVEY_SUBMITTED is set", () => {
-      test("THEN: maybePromptInitialSurvey is not called", (done) => {
+      test("THEN: showInitialSurvey is not called", (done) => {
         runLegacyMultiWorkspaceTest({
           ctx,
           preSetupHook: async() => {},
           onInit: async () => {
             sinon.stub(StateService.instance(), "getGlobalState").resolves("submitted");
-            const surveySpy = sinon.spy(SurveyUtils, "maybePromptInitialSurvey")
+            const surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey")
             const tutorialInitializer = new TutorialInitializer();
             const ws = getDWorkspace();
             await tutorialInitializer.onWorkspaceOpen({ws});

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -103,7 +103,7 @@ export class TutorialInitializer
     );
 
     if (!initialSurveySubmitted) {
-      await SurveyUtils.maybePromptInitialSurvey({forcePrompt: true});
+      await SurveyUtils.showInitialSurvey();
     }
 
     // Register a special analytics handler for the tutorial:


### PR DESCRIPTION
# chore: make initial survey always prompt
This PR:
- Makes initial survey always prompt (if a user hasn't been prompted before)

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [~] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
