### PR TITLE
fix: notes added outside Dendron missing backlinks

### DIFF
--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -17,6 +17,7 @@ import _ from "lodash";
 import path from "path";
 import * as vscode from "vscode";
 import { Logger } from "./logger";
+import { NoteSyncService } from "./services/NoteSyncService";
 import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
 import { getDWorkspace, getExtension } from "./workspace";
 
@@ -134,6 +135,10 @@ export class FileWatcher {
         }
 
         // add note
+        note = await NoteSyncService.updateNoteMeta({
+          note,
+          fmChangeOnly: false,
+        });
         await engine.updateNote(note as NoteProps, {
           newNode: true,
         });
@@ -203,6 +208,7 @@ export class FileWatcher {
     const ctx = "refreshTree";
     Logger.info({ ctx });
     getExtension().dendronTreeView?.treeProvider.refresh();
+    getExtension().backlinksDataProvider?.refresh();
   }, 100);
 }
 

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -151,6 +151,25 @@ export class NoteSyncService {
     });
     note = NoteUtils.hydrate({ noteRaw: note, noteHydrated: oldNote });
 
+    note = await NoteSyncService.updateNoteMeta({ note, fmChangeOnly });
+
+    const now = NoteUtils.genUpdateTime();
+    note.updated = now;
+
+    this.L.debug({ ctx, fname: note.fname, msg: "exit" });
+    const noteClean = await engine.updateNote(note);
+    ShowPreviewV2Command.refresh(noteClean);
+    return noteClean;
+  }
+
+  static async updateNoteMeta({
+    note,
+    fmChangeOnly,
+  }: {
+    note: NoteProps;
+    fmChangeOnly: boolean;
+  }) {
+    const { engine } = getDWorkspace();
     // Links have to be updated even with frontmatter only changes
     // because `tags` in frontmatter adds new links
     const links = LinkUtils.findLinks({ note, engine });
@@ -178,12 +197,6 @@ export class NoteSyncService {
       }
     }
 
-    const now = NoteUtils.genUpdateTime();
-    note.updated = now;
-
-    this.L.debug({ ctx, fname, msg: "exit" });
-    const noteClean = await engine.updateNote(note);
-    ShowPreviewV2Command.refresh(noteClean);
-    return noteClean;
+    return note;
   }
 }

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -135,6 +135,7 @@ export class DendronExtension {
   static DENDRON_WORKSPACE_FILE: string = "dendron.code-workspace";
   static _SERVER_CONFIGURATION: Partial<ServerConfiguration>;
 
+  public backlinksDataProvider: BacklinksTreeDataProvider | undefined;
   public dendronTreeView: DendronTreeView | undefined;
   public dendronTreeViewV2: DendronTreeViewV2 | undefined;
   public fileWatcher?: FileWatcher;
@@ -531,6 +532,7 @@ export class DendronExtension {
         showCollapseAll: true,
       }
     );
+    getExtension().backlinksDataProvider = backlinksTreeDataProvider;
 
     vscode.commands.registerCommand(
       "dendron.backlinks.expandAll",


### PR DESCRIPTION
Updates the links for notes added by the file watcher, and refreshes the backlinks view. This fixes issues with backlinks not updating when notes are added or removed outside of Dendron, for example with another editor or with git sync.