### PR TITLE
enhance: allow configuration of workspace to make 'Create New' not bubble up in note lookup.

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -220,6 +220,14 @@ export type DendronConfig = {
    */
   vaults: DVault[];
   hooks?: DHookDict;
+
+  /**
+   * When set to true `Create New` will not bubble up to the top of lookup results.
+   *
+   * default: false.
+   * */
+  lookupDontBubbleUpCreateNew?: boolean;
+
   /**
    * Pick vault when creating new note.
    * [Docs](https://dendron.so/notes/24b176f1-685d-44e1-a1b0-1704b1a92ca0.html#specify-vault-location-when-creating-a-note)

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -78,12 +78,14 @@ export type SchemaLookupProviderSuccessResp<T = never> = {
 
 /** This function presumes that 'CreateNew' should be shown and determines whether
  *  CreateNew should be at the top of the look up results or not. */
-function shouldBubbleUpCreateNew({
+export function shouldBubbleUpCreateNew({
   numberOfExactMatches,
   querystring,
+  dontBubbleUpCreateNew,
 }: {
   numberOfExactMatches: number;
   querystring: string;
+  dontBubbleUpCreateNew?: boolean;
 }) {
   // We don't want to bubble up create new if there is an exact match since
   // vast majority of times if there is an exact match user wants to navigate to it
@@ -98,7 +100,7 @@ function shouldBubbleUpCreateNew({
   const noSpecialQueryChars =
     !FuseEngine.doesContainSpecialQueryChars(querystring);
 
-  return noSpecialQueryChars && noExactMatches;
+  return noSpecialQueryChars && noExactMatches && !dontBubbleUpCreateNew;
 }
 
 export class NoteLookupProvider implements ILookupProviderV3 {
@@ -405,6 +407,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
           shouldBubbleUpCreateNew({
             numberOfExactMatches,
             querystring: queryOrig,
+            dontBubbleUpCreateNew: ws.config.lookupDontBubbleUpCreateNew,
           })
         ) {
           updatedItems = [entryCreateNew, ...updatedItems];

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, it, suite } from "mocha";
+import { expect } from "../testUtilsv2";
+import { shouldBubbleUpCreateNew } from "../../components/lookup/LookupProviderV3";
+
+suite("LookupProviderV3 utility methods:", () => {
+  describe(`shouldBubbleUpCreateNew`, () => {
+    describe(`WHEN no special characters and no exact matches`, () => {
+      let querystring: string;
+      let numberOfExactMatches: number;
+
+      beforeEach(() => {
+        querystring = "simple-query-no-special-chars";
+        numberOfExactMatches = 0;
+      });
+
+      it(`AND dont bubble up is omitted THEN bubble up`, () => {
+        expect(
+          shouldBubbleUpCreateNew({ querystring, numberOfExactMatches })
+        ).toBeTruthy();
+
+        expect(
+          shouldBubbleUpCreateNew({
+            querystring,
+            numberOfExactMatches,
+            dontBubbleUpCreateNew: undefined,
+          })
+        ).toBeTruthy();
+      });
+
+      it("AND dont bubble up is set to true THEN do NOT bubble up", () => {
+        const actual = shouldBubbleUpCreateNew({
+          querystring,
+          numberOfExactMatches,
+          dontBubbleUpCreateNew: true,
+        });
+        expect(actual).toBeFalsy();
+      });
+
+      it("AND dont bubble up is set to false THEN bubble up", () => {
+        const actual = shouldBubbleUpCreateNew({
+          querystring,
+          numberOfExactMatches,
+          dontBubbleUpCreateNew: false,
+        });
+        expect(actual).toBeTruthy();
+      });
+    });
+
+    it(`WHEN special char is used THEN do NOT bubble up`, () => {
+      const actual = shouldBubbleUpCreateNew({
+        querystring: "query with space",
+        numberOfExactMatches: 0,
+      });
+      expect(actual).toBeFalsy();
+    });
+
+    it(`WHEN number of exact matches is more than 0 THEN do NOT bubble up`, () => {
+      const actual = shouldBubbleUpCreateNew({
+        querystring: "query-val",
+        numberOfExactMatches: 1,
+      });
+      expect(actual).toBeFalsy();
+    });
+  });
+});

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -11,6 +11,7 @@ vaults:
 useFMTitle: true
 useNoteTitleForLink: true
 autoFoldFrontmatter: true
+# lookupDontBubbleUpCreateNew: true
 lookupConfirmVaultOnCreate: true
 mermaid: true
 useKatex: true


### PR DESCRIPTION
# enhance: allow configuration of workspace to make 'Create New' not bubble up in note lookup.
Adding optional configuration value `lookupDontBubbleUpCreateNew` inside workspace configuration. When this value is set `Create New` will not bubble up to the top of lookup results. 

# Description
This has been mentioned in Discord, adding this configuration will allow users to choose what type of `Create New` behavior they would like to have within the lookup note. The default behavior stays as is (if the value is not set `Create New`  will bubble up to the top.)

## General

### Quality Assurance
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows
