### PR TITLE
feat: update title aliases when note is renamed

### DIFF
--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -137,6 +137,26 @@ const NOTES = {
       preSetupHook: (opts) => preSetupHook(opts, { barBody: `[[secret|foo]]` }),
     }
   ),
+  UPDATES_DEFAULT_ALIAS: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runRename({
+        wsRoot,
+        vaults,
+        engine,
+        cb: ({ barChange }) => {
+          return [
+            {
+              actual: _.trim(barChange?.note.body),
+              expected: "[[Baz|baz]]",
+            },
+          ];
+        },
+      });
+    },
+    {
+      preSetupHook: (opts) => preSetupHook(opts, { barBody: `[[Foo|foo]]` }),
+    }
+  ),
   MULTIPLE_LINKS: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       return runRename({
@@ -947,7 +967,7 @@ const NOTES = {
       return [
         {
           actual: _.pick(error, "severity"),
-          expected: { severity: "fatal"},
+          expected: { severity: "fatal" },
         },
         {
           actual: error?.message?.includes("Unable to delete"),


### PR DESCRIPTION
When a note is renamed, any wikilinks to that note that use the previous title of the note as their alias will be updated to use the new title.

#1502