### PR TITLE
feat: adding new command: create schema from hierarchy

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1213,6 +1213,10 @@ export class NoteUtils {
       if (note) yield note;
     }
   }
+
+  static isNote(uri: URI) {
+    return uri.fsPath.endsWith(".md");
+  }
 }
 
 type SchemaMatchResult = {
@@ -1520,6 +1524,20 @@ export class SchemaUtils {
       return true;
     });
     return out;
+  }
+
+  static getSchema({ engine, id }: { engine: DEngineClient; id: string }) {
+    return engine.schemas[id];
+  }
+
+  static doesSchemaExist({
+    id,
+    engine,
+  }: {
+    id: string;
+    engine: DEngineClient;
+  }) {
+    return !_.isUndefined(engine.schemas[id]);
   }
 
   static getSchemaFromNote({

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -40,6 +40,34 @@ export type CreateSchemaOptsV4 = {
   modifier?: (schema: SchemaModuleProps) => SchemaModuleProps;
 };
 
+/**
+ * Class for simplifying creation of multiple notes for tests by being
+ * able to specify defaults upon construction. */
+export class TestNoteFactory {
+  private readonly _defaults: Omit<CreateNoteOptsV4, "fname">;
+
+  constructor(defaults: Omit<CreateNoteOptsV4, "fname">) {
+    this._defaults = {
+      ...defaults,
+    };
+  }
+
+  async createForFName(fname: string): Promise<NoteProps> {
+    return await NoteTestUtilsV4.createNote({
+      fname,
+      ...this._defaults,
+    });
+  }
+
+  async createForFNames(fnames: string[]): Promise<NoteProps[]> {
+    const noteProps: NoteProps[] = [];
+    for (let i = 0; i < fnames.length; i++) {
+      noteProps.push(await this.createForFName(fnames[i]));
+    }
+    return noteProps;
+  }
+}
+
 export class NoteTestUtilsV4 {
   static createSchema = async (opts: CreateSchemaOptsV4) => {
     const { fname, vault, noWrite, wsRoot } = _.defaults(opts, {

--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
@@ -35,9 +35,6 @@ async function parseSchemas(
         include: ["*.schema.yml"],
       }) as string[];
 
-      console.log(`vpath`);
-      console.log(`Schema files: '${JSON.stringify(schemaFiles)}'`);
-
       payload = await parser.parse(schemaFiles, vault);
     },
     { expect, preSetupHook: preSetupHook }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -103,6 +103,12 @@
         "desc": "Go to a note"
       },
       {
+        "command": "dendron.createSchemaFromHierarchy",
+        "title": "Dendron: Create Schema From Note Hierarchy",
+        "desc": "Create Schema from existing note hierarchy",
+        "docLink": "dendron.topic.schema.create-from-hierarchy.md"
+      },
+      {
         "command": "dendron.createDailyJournalNote",
         "title": "Dendron: Create Daily Journal Note",
         "desc": "Create a global journal note",
@@ -725,6 +731,10 @@
         "command": "dendron.gotoNote",
         "key": "ctrl+enter",
         "when": "editorFocus"
+      },
+      {
+        "command": "dendron.createSchemaFromHierarchy",
+        "when": "editorFocus && dendron:pluginActive"
       },
       {
         "command": "dendron.createDailyJournalNote",

--- a/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
+++ b/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
@@ -151,7 +151,7 @@ function getSchemaUri(vault: DVault, schemaName: string) {
  * asking user for input data.
  * */
 export class UserQueries {
-  static async haveUserPickSchemaFileName(
+  static async promptUserForSchemaFileName(
     hierarchyLevel: HierarchyLevel,
     vault: DVault
   ): Promise<string | undefined> {
@@ -172,7 +172,7 @@ export class UserQueries {
       alreadyExists = fs.existsSync(getSchemaUri(vault, schemaName).fsPath);
       if (alreadyExists) {
         vscode.window.showInformationMessage(
-          `Schema with name '${schemaName}' already exists. Pick a different name or cancel.`
+          `Schema with name '${schemaName}' already exists. Please choose a different name.`
         );
       }
     } while (alreadyExists);
@@ -180,14 +180,14 @@ export class UserQueries {
     return schemaName;
   }
 
-  static async haveUserSelectHierarchyLevel(currDocFsPath: string) {
+  static async promptUserToSelectHierarchyLevel(currDocFsPath: string) {
     const hierarchy = new Hierarchy(path.basename(currDocFsPath, ".md"));
 
     if (hierarchy.depth() <= 2) {
       // We require some depth to the hierarchy to be able to choose a variance
       // pattern within in it. More info within Hierarchy object.
       await vscode.window.showErrorMessage(
-        `Pick a note deeper within the note hierarchy.`
+        `Pick a note with note depth greater than 2.`
       );
 
       return undefined;
@@ -219,7 +219,7 @@ export class UserQueries {
     return hierarchyLevel;
   }
 
-  static haveUserPickPatternsFromCandidates(
+  static promptUserToPickPatternsFromCandidates(
     labeledCandidates: SchemaCandidate[]
   ): Promise<readonly SchemaCandidate[]> {
     return new Promise((resolve) => {
@@ -438,7 +438,7 @@ export class CreateSchemaFromHierarchyCommand extends BasicCommand<
     const vault = PluginVaultUtils.getVaultByNotePath({
       fsPath: currDocumentFSPath,
     });
-    const hierarchyLevel = await UserQueries.haveUserSelectHierarchyLevel(
+    const hierarchyLevel = await UserQueries.promptUserToSelectHierarchyLevel(
       currDocumentFSPath
     );
     if (hierarchyLevel === undefined) {
@@ -448,9 +448,9 @@ export class CreateSchemaFromHierarchyCommand extends BasicCommand<
 
     const candidates = this.getHierarchyCandidates(hierarchyLevel);
     const pickedCandidates =
-      await UserQueries.haveUserPickPatternsFromCandidates(candidates);
+      await UserQueries.promptUserToPickPatternsFromCandidates(candidates);
 
-    const schemaName = await UserQueries.haveUserPickSchemaFileName(
+    const schemaName = await UserQueries.promptUserForSchemaFileName(
       hierarchyLevel,
       vault
     );

--- a/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
+++ b/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
@@ -1,0 +1,528 @@
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+import { VSCodeUtils } from "../utils";
+import {
+  DVault,
+  NoteProps,
+  NoteUtils,
+  SchemaModuleProps,
+  SchemaUtils,
+} from "@dendronhq/common-all";
+import path from "path";
+import * as _ from "lodash";
+import { getDWorkspace } from "../workspace";
+import * as vscode from "vscode";
+import { Uri } from "vscode";
+import YAML from "js-yaml";
+import { PluginVaultUtils } from "../pluginVaultUtils";
+import { vault2Path } from "@dendronhq/common-server";
+import { SchemaSyncService } from "../services/SchemaSyncService";
+import * as fs from "fs";
+import { PluginSchemaUtils } from "../pluginSchemaUtils";
+
+type CommandOpts = {
+  candidates: readonly SchemaCandidate[];
+  schemaName: string;
+  hierarchyLevel: HierarchyLevel;
+  uri: Uri;
+};
+
+type CommandOutput = void;
+
+/**
+ * Represents the level of the file hierarchy that will have the '*' pattern.
+ * */
+export class HierarchyLevel {
+  label: string;
+  hierarchyTokens: string[];
+  idx: number;
+  noteMatchRegex: RegExp;
+
+  constructor(idx: number, tokens: string[]) {
+    this.hierarchyTokens = tokens;
+    this.idx = idx;
+    // https://regex101.com/r/VLrXxC/1
+    this.noteMatchRegex = new RegExp(
+      "^" + this.hierarchyTokens.slice(0, this.idx).join(".") + "\\..*\\..*.*"
+    );
+    this.label =
+      [...tokens.slice(0, idx), "*", ...tokens.slice(idx + 1)].join(".") +
+      ` (${tokens[idx]})`;
+  }
+
+  /** Id of the first token of the hierarchy (will be utilized for identifying the schema) */
+  topId() {
+    return this.hierarchyTokens[0];
+  }
+
+  tokenize(fname: string): string[] {
+    const tokens = fname.split(".");
+
+    return [...tokens.slice(0, this.idx), "*", ...tokens.slice(this.idx + 1)];
+  }
+
+  isCandidateNote(fname: string): boolean {
+    return this.noteMatchRegex.test(fname);
+  }
+
+  getDefaultSchemaName() {
+    // Schema naming currently is set to be a single level deep hence
+    // we should avoid using '.' in schema names.
+    return this.hierarchyTokens.slice(0, this.idx).join("-");
+  }
+}
+
+export class Hierarchy {
+  fname: string;
+  levels: HierarchyLevel[];
+  tokens: string[];
+
+  constructor(fname: string) {
+    this.fname = fname;
+    this.tokens = fname.split(".");
+    this.levels = [];
+    for (let i = 0; i < this.tokens.length; i += 1) {
+      this.levels.push(new HierarchyLevel(i, this.tokens));
+    }
+  }
+
+  depth() {
+    return this.tokens.length;
+  }
+
+  topId() {
+    return this.levels[0].topId();
+  }
+
+  /**
+   * Levels of the hierarchy that we deem as viable options for creating a schema for.
+   * We remove the first level since having something like `*.h1.h2` with `*` at the
+   * beginning will match all hierarchies. Therefore we slice off the first level.
+   *
+   * We also slice off the last level since we need child notes to exist to
+   * create a meaningful hierarchy.
+   * */
+  getSchemaebleLevels() {
+    return this.levels.slice(1, this.levels.length - 1);
+  }
+}
+
+export type SchemaCandidate = {
+  note: NoteProps;
+  label: string;
+  detail: string;
+};
+
+function isDescendentOf(
+  descendentCandidate: SchemaCandidate,
+  ancestorCandidate: SchemaCandidate
+) {
+  const isChild = descendentCandidate.note.fname.startsWith(
+    ancestorCandidate.note.fname + "."
+  );
+  return isChild;
+}
+
+function createCandidatesMapByFname(items: readonly SchemaCandidate[]) {
+  return new Map(items.map((item) => [item.note.fname, item]));
+}
+
+function getUriFromSchema(schema: SchemaModuleProps) {
+  const vaultPath = vault2Path({
+    vault: schema.vault,
+    wsRoot: getDWorkspace().wsRoot,
+  });
+  const uri = Uri.file(
+    SchemaUtils.getPath({ root: vaultPath, fname: schema.fname })
+  );
+  return uri;
+}
+
+function getSchemaUri(vault: DVault, schemaName: string) {
+  const vaultPath = vault2Path({ vault, wsRoot: getDWorkspace().wsRoot });
+  const uri = Uri.file(
+    SchemaUtils.getPath({ root: vaultPath, fname: schemaName })
+  );
+  return uri;
+}
+
+/**
+ * Encapsulates methods that are responsible for user interaction when
+ * asking user for input data.
+ * */
+export class UserQueries {
+  static async haveUserPickSchemaFileName(
+    hierarchyLevel: HierarchyLevel,
+    vault: DVault
+  ): Promise<string | undefined> {
+    let alreadyExists = false;
+    let schemaName: string | undefined;
+
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      schemaName = await VSCodeUtils.showInputBox({
+        value: hierarchyLevel.getDefaultSchemaName(),
+      });
+
+      if (!schemaName) {
+        // Cancelled.
+        return schemaName;
+      }
+
+      alreadyExists = fs.existsSync(getSchemaUri(vault, schemaName).fsPath);
+      if (alreadyExists) {
+        vscode.window.showInformationMessage(
+          `Schema with name '${schemaName}' already exists. Pick a different name or cancel.`
+        );
+      }
+    } while (alreadyExists);
+
+    return schemaName;
+  }
+
+  static async haveUserSelectHierarchyLevel(currDocFsPath: string) {
+    const hierarchy = new Hierarchy(path.basename(currDocFsPath, ".md"));
+
+    if (hierarchy.depth() <= 2) {
+      // We require some depth to the hierarchy to be able to choose a variance
+      // pattern within in it. More info within Hierarchy object.
+      await vscode.window.showErrorMessage(
+        `Pick a note deeper within the note hierarchy.`
+      );
+
+      return undefined;
+    }
+
+    if (PluginSchemaUtils.doesSchemaExist(hierarchy.topId())) {
+      // To avoid unpredictable conflicts of schemas: for now we will not allow
+      // creation schemas for hierarchies that already have existing top
+      // level schema id. Instead we will pop up error message with navigation
+      // action to the existing schema.
+      const msgGoToSchema = "Go to schema";
+      const action = await vscode.window.showErrorMessage(
+        `Schema with top level id: '${hierarchy.topId()}' already exists.`,
+        msgGoToSchema
+      );
+      if (action === msgGoToSchema) {
+        const schema = PluginSchemaUtils.getSchema(hierarchy.topId());
+
+        await VSCodeUtils.openFileInEditor(getUriFromSchema(schema));
+      }
+
+      return undefined;
+    }
+
+    const hierarchyLevel: HierarchyLevel | undefined =
+      await VSCodeUtils.showQuickPick(hierarchy.getSchemaebleLevels(), {
+        title: "Select hierarchy level that will vary within note hierarchies.",
+      });
+    return hierarchyLevel;
+  }
+
+  static haveUserPickPatternsFromCandidates(
+    labeledCandidates: SchemaCandidate[]
+  ): Promise<readonly SchemaCandidate[]> {
+    return new Promise((resolve) => {
+      // There are limitations with .showQuickPick() for our use case (like checking/unchecking items)
+      // hence we are using lower level createQuickPick().
+      const quickPick = vscode.window.createQuickPick<SchemaCandidate>();
+      quickPick.canSelectMany = true;
+      quickPick.items = labeledCandidates;
+      quickPick.selectedItems = quickPick.items;
+
+      // By the time we get to onDidChangeSelection function quickPick.selectedItems
+      // is already changed, hence we will keep our own copy of what was previously selected.
+      let prevSelected: readonly SchemaCandidate[] = quickPick.selectedItems;
+
+      quickPick.onDidChangeSelection(() => {
+        const currSelected = quickPick.selectedItems;
+
+        if (this.hasUnselected(prevSelected, currSelected)) {
+          quickPick.selectedItems = this.determineAfterUnselect(
+            prevSelected,
+            currSelected
+          );
+        } else if (this.hasSelected(prevSelected, currSelected)) {
+          quickPick.selectedItems = this.determineAfterSelect(
+            prevSelected,
+            currSelected,
+            labeledCandidates
+          );
+        }
+
+        prevSelected = quickPick.selectedItems;
+      });
+      quickPick.onDidHide(() => quickPick.dispose());
+      quickPick.onDidAccept(() => {
+        resolve(quickPick.selectedItems);
+        quickPick.hide();
+      });
+      quickPick.show();
+    });
+  }
+
+  static determineAfterSelect(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[],
+    all: SchemaCandidate[]
+  ) {
+    // When something is selected we want to make sure its hierarchical parents are selected
+    // as well, since it makes no sense to have 'h1.h2.h3' selected without having
+    // 'h1.h2' selected (since we will still need to create a schema path for 'h1.h2'.
+    const justChecked = this.findCheckedItem(prevSelected, currSelected);
+
+    const ancestorsToCheck = all.filter((ancestorCandidate) =>
+      isDescendentOf(justChecked, ancestorCandidate)
+    );
+
+    // Create a map to avoid double counting ancestors
+    const selectedMap = createCandidatesMapByFname(currSelected);
+    ancestorsToCheck.forEach((ancestor) =>
+      selectedMap.set(ancestor.note.fname, ancestor)
+    );
+
+    return Array.from(selectedMap.values());
+  }
+
+  static determineAfterUnselect(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[]
+  ) {
+    // When something is unselected we want to unselect all hierarchical
+    // children of that note.
+    const justUnchecked = this.findUncheckedItem(prevSelected, currSelected);
+
+    const withoutUncheckedChildren = currSelected.filter(
+      (item) => !isDescendentOf(item, justUnchecked)
+    );
+    return withoutUncheckedChildren;
+  }
+
+  static hasSelected(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[]
+  ) {
+    return prevSelected.length < currSelected.length;
+  }
+
+  static hasUnselected(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[]
+  ) {
+    return prevSelected.length > currSelected.length;
+  }
+
+  /** Finds the item from previously selected that is not selected anymore. */
+  static findUncheckedItem(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[]
+  ) {
+    const map = createCandidatesMapByFname(currSelected);
+
+    // The only time there will be more than one item unchecked in a single update event
+    // is when all the items are unchecked at the same time. At such case we don't need to
+    // worry about unchecking things anyway, hence we can just grab the first unchecked.
+    const uncheckedItem = prevSelected.filter(
+      (item) => !map.has(item.note.fname)
+    )[0];
+
+    return uncheckedItem;
+  }
+
+  /** Finds newly selected item.*/
+  static findCheckedItem(
+    prevSelected: readonly SchemaCandidate[],
+    currSelected: readonly SchemaCandidate[]
+  ) {
+    const map = createCandidatesMapByFname(prevSelected);
+    // The only time there will be more than checked one item in a single event
+    // is when everything got checked. In that case we don't need to worry
+    // about checking the parents anyway, hence we can just grab the first item.
+    return currSelected.filter((item) => !map.has(item.note.fname))[0];
+  }
+}
+
+type SchemaInMaking = {
+  id?: string;
+  title?: string;
+  parent?: string;
+  pattern?: string;
+  children?: SchemaInMaking[];
+};
+
+/**
+ * Responsible for forming the schema body from the hierarchical files that user chose. */
+export class SchemaCreator {
+  static makeSchemaBody({
+    candidates,
+    hierarchyLevel,
+  }: {
+    candidates: readonly SchemaCandidate[];
+    hierarchyLevel: HierarchyLevel;
+  }): string {
+    const tokenizedMatrix: string[][] = candidates.map((cand) =>
+      hierarchyLevel.tokenize(cand.note.fname)
+    );
+
+    const topLevel: SchemaInMaking = {
+      // Top level schema requires an id to function.
+      id: hierarchyLevel.topId(),
+      title: hierarchyLevel.topId(),
+      parent: "root",
+    };
+
+    for (let r = 0; r < tokenizedMatrix.length; r += 1) {
+      const tokenizedRow = tokenizedMatrix[r];
+
+      let currParent = topLevel;
+      // Top level is already taken care of hence we start out and index 1.
+      for (let i = 1; i < tokenizedRow.length; i += 1) {
+        if (_.isUndefined(currParent["children"])) {
+          currParent.children = [];
+        }
+        const currPattern = tokenizedRow[i];
+
+        if (currParent.children?.some((ch) => ch.pattern === currPattern)) {
+          // There is already our pattern in the schema schema hierarchy, so we should
+          // not double add it, find the matching element and assign it as parent for next iteration.
+          currParent = currParent.children?.filter(
+            (ch) => ch.pattern === currPattern
+          )[0];
+        } else {
+          const curr: SchemaInMaking = {
+            pattern: currPattern,
+          };
+          currParent.children?.push(curr);
+          currParent = curr;
+        }
+      }
+    }
+
+    const schemaJson = {
+      version: 1,
+      imports: [],
+      schemas: [topLevel],
+    };
+
+    return YAML.dump(schemaJson);
+  }
+}
+
+export class CreateSchemaFromHierarchyCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CREATE_SCHEMA_FROM_HIERARCHY.key;
+
+  async sanityCheck() {
+    const activeTextEditor = VSCodeUtils.getActiveTextEditor();
+
+    if (
+      _.isUndefined(activeTextEditor) ||
+      !NoteUtils.isNote(activeTextEditor.document.uri)
+    ) {
+      return "No note document open. Must have note document open for Create Schema from Hierarchy command.";
+    }
+
+    return;
+  }
+
+  async gatherInputs(): Promise<CommandOpts | undefined> {
+    const activeTextEditor = VSCodeUtils.getActiveTextEditor();
+    if (!activeTextEditor) {
+      // Error message will be displayed from the sanityCheck function.
+      return;
+    }
+
+    const currDocumentFSPath = activeTextEditor.document.uri.fsPath;
+    const vault = PluginVaultUtils.getVaultByNotePath({
+      fsPath: currDocumentFSPath,
+    });
+    const hierarchyLevel = await UserQueries.haveUserSelectHierarchyLevel(
+      currDocumentFSPath
+    );
+    if (hierarchyLevel === undefined) {
+      // User must have cancelled the command, get out.
+      return;
+    }
+
+    const candidates = this.getHierarchyCandidates(hierarchyLevel);
+    const pickedCandidates =
+      await UserQueries.haveUserPickPatternsFromCandidates(candidates);
+
+    const schemaName = await UserQueries.haveUserPickSchemaFileName(
+      hierarchyLevel,
+      vault
+    );
+    if (schemaName === undefined || schemaName.length === 0) {
+      // User must have cancelled the command, get out.
+      return;
+    }
+
+    const uri = getSchemaUri(vault, schemaName);
+
+    const commandOpts: CommandOpts = {
+      candidates: pickedCandidates,
+      schemaName,
+      hierarchyLevel,
+      uri,
+    };
+    return commandOpts;
+  }
+
+  private getHierarchyCandidates(
+    hierarchyLevel: HierarchyLevel
+  ): SchemaCandidate[] {
+    const { engine } = getDWorkspace();
+    const notes = engine.notes;
+    const noteCandidates = _.filter(notes, (n) =>
+      hierarchyLevel.isCandidateNote(n.fname)
+    );
+
+    return this.formatSchemaCandidates(noteCandidates, hierarchyLevel);
+  }
+
+  formatSchemaCandidates(
+    noteCandidates: NoteProps[],
+    hierarchyLevel: HierarchyLevel
+  ): SchemaCandidate[] {
+    return noteCandidates
+      .map((note) => {
+        const tokens = note.fname.split(".");
+
+        const patternStr = [
+          ...tokens.slice(0, hierarchyLevel.idx),
+          "*",
+          ...tokens.slice(hierarchyLevel.idx + 1),
+        ].join(".");
+
+        return {
+          label: patternStr,
+          detail: `Will match notes like ${note.fname}`,
+          note,
+        };
+      })
+      .sort((a, b) => {
+        if (a.note.fname === b.note.fname) {
+          return 0;
+        }
+        return a.note.fname < b.note.fname ? -1 : 1;
+      });
+  }
+
+  async execute({ candidates, hierarchyLevel, uri }: CommandOpts) {
+    const schemaBody = SchemaCreator.makeSchemaBody({
+      candidates,
+      hierarchyLevel,
+    });
+
+    fs.writeFileSync(uri.fsPath, schemaBody);
+
+    await SchemaSyncService.instance().saveSchema({
+      uri,
+      isBrandNewFile: true,
+    });
+
+    await VSCodeUtils.openFileInEditor(uri);
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -64,6 +64,7 @@ import { SeedRemoveCommand } from "./SeedRemoveCommand";
 import { RunMigrationCommand } from "./RunMigrationCommand";
 import { SeedBrowseCommand } from "./SeedBrowseCommand";
 import { CreateTaskCommand } from "./CreateTask";
+import { CreateSchemaFromHierarchyCommand } from "./CreateSchemaFromHierarchyCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 
 const ALL_COMMANDS = [
@@ -80,6 +81,7 @@ const ALL_COMMANDS = [
   CopyNoteURLCommand,
   CreateDailyJournalCommand,
   CreateHookCommand,
+  CreateSchemaFromHierarchyCommand,
   DeleteHookCommand,
   DeleteNodeCommand,
   DiagnosticsReportCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -87,7 +87,8 @@ type CommandEntry = {
     | "navigation"
     | "misc"
     | "publishing"
-    | "seeds";
+    | "seeds"
+    | "schemas";
   /**
    * Skip doc generation
    */
@@ -213,6 +214,16 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
       key: "ctrl+enter",
       when: "editorFocus",
     },
+  },
+  CREATE_SCHEMA_FROM_HIERARCHY: {
+    key: "dendron.createSchemaFromHierarchy",
+    title: `${CMD_PREFIX} Create Schema From Note Hierarchy`,
+    group: "schemas",
+    keybindings: {
+      when: `editorFocus && ${DendronContext.PLUGIN_ACTIVE}`,
+    },
+    desc: "Create Schema from existing note hierarchy",
+    docLink: "dendron.topic.schema.create-from-hierarchy.md",
   },
   CREATE_DAILY_JOURNAL_NOTE: {
     key: "dendron.createDailyJournalNote",

--- a/packages/plugin-core/src/pluginSchemaUtils.ts
+++ b/packages/plugin-core/src/pluginSchemaUtils.ts
@@ -1,0 +1,22 @@
+import { SchemaUtils } from "@dendronhq/common-all";
+import { getDWorkspace } from "./workspace";
+
+/**
+ * Wrapper around SchemaUtils which can fills out values available in the
+ * plugin (primarily the engine)
+ */
+export class PluginSchemaUtils {
+  public static doesSchemaExist(id: string) {
+    return SchemaUtils.doesSchemaExist({
+      id,
+      engine: getDWorkspace().engine,
+    });
+  }
+
+  public static getSchema(id: string) {
+    return SchemaUtils.getSchema({
+      id,
+      engine: getDWorkspace().engine,
+    });
+  }
+}

--- a/packages/plugin-core/src/pluginVaultUtils.ts
+++ b/packages/plugin-core/src/pluginVaultUtils.ts
@@ -1,0 +1,31 @@
+import { DVault, VaultUtils } from "@dendronhq/common-all";
+import { getDWorkspace } from "./workspace";
+
+/**
+ * Wrapper around common-all VaultUtils which provides defaults
+ * using the the current workspace accessible from the plugin. */
+export class PluginVaultUtils {
+  static getVaultByNotePath({
+    vaults,
+    wsRoot,
+    fsPath,
+  }: {
+    /** Absolute or relative path to note  */
+    fsPath: string;
+    wsRoot?: string;
+    vaults?: DVault[];
+  }): DVault {
+    if (!wsRoot) {
+      wsRoot = getDWorkspace().wsRoot;
+    }
+    if (!vaults) {
+      vaults = getDWorkspace().vaults;
+    }
+
+    return VaultUtils.getVaultByNotePath({
+      vaults,
+      wsRoot,
+      fsPath,
+    });
+  }
+}

--- a/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
@@ -217,7 +217,7 @@ schemas:
             .onFirstCall()
             .returns(Promise.resolve("happy"));
 
-          const actual = await UserQueries.haveUserPickSchemaFileName(
+          const actual = await UserQueries.promptUserForSchemaFileName(
             new HierarchyLevel(1, ["languages", "python", "data"]),
             vault
           );
@@ -236,7 +236,7 @@ schemas:
             .returns(Promise.resolve("inlined"))
             .returns(Promise.resolve("happy"));
 
-          const actual = await UserQueries.haveUserPickSchemaFileName(
+          const actual = await UserQueries.promptUserForSchemaFileName(
             TEST_HIERARCHY_LVL,
             vault
           );
@@ -255,7 +255,7 @@ schemas:
 
       it(`WHEN happy input THEN return user picked hierarchy level`, () => {
         runTestWithInlineSchemaSetup(async () => {
-          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+          const actual = await UserQueries.promptUserToSelectHierarchyLevel(
             "/tmp/languages.python.data.md"
           );
 
@@ -265,7 +265,7 @@ schemas:
 
       it(`WHEN hierarchy depth of current file is too small THEN undefined`, () => {
         runTestWithInlineSchemaSetup(async () => {
-          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+          const actual = await UserQueries.promptUserToSelectHierarchyLevel(
             "/tmp/languages.data.md"
           );
 
@@ -275,7 +275,7 @@ schemas:
 
       it(`WHEN top id is already used by existing schema THEN undefined`, () => {
         runTestWithInlineSchemaSetup(async () => {
-          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+          const actual = await UserQueries.promptUserToSelectHierarchyLevel(
             "/tmp/daily.python.data.md"
           );
 

--- a/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
@@ -1,0 +1,425 @@
+import {
+  CreateSchemaFromHierarchyCommand,
+  HierarchyLevel,
+  SchemaCandidate,
+  SchemaCreator,
+  UserQueries,
+} from "../../commands/CreateSchemaFromHierarchyCommand";
+import { TestNoteFactory } from "@dendronhq/common-test-utils";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import sinon from "sinon";
+import { beforeEach, describe, it } from "mocha";
+import { VSCodeUtils } from "../../utils";
+import { DVault } from "@dendronhq/common-all";
+import { expect } from "../testUtilsv2";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import vscode from "vscode";
+
+const TEST_HIERARCHY_LVL = new HierarchyLevel(1, [
+  "languages",
+  "python",
+  "data",
+]);
+
+const noteFactory = new TestNoteFactory({
+  vault: { fsPath: "/tmp/ws/v1" },
+  noWrite: true,
+  wsRoot: "/tmp/ws",
+});
+
+async function createSchemaCandidates(fnames: string[]) {
+  const candidates = [];
+  for (const fname of fnames) {
+    // eslint-disable-next-line no-await-in-loop
+    const note = await noteFactory.createForFName(fname);
+    candidates.push({
+      note,
+      label: `label for fname:'${note.fname}'`,
+      detail: `detail for fname:'${note.fname}'`,
+    });
+  }
+  return candidates;
+}
+
+async function createTestSchemaCandidatesDefault() {
+  const fnames = [
+    "languages.python.data",
+    "languages.python.data.integer",
+    "languages.python.data.string",
+    "languages.python.machine-learning",
+    "languages.python.machine-learning.pandas",
+  ];
+
+  return createSchemaCandidates(fnames);
+}
+
+suite("CreateSchemaFromHierarchyCommand tests", () => {
+  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
+    noSetTimeout: true,
+  });
+
+  function runTestWithInlineSchemaSetup(
+    func: ({ vaults }: { vaults: any }) => Promise<void>
+  ) {
+    runLegacyMultiWorkspaceTest({
+      ctx,
+      preSetupHook: ENGINE_HOOKS.setupInlineSchema,
+      onInit: func,
+    });
+  }
+
+  describe(`HierarchyLevel tests:`, () => {
+    describe(`GIVEN 'languages.*.data' hierarchy level`, () => {
+      let level: HierarchyLevel;
+      beforeEach(() => {
+        level = new HierarchyLevel(1, ["languages", "python", "data"]);
+      });
+
+      it(`THEN have expected label`, () => {
+        expect(level.label).toEqual("languages.*.data (python)");
+      });
+
+      it(`THEN have expected top id`, () => {
+        expect(level.topId()).toEqual("languages");
+      });
+
+      it(`THEN produce expected default schema name`, () => {
+        expect(level.getDefaultSchemaName()).toEqual("languages");
+      });
+
+      describe(`tokenize tests`, () => {
+        [
+          {
+            in: "languages.python.data",
+            out: ["languages", "*", "data"],
+          },
+          {
+            in: "languages.python.data.integer",
+            out: ["languages", "*", "data", "integer"],
+          },
+          {
+            in: "languages.python.machine-learning",
+            out: ["languages", "*", "machine-learning"],
+          },
+        ].forEach((input) =>
+          it(`WHEN fname is '${input.in}' THEN tokenize to '${JSON.stringify(
+            input.out
+          )}'.`, () => {
+            expect(level.tokenize(input.in)).toEqual(input.out);
+          })
+        );
+      });
+
+      describe(`isCandidateNote tests`, () => {
+        [
+          { in: "languages", out: false },
+          { in: "languages.python", out: false },
+          { in: "languages.python.data", out: true },
+          { in: "languages.python.data.integer", out: true },
+          { in: "languages.python.machine-learning", out: true },
+        ].forEach((input) =>
+          it(`WHEN testing '${input.in}' note THEN ${
+            input.out ? "do match" : "do NOT match"
+          }.`, () => {
+            expect(level.isCandidateNote(input.in)).toEqual(input.out);
+          })
+        );
+      });
+    });
+  });
+
+  describe(`SchemaCreator tests: `, () => {
+    let schemaCandidates: SchemaCandidate[];
+
+    beforeEach(async () => {
+      schemaCandidates = await createTestSchemaCandidatesDefault();
+    });
+
+    it(`WHEN valid schema candidates THEN generate schema`, () => {
+      const actual = SchemaCreator.makeSchemaBody({
+        candidates: schemaCandidates,
+        hierarchyLevel: new HierarchyLevel(1, ["languages", "python", "data"]),
+      });
+
+      const expected = `version: 1
+imports: []
+schemas:
+  - id: languages
+    title: languages
+    parent: root
+    children:
+      - pattern: '*'
+        children:
+          - pattern: data
+            children:
+              - pattern: integer
+              - pattern: string
+          - pattern: machine-learning
+            children:
+              - pattern: pandas\n`;
+
+      expect(expected).toEqual(actual);
+    });
+  });
+
+  describe(`CreateSchemaFromHierarchyCommand`, () => {
+    describe(`sanityCheck tests:`, () => {
+      it(`WHEN no active text editor THEN give error`, async () => {
+        sinon.stub(VSCodeUtils, "getActiveTextEditor").returns(undefined);
+
+        const cmd = new CreateSchemaFromHierarchyCommand();
+        const actual = await cmd.sanityCheck();
+        expect(actual?.includes("No note document open")).toBeTruthy();
+      });
+    });
+
+    describe(`formatSchemaCandidates tests:`, () => {
+      describe(`WHEN formatting valid input idx=1 ['h1.h2.h3a', 'h1.h2.h3b']`, () => {
+        let schemaCandidates: SchemaCandidate[];
+
+        beforeEach(async () => {
+          const cmd = new CreateSchemaFromHierarchyCommand();
+
+          const notes = await noteFactory.createForFNames([
+            "h1.h2.h3a",
+            "h1.h2.h3b",
+          ]);
+
+          schemaCandidates = cmd.formatSchemaCandidates(
+            notes,
+            new HierarchyLevel(1, ["h1", "h2", "h3a"])
+          );
+        });
+
+        it(`THEN include 'h1.*.h3a' label`, () => {
+          expect(
+            schemaCandidates.some((cand) => cand.label === "h1.*.h3a")
+          ).toBeTruthy();
+        });
+      });
+    });
+  });
+
+  describe(`UserQueries tests`, () => {
+    let ONE_SCHEMA_CAND: SchemaCandidate[];
+    let TWO_SCHEMA_CAND: SchemaCandidate[];
+    beforeEach(async () => {
+      ONE_SCHEMA_CAND = await createSchemaCandidates(["1"]);
+      TWO_SCHEMA_CAND = await createSchemaCandidates(["1", "2"]);
+    });
+
+    describe(`haveUserPickSchemaFileName tests:`, () => {
+      it(`WHEN user picked non existent name THEN prompt use the name`, async () => {
+        runTestWithInlineSchemaSetup(async ({ vaults }) => {
+          const vault: DVault = vaults[0];
+          sinon
+            .stub(VSCodeUtils, "showInputBox")
+            .onFirstCall()
+            .returns(Promise.resolve("happy"));
+
+          const actual = await UserQueries.haveUserPickSchemaFileName(
+            new HierarchyLevel(1, ["languages", "python", "data"]),
+            vault
+          );
+
+          expect(actual).toEqual("happy");
+        });
+      });
+
+      it(`WHEN user picked pre existing name THEN prompt again`, async () => {
+        runTestWithInlineSchemaSetup(async ({ vaults }) => {
+          const vault: DVault = vaults[0];
+          sinon
+            .stub(VSCodeUtils, "showInputBox")
+            .onFirstCall()
+            // 'inlined' already exists.
+            .returns(Promise.resolve("inlined"))
+            .returns(Promise.resolve("happy"));
+
+          const actual = await UserQueries.haveUserPickSchemaFileName(
+            TEST_HIERARCHY_LVL,
+            vault
+          );
+
+          expect(actual).toEqual("happy");
+        });
+      });
+    });
+
+    describe(`haveUserSelectHierarchyLevel tests:`, () => {
+      beforeEach(() => {
+        sinon
+          .stub(VSCodeUtils, "showQuickPick")
+          .returns(Promise.resolve(TEST_HIERARCHY_LVL));
+      });
+
+      it(`WHEN happy input THEN return user picked hierarchy level`, () => {
+        runTestWithInlineSchemaSetup(async () => {
+          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+            "/tmp/languages.python.data.md"
+          );
+
+          expect(actual).toEqual(TEST_HIERARCHY_LVL);
+        });
+      });
+
+      it(`WHEN hierarchy depth of current file is too small THEN undefined`, () => {
+        runTestWithInlineSchemaSetup(async () => {
+          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+            "/tmp/languages.data.md"
+          );
+
+          expect(actual).toEqual(undefined);
+        });
+      });
+
+      it(`WHEN top id is already used by existing schema THEN undefined`, () => {
+        runTestWithInlineSchemaSetup(async () => {
+          const actual = await UserQueries.haveUserSelectHierarchyLevel(
+            "/tmp/daily.python.data.md"
+          );
+
+          expect(actual).toEqual(undefined);
+        });
+      });
+    });
+
+    describe(`hasSelected tests:`, () => {
+      it(`WHEN curr is greater than prev THEN true`, async () => {
+        expect(
+          UserQueries.hasSelected(ONE_SCHEMA_CAND, TWO_SCHEMA_CAND)
+        ).toEqual(true);
+      });
+
+      it(`WHEN curr is equal to prev THEN false`, async () => {
+        expect(
+          UserQueries.hasSelected(ONE_SCHEMA_CAND, ONE_SCHEMA_CAND)
+        ).toEqual(false);
+      });
+
+      it(`WHEN curr is less than prev THEN false`, async () => {
+        expect(
+          UserQueries.hasSelected(TWO_SCHEMA_CAND, ONE_SCHEMA_CAND)
+        ).toEqual(false);
+      });
+    });
+
+    describe(`hasUnselected tests:`, () => {
+      it("WHEN curr is greater thhan prev THEN false", () => {
+        expect(
+          UserQueries.hasUnselected(ONE_SCHEMA_CAND, TWO_SCHEMA_CAND)
+        ).toEqual(false);
+      });
+
+      it(`WHEN curr is equal to prev THEN false`, async () => {
+        expect(
+          UserQueries.hasUnselected(ONE_SCHEMA_CAND, ONE_SCHEMA_CAND)
+        ).toEqual(false);
+      });
+
+      it(`WHEN curr is less than prev THEN true`, async () => {
+        expect(
+          UserQueries.hasUnselected(TWO_SCHEMA_CAND, ONE_SCHEMA_CAND)
+        ).toEqual(true);
+      });
+    });
+
+    describe(`findUncheckedItem tests:`, () => {
+      it(`WHEN unchecked THEN get the candidate`, () => {
+        const actual = UserQueries.findUncheckedItem(
+          TWO_SCHEMA_CAND,
+          ONE_SCHEMA_CAND
+        );
+        expect(actual.note.fname).toEqual("2");
+      });
+    });
+
+    describe(`findCheckedItems tests:`, () => {
+      it(`WHEN checked THEN get the candidate`, () => {
+        const actual = UserQueries.findCheckedItem(
+          ONE_SCHEMA_CAND,
+          TWO_SCHEMA_CAND
+        );
+        expect(actual.note.fname).toEqual("2");
+      });
+    });
+
+    describe(`determineAfterSelect tests:`, () => {
+      describe(`WHEN a child of non selected hierarchy is checked`, () => {
+        let actual: SchemaCandidate[];
+
+        beforeEach(async () => {
+          const all = await createSchemaCandidates([
+            "h1.h2",
+            "h1.h2.h3a",
+            "h1.h2.h3b",
+            "h1.h2.h3c",
+            "h1.h2.h3c.h4",
+            "otherHierarchy.h2",
+          ]);
+
+          const prev = await createSchemaCandidates(["otherHierarchy.h2"]);
+
+          const curr = await createSchemaCandidates([
+            "otherHierarchy.h2",
+            "h1.h2.h3c.h4",
+          ]);
+
+          actual = UserQueries.determineAfterSelect(prev, curr, all);
+        });
+
+        it(`THEN make sure length is as expected`, () => {
+          expect(actual.length).toEqual(4);
+        });
+
+        it("THEN retain the checked items", () => {
+          expect(
+            actual.some((c) => c.note.fname === "otherHierarchy.h2")
+          ).toBeTruthy();
+          expect(actual.some((c) => c.note.fname === "h1.h2.h3c")).toBeTruthy();
+        });
+
+        it(`THEN select parent of item`, () => {
+          expect(actual.some((c) => c.note.fname === "h1.h2.h3c")).toBeTruthy();
+        });
+
+        it(`THEN select grand-parent (ancestor) of item`, () => {
+          expect(actual.some((c) => c.note.fname === "h1.h2")).toBeTruthy();
+        });
+      });
+    });
+
+    describe(`determineAfterUnselect tests:`, () => {
+      describe(`WHEN ancestor is unchecked`, () => {
+        let actual: SchemaCandidate[];
+
+        beforeEach(async () => {
+          const prev = await createSchemaCandidates([
+            "h1.h2",
+            "h1.h2.h3a",
+            "h1.h2.h3c.h4",
+            "otherHierarchy.h2",
+          ]);
+
+          const curr = await createSchemaCandidates([
+            "h1.h2.h3a",
+            "h1.h2.h3c.h4",
+            "otherHierarchy.h2",
+          ]);
+
+          actual = UserQueries.determineAfterUnselect(prev, curr);
+        });
+
+        it(`THEN keep another hierarchy as is`, () => {
+          expect(
+            actual.some((c) => c.note.fname === "otherHierarchy.h2")
+          ).toBeTruthy();
+        });
+
+        it(`THEN unselect all the descendents`, () => {
+          expect(actual.length).toEqual(1);
+        });
+      });
+    });
+  });
+});

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -307,10 +307,13 @@ export function setupBeforeAfter(
     beforeHook?: (ctx: ExtensionContext) => any;
     afterHook?: any;
     noSetInstallStatus?: boolean;
+    noSetTimeout?: boolean;
   }
 ) {
   // allows for
-  _this.timeout(TIMEOUT);
+  if (!opts?.noSetTimeout) {
+    _this.timeout(TIMEOUT);
+  }
   const ctx = VSCodeUtils.getOrCreateMockContext();
   beforeEach(async () => {
     // DendronWorkspace.getOrCreate(ctx);

--- a/test-workspace/vault/dendron.cmd.create-schema-from-hierarchy.md
+++ b/test-workspace/vault/dendron.cmd.create-schema-from-hierarchy.md
@@ -1,0 +1,43 @@
+---
+id: WhVbhkBCANk5K2M6PPMVz
+title: Create Schema from Hierarchy
+desc: ''
+updated: 1636390303597
+created: 1636388496504
+---
+
+## Test happy case:
+1. Navigate to [[languages.python.data.integer]]
+2. Activate `Dendron: Create Schema From Note Hierarchy` command.
+   (if there is an error saying languages already exists someone probably forgot to delete languages.schema.yml after running this test.)
+3. Select `languages.*.data.integer` hierarchy level.
+4. Play around with selection of patterns:
+4a. Unselect `languages.*.machine-learning`, make sure that all descendents of `languages.*.machine-learning` are automatically unselected.
+4b. Select `languages.*.machine-learning.pandas`, make sure that `languages.*.machine-learning` is automatically selected again. 
+4c. Make sure that the following are selected and press Enter.
+* languages.*.data.integer
+* languages.*.data.bool
+* languages.*.data.string
+5. Accept the default `languages` schema name press enter.
+6. Now you should be taken to `languages.schema.yml` file with the following content.
+
+```
+version: 1
+imports: []
+schemas:
+  - id: languages
+    title: languages
+    parent: root
+    children:
+      - pattern: '*'
+        children:
+          - pattern: data
+            children:
+              - pattern: bool
+              - pattern: integer
+              - pattern: string
+
+```
+
+AFTER: Delete languages.schema.yml
+

--- a/test-workspace/vault/languages.python.data.bool.md
+++ b/test-workspace/vault/languages.python.data.bool.md
@@ -1,0 +1,8 @@
+---
+id: ml2iUxT9ljJMXSC4b1yzo
+title: Bool
+desc: ''
+updated: 1635935099746
+created: 1635935099746
+---
+

--- a/test-workspace/vault/languages.python.data.integer.md
+++ b/test-workspace/vault/languages.python.data.integer.md
@@ -1,0 +1,8 @@
+---
+id: 6tG2OW2u9mYlzf9F09u4j
+title: Integer
+desc: ''
+updated: 1635935103481
+created: 1635935103481
+---
+

--- a/test-workspace/vault/languages.python.data.md
+++ b/test-workspace/vault/languages.python.data.md
@@ -1,0 +1,8 @@
+---
+id: bDBYPZYlhiZUzqvnW3FGJ
+title: Data
+desc: ''
+updated: 1635935094665
+created: 1635935094665
+---
+

--- a/test-workspace/vault/languages.python.data.string.md
+++ b/test-workspace/vault/languages.python.data.string.md
@@ -1,0 +1,8 @@
+---
+id: LmfREuriowlRnQ4BTCrUa
+title: String
+desc: ''
+updated: 1636377310042
+created: 1635935109644
+---
+

--- a/test-workspace/vault/languages.python.machine-learning.md
+++ b/test-workspace/vault/languages.python.machine-learning.md
@@ -1,0 +1,8 @@
+---
+id: FIHLF81wxYDFKq0d2PPoI
+title: Machine Learning
+desc: ''
+updated: 1635935113552
+created: 1635935113552
+---
+

--- a/test-workspace/vault/languages.python.machine-learning.pandas.md
+++ b/test-workspace/vault/languages.python.machine-learning.pandas.md
@@ -1,0 +1,8 @@
+---
+id: qp9GpwdH7mWiYKDhR1aPN
+title: Pandas
+desc: ''
+updated: 1636371216544
+created: 1636371216544
+---
+

--- a/test-workspace/vault/languages.python.machine-learning.scipy.md
+++ b/test-workspace/vault/languages.python.machine-learning.scipy.md
@@ -1,0 +1,8 @@
+---
+id: f4qdTnePkV8rA1uu9gSyJ
+title: Scipy
+desc: ''
+updated: 1635935123364
+created: 1635935123364
+---
+


### PR DESCRIPTION
# adding new command: create schema from hierarchy

Adding new command: `Dendron: Create Schema From Note Hierarchy` 

[PR Dendron Site Documentation](https://github.com/dendronhq/dendron-site/commit/9aa4870608b1ed189d991514363fc06314eb47e2)  
## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
```
   CreateSchemaFromHierarchyCommand tests
     HierarchyLevel tests:
       GIVEN 'languages.*.data' hierarchy level
         ✓ THEN have expected label
         ✓ THEN have expected top id
         ✓ THEN produce expected default schema name
         tokenize tests
           ✓ WHEN fname is 'languages.python.data' THEN tokenize to '["languages","*","data"]'.
           ✓ WHEN fname is 'languages.python.data.integer' THEN tokenize to '["languages","*","data","integer"]'.
           ✓ WHEN fname is 'languages.python.machine-learning' THEN tokenize to '["languages","*","machine-learning"]'.
         isCandidateNote tests
           ✓ WHEN testing 'languages' note THEN do NOT match.
           ✓ WHEN testing 'languages.python' note THEN do NOT match.
           ✓ WHEN testing 'languages.python.data' note THEN do match.
           ✓ WHEN testing 'languages.python.data.integer' note THEN do match.
           ✓ WHEN testing 'languages.python.machine-learning' note THEN do match.
     SchemaCreator tests:
       ✓ WHEN valid schema candidates THEN generate schema
     CreateSchemaFromHierarchyCommand
       sanityCheck tests:
         ✓ WHEN no active text editor THEN give error
       formatSchemaCandidates tests:
         WHEN formatting valid input idx=1 ['h1.h2.h3a', 'h1.h2.h3b']
           ✓ THEN include 'h1.*.h3a' label
      haveUserPickSchemaFileName tests:
        ✓ WHEN user picked non existent name THEN prompt use the name
        ✓ WHEN user picked pre existing name THEN prompt again
      haveUserSelectHierarchyLevel tests:
        ✓ WHEN happy input THEN return user picked hierarchy level
        ✓ WHEN hierarchy depth of current file is too small THEN undefined
        ✓ WHEN top id is already used by existing schema THEN undefined
      hasSelected tests:
        ✓ WHEN curr is greater than prev THEN true
        ✓ WHEN curr is equal to prev THEN false
        ✓ WHEN curr is less than prev THEN false
      hasUnselected tests:
        ✓ WHEN curr is greater thhan prev THEN false
        ✓ WHEN curr is equal to prev THEN false
        ✓ WHEN curr is less than prev THEN true
      findUncheckedItem tests:
        ✓ WHEN unchecked THEN get the candidate
      findCheckedItems tests:
        ✓ WHEN checked THEN get the candidate
      determineAfterSelect tests:
        WHEN a child of non selected hierarchy is checked
          ✓ THEN make sure length is as expected
          ✓ THEN retain the checked items
          ✓ THEN select parent of item
          ✓ THEN select grand-parent (ancestor) of item
      determineAfterUnselect tests:
        WHEN ancestor is unchecked
          ✓ THEN keep another hierarchy as is
          ✓ THEN unselect all the descendents
  33 passing (497ms)
```
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
Added `test-workspace/vault/dendron.cmd.create-schema-from-hierarchy.md`
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows