### PR TITLE
enhance: allow inline children within schemas

### DIFF
--- a/packages/common-server/src/parser.ts
+++ b/packages/common-server/src/parser.ts
@@ -1,21 +1,23 @@
 import {
   DendronError,
+  DNodePointer,
   DNodeUtils,
   DStore,
   DVault,
+  ERROR_SEVERITY,
   ERROR_STATUS,
+  genUUID,
   SchemaModuleOpts,
   SchemaModuleProps,
   SchemaOpts,
-  SchemaPropsDict,
   SchemaProps,
+  SchemaPropsDict,
   SchemaUtils,
 } from "@dendronhq/common-all";
 import _ from "lodash";
 import path from "path";
 import { file2Schema, vault2Path } from "./filesv2";
-import { DLogger } from "./logger";
-import { createLogger } from "./logger";
+import { createLogger, DLogger } from "./logger";
 
 let _LOGGER: DLogger | undefined;
 
@@ -32,6 +34,37 @@ export class ParserBaseV2 {
   get logger() {
     return this.opts.logger;
   }
+}
+const DEFAULT_LOG_CTX = "parsingSchemas";
+
+async function getSchemasFromImport(
+  imports: string[] | undefined,
+  opts: { fname: string; root: DVault; wsRoot: string }
+) {
+  const vpath = vault2Path({ vault: opts.root, wsRoot: opts.wsRoot });
+  let schemaModulesFromImport: SchemaModuleProps[] = [];
+  await Promise.all(
+    _.map(imports, async (ent) => {
+      const fpath = path.join(vpath, ent + ".schema.yml");
+      schemaModulesFromImport.push(await file2Schema(fpath, opts.wsRoot));
+    })
+  );
+  const schemaPropsFromImport = schemaModulesFromImport.flatMap((mod) => {
+    const domain = mod.fname;
+    return _.values(mod.schemas).map((ent) => {
+      ent.data.pattern = ent.data.pattern || ent.id;
+      ent.id = `${domain}.${ent.id}`;
+      ent.fname = opts.fname;
+      ent.parent = null;
+      ent.children = ent.children.map((ent) => `${domain}.${ent}`);
+      ent.vault = opts.root;
+      return ent;
+    });
+  });
+
+  getLogger().debug({ ctx: DEFAULT_LOG_CTX, schemaPropsFromImport });
+
+  return schemaPropsFromImport;
 }
 
 export class SchemaParserV2 extends ParserBaseV2 {
@@ -65,61 +98,116 @@ export class SchemaParserV2 extends ParserBaseV2 {
     }
   }
 
+  private static noInlineChildren(ent: SchemaOpts) {
+    return (
+      !ent.children || ent.children.length === 0 || _.isString(ent.children[0])
+    );
+  }
+
+  private static getSchemasFromFile(schemas: SchemaOpts[], vault: DVault) {
+    const collector: SchemaProps[] = [];
+
+    schemas.forEach((ent) => {
+      if (this.noInlineChildren(ent)) {
+        // Means we are dealing with non-inline schema and can just collect
+        // the parsed value.
+        collector.push(SchemaUtils.create({ ...ent, vault }));
+      } else {
+        // When we are dealing with inline children we need to process/collect
+        // the children bottom up from the inline tree and replace the children
+        // object with collected/generated ids of the inline children.
+        ent.children = this.processChildren(ent.children, collector, vault);
+
+        // No all the entity children objects are collected and they have
+        // been replaced with identifiers we can collect the root element itself.
+        collector.push(SchemaUtils.create({ ...ent, vault }));
+      }
+    });
+
+    getLogger().debug({ ctx: DEFAULT_LOG_CTX, schemaPropsFromFile: collector });
+
+    return collector;
+  }
+
+  private static processChildren(
+    children: any[] | undefined,
+    collector: SchemaProps[],
+    vault: DVault
+  ): DNodePointer[] {
+    if (!children) {
+      return [];
+    }
+
+    return children.map((child) => {
+      // To process the node we need all its children to already be processed
+      // hence call process children recursively to process the graph from bottom up.
+      child.children = this.processChildren(child.children, collector, vault);
+
+      this.setIdIfMissing(child);
+
+      collector.push(SchemaUtils.create({ ...child, vault }));
+
+      return child.id;
+    });
+  }
+
+  /**
+   * Ids are optional for inline schemas hence if there isn't an id
+   * we will generate the identifier. */
+  private static setIdIfMissing(ent: any) {
+    if (!ent.id) {
+      // When id is missing than we must have a pattern for the schema.
+      if (!ent.pattern) {
+        throw new DendronError({
+          message: `Pattern is missing in schema without id schema='${JSON.stringify(
+            ent
+          )}'`,
+          // Setting severity as minor since Dendron could still be functional even
+          // if some particular schema is malformed.
+          severity: ERROR_SEVERITY.MINOR,
+        });
+      }
+
+      ent.id = genUUID();
+    }
+  }
+
   static async parseSchemaModuleOpts(
     schemaModuleProps: SchemaModuleOpts,
     opts: { fname: string; root: DVault; wsRoot: string }
   ): Promise<SchemaModuleProps> {
     const { imports, schemas, version } = schemaModuleProps;
-    const { fname, root, wsRoot } = opts;
-    getLogger().info({ ctx: "parseSchemaModuleOpts", fname, root, imports });
-    const vpath = vault2Path({ vault: root, wsRoot });
-    let schemaModulesFromImport: SchemaModuleProps[] = [];
-    await Promise.all(
-      _.map(imports, async (ent) => {
-        const fpath = path.join(vpath, ent + ".schema.yml");
-        schemaModulesFromImport.push(await file2Schema(fpath, wsRoot));
-      })
-    );
-    const schemaPropsFromImport = schemaModulesFromImport.flatMap((mod) => {
-      const domain = mod.fname;
-      return _.values(mod.schemas).map((ent) => {
-        ent.data.pattern = ent.data.pattern || ent.id;
-        ent.id = `${domain}.${ent.id}`;
-        ent.fname = fname;
-        ent.parent = null;
-        ent.children = ent.children.map((ent) => `${domain}.${ent}`);
-        ent.vault = root;
-        return ent;
-      });
-    });
-    getLogger().debug({ ctx: "parseSchemaModuleOpts", schemaPropsFromImport });
-    const schemaPropsFromFile = schemas.map((ent) => {
-      return SchemaUtils.create({ ...ent, vault: root });
-    });
-    getLogger().debug({ ctx: "parseSchemaModuleOpts", schemaPropsFromFile });
-    const schemasAll = schemaPropsFromImport.concat(schemaPropsFromFile);
+    const { fname, root } = opts;
+    getLogger().info({ ctx: DEFAULT_LOG_CTX, fname, root, imports });
+
+    const schemasAll = [
+      ...(await getSchemasFromImport(imports, opts)),
+      ...this.getSchemasFromFile(schemas, root),
+    ];
 
     const schemasDict: SchemaPropsDict = {};
     schemasAll.forEach((ent) => {
       schemasDict[ent.id] = ent;
     });
 
-    const rootModule = SchemaUtils.getModuleRoot(schemaModuleProps);
-
     const addConnections = (parent: SchemaProps) => {
-      _.map(parent.children, (ch) => {
+      _.forEach(parent.children, (ch) => {
         const child = schemasDict[ch];
-        if (!child) {
+        if (child) {
+          DNodeUtils.addChild(parent, child);
+
+          addConnections(child);
+        } else {
           throw new DendronError({
             status: ERROR_STATUS.MISSING_SCHEMA,
             message: JSON.stringify({ parent, missingChild: ch }),
           });
         }
-        DNodeUtils.addChild(parent, child);
-        return addConnections(child);
       });
     };
+
     // add parent relationship
+    const rootModule = SchemaUtils.getModuleRoot(schemaModuleProps);
     addConnections(rootModule);
 
     return {

--- a/packages/engine-server/src/drivers/file/index.ts
+++ b/packages/engine-server/src/drivers/file/index.ts
@@ -1,0 +1,1 @@
+export * from "./schemaParser";

--- a/packages/engine-server/src/drivers/file/schemaParser.ts
+++ b/packages/engine-server/src/drivers/file/schemaParser.ts
@@ -15,13 +15,17 @@ import YAML from "yamljs";
 import { ParserBase } from "./parseBase";
 
 export class SchemaParser extends ParserBase {
-  async parseFile(fpath: string, root: DVault): Promise<SchemaModuleProps> {
+  private async parseFile(
+    fpath: string,
+    root: DVault
+  ): Promise<SchemaModuleProps> {
     const fname = path.basename(fpath, ".schema.yml");
     const wsRoot = this.opts.store.wsRoot;
     const vpath = vault2Path({ vault: root, wsRoot });
     const schemaOpts: any = YAML.parse(
       fs.readFileSync(path.join(vpath, fpath), "utf8")
     );
+
     return await cSchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
   }
 

--- a/packages/engine-server/src/drivers/index.ts
+++ b/packages/engine-server/src/drivers/index.ts
@@ -1,0 +1,1 @@
+export * from "./file";

--- a/packages/engine-server/src/index.ts
+++ b/packages/engine-server/src/index.ts
@@ -19,3 +19,4 @@ export * from "./migrations";
 export * from "./metadata";
 export { execa };
 export * from "./util/inMemoryNoteCache";
+export * from "./drivers";

--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
@@ -1,0 +1,345 @@
+import { runEngineTestV5 } from "../../../../engine";
+import { ENGINE_HOOKS } from "../../../../presets";
+import { DendronEngineClient, SchemaParser } from "@dendronhq/engine-server";
+import { getAllFiles, vault2Path } from "@dendronhq/common-server";
+import {
+  DendronError,
+  SchemaModuleProps,
+  SchemaProps,
+  WorkspaceOpts,
+} from "@dendronhq/common-all";
+
+async function parseSchemas(
+  preSetupHook: (opts: WorkspaceOpts & { extra?: any }) => Promise<any>
+): Promise<{
+  schemas: SchemaModuleProps[];
+  errors: DendronError[] | null;
+}> {
+  let payload: {
+    schemas: SchemaModuleProps[];
+    errors: DendronError[] | null;
+  };
+
+  await runEngineTestV5(
+    async ({ engine, vaults, wsRoot }) => {
+      const engineClient = engine as DendronEngineClient;
+
+      const parser: SchemaParser = new SchemaParser({
+        store: engineClient.store,
+        logger: engineClient.logger,
+      });
+      const vault = vaults[0];
+      const vpath = vault2Path({ vault, wsRoot });
+      const schemaFiles = getAllFiles({
+        root: vpath,
+        include: ["*.schema.yml"],
+      }) as string[];
+
+      console.log(`vpath`);
+      console.log(`Schema files: '${JSON.stringify(schemaFiles)}'`);
+
+      payload = await parser.parse(schemaFiles, vault);
+    },
+    { expect, preSetupHook: preSetupHook }
+  );
+
+  // @ts-ignore
+  return payload;
+}
+
+describe(`schemaParser tests:`, () => {
+  describe(`WHEN parsing non-inlined basic schema`, () => {
+    let payload: {
+      schemas: SchemaModuleProps[];
+      errors: DendronError[] | null;
+    };
+
+    beforeAll(async () => {
+      payload = await parseSchemas(ENGINE_HOOKS.setupSchemaPreseet);
+    });
+
+    it(`THEN payload has no errors`, () => {
+      expect(payload.errors).toEqual(null);
+    });
+
+    describe(`AND 'bar' related schemas are present`, () => {
+      let barSchema: SchemaProps;
+      let ch1Schema: SchemaProps;
+      let ch2Schema: SchemaProps;
+
+      beforeAll(() => {
+        // Bar schemas are at 0 index in the basic setup case.
+        const barSchemaGroup = payload.schemas[0];
+
+        barSchema = barSchemaGroup.schemas["bar"];
+        ch1Schema = barSchemaGroup.schemas["ch1"];
+        ch2Schema = barSchemaGroup.schemas["ch2"];
+
+        expect(barSchema).toBeDefined();
+        expect(ch1Schema).toBeDefined();
+        expect(ch2Schema).toBeDefined();
+      });
+
+      it(`THEN bar schema has 2 children`, () => {
+        expect(barSchema.children.length).toEqual(2);
+      });
+
+      it(`THEN both of the children are accounted`, () => {
+        expect(barSchema.children[0]).toEqual("ch1");
+        expect(barSchema.children[1]).toEqual("ch2");
+      });
+
+      it(`THEN vault of schema is correctly specified`, () => {
+        expect(barSchema.vault.fsPath).toEqual("vault1");
+      });
+
+      it(`THEN id of bar schema is set`, () => {
+        expect(barSchema.id).toEqual("bar");
+      });
+
+      it(`THEN title of bar schema is set`, () => {
+        expect(barSchema.title).toEqual("bar");
+      });
+
+      it(`THEN type of schema is set`, () => {
+        expect(barSchema.type).toEqual("schema");
+      });
+
+      it(`THEN ch1 has parent set`, () => {
+        expect(ch1Schema.parent).toEqual("bar");
+      });
+
+      it(`THEN ch1 does NOT have namespace set`, () => {
+        expect(ch1Schema.data.namespace).toBeFalsy();
+      });
+
+      it(`THEN ch1 has template set`, () => {
+        expect(ch1Schema.data.template?.id).toEqual(`bar.template.ch1`);
+        expect(ch1Schema.data.template?.type).toEqual(`note`);
+      });
+
+      it(`THEN ch2 has namespace set`, () => {
+        expect(ch2Schema.data.namespace).toBeTruthy();
+      });
+
+      it(`THEN ch2 has template set`, () => {
+        expect(ch2Schema.data.template?.id).toEqual(`bar.template.ch2`);
+        expect(ch2Schema.data.template?.type).toEqual(`note`);
+      });
+    });
+
+    // Make sure we aren't forgetting the other schemas that are present.
+    it(`THEN 'foo' schema is also present`, () => {
+      // Foo schemas are at index [1] in the basic case.
+      const fooSchemaGroup = payload.schemas[1];
+      expect(fooSchemaGroup.schemas["foo"]).toBeTruthy();
+    });
+  });
+
+  describe(`WHEN parsing non-inlined schema with patterns`, () => {
+    let payload: {
+      schemas: SchemaModuleProps[];
+      errors: DendronError[] | null;
+    };
+
+    beforeAll(async () => {
+      payload = await parseSchemas(
+        ENGINE_HOOKS.setupSchemaPresetWithNamespaceTemplate
+      );
+    });
+
+    it(`THEN payload has no errors`, () => {
+      expect(payload.errors).toEqual(null);
+    });
+
+    describe(`AND parsed the daily journal grouped schema:`, () => {
+      let journalSchemaGroup: SchemaModuleProps;
+
+      beforeAll(() => {
+        journalSchemaGroup = payload.schemas[1];
+      });
+
+      it(`THEN root id is set as daily`, () => {
+        expect(journalSchemaGroup.root.id).toEqual("daily");
+      });
+
+      it(`THEN root child is journal`, () => {
+        expect(journalSchemaGroup.root.children[0]).toEqual("journal");
+      });
+
+      it(`THEN root parent is root`, () => {
+        expect(journalSchemaGroup.root.parent).toEqual("root");
+      });
+
+      describe(`AND parsed journal schema`, () => {
+        let journalSchema: SchemaProps;
+
+        beforeAll(() => {
+          journalSchema = journalSchemaGroup.schemas["journal"];
+        });
+
+        it(`THEN journal schema has parent set to daily`, () => {
+          expect(journalSchema.parent).toEqual("daily");
+        });
+
+        it(`THEN journal schema has child set to year`, () => {
+          expect(journalSchema.children[0]).toEqual("year");
+        });
+      });
+
+      describe(`AND parsed year schema`, () => {
+        let yearSchema: SchemaProps;
+
+        beforeAll(() => {
+          yearSchema = journalSchemaGroup.schemas["year"];
+        });
+
+        it(`THEN year schema has pattern`, () => {
+          expect(yearSchema.data.pattern).toEqual("[0-2][0-9][0-9][0-9]");
+        });
+
+        it(`THEN year schema has journal parent`, () => {
+          expect(yearSchema.parent).toEqual("journal");
+        });
+      });
+
+      describe(`AND parsed month schema`, () => {
+        it(`THEN month schema has pattern`, () => {
+          expect(journalSchemaGroup.schemas["month"].data.pattern).toEqual(
+            "[0-9][0-9]"
+          );
+        });
+      });
+
+      describe(`AND parsed day schema`, () => {
+        let daySchema: SchemaProps;
+
+        beforeAll(() => {
+          daySchema = journalSchemaGroup.schemas["day"];
+        });
+
+        it(`THEN day schema is set to namespace`, () => {
+          expect(daySchema.data.namespace).toBeTruthy();
+        });
+
+        it(`THEN day schema has pattern`, () => {
+          expect(daySchema.data.pattern).toEqual("[0-9][0-9]");
+        });
+
+        it(`THEN day schema has template`, () => {
+          expect(daySchema.data.template?.id).toEqual("journal.template");
+          expect(daySchema.data.template?.type).toEqual("note");
+        });
+      });
+    });
+  });
+
+  /**
+   * Most of the inlined children in the test case for inline schemas will not have
+   * id value within the test input (id values for those entries will be generated
+   * by the parse logic).
+   * */
+  describe(`WHEN parsing inline schema`, () => {
+    let payload: {
+      schemas: SchemaModuleProps[];
+      errors: DendronError[] | null;
+    };
+    let inlined: SchemaModuleProps;
+
+    beforeAll(async () => {
+      payload = await parseSchemas(ENGINE_HOOKS.setupInlineSchema);
+      inlined = payload.schemas.filter((sch) => sch.fname === "inlined")[0];
+    });
+
+    it(`THEN payload does not have errors`, () => {
+      expect(payload.errors).toEqual(null);
+    });
+
+    describe(`AND parsing non inline part of schema which contains imported id`, () => {
+      let foosParent: SchemaProps;
+
+      beforeAll(() => {
+        foosParent = inlined.schemas["foos_parent"];
+      });
+
+      it(`THEN we have id to imported schema within node that used it.`, () => {
+        expect(foosParent.children[0]).toEqual("foo.foo");
+      });
+
+      it(`THEN we can reference imported schema object`, () => {
+        expect(inlined.schemas["foo.foo"].id).toEqual("foo.foo");
+      });
+    });
+
+    describe(`AND inline schema is parsed`, () => {
+      it(`THEN inlined root has daily id`, () => {
+        expect(inlined.root.id).toEqual("daily");
+      });
+
+      describe(`AND daily has journal child`, () => {
+        let journal: SchemaProps;
+
+        beforeAll(() => {
+          journal = inlined.schemas[inlined.root.children[0]];
+        });
+
+        it(`THEN patternless journal id is equal to journal`, () => {
+          // Journal entry does not have a pattern but its manual id should be
+          // good enough for our schema.
+          expect(journal.id).toEqual("journal");
+        });
+
+        it(`THEN journal title is set to id`, () => {
+          // Journal does not have a title set within the test input so its title
+          // is expected to default to id.
+          expect(journal.title).toEqual(journal.id);
+        });
+
+        describe(`AND journal has year child. (year has optional id set)`, () => {
+          let year: SchemaProps;
+
+          beforeAll(() => {
+            year = inlined.schemas["year_id"];
+          });
+
+          it(`THEN year has expected pattern`, () => {
+            expect(year.data.pattern).toEqual("[0-2][0-9][0-9][0-9]");
+          });
+
+          describe(`AND year has month child`, () => {
+            let month: SchemaProps;
+
+            beforeAll(() => {
+              month = inlined.schemas[year.children[0]];
+            });
+
+            it(`THEN month has expected pattern`, () => {
+              expect(month.data.pattern).toEqual("[0-1][0-9]");
+            });
+
+            it(`THEN title-less month has title set to its id`, () => {
+              expect(month.title).toEqual(month.id);
+            });
+
+            describe(`AND month has day child`, () => {
+              let day: SchemaProps;
+
+              beforeAll(() => {
+                day = inlined.schemas[month.children[0]];
+              });
+
+              it(`THEN day has expected pattern`, () => {
+                expect(day.data.pattern).toEqual("[0-3][0-9]");
+              });
+
+              it(`THEN day has expected template`, () => {
+                expect(day.data.template?.id).toEqual("templates.day");
+                expect(day.data.template?.type).toEqual("note");
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test-workspace/vault/dendron.note-create.md
+++ b/test-workspace/vault/dendron.note-create.md
@@ -1,0 +1,32 @@
+---
+id: 1Aq9iO0apYmnUORkmX87e
+title: Note Create
+desc: ''
+updated: 1634726107138
+created: 1634725641716
+---
+
+## Simple case
+* Type in `delete.me.some.note`
+* Press `Create new`
+* Validate note is created with the given name
+* Delete the note.
+
+## With matching simple schema
+```md
+In Note look up Type `book.book1.characters`
+    EXPECTED `book.book1.characters` schema matched shows up as top result
+    THEN click on `book.book1.characters` 
+        EXPECTED `book.book1.characters` note is created 
+            AND it used template `templates.book.characters`
+```
+AFTER: delete `book.book1.characters`
+
+## With matching inline schema
+```md
+Navigate to `daily` note
+    1. Press cmd+shift+j (to activate create journal)
+    2. Create suggested journal note
+    3. Validate that created note matches the template `templates.daily`
+```
+AFTER: delete the created note.

--- a/test-workspace/vault/dendron.note-lookup.md
+++ b/test-workspace/vault/dendron.note-lookup.md
@@ -2,7 +2,7 @@
 id: bNkYI2WWK6Jhm2eeVwqrh
 title: Note Lookup
 desc: ''
-updated: 1634279966914
+updated: 1634725877431
 created: 1633501913732
 ---
 
@@ -40,20 +40,8 @@ Note look up `cmd+l`:
 * [[with description|dendron.welcome]]
 * [[dendron.welcome]]
 
-## Create notes
-### Simple case:
-* Type in `delete.me.some.note`
-* Press `Create new`
-* Validate note is created with the given name
-* Delete the note.
+## Create notes look up related
+![[dendron.note-create#simple-case,1:#*]]
 
-### With matching schema
-```md
-In Note look up Type ``
-    EXPECTED `book.book1.characters` schema matched shows up as top result
-    THEN click on `book.book1.characters` 
-        EXPECTED `book.book1.characters` note is created 
-            AND it used template `templates.book.characters`
-```
-AFTER: delete `book.book1.characters`
+![[dendron.note-create#with-matching-simple-schema,1]]
 

--- a/test-workspace/vault/journal.schema.yml
+++ b/test-workspace/vault/journal.schema.yml
@@ -1,0 +1,15 @@
+version: 1
+schemas:
+  - id: daily
+    parent: root
+    children:
+      - pattern: journal
+        children:
+          - pattern: "[0-2][0-9][0-9][0-9]"
+            children:
+              - pattern: "[0-1][0-9]"
+                children:
+                  - pattern: "[0-3][0-9]"
+                    template:
+                      id: templates.daily
+                      type: note

--- a/test-workspace/vault/templates.daily.md
+++ b/test-workspace/vault/templates.daily.md
@@ -1,0 +1,10 @@
+---
+id: z8Jr41tR1PJxWc7qXrgwD
+title: Daily
+desc: ''
+updated: 1634725357715
+created: 1634725228527
+---
+
+
+Daily Journal template value.

--- a/test-workspace/vault2/daily.md
+++ b/test-workspace/vault2/daily.md
@@ -1,0 +1,9 @@
+---
+id: ar3WPlF6H7rpVR9AFaUFO
+title: Daily
+desc: ''
+updated: 1634725302848
+created: 1634725302848
+stub: true
+---
+


### PR DESCRIPTION
## enhance: allow inline children within schemas

Allows inline children within schemas to simplify schema creation.

DOCs PR: https://github.com/dendronhq/dendron-site/commit/244a3aa19b9a462d2b38b789fa9b1ed72c93250a

Example of inline schema:
```
version: 1
schemas:
  - id: daily
    parent: root
    children:
      - pattern: journal
        children:
          - pattern: "[0-2][0-9][0-9][0-9]"
            children:
              - pattern: "[0-1][0-9]"
                children:
                  - pattern: "[0-3][0-9]"
                    template:
                      id: templates.daily
                      type: note
```

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
```
  schemaParser tests:
    WHEN parsing non-inlined basic schema
      ✓ THEN payload has no errors (2ms)
      ✓ THEN 'foo' schema is also present
      AND 'bar' related schemas are present
        ✓ THEN bar schema has 2 children
        ✓ THEN both of the children are accounted
        ✓ THEN vault of schema is correctly specified (1ms)
        ✓ THEN id of bar schema is set
        ✓ THEN title of bar schema is set
        ✓ THEN type of schema is set
        ✓ THEN ch1 has parent set
        ✓ THEN ch1 does NOT have namespace set (1ms)
        ✓ THEN ch1 has template set
        ✓ THEN ch2 has namespace set
        ✓ THEN ch2 has template set
    WHEN parsing non-inlined schema with patterns
      ✓ THEN payload has no errors
      AND parsed the daily journal grouped schema:
        ✓ THEN root id is set as daily (1ms)
        ✓ THEN root child is journal
        ✓ THEN root parent is root
        AND parsed journal schema
          ✓ THEN journal schema has parent set to daily
          ✓ THEN journal schema has child set to year
        AND parsed year schema
          ✓ THEN year schema has pattern (1ms)
          ✓ THEN year schema has journal parent
        AND parsed month schema
          ✓ THEN month schema has pattern
        AND parsed day schema
          ✓ THEN day schema is set to namespace
          ✓ THEN day schema has pattern
          ✓ THEN day schema has template (1ms)
    WHEN parsing inline schema
      ✓ THEN payload does not have errors
      AND parsing non inline part of schema which contains imported id
        ✓ THEN we have id to imported schema within node that used it.
        ✓ THEN we can reference imported schema object
      AND inline schema is parsed
        ✓ THEN inlined root has daily id
        AND daily has journal child
          ✓ THEN patternless journal id is equal to journal
          ✓ THEN journal title is set to id
          AND journal has year child. (year has optional id set)
            ✓ THEN year has expected pattern
            AND year has month child
              ✓ THEN month has expected pattern (1ms)
              ✓ THEN title-less month has title set to its id
              AND month has day child
                ✓ THEN day has expected pattern
                ✓ THEN day has expected template (1ms)
```
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
Added new manual test for note creation regarding inline schemas.

- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running mac/linux, check the windows output and vice versa if you are developing on windows

### Docs
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [x] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

https://github.com/dendronhq/dendron-site/pull/236

