### PR TITLE
fix: Title parts duplicated in Next publishing search

### DIFF
--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -136,7 +136,11 @@ function MatchTitle(props: {
   if (_.isUndefined(props.matches)) return <>{title}</>;
   const titleMatches = props.matches
     .filter((match) => match.key === "title")
-    .flatMap((match) => match.indices);
+    .flatMap((match) => match.indices)
+    .sort(
+      // Sort from earliest to latest match
+      ([leftStart, _leftEnd], [rightStart, _rightEnd]) => leftStart - rightStart
+    );
 
   let lastIndex = 0;
   const renderedTitle: (String | JSX.Element)[] = [];


### PR DESCRIPTION
Sometimes fuse.js returns the matched title parts out-of-order, which breaks the match highlighting algorithm and duplicates these parts. This fix sorts the matched parts first to avoid the issue.