### PR TITLE
enhance: add file navigation upon schema malfored when loaded

### DIFF
--- a/packages/engine-server/src/drivers/file/schemaParser.ts
+++ b/packages/engine-server/src/drivers/file/schemaParser.ts
@@ -52,14 +52,18 @@ export class SchemaParser {
         try {
           return await this.parseFile(fpath, vault);
         } catch (err) {
-          let message = "";
+          let message = undefined;
           if (err instanceof Error) {
             message = err.message;
           }
 
+          const vpath = vault2Path({ wsRoot: this.wsRoot, vault: vault });
+          const fullPath = path.join(vpath, fpath);
+
           return new DendronError({
-            message: ERROR_STATUS.BAD_PARSE_FOR_SCHEMA,
-            payload: { fpath, message, cause: err },
+            message: message ? message : ERROR_STATUS.BAD_PARSE_FOR_SCHEMA,
+            status: ERROR_STATUS.BAD_PARSE_FOR_SCHEMA,
+            payload: { fpath, message, fullPath },
           });
         }
       })

--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/storev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/storev2.spec.ts
@@ -16,7 +16,7 @@ describe(`FileStorage tests:`, () => {
 
       const response = FileStorage.createMalformedSchemaError(input);
       expect(response.message).toEqual(
-        `Schema 'dvd.schema.yml' is malformed. Reason: Schema id is missing from top level schema. Schema at fault: '{"id2":"dvd","children":[{"pattern":"hi"}],"title":"dvd","parent":"root"}'. Use 'Go to File...' command to resolve malformed schema.`
+        `Schema 'dvd.schema.yml' is malformed. Reason: Schema id is missing from top level schema. Schema at fault: '{"id2":"dvd","children":[{"pattern":"hi"}],"title":"dvd","parent":"root"}'`
       );
     });
   });

--- a/packages/plugin-core/src/test/suite-integ/logger.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/logger.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "mocha";
+import { Logger } from "../../logger";
+import { expect } from "../testUtilsv2";
+
+suite("logger tests", () => {
+  describe(`tryExtractFullPath tests`, () => {
+    it(`WHEN payload has full path THEN extract it`, () => {
+      const inputPayload = {
+        error: {
+          payload: '"{\\"fullPath\\":\\"/tmp/full-path-val\\"}"',
+        },
+      };
+      // @ts-ignore
+      const actual = Logger.tryExtractFullPath(inputPayload);
+      expect(actual).toEqual("/tmp/full-path-val");
+    });
+
+    it("WHEN payload does not have full path THEN do NOT throw", () => {
+      const inputPayload = {
+        error: {
+          payload: '"{\\"noFullPath\\":\\"/tmp/full-path-val\\"}"',
+        },
+      };
+      // @ts-ignore
+      const actual = Logger.tryExtractFullPath(inputPayload);
+      expect(actual).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
# enhance: add file navigation upon schema malfored when loaded

Adds `Go to File` action on the error message. Improves error message formatting on save of schemas. Adds the error message into status bar. 

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
