### PR TITLE
fix(publish): wikilinks inside note references don't have right link

### DIFF
--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -820,12 +820,15 @@ function convertNoteRefHelperAST(
     });
     if (isV5Active) {
       if (procOpts.dest === DendronASTDest.HTML) {
-        tmpProc = MDUtilsV5.procRemarkFull({
-          ...MDUtilsV5.getProcData(proc),
-          insideNoteRef: true,
-          fname: note.fname,
-          vault: note.vault,
-        });
+        tmpProc = MDUtilsV5.procRemarkFull(
+          {
+            ...MDUtilsV5.getProcData(proc),
+            insideNoteRef: true,
+            fname: note.fname,
+            vault: note.vault,
+          },
+          MDUtilsV5.getProcOpts(proc)
+        );
       }
     }
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
@@ -1,7 +1,4 @@
-import {
-  NoteTestUtilsV4,
-  TestPresetEntryV4,
-} from "@dendronhq/common-test-utils";
+import { TestPresetEntryV4 } from "@dendronhq/common-test-utils";
 import {
   DendronASTDest,
   Processor,
@@ -9,10 +6,10 @@ import {
 } from "@dendronhq/engine-server";
 import os from "os";
 import path from "path";
-import { ENGINE_HOOKS } from "../../../presets";
-import { checkNotInString, checkString } from "../../../utils";
-import { checkVFile, cleanVerifyOpts, createProcCompileTests } from "./utils";
 import { createEngineFromServer, runEngineTestV5 } from "../../../engine";
+import { ENGINE_HOOKS } from "../../../presets";
+import { checkString } from "../../../utils";
+import { cleanVerifyOpts, createProcCompileTests } from "./utils";
 
 const getOpts = (opts: any) => {
   const _copts = opts.extra as { proc: Processor; dest: DendronASTDest };
@@ -125,77 +122,6 @@ describe("MDUtils.proc", () => {
       await ENGINE_HOOKS.setupBasic(opts);
     },
   });
-  const NOTE_REF_BASIC_WITH_REHYPE = createProcCompileTests({
-    name: "NOTE_REF_WITH_REHYPE",
-    setup: async (opts) => {
-      const { proc } = getOpts(opts);
-      const txt = `![[alpha.md]]`;
-      const resp = await proc.process(txt);
-      return { resp, proc };
-    },
-    verify: {
-      [DendronASTDest.HTML]: {
-        [ProcFlavor.REGULAR]: async ({ extra }) => {
-          const { resp } = extra;
-          expect(resp).toMatchSnapshot();
-          await checkVFile(
-            resp,
-            // should have id for link
-            `<a href="alpha-id"`,
-            // html quoted
-            `<p><a href="bar.html">Bar</a></p>`
-          );
-          await checkNotInString(
-            resp.contents,
-            // should not have title
-            `Alpha<h1>`
-          );
-        },
-        [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
-        [ProcFlavor.PUBLISHING]: async ({ extra }) => {
-          const { resp } = extra;
-          expect(resp).toMatchSnapshot();
-          await checkString(
-            resp.contents,
-            // should have id for link
-            `<a href="/notes/alpha-id"`
-          );
-        },
-      },
-    },
-    preSetupHook: async (opts) => {
-      await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
-      await NoteTestUtilsV4.createNote({
-        fname: "alpha",
-        body: "[[bar]]",
-        vault: opts.vaults[0],
-        wsRoot: opts.wsRoot,
-        props: { id: "alpha-id" },
-      });
-    },
-  });
-  const NOTE_REF_MISSING = createProcCompileTests({
-    name: "NOTE_REF_MISSING",
-    setup: async (opts) => {
-      const { proc } = getOpts(opts);
-      const txt = `![[alpha.md]]`;
-      const resp = await proc.process(txt);
-      return { resp, proc };
-    },
-    verify: {
-      [DendronASTDest.HTML]: {
-        [ProcFlavor.REGULAR]: async ({ extra }) => {
-          const { resp } = extra;
-          await checkString(resp.contents, "No note with name alpha found");
-        },
-        [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
-        [ProcFlavor.PUBLISHING]: ProcFlavor.REGULAR,
-      },
-    },
-    preSetupHook: async (opts) => {
-      await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
-    },
-  });
 
   const WILDCARD_NOTE_REF_MISSING = createProcCompileTests({
     name: "WILDCARD_NOTE_REF_MISSING",
@@ -257,8 +183,6 @@ describe("MDUtils.proc", () => {
     ...WITH_FOOTNOTES,
     ...IMAGE_NO_LEAD_FORWARD_SLASH,
     ...IMAGE_WITH_LEAD_FORWARD_SLASH,
-    ...NOTE_REF_BASIC_WITH_REHYPE,
-    ...NOTE_REF_MISSING,
     ...WILDCARD_NOTE_REF_MISSING,
   ];
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/noteRef.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/noteRef.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MDUtils.proc "HTML: NOTE_REF_WITH_REHYPE: PREVIEW" 1`] = `
+exports[`GIVEN noteRef plugin WHEN note ref to html AND prettyLinks = true "HTML: NOTE_REF_WITH_REHYPE: PREVIEW" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
 <p></p><p></p><div class=\\"portal-container\\">
@@ -12,12 +12,12 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>
 <ol>
-<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"foo.ch1\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -26,7 +26,7 @@ VFile {
 }
 `;
 
-exports[`MDUtils.proc "HTML: NOTE_REF_WITH_REHYPE: PREVIEW" 2`] = `
+exports[`GIVEN noteRef plugin WHEN note ref to html AND prettyLinks = true "HTML: NOTE_REF_WITH_REHYPE: PREVIEW" 2`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
 <p></p><p></p><div class=\\"portal-container\\">
@@ -38,12 +38,12 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>
 <ol>
-<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"foo.ch1\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -52,7 +52,7 @@ VFile {
 }
 `;
 
-exports[`MDUtils.proc "HTML: NOTE_REF_WITH_REHYPE: PUBLISHING" 1`] = `
+exports[`GIVEN noteRef plugin WHEN note ref to html AND prettyLinks = true "HTML: NOTE_REF_WITH_REHYPE: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
 <p></p><p></p><div class=\\"portal-container\\">
@@ -64,12 +64,12 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"/notes/bar\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#children\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Children</h2>
 <ol>
-<li><a href=\\"/notes/foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"/notes/foo.ch1\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -78,7 +78,7 @@ VFile {
 }
 `;
 
-exports[`MDUtils.proc "HTML: NOTE_REF_WITH_REHYPE: REGULAR" 1`] = `
+exports[`GIVEN noteRef plugin WHEN note ref to html AND prettyLinks = true "HTML: NOTE_REF_WITH_REHYPE: REGULAR" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
 <p></p><p></p><div class=\\"portal-container\\">
@@ -90,12 +90,12 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>
 <ol>
-<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"foo.ch1\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -104,7 +104,7 @@ VFile {
 }
 `;
 
-exports[`MDUtils.proc "HTML: NOTE_REF_WITH_REHYPE: REGULAR" 2`] = `
+exports[`GIVEN noteRef plugin WHEN note ref to html AND prettyLinks = true "HTML: NOTE_REF_WITH_REHYPE: REGULAR" 2`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
 <p></p><p></p><div class=\\"portal-container\\">
@@ -116,12 +116,12 @@ VFile {
 </div>
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
-<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar.html\\">Bar</a></p>
+<div class=\\"portal-parent-fader-bottom\\"></div><p><a href=\\"bar\\">Bar</a></p>
 </div></div><p></p><p></p>
 <hr>
 <h2 id=\\"children\\">Children</h2>
 <ol>
-<li><a href=\\"foo.ch1.html\\">Ch1</a></li>
+<li><a href=\\"foo.ch1\\">Ch1</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/noteRef.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/noteRef.spec.ts
@@ -1,0 +1,125 @@
+import {
+  NoteTestUtilsV4,
+  TestPresetEntryV4,
+} from "@dendronhq/common-test-utils";
+import {
+  DendronASTDest,
+  Processor,
+  ProcFlavor,
+} from "@dendronhq/engine-server";
+import { TestConfigUtils } from "../../../..";
+import { createEngineFromServer, runEngineTestV5 } from "../../../../engine";
+import { ENGINE_HOOKS } from "../../../../presets";
+import { checkNotInString, checkString } from "../../../../utils";
+import { checkVFile, createProcCompileTests, ProcTests } from "../utils";
+
+const getOpts = (opts: any) => {
+  const _copts = opts.extra as { proc: Processor; dest: DendronASTDest };
+  return _copts;
+};
+
+const runTestCases = (testCases: ProcTests[]) => {
+  test.each(
+    testCases.map((ent) => [
+      `${ent.dest}: ${ent.name}: ${ent.flavor}`,
+      ent.testCase,
+    ])
+  )("%p", async (_key, testCase: TestPresetEntryV4) => {
+    await runEngineTestV5(testCase.testFunc, {
+      expect,
+      preSetupHook: testCase.preSetupHook,
+      createEngine: createEngineFromServer,
+    });
+  });
+};
+
+describe("GIVEN noteRef plugin", () => {
+  describe("WHEN note ref missing", () => {
+    runTestCases(
+      createProcCompileTests({
+        name: "NOTE_REF_MISSING",
+        setup: async (opts) => {
+          const { proc } = getOpts(opts);
+          const txt = `![[alpha.md]]`;
+          const resp = await proc.process(txt);
+          return { resp, proc };
+        },
+        verify: {
+          [DendronASTDest.HTML]: {
+            [ProcFlavor.REGULAR]: async ({ extra }) => {
+              const { resp } = extra;
+              await checkString(resp.contents, "No note with name alpha found");
+            },
+            [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
+            [ProcFlavor.PUBLISHING]: ProcFlavor.REGULAR,
+          },
+        },
+        preSetupHook: async (opts) => {
+          await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
+        },
+      })
+    );
+  });
+
+  describe("WHEN note ref to html AND prettyLinks = true", () => {
+    runTestCases(
+      createProcCompileTests({
+        name: "NOTE_REF_WITH_REHYPE",
+        setup: async (opts) => {
+          const { proc } = getOpts(opts);
+          const txt = `![[alpha.md]]`;
+          const resp = await proc.process(txt);
+          return { resp, proc };
+        },
+        verify: {
+          [DendronASTDest.HTML]: {
+            [ProcFlavor.REGULAR]: async ({ extra }) => {
+              const { resp } = extra;
+              expect(resp).toMatchSnapshot();
+              await checkVFile(
+                resp,
+                // should have id for link
+                `<a href="alpha-id"`,
+                // html quoted
+                `<p><a href="bar">Bar</a></p>`
+              );
+              await checkNotInString(
+                resp.contents,
+                // should not have title
+                `Alpha<h1>`
+              );
+            },
+            [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
+            [ProcFlavor.PUBLISHING]: async ({ extra }) => {
+              const { resp } = extra;
+              expect(resp).toMatchSnapshot();
+              await checkString(
+                resp.contents,
+                // should have id for link
+                `<a href="/notes/alpha-id"`,
+                `<a href="/notes/bar">Bar</a>`
+              );
+            },
+          },
+        },
+        preSetupHook: async (opts) => {
+          await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
+          await NoteTestUtilsV4.createNote({
+            fname: "alpha",
+            body: "[[bar]]",
+            vault: opts.vaults[0],
+            wsRoot: opts.wsRoot,
+            props: { id: "alpha-id" },
+          });
+          TestConfigUtils.withConfig(
+            (config) => {
+              config.site.usePrettyLinks = true;
+              return config;
+            },
+            { wsRoot: opts.wsRoot }
+          );
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
fix(publish): wikilinks inside note references don't have right link

When we parse markdown as part of a note ref, we create a new processor. This processor did not have the proc.opts copied over from the original processor.
We append a `/notes/` prefix to a wikilink when it will be published so the `proc.opts` needs to be passed down to the processor used to parse the note ref.

Also used this commit to clean up testing of note refs

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

#### Special Cases
- [x ] if your tests changes an existing snaphot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testiing 

