### PR TITLE
fix(template): table of contents layout

### DIFF
--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -92,24 +92,21 @@ export default function Note({
         )
       : null;
 
-  // const tocStyle = isMobile
-  //   ? { display: "none" }
-  //   : {
-  //       position: "absolute" as const,
-  //       top: HEADER.HEIGHT + 40,
-  //       right: 20,
-  //       marginTop: 20,
-  //       marginRight: 20,
-  //     };
-
   return (
     <>
       <DendronSEO note={note} config={config} />
       {customHeadContent && <DendronCustomHead content={customHeadContent} />}
       <Row>
         <Col span={24}>
-          <DendronNote noteContent={noteBody} />
-          {maybeCollection}
+          <Row gutter={20}>
+            <Col xs={24} md={20}>
+              <DendronNote noteContent={noteBody} />
+              {maybeCollection}
+            </Col>
+            <Col xs={0} md={4}>
+              <DendronTOC note={note} offsetTop={HEADER.HEIGHT} />
+            </Col>
+          </Row>
         </Col>
       </Row>
     </>

--- a/packages/nextjs-template/styles/constants.ts
+++ b/packages/nextjs-template/styles/constants.ts
@@ -25,7 +25,7 @@ const LAYOUT = {
     xl: "1200px",
     xxl: "1600px",
   },
-  CONTENT_MAX_WIDTH: 800,
+  CONTENT_MAX_WIDTH: 960,
 };
 
 export const DENDRON_STYLE_CONSTANTS = {


### PR DESCRIPTION
- Adding a Table of contents on the right side. Once the browser reach a small screen size, the table is not displayed anymore.

fix: [[Table of Contents for mobile display|scratch.2021.10.24.214152.table-of-contents-for-mobile-display]]


https://user-images.githubusercontent.com/989826/140085319-37bf348a-4f1a-4ecf-b3c2-14e8f239fd45.mov


