### PR TITLE
enhance: looks ups with dot at the end now look up hierarchies without having exact postfix

### DIFF
--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -22,7 +22,7 @@ type CreateNoteFactoryOpts = Omit<CreateNoteOptsV4, "vault" | "wsRoot"> & {
 };
 const SIMPLE_SELECTION: [number, number, number, number] = [7, 0, 7, 12];
 
-const CreateNoteFactory = (opts: CreateNoteFactoryOpts) => {
+export const CreateNoteFactory = (opts: CreateNoteFactoryOpts) => {
   const func = ({
     vault,
     wsRoot,

--- a/packages/engine-test-utils/src/__mocks__/vscode.ts
+++ b/packages/engine-test-utils/src/__mocks__/vscode.ts
@@ -3,5 +3,5 @@ export const window = {
 };
 export const vscode = {
   // mock the vscode API which you use in your project. Jest will tell you which keys are missing.
-  window
+  window,
 };

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -1,5 +1,6 @@
 import { NoteProps, SchemaUtils } from "@dendronhq/common-all";
 import {
+  CreateNoteFactory,
   NOTE_PRESETS_V4,
   NoteTestUtilsV4,
   PreSetupHookFunction,
@@ -43,6 +44,58 @@ export const setupBasic: PreSetupHookFunction = async ({
     wsRoot,
   });
   await SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.create({ vault, wsRoot });
+};
+
+/**
+ <pre>
+ /vault1
+ ├── bar.ch1.gch1.ggch1.md
+ ├── bar.ch1.gch1.md
+ ├── bar.ch1.md
+ ├── bar.md
+ ├── foo.ch1.gch1.ggch1.md
+ ├── foo.ch1.gch1.md
+ ├── foo.ch1.gch2.md
+ ├── foo.ch1.md
+ ├── foo.ch2.md
+ ├── foo.md
+ ├── root.md
+ └── root.schema.yml
+
+/vault2
+ ├── root.md
+ └── root.schema.yml
+
+ /vault3
+ ├── root.md
+ └── root.schema.yml
+</pre>
+ * */
+export const setupHierarchyForLookupTests: PreSetupHookFunction = async ({
+  vaults,
+  wsRoot,
+}) => {
+  const opts = {
+    vault: vaults[0],
+    wsRoot,
+  };
+  const fnames = [
+    "foo",
+    "foo.ch1",
+    "foo.ch1.gch1",
+    "foo.ch1.gch1.ggch1",
+    "foo.ch1.gch2",
+    "foo.ch2",
+    "bar",
+    "bar.ch1",
+    "bar.ch1.gch1",
+    "bar.ch1.gch1.ggch1",
+    "goo.ends-with-ch1.no-ch1-by-itself",
+  ];
+
+  for (const fname of fnames) {
+    await CreateNoteFactory({ fname, body: `${fname} body` }).create(opts);
+  }
 };
 
 export const setupJournals: PreSetupHookFunction = async ({
@@ -496,6 +549,7 @@ export const ENGINE_HOOKS_BASE = {
 
 export const ENGINE_HOOKS = {
   setupBasic,
+  setupHierarchyForLookupTests,
   setupSchemaPreseet,
   setupSchemaPresetWithNamespaceTemplate,
   setupInlineSchema,

--- a/packages/plugin-core/src/components/lookup/queryStringTransformer.ts
+++ b/packages/plugin-core/src/components/lookup/queryStringTransformer.ts
@@ -26,6 +26,7 @@ function wikiTransform(trimmedQuery: string): TransformedQueryString {
   }
 
   return {
+    originalQuery: trimmedQuery,
     queryString: transformed,
     wasMadeFromWikiLink: true,
     vaultName,
@@ -49,11 +50,10 @@ function regularTransform(
   let queryString = PickerUtilsV2.slashToDot(trimmedQuery);
   let splitByDots: string[] | undefined;
 
+  // When we are doing direct children lookup & when query ends with '.' we want exact
+  // matches of the query. Hence we would not be splitting by dots, more info
+  // on split by dots in {@link TransformedQueryString.splitByDots} documentation.
   if (!onlyDirectChildren && !queryString.endsWith(".")) {
-    // When we are doing direct children lookup we want exact matches of the hierarchy
-    // Hence we would not be splitting by dots, more info on split by dots in
-    // {@link TransformedQueryString.splitByDots} documentation.
-    //
     // https://regex101.com/r/vMwX9C/2
     const dotCandidateMatch = queryString.match(/(^[^\s]*?\.[^\s]*)/);
     if (dotCandidateMatch) {
@@ -65,15 +65,16 @@ function regularTransform(
     }
   }
 
-  // When querying for children of the note then the prefix should match exactly.
+  // When querying for direct children of the note then the prefix should match exactly.
   if (
-    (onlyDirectChildren || queryString.endsWith(".")) &&
+    onlyDirectChildren &&
     !queryString.startsWith(FuseExtendedSearchConstants.PrefixExactMatch)
   ) {
     queryString = FuseExtendedSearchConstants.PrefixExactMatch + queryString;
   }
 
   return {
+    originalQuery: trimmedQuery,
     queryString,
     wasMadeFromWikiLink: false,
     splitByDots,

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -205,4 +205,7 @@ export type TransformedQueryString = {
   /**
    * Set to true when we only want to match direct children of the hierarchy. */
   onlyDirectChildren?: boolean;
+
+  /** Original query string value */
+  originalQuery: string;
 };

--- a/packages/plugin-core/src/test/suite-integ/queryStringTransformer.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/queryStringTransformer.test.ts
@@ -73,8 +73,8 @@ suite("transformQueryString tests:", () => {
       });
     });
 
-    it(`THEN ^ prefix is added`, () => {
-      expect(transformed.queryString).toEqual("^some.string.value.");
+    it(`THEN do NOT split by dots`, () => {
+      expect(transformed.queryString).toEqual("some.string.value.");
     });
 
     it(`THEN split by dots is not populated`, () => {

--- a/test-workspace/vault/data.driven.md
+++ b/test-workspace/vault/data.driven.md
@@ -1,0 +1,8 @@
+---
+id: JoqfuUgzr5RHoXNQGXzOc
+title: Driven
+desc: ''
+updated: 1636543383559
+created: 1636543383559
+---
+

--- a/test-workspace/vault/dendron.note-lookup.md
+++ b/test-workspace/vault/dendron.note-lookup.md
@@ -2,7 +2,7 @@
 id: bNkYI2WWK6Jhm2eeVwqrh
 title: Note Lookup
 desc: ''
-updated: 1634725877431
+updated: 1636555365403
 created: 1633501913732
 ---
 
@@ -33,6 +33,20 @@ Note look up `cmd+l`:
 1. Navigate to `dendron.blog.one`
 1. Activate `Note lookup`
 1. Make sure to be able to see siblings of `dendron.blog.one` such as ``dendron.blog.two`.
+
+### Lookup with dot at the end
+1. Look up `data.` 
+Should see results with roughly the following order:
+* `data.driven`     
+    * first show matches with `data.` exact matched and `data.` highest in hierarchy
+* `languages.python.data.string`
+    * then show matches that have `data.` exact matched but lower in hierarchy.
+* ...
+* `languages.with-data.make-sense` 
+    * later show matches that are not exact matched `with-data.`
+* `languages.python.data.string.memory` 
+    * lastly show matches that have not just children but grand children etc.
+All matches should have `data.` and some value after `data.`
 
 ### Look up with wiki links
 * [[with description with header with vault|dendron://vault/dendron.welcome#header1]]

--- a/test-workspace/vault/languages.python.data.string.memory.md
+++ b/test-workspace/vault/languages.python.data.string.memory.md
@@ -1,0 +1,8 @@
+---
+id: p9peEtJdzui5qJ8z4rfrt
+title: Memory
+desc: ''
+updated: 1636555151090
+created: 1636555151090
+---
+

--- a/test-workspace/vault/languages.with-data.make-sense.md
+++ b/test-workspace/vault/languages.with-data.make-sense.md
@@ -1,0 +1,8 @@
+---
+id: 9n6E59Cu8Mb0ppbQpmIVm
+title: Make Sense
+desc: ''
+updated: 1636543408818
+created: 1636543408818
+---
+


### PR DESCRIPTION
# Summary
Having a dot at the end will now look up child & descendant notes (bubbling up the child notes to the top) that match the query but without requiring the full match of the prefix note. 

# Usage details in test workspace
```
1. Look up `data.` 
Should see results with roughly the following order:
* `data.driven`     
    * first show matches with `data.` exact matched and `data.` highest in hierarchy
* `languages.python.data.string`
    * then show matches that have `data.` exact matched but lower in hierarchy.
* ...
* `languages.with-data.make-sense` 
    * later show matches that are not exact matched `with-data.`
* `languages.python.data.string.memory` 
    * lastly show matches that have not just children but grand children etc.
All matches should have `data.` and some value after `data.`
```

# Details
In the task note for this task it was proposed that one way to handle the `.` at the end would be to grab the closest hierarchy that matches. However, doing some testing it appeared we can improve the usability of dot ended queries more by doing special sort of the results so that we show results from multiple hierarchies that match the given dot ended query, while with special sorting helping to bubble up the most relevant results.
Task note: [[adding . to lookup should show all results in the level|scratch.2021.10.31.143958.adding--to-lookup-should-show-all-results-in-the-level]]

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] after you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: if you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
