### PR TITLE
fix: footnote links move view in publishing & preview

### DIFF
--- a/packages/common-all/src/constants/frontend.ts
+++ b/packages/common-all/src/constants/frontend.ts
@@ -1,0 +1,4 @@
+/** The HTML element class used for footnote definitions. */
+export const FOOTNOTE_DEF_CLASS = "fn";
+/** The HTML element class used for footnote references. */
+export const FOOTNOTE_REF_CLASS = "fnref";

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -4,6 +4,7 @@ export * from "./env";
 export * from "./assert";
 export * from "./uuid";
 export * from "./constants";
+export * from "./constants/frontend";
 export * from "./error";
 export * from "./time";
 export * from "./utils";

--- a/packages/engine-server/src/markdown/remark/hierarchies.ts
+++ b/packages/engine-server/src/markdown/remark/hierarchies.ts
@@ -1,4 +1,9 @@
-import { NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import {
+  NoteUtils,
+  VaultUtils,
+  FOOTNOTE_DEF_CLASS,
+  FOOTNOTE_REF_CLASS,
+} from "@dendronhq/common-all";
 import visit from "unist-util-visit";
 import _ from "lodash";
 import { Content, FootnoteDefinition, FootnoteReference, Root } from "mdast";
@@ -18,15 +23,15 @@ type PluginOpts = {
 };
 
 // These are the HTML IDs for footnotes. This replicates what the footnotes plugin was doing.
-const FOOTNOTE_DEF_ID_PREFIX = "fn-";
-const FOOTNOTE_REF_ID_PREFIX = "fnref-";
+const FOOTNOTE_DEF_ID_PREFIX = `${FOOTNOTE_DEF_CLASS}-`;
+const FOOTNOTE_REF_ID_PREFIX = `${FOOTNOTE_REF_CLASS}-`;
 /** The symbol that will be shown as the "return to reference" button. */
 const FOOTNOTE_RETURN_SYMBOL = "˄";
 
 function footnote2html(reference: FootnoteReference) {
   return html(
     `<a id="${FOOTNOTE_REF_ID_PREFIX}${reference.identifier}"` +
-      `class="fnref"` +
+      `class="${FOOTNOTE_REF_CLASS}"` +
       `href="#${FOOTNOTE_DEF_ID_PREFIX}${reference.identifier}">` +
       (reference.label || reference.identifier) +
       `</a>`
@@ -38,7 +43,7 @@ function footnoteDef2html(definition: FootnoteDefinition) {
   // footnote reference. We have to inject the back arrow into the text inside
   // the definition, otherwise it renders in a different line than the definition.
   const backArrow = html(
-    `<a class="fn" href="#${FOOTNOTE_REF_ID_PREFIX}${definition.identifier}">${FOOTNOTE_RETURN_SYMBOL}</a>`
+    `<a class="${FOOTNOTE_DEF_CLASS}" href="#${FOOTNOTE_REF_ID_PREFIX}${definition.identifier}">${FOOTNOTE_RETURN_SYMBOL}</a>`
   );
   let lastParent: Parent | undefined;
   visit(definition, (node) => {
@@ -48,7 +53,7 @@ function footnoteDef2html(definition: FootnoteDefinition) {
   return paragraph([
     // Put the ID target first, so even if the footnote is multiple lines long, it jumps to the start
     html(
-      `<span id="${FOOTNOTE_DEF_ID_PREFIX}${definition.identifier}" style="display: none;"></span>`
+      `<span id="${FOOTNOTE_DEF_ID_PREFIX}${definition.identifier}" style="width: 0; height: 0;"></span>`
     ),
     ...definition.children,
   ]);

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -2675,7 +2675,7 @@ VFile {
 <hr>
 <h2 id=\\"footnotes\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#footnotes\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Footnotes</h2>
 <ol>
-<li><span id=\\"fn-minus\\" style=\\"display: none;\\"></span><p>Et porro minus facilis qui.<a class=\\"fn\\" href=\\"#fnref-minus\\">˄</a></p></li>
+<li><span id=\\"fn-minus\\" style=\\"width: 0; height: 0;\\"></span><p>Et porro minus facilis qui.<a class=\\"fn\\" href=\\"#fnref-minus\\">˄</a></p></li>
 </ol>
 </div></div><p></p><p></p>
 <hr>
@@ -2685,7 +2685,7 @@ VFile {
 </ol>
 <h2 id=\\"footnotes-1\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#footnotes-1\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Footnotes</h2>
 <ol>
-<li><span id=\\"fn-quo\\" style=\\"display: none;\\"></span><p>Id et velit ducimus quo ut.<a class=\\"fn\\" href=\\"#fnref-quo\\">˄</a></p></li>
+<li><span id=\\"fn-quo\\" style=\\"width: 0; height: 0;\\"></span><p>Id et velit ducimus quo ut.<a class=\\"fn\\" href=\\"#fnref-quo\\">˄</a></p></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -2714,7 +2714,7 @@ VFile {
 <hr>
 <h2 id=\\"footnotes\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#footnotes\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Footnotes</h2>
 <ol>
-<li><span id=\\"fn-minus\\" style=\\"display: none;\\"></span><p>Et porro minus facilis qui.<a class=\\"fn\\" href=\\"#fnref-minus\\">˄</a></p></li>
+<li><span id=\\"fn-minus\\" style=\\"width: 0; height: 0;\\"></span><p>Et porro minus facilis qui.<a class=\\"fn\\" href=\\"#fnref-minus\\">˄</a></p></li>
 </ol>
 </div></div><p></p><p></p>
 <hr>
@@ -2724,7 +2724,7 @@ VFile {
 </ol>
 <h2 id=\\"footnotes-1\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#footnotes-1\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Footnotes</h2>
 <ol>
-<li><span id=\\"fn-quo\\" style=\\"display: none;\\"></span><p>Id et velit ducimus quo ut.<a class=\\"fn\\" href=\\"#fnref-quo\\">˄</a></p></li>
+<li><span id=\\"fn-quo\\" style=\\"width: 0; height: 0;\\"></span><p>Id et velit ducimus quo ut.<a class=\\"fn\\" href=\\"#fnref-quo\\">˄</a></p></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},


### PR DESCRIPTION
Fixes the footnote links not working (both in publishing and preview).

Also for preview, it configures footnote links to not be forwarded to the VSCode UI. Otherwise, clicking footnote links in preview would just move to the start of the note in the editor.