### PR TITLE
fix: preview refs to only show appropriate header content

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -31,6 +31,18 @@ export class DUtils {
   }
 }
 
+/**
+ * Special characters get completely removed when slug(str) gets called,
+ * includes removal of characters such as parenthesis () and UTF8 trees 🌲.
+ * --------------------------------------------------------------------------------
+ * Note when using GithubSlugger/BananaSlug each time that slug('value') is called
+ * on the same instance of slugger with duplicate value a new postfix with incrementing
+ * value will be assigned and returned:
+ *
+ * slugger.slug('val') -> 'val'
+ * slugger.slug('val') -> 'val-1'
+ * slugger.slug('val') -> 'val-2'
+ * */
 export const getSlugger = () => {
   return new GithubSlugger();
 };

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -557,7 +557,8 @@ export class DendronEngineV2 implements DEngine {
       },
       { flavor: ProcFlavor.PREVIEW }
     );
-    const payload = await proc.process(NoteUtils.serialize(note));
+    const serialized = NoteUtils.serialize(note);
+    const payload = await proc.process(serialized);
     return payload.toString();
   }
   async sync() {

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -306,7 +306,7 @@ export class MDUtilsV4 {
     }
 
     if (text) {
-      var headingText = toString(node);
+      const headingText = toString(node);
       return text.trim().toLowerCase() === slugger.slug(headingText.trim());
     }
 
@@ -598,8 +598,8 @@ export class MDUtilsV4 {
 
 export class PublishUtils {
   static getAbsUrlForAsset(opts: {
-    suffix?: string; 
-    config: IntermediateDendronConfig 
+    suffix?: string;
+    config: IntermediateDendronConfig;
   }) {
     const suffix = opts.suffix || "";
     const { config } = opts;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -761,7 +761,7 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>        
+<div class=\\"portal-parent-fader-bottom\\"></div>
 
 # Foo.One
 
@@ -774,17 +774,17 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>        
+<div class=\\"portal-parent-fader-bottom\\"></div>
 
 # Foo.Two
 
 blah
 
-</div>    
+</div>
 </div>
 Regular wikilink: [Two](foo.two.md)
 
-</div>    
+</div>
 </div>
 
 
@@ -1039,7 +1039,7 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>        
+<div class=\\"portal-parent-fader-bottom\\"></div>
 
 # Foo.One
 
@@ -1052,17 +1052,17 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div>        
+<div class=\\"portal-parent-fader-bottom\\"></div>
 
 # Foo.Two
 
 blah
 
-</div>    
+</div>
 </div>
 Regular wikilink: [Two](foo.two)
 
-</div>    
+</div>
 </div>
 
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -1,7 +1,7 @@
 import {
   IntermediateDendronConfig,
   NoteProps,
-  WorkspaceOpts
+  WorkspaceOpts,
 } from "@dendronhq/common-all";
 import {
   AssertUtils,

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -104,6 +104,41 @@ export const setupBasicMulti: PreSetupHookFunction = async ({
   await SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.create({ vault: vault1, wsRoot });
 };
 
+export const setupNoteRefHeader: PreSetupHookFunction = async ({
+  vaults,
+  wsRoot,
+  extra,
+}) => {
+  const vault = vaults[0];
+  let props;
+
+  if (extra?.idv2) {
+    props = { id: "foo-id" };
+  }
+  await NOTE_PRESETS_V4.NOTE_SIMPLE.create({
+    vault,
+    wsRoot,
+    body: "![[foo.one#sub-header--1a]]",
+    props,
+  });
+  await NoteTestUtilsV4.createNote({
+    vault,
+    fname: "foo.one",
+    body: [
+      "# header-🌲-1",
+      `header-1-content`,
+      `## sub-header-🌲-1a`,
+      `sub-header-1a-content`,
+      `# header-🌲-2`,
+      `header-2-content`,
+    ].join("\n"),
+    wsRoot,
+    props: {
+      id: "foo.one-id",
+    },
+  });
+};
+
 /**
  *
  * - foo
@@ -437,6 +472,7 @@ export const ENGINE_HOOKS = {
   setupSchemaPreseet,
   setupSchemaPresetWithNamespaceTemplate,
   setupNoteRefRecursive,
+  setupNoteRefHeader,
   setupJournals,
   setupEmpty,
   setupLinks,

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1633435266305
+updated: 1634031703026
 created: 1608518909864
 ---
 
@@ -49,7 +49,11 @@ Vault2
 
 ![[dendron.welcome#header-special-chars]]
 
-***
+### Sub header: just the subheader content should be rendered.
+![[dendron.ref.links.target-with-headers#sub-header-1]]
+
+### Sub header with special chars: just the subheader content should be rendered.
+![[dendron.ref.links.target-with-headers#sub-header--2]]
 
 ## Block References
 

--- a/test-workspace/vault/dendron.ref.links.target-with-headers.md
+++ b/test-workspace/vault/dendron.ref.links.target-with-headers.md
@@ -1,0 +1,19 @@
+---
+id: XApjW1Y2cBojNqNndsD0A
+title: Target with Headers
+desc: ''
+updated: 1634030728972
+created: 1633955736330
+---
+
+## header-1
+header-1-content
+
+### sub-header-1
+sub-header-1-content
+
+### sub-header-🌲-2
+sub-header-2-content
+
+## header-2
+header-2-content

--- a/test-workspace/vault/dendron.welcome.md
+++ b/test-workspace/vault/dendron.welcome.md
@@ -2,7 +2,7 @@
 id: 05774b2e-ebf7-4bbc-8171-ad191ba0ae0a
 title: "Welcome to Dendron \U0001F332"
 desc: ""
-updated: 1598457956604
+updated: 1634031684546
 created: 1598457956604
 stub: false
 nav_exclude: true
@@ -11,5 +11,6 @@ nav_exclude: true
 Some text
 
 ## Header1
+header-1-content.
 
 ## Header (special chars)


### PR DESCRIPTION
# fix: preview refs to only show appropriate header content

`![[ref-note#heading]]` should only take the `#heading` portion of the note without over-running into subsequent headings. 


# Related 
https://github.com/dendronhq/dendron/issues/837

# Description

[[scratch.2021.10.11.162807.preview-note-ref-heading-should-show-just-the-heading]]
## Current state:
### foo.md:
```md
![[bar#sub-heading-1a]]
```

### bar.md:
```md
## heading-1
content-1

### sub-heading-1a
sub-content-1a

## heading-2
content-2
```

### Expected foo.md preview render
```text
sub-heading-1a
sub-content-1a
```

### Actual foo.md preview render
```text
sub-heading-1a
sub-content-1a

heading-2
content-2
```



## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
