### PR TITLE
enhance: allow untyped templates in schemas

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1240,6 +1240,9 @@ export class SchemaUtils {
     ];
     const optsWithoutData = _.omit(opts, schemaDataOpts);
     const optsData = _.pick(opts, schemaDataOpts);
+
+    this.processUntypedTemplate(optsData);
+
     const vault = opts.vault;
     return DNodeUtils.create({
       vault,
@@ -1250,6 +1253,23 @@ export class SchemaUtils {
       }),
       type: "schema",
     });
+  }
+
+  private static processUntypedTemplate(optsData: any) {
+    // Standard templates have the format of
+    //  `template: {id:'', type:''}`
+    //
+    // However we also want to support shorthand for declaring templates when just
+    // the id of the template is specified with the format of
+    //  `template: ''`
+    if (_.isString(optsData.template)) {
+      const typedTemplate = {
+        id: optsData.template,
+        type: "note",
+      };
+
+      optsData.template = typedTemplate;
+    }
   }
 
   static createModule(opts: SchemaModuleOpts): SchemaModuleOpts {

--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
@@ -259,7 +259,7 @@ describe(`schemaParser tests:`, () => {
       let foosParent: SchemaProps;
 
       beforeAll(() => {
-        foosParent = inlined.schemas["foos_parent"];
+        foosParent = inlined.schemas["id_with_imported_child"];
       });
 
       it(`THEN we have id to imported schema within node that used it.`, () => {
@@ -338,6 +338,39 @@ describe(`schemaParser tests:`, () => {
               });
             });
           });
+        });
+      });
+    });
+
+    describe(`AND parsing part which has untyped template`, () => {
+      let parentOfDesired: SchemaProps;
+
+      beforeAll(() => {
+        parentOfDesired =
+          inlined.schemas["with_child_that_has_untyped_template"];
+      });
+
+      describe(`AND parses element which has untyped template`, () => {
+        let withUntypedTemplate: SchemaProps;
+
+        beforeAll(() => {
+          withUntypedTemplate = inlined.schemas[parentOfDesired.children[0]];
+        });
+
+        it(`THEN has expected pattern`, () => {
+          expect(withUntypedTemplate.data.pattern).toEqual(
+            "has_untyped_template"
+          );
+        });
+
+        it(`THEN sets the id of the template`, () => {
+          expect(withUntypedTemplate.data.template?.id).toEqual(
+            "templates.untyped"
+          );
+        });
+
+        it(`THEN defaults to note type for template`, () => {
+          expect(withUntypedTemplate.data.template?.type).toEqual("note");
         });
       });
     });

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -246,9 +246,13 @@ schemas:
                     template:
                       id: templates.day
                       type: note
-  - id: foos_parent
+  - id: id_with_imported_child
     children:
       - foo.foo
+  - id: with_child_that_has_untyped_template
+    children:
+      - pattern: has_untyped_template
+        template: templates.untyped
 `
   );
 
@@ -256,6 +260,13 @@ schemas:
     wsRoot,
     body: "Template text",
     fname: "templates.day",
+    vault: vault1,
+  });
+
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    body: "Untyped template",
+    fname: "templates.untyped",
     vault: vault1,
   });
 };

--- a/test-workspace/vault/dendron.note-create.md
+++ b/test-workspace/vault/dendron.note-create.md
@@ -2,31 +2,45 @@
 id: 1Aq9iO0apYmnUORkmX87e
 title: Note Create
 desc: ''
-updated: 1634726107138
+updated: 1635139005752
 created: 1634725641716
 ---
 
-## Simple case
+## Main test cases:
+### Simple case
 * Type in `delete.me.some.note`
 * Press `Create new`
 * Validate note is created with the given name
 * Delete the note.
 
-## With matching simple schema
+### With matching simple schema
 ```md
 In Note look up Type `book.book1.characters`
     EXPECTED `book.book1.characters` schema matched shows up as top result
     THEN click on `book.book1.characters` 
         EXPECTED `book.book1.characters` note is created 
             AND it used template `templates.book.characters`
-```
-AFTER: delete `book.book1.characters`
 
-## With matching inline schema
+AFTER: delete `book.book1.characters`
+```
+
+### With matching inline schema
 ```md
 Navigate to `daily` note
     1. Press cmd+shift+j (to activate create journal)
     2. Create suggested journal note
     3. Validate that created note matches the template `templates.daily`
-```
+
 AFTER: delete the created note.
+```
+
+## Further test cases 
+Refer to [[Main test cases|#main-test-cases]] for primary test cases to run regarding note creation. 
+
+### With untyped template schema.
+```md
+1. Create a new note `untyped_template.one` 
+2. Validate that value in created note matches `templates.untyped.md`
+
+AFTER: delete `untyped_template.one` note. 
+```

--- a/test-workspace/vault/dendron.schema.md
+++ b/test-workspace/vault/dendron.schema.md
@@ -1,0 +1,9 @@
+---
+id: VSikPUBbpFNUiFe4R8BLy
+title: Schema
+desc: ''
+updated: 1635138913670
+created: 1635138851300
+---
+
+For now schema related testing is primarily with note creation which can be found in [[dendron.note-create]] (look for schema related tests).

--- a/test-workspace/vault/templates.untyped.md
+++ b/test-workspace/vault/templates.untyped.md
@@ -1,0 +1,9 @@
+---
+id: VphLAicqoz3lcGsBesdmD
+title: Untyped
+desc: ''
+updated: 1635138378476
+created: 1635138374572
+---
+
+Untyped template value.

--- a/test-workspace/vault/untyped_template.schema.yml
+++ b/test-workspace/vault/untyped_template.schema.yml
@@ -1,0 +1,9 @@
+version: 1
+imports: []
+schemas:
+  - id: untyped_template
+    parent: root
+    children:
+      - pattern: one
+        template: templates.untyped
+        


### PR DESCRIPTION
# enhance: allow untyped templates in schemas

Enable untyped schema template syntax for simplified schema creation. 

[PR doc](https://github.com/dendronhq/dendron-site/commit/0c13f2ba555a6855684949219a1c0a9e8ace3e62) 


## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

