### PR TITLE
chore: fix expect.toContain to actually assert

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -1,4 +1,9 @@
-import { DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import {
+  DendronError,
+  DVault,
+  NoteProps,
+  NoteUtils,
+} from "@dendronhq/common-all";
 import {
   NoteTestUtilsV4,
   PreSetupHookFunction,
@@ -210,6 +215,7 @@ suite("MoveHeader", function () {
           onInit: onInitFunc(async () => {
             const cmd = new MoveHeaderCommand();
             let out;
+            let wasThrown = false;
             try {
               out = await cmd.gatherInputs({
                 initialValue: "dest",
@@ -217,10 +223,17 @@ suite("MoveHeader", function () {
                 nonInteractive: true,
               });
             } catch (error) {
-              expect(error).toContain(
-                "You must first select the header you want to move."
-              );
+              wasThrown = true;
+              expect(error instanceof DendronError).toBeTruthy();
+              // Commented out since `.toContain` used to not do anything, now that `.toContain`
+              // is fixed this assertion does not pass:
+              //
+              // expect(error).toContain(
+              //   "You must first select the header you want to move."
+              // );
             }
+
+            expect(wasThrown).toBeTruthy();
             expect(_.isUndefined(out)).toBeTruthy();
             done();
           }),
@@ -242,11 +255,18 @@ suite("MoveHeader", function () {
           onInit: onInitFunc(async () => {
             const cmd = new MoveHeaderCommand();
             let out;
+            let wasThrown = false;
             try {
               out = await cmd.gatherInputs({});
             } catch (error) {
-              expect(error).toContain("no note open.");
+              wasThrown = true;
+              expect(error instanceof DendronError).toBeTruthy();
+              // Commented out since `.toContain` used to not do anything, now that `.toContain`
+              // is fixed this assertion does not pass:
+              //
+              // expect(error).toContain("no note open.");
             }
+            expect(wasThrown).toBeTruthy();
             expect(_.isUndefined(out)).toBeTruthy();
             done();
           }),

--- a/packages/plugin-core/src/test/suite-integ/SeedCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SeedCommand.test.ts
@@ -52,7 +52,7 @@ suite(DENDRON_COMMANDS.SEED_ADD.key, function seedAddTests() {
         const resp = await cmd.execute({ seedId: id });
         expect(resp.error).toBeFalsy();
         expect(resp.data?.seed.name).toEqual("foo");
-        expect(resp.data?.seedPath).toContain("dendron.foo");
+        expect(resp.data?.seedPath?.includes("dendron.foo")).toBeTruthy();
 
         expect(fakedOnUpdating.callCount).toEqual(1);
         expect(fakedOnUpdated.callCount).toEqual(1);

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -464,10 +464,33 @@ export const stubWorkspace = ({ wsRoot, vaults }: WorkspaceOpts) => {
   stubWorkspaceFolders(wsRoot, vaults);
 };
 
+function safeStringify(obj: any) {
+  try {
+    return JSON.stringify(obj);
+  } catch (err) {
+    return `failed_to_stringify_obj`;
+  }
+}
+
 export function expect(value: any) {
   return {
+    /**
+     * NOTE: This method currently only works for checking object properties.
+     *
+     * Such as:
+     * var object = { 'user': 'fred', 'age': 40 };
+     * _.isMatch(object, { 'age': 40 });
+     * // => true
+     * _.isMatch(object, { 'age': 36 });
+     * // => false
+     * */
     toContain: (value2: any) => {
-      return _.isMatch(value, value2);
+      assert.ok(
+        _.isMatch(value, value2),
+        `Object:'${safeStringify(value)}' does NOT contain: '${safeStringify(
+          value2
+        )}'`
+      );
     },
     toEqual: (value2: any) => {
       assert.deepStrictEqual(value, value2);


### PR DESCRIPTION
# Pull Request Checklist

expect.toContain() used to not actually assert anything prior to this change. 

## General

### Quality Assurance
- [ ] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
