### PR TITLE
chore: resolve same level dir wikilinks

### DIFF
--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -294,6 +294,13 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
       notes
         .filter((n) => !n.stub)
         .map(async (n) => {
+          const noteDirlevel = n.fname.split(".").length;
+          //notes in same level with n
+          const siblingNotes = hDict[noteDirlevel];
+          const wikilinkPrefix = n.fname.substring(
+            0,
+            n.fname.lastIndexOf(".") + 1
+          );
           const cBody = await MDUtilsV5.procRemarkFull(
             {
               fname: n.fname,
@@ -303,7 +310,14 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
             },
             { mode: ProcMode.IMPORT }
           )
-            .use(RemarkUtils.convertLinksToDotNotation(n, []))
+            .use(
+              RemarkUtils.convertLinksToDotNotation(
+                n,
+                [],
+                wikilinkPrefix,
+                siblingNotes
+              )
+            )
             .use(RemarkUtils.convertAssetReferences(n, assetHashMap, []))
             .process(n.body);
           n.body = cBody.toString();


### PR DESCRIPTION
# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

#### Special Cases
- [ ] if your tests changes an existing snapshot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] if you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

### Analytics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated
