### PR TITLE
fix(pods): github import pod handle deleted authors

### DIFF
--- a/packages/pods-core/src/builtin/GithubIssuePod.ts
+++ b/packages/pods-core/src/builtin/GithubIssuePod.ts
@@ -242,7 +242,8 @@ export class GithubIssueImportPod extends ImportPod<GithubIssueImportPodConfig> 
           url: d.node.url,
           status: d.node.state,
           issueID: d.node.id,
-          author: d.node.author.url,
+          // can be null if user deleted their github account
+          author: d.node.author?.url,
         },
         tags,
       };


### PR DESCRIPTION
We currently assume all authors have urls. This isn't the case when the
author has deleted their account
