### PR TITLE
fix: backward compatibility of id matching adding '_' to id regex match.

### DIFF
--- a/packages/common-all/src/uuid.ts
+++ b/packages/common-all/src/uuid.ts
@@ -1,5 +1,4 @@
 import { customAlphabet as nanoid } from "nanoid";
-import { customAlphabet as nanoidAsync } from "nanoid/async";
 import { customAlphabet as nanoidInsecure } from "nanoid/non-secure";
 import { alphanumeric } from "nanoid-dictionary";
 
@@ -11,19 +10,22 @@ const SHORT_ID_LENGTH = 12;
 /** Default length for nanoids. */
 const LONG_ID_LENGTH = 21;
 
-/** Generates a random identifier.
+/**
+ * Generates a random identifier.
+ *
+ * Backward compatibility notes:
+ * Previously this id has been generated differently including using
+ * ------------------------------
+ * * uuidv4(); from "uuid/v4";
+ * * { v4 } from "uuid";
+ * * nanoid(); from "nanoid";  uses: [A-Za-z0-9_-]
+ * ------------------------------
+ * Hence even though right now we only have alphanumeric ids, previously there
+ * has been ids with `-` and `_` around, that still exist in our users notes.
  *
  * @returns A url-safe, random identifier.
  */
 export const genUUID = nanoid(alphanumeric, LONG_ID_LENGTH);
-
-/** Generates a random identifier asynchronously.
- *
- * The entropy collection is performed asynchronously, allowing other code to run in the meantime.
- *
- * @returns A url-safe, random identifier.
- */
-export const genUUIDasync = nanoidAsync(alphanumeric, LONG_ID_LENGTH);
 
 /** Generates a shorter random identifier, faster but with potential cryptographic risks.
  *

--- a/packages/plugin-core/src/commands/ShowPreviewV2.ts
+++ b/packages/plugin-core/src/commands/ShowPreviewV2.ts
@@ -94,9 +94,10 @@ export const extractNoteIdFromHref = (data: {
   // * http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ#head2
   // * http://localhost:3005/vscode/0TDNEYgYvCs3ooZEuknNZ
   //
-  // Regex: https://regex101.com/r/Ql3h3t/1
+  // Regex is in reference to uuid.ts/genUUID() to match the note id.
+  // Regex: https://regex101.com/r/7pDj6G/1
   const { path } = vscode.Uri.parse(data.href);
-  const noteId = path.match(/vscode\/([a-zA-Z0-9-]*)/)?.[1];
+  const noteId = path.match(/vscode\/([a-zA-Z0-9-_]*)/)?.[1];
 
   return noteId;
 };

--- a/packages/plugin-core/src/test/suite-integ/ShowPreviewV2.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowPreviewV2.test.ts
@@ -35,6 +35,15 @@ suite("ShowPreviewV2 utility methods", () => {
         expect(actual).toEqual("0TDNEYgYvCs3ooZEuknNZ");
       });
 
+      it("AND has underscore THEN extract id", () => {
+        const actual = extractNoteIdFromHref({
+          id: "id1",
+          href: "http://localhost:3000/vscode/DO_RXSlAbwNwbz-ILKoQa.html",
+        });
+
+        expect(actual).toEqual("DO_RXSlAbwNwbz-ILKoQa");
+      });
+
       it("AND does not have header anchor THEN extract id", () => {
         const actual = extractNoteIdFromHref({
           id: "id1",


### PR DESCRIPTION
# fix: backward compatibility of id matching adding '_' to id regex match.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

## Related 
https://github.com/dendronhq/dendron/issues/1476