### PR TITLE
enhance: cmd create-schema-from-hierarchy allow schema to end with '*'

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
@@ -69,6 +69,28 @@ suite("CreateSchemaFromHierarchyCommand tests", () => {
   }
 
   describe(`HierarchyLevel tests:`, () => {
+    describe(`GIVEN 'languages.python.*' hierarchy level`, () => {
+      let level: HierarchyLevel;
+      beforeEach(() => {
+        level = new HierarchyLevel(2, ["languages", "python", "data"]);
+      });
+
+      describe(`isCandidateNote tests`, () => {
+        [
+          { in: "languages", out: false },
+          { in: "languages.python", out: false },
+          { in: "languages.python.data", out: true },
+          { in: "languages.python.data.integer", out: true },
+          { in: "languages.python.machine-learning", out: true },
+        ].forEach((input) =>
+          it(`WHEN testing '${input.in}' note THEN ${
+            input.out ? "do match" : "do NOT match"
+          }.`, () => {
+            expect(level.isCandidateNote(input.in)).toEqual(input.out);
+          })
+        );
+      });
+    });
     describe(`GIVEN 'languages.*.data' hierarchy level`, () => {
       let level: HierarchyLevel;
       beforeEach(() => {
@@ -113,7 +135,7 @@ suite("CreateSchemaFromHierarchyCommand tests", () => {
       describe(`isCandidateNote tests`, () => {
         [
           { in: "languages", out: false },
-          { in: "languages.python", out: false },
+          { in: "languages.python", out: true },
           { in: "languages.python.data", out: true },
           { in: "languages.python.data.integer", out: true },
           { in: "languages.python.machine-learning", out: true },


### PR DESCRIPTION
# enhance: cmd create-schema-from-hierarchy allow schema to end with '*'

Allow creation of schema from hierarchy with '*' at the end.

Example allows creation of schema such as:

```
version: 1
imports: []
schemas:
  - id: languages
    title: languages
    parent: root
    children:
      - pattern: python
        children:
          - pattern: data
            children:
              - pattern: '*'

```

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows