### PR TITLE
fix: hover & goto note should respect enableUser/HashTags

### DIFF
--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -259,6 +259,13 @@ const getLinks = ({
       return ent.value === filter?.loc?.fname;
     });
   }
+  createLogger("LinkUtils.getLinks").info({
+    ctx: "getLinks",
+    dlinksLength: dlinks.length,
+    noteRefsLength: noteRefs.length,
+    wikiLinksLength: wikiLinks.length,
+    filterLocFname: filter?.loc?.fname,
+  });
   return dlinks;
 };
 

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -1004,6 +1004,43 @@ suite("ReferenceProvider", function () {
       });
     });
 
+    test("hashtags are ignored when disabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo.test",
+            body: "this is tag foo.test",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "#foo.test",
+          });
+        },
+        modConfigCb: (config) => {
+          config.workspace!.enableHashTags = false;
+          return config;
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await VSCodeUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeFalsy();
+          done();
+        },
+      });
+    });
+
     test("user tag", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
@@ -1036,6 +1073,43 @@ suite("ReferenceProvider", function () {
             body: hover!.contents.join(""),
             match: ["this is user test.mctestface"],
           });
+          done();
+        },
+      });
+    });
+
+    test("user tags are ignored when disabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "user.test.mctestface",
+            body: "this is user test.mctestface",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "@test.mctestface",
+          });
+        },
+        modConfigCb: (config) => {
+          config.workspace!.enableUserTags = false;
+          return config;
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await VSCodeUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeFalsy();
           done();
         },
       });

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -1,4 +1,5 @@
 import {
+  ConfigUtils,
   DLink,
   DLinkType,
   DNoteAnchor,
@@ -295,37 +296,44 @@ export const getReferenceAtPosition = (
   const re = partial ? partialRefPattern : refPattern;
   const range = document.getWordRangeAtPosition(position, new RegExp(re));
   if (!range) {
-    // if not, it could be a hashtag
-    const rangeForHashTag = document.getWordRangeAtPosition(
-      position,
-      HASHTAG_REGEX_BASIC
+    const { enableUserTags, enableHashTags } = ConfigUtils.getWorkspace(
+      getDWorkspace().config
     );
-    if (rangeForHashTag) {
-      const docText = document.getText(rangeForHashTag);
-      const match = docText.match(HASHTAG_REGEX_LOOSE);
-      if (_.isNull(match)) return null;
-      return {
-        range: rangeForHashTag,
-        label: match[0],
-        ref: `${TAGS_HIERARCHY}${match.groups!.tagContents}`,
-        refText: docText,
-      };
+    if (enableHashTags) {
+      // if not, it could be a hashtag
+      const rangeForHashTag = document.getWordRangeAtPosition(
+        position,
+        HASHTAG_REGEX_BASIC
+      );
+      if (rangeForHashTag) {
+        const docText = document.getText(rangeForHashTag);
+        const match = docText.match(HASHTAG_REGEX_LOOSE);
+        if (_.isNull(match)) return null;
+        return {
+          range: rangeForHashTag,
+          label: match[0],
+          ref: `${TAGS_HIERARCHY}${match.groups!.tagContents}`,
+          refText: docText,
+        };
+      }
     }
-    // if not, it could be a user tag
-    const rangeForUserTag = document.getWordRangeAtPosition(
-      position,
-      USERTAG_REGEX_LOOSE
-    );
-    if (rangeForUserTag) {
-      const docText = document.getText(rangeForUserTag);
-      const match = docText.match(USERTAG_REGEX_LOOSE);
-      if (_.isNull(match)) return null;
-      return {
-        range: rangeForUserTag,
-        label: match[0],
-        ref: `${USERS_HIERARCHY}${match.groups!.userTagContents}`,
-        refText: docText,
-      };
+    if (enableUserTags) {
+      // if not, it could be a user tag
+      const rangeForUserTag = document.getWordRangeAtPosition(
+        position,
+        USERTAG_REGEX_LOOSE
+      );
+      if (rangeForUserTag) {
+        const docText = document.getText(rangeForUserTag);
+        const match = docText.match(USERTAG_REGEX_LOOSE);
+        if (_.isNull(match)) return null;
+        return {
+          range: rangeForUserTag,
+          label: match[0],
+          ref: `${USERS_HIERARCHY}${match.groups!.userTagContents}`,
+          refText: docText,
+        };
+      }
     }
     // if not, it could be a frontmatter tag
     let parsed: ReturnType<typeof parseFrontmatter> | undefined;


### PR DESCRIPTION
Hover & goto note should now ignore user tags & hashtags when they are disabled.
I could not reproduce the issue with Dendron Doctor reported in #1503, but I added some additional logging which might help diagnose the issue if it reoccurs.

Added tests for hover & doctor when user/hashtags are disabled. Also fixed a missing feature in engine test harness where config modifications wouldn't be applied.
