### PR TITLE
fix:(layout): position sidebar, main content and footer

### DIFF
--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, Row, Col, Divider } from "antd";
+import { Layout, Row, Col, Divider, Typography } from "antd";
 import { MenuOutlined } from "@ant-design/icons";
 import * as React from "react";
 import { DENDRON_STYLE_CONSTANTS } from "../styles/constants";
@@ -14,6 +14,8 @@ import DendronNotice from "./DendronNotice";
 import { getStage } from "@dendronhq/common-all";
 
 const { Header, Content, Sider, Footer } = Layout;
+const { Text, Link } = Typography;
+
 const { LAYOUT, HEADER, SIDER } = DENDRON_STYLE_CONSTANTS;
 
 export default function DendronLayout(
@@ -36,43 +38,73 @@ export default function DendronLayout(
         setResponsive(broken);
       }}
       style={{
-        position: "fixed",
+        position: isResponsive ? "fixed" : "sticky",
+        top: `${HEADER.HEIGHT}px`,
         overflow: "auto",
         height: `calc(100vh - ${HEADER.HEIGHT}px)`,
+        isolation: "isolate",
+        zIndex: 1,
       }}
       trigger={null}
     >
-      {isResponsive && (
-        <div style={{ padding: 16 }}>
-          <DendronSearch {...props} />
-        </div>
-      )}
-      <DendronTreeMenu
-        {...props}
-        collapsed={isCollapsed && isResponsive}
-        setCollapsed={setCollapsed}
-      />
+      <div style={{ height: "100%" }}>
+        {isResponsive && (
+          <div style={{ padding: 16 }}>
+            <DendronSearch {...props} />
+          </div>
+        )}
+        <Col
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            height: "100%",
+          }}
+        >
+          <DendronTreeMenu
+            {...props}
+            collapsed={isCollapsed && isResponsive}
+            setCollapsed={setCollapsed}
+          />
+          <Row gutter={1} style={{ margin: "0 auto", padding: "1rem" }}>
+            <Text>
+              {" "}
+              🌱 with 💕 using{" "}
+              <Link href="https://www.dendron.so/" target="_blank">
+                Dendron 🌲
+              </Link>
+            </Text>
+          </Row>
+        </Col>
+      </div>
     </Sider>
   );
 
   const content = (
     <>
-      <Content
-        className="main-content"
-        role="main"
-        style={{ padding: `0 ${LAYOUT.PADDING}px` }}
-      >
-        <DendronBreadCrumb {...props} />
-        {props.children}
+      <Content className="main-content" role="main">
+        <Layout>
+          <DendronNotice show={getStage() === "dev"}>
+            NOTE: Pages are{" "}
+            <a href="https://wiki.dendron.so/notes/yYMuhi2TmTC63MysmtwqH.html#navigating-pages-is-slow-for-local-preview">
+              dynamically compiled in local preview
+            </a>{" "}
+            and will take a second to load.
+          </DendronNotice>
+        </Layout>
+        <Layout
+          style={{ maxWidth: "1320px", margin: "0 auto", padding: "0 1.5rem" }}
+        >
+          <DendronBreadCrumb {...props} />
+          {props.children}
+        </Layout>
+        <Layout style={{ maxWidth: "1180px" }}>
+          <Divider type="horizontal" />
+          <Footer>
+            <FooterText />
+          </Footer>
+        </Layout>
       </Content>
-      <Divider />
-      <Footer
-        style={{
-          padding: `0 ${LAYOUT.PADDING}px ${LAYOUT.PADDING}px`,
-        }}
-      >
-        <FooterText />
-      </Footer>
     </>
   );
 
@@ -103,85 +135,37 @@ export default function DendronLayout(
           width: "100%",
           borderBottom: "1px solid #d4dadf",
           height: HEADER.HEIGHT,
-          padding: isResponsive ? 0 : `0 ${LAYOUT.PADDING}px 0 2px`,
         }}
       >
         <Row
-          justify="center"
           style={{
-            maxWidth: "992px",
-            justifyContent: "space-between",
             margin: "0 auto",
           }}
+          justify={isResponsive ? "space-between" : undefined}
         >
-          <Col>
+          <Col span={4}>
             <DendronLogoOrTitle />
           </Col>
-          <Col xs={0} sm={20} md={20} lg={19} className="gutter-row">
+          <Col xs={0} sm={0} md={18} lg={{ span: 16 }} className="gutter-row">
             <DendronSearch {...props} />
           </Col>
-          <Col
-            xs={4}
-            sm={4}
-            md={0}
-            lg={0}
-            style={{
-              marginLeft: "4px",
-              display: isResponsive ? "flex" : "none",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <MenuOutlined
-              style={{ fontSize: 24 }}
-              onClick={() => setCollapsed(!isCollapsed)}
-            />
-          </Col>
+          {isResponsive && (
+            <Col xs={4} sm={4} md={0} lg={0}>
+              <MenuOutlined
+                style={{ fontSize: 24 }}
+                onClick={() => setCollapsed(!isCollapsed)}
+              />
+            </Col>
+          )}
         </Row>
       </Header>
       <Layout
-        className="site-layout"
         style={{
           marginTop: 64,
         }}
       >
-        <DendronNotice show={getStage() === "dev"}>
-          NOTE: Pages are{" "}
-          <a href="https://wiki.dendron.so/notes/yYMuhi2TmTC63MysmtwqH.html#navigating-pages-is-slow-for-local-preview">
-            dynamically compiled in local preview
-          </a>{" "}
-          and will take a second to load.
-        </DendronNotice>
-        <Layout className="site-layout" style={{ flexDirection: "row" }}>
-          <Layout
-            className="site-layout-sidebar"
-            style={{
-              flex: "0 0 auto",
-              width: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2 + ${
-                // eslint-disable-next-line no-nested-ternary
-                isResponsive
-                  ? isCollapsed
-                    ? SIDER.COLLAPSED_WIDTH
-                    : "100%"
-                  : SIDER.WIDTH
-              }px)`,
-              minWidth: isResponsive || isCollapsed ? 0 : SIDER.WIDTH,
-              paddingLeft: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2)`,
-              // eslint-disable-next-line no-nested-ternary
-            }}
-          >
-            {sidebar}
-          </Layout>
-          <Layout
-            className="side-layout-main"
-            style={{
-              maxWidth: LAYOUT.CONTENT_MAX_WIDTH,
-              display: !isCollapsed && isResponsive ? "none" : "initial",
-            }}
-          >
-            {content}
-          </Layout>
-        </Layout>
+        {sidebar}
+        {content}
       </Layout>
     </Layout>
   );

--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -68,8 +68,7 @@ export default function DendronLayout(
           />
           <Row gutter={1} style={{ margin: "0 auto", padding: "1rem" }}>
             <Text>
-              {" "}
-              🌱 with 💕 using{" "}
+              🌱 with{" "}
               <Link href="https://www.dendron.so/" target="_blank">
                 Dendron 🌲
               </Link>

--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -146,15 +146,6 @@ export function FooterText() {
           )}
         </Col>
       </Row>
-      <Col sm={24} md={12} style={{ textAlign: "right" }}>
-        <Text>
-          {" "}
-          🌱 with 💕 using{" "}
-          <Link href="https://www.dendron.so/" target="_blank">
-            Dendron 🌲
-          </Link>
-        </Text>
-      </Col>
     </Row>
   );
 }

--- a/packages/nextjs-template/components/DendronNotice.tsx
+++ b/packages/nextjs-template/components/DendronNotice.tsx
@@ -17,12 +17,9 @@ export const DendronNotice = ({
     <>
       {val && (
         <Alert
+          style={{ textAlign: "center" }}
           type="info"
           banner
-          style={{
-            paddingLeft: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2)`,
-            paddingRight: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2)`,
-          }}
           message={children}
           closable
           afterClose={() => toggle(false)}

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -150,7 +150,7 @@ function DendronSearchComponent(
     <AutoComplete
       size="large"
       allowClear
-      style={{ width: "100%" }}
+      style={{ width: "100%", maxWidth: '1000px' }}
       value={searchQueryValue}
       onClick={results === SearchMode.SEARCH_MODE ? () => null : onClickLookup}
       onChange={

--- a/packages/nextjs-template/components/DendronTOC.tsx
+++ b/packages/nextjs-template/components/DendronTOC.tsx
@@ -27,6 +27,7 @@ export const DendronTOC = ({
         {Object.entries(note?.anchors).map(([key, entry]) =>
           entry?.type === "header" ? (
             <Link
+              key={key}
               href={`#${key}`}
               title={unslug(entry?.text ?? entry?.value)}
             />

--- a/packages/nextjs-template/styles/scss/main.scss
+++ b/packages/nextjs-template/styles/scss/main.scss
@@ -1,4 +1,3 @@
-
 //
 // Base
 //
@@ -16,18 +15,18 @@
 
 // Portal Start
 $base-line-height: 1 !default;
-$spacing-unit:     30px !default;
-$text-color:       #111 !default;
+$spacing-unit: 30px !default;
+$text-color: #111 !default;
 // Portal end
 @import "portal.scss";
 
 // TODO: new
 #__next {
-	height: 100%; // or min-height
+  height: 100%; // or min-height
 }
 
 hr {
-	height: "1px";
+  height: "1px";
 }
 
 // Components
@@ -35,74 +34,80 @@ hr {
 // DendronLayout
 
 // from from packages/dendron-next-server/assets/themes/light-theme.less
-$layout-header-background: #F5F7F9; // @layout-header-background
-$text-color: 'rgba(0,0,0,.85)'; // @text-color
+$layout-header-background: #f5f7f9; // @layout-header-background
+$text-color: "rgba(0,0,0,.85)"; // @text-color
 
 .site-layout-sidebar.ant-layout {
-	background-color: $layout-header-background;
-	.ant-menu.ant-menu-inline {
-		background-color: $layout-header-background;
-	}
+  background-color: $layout-header-background;
+  .ant-menu.ant-menu-inline {
+    background-color: $layout-header-background;
+  }
 }
 
 // DendronTreeMenu
 
 .dendron-tree-menu.ant-menu {
-	.ant-menu-submenu-title {
-		[data-expandedicon="true"] {
-			position: absolute;
-			top: 0;
-			right: 3px;
-			height: 100%;
-			margin: 0;
-			padding: 10px;
-			display: flex;
-			align-items: center;
-		}
-	}
+  background-color: #f5f7f9;
 
-	.ant-menu-item-selected {
-		color: rgba(0,0,0,.85);
-	}
+  .ant-menu-submenu-title {
+    [data-expandedicon="true"] {
+      position: absolute;
+      top: 0;
+      right: 3px;
+      height: 100%;
+      margin: 0;
+      padding: 10px;
+      display: flex;
+      align-items: center;
+    }
+  }
 
-	&.ant-menu-inline {
-		.ant-menu-title-content:hover {
-			text-decoration: underline;
-		}
-		[data-expandedicon="true"]:hover {
-			background-color: rgba(0, 0, 0, 0.05);
-		}
-	}
+  .ant-menu-item-selected {
+    color: rgba(0, 0, 0, 0.85);
+  }
 
-	&.ant-menu-inline-collapsed {
-		[data-expandedicon="true"] {
-			// remove submenu icon in collapsed Menu for first level
-			display: none;
-		}
-	}
+  &.ant-menu-inline {
+    .ant-menu-title-content:hover {
+      text-decoration: underline;
+    }
+    [data-expandedicon="true"]:hover {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+  }
 
-	.ant-menu-submenu {
-		> .ant-menu-submenu-title:after {
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			border-right: 3px solid rgb(67, 176, 42); // antd's @border-color-split
-			transform: scaleY(0.0001);
-			opacity: 0;
-			content: '';
-			pointer-events: none; // makes open/close arrows touch-area bigger by giving it "space" to the right from this after element
-		}
-	}
+  &.ant-menu-inline-collapsed {
+    [data-expandedicon="true"] {
+      // remove submenu icon in collapsed Menu for first level
+      display: none;
+    }
+  }
 
-	.ant-menu-submenu.dendron-ant-menu-submenu-selected {
-		> .ant-menu-submenu-title {
-			background-color: rgb(230, 240, 225);  // antd's @menu-item-active-bg with ich @primary-1
-		}
+  .ant-menu-submenu {
+    > .ant-menu-submenu-title:after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      border-right: 3px solid rgb(67, 176, 42); // antd's @border-color-split
+      transform: scaleY(0.0001);
+      opacity: 0;
+      content: "";
+      pointer-events: none; // makes open/close arrows touch-area bigger by giving it "space" to the right from this after element
+    }
+  }
 
-		> .ant-menu-submenu-title:after {
-			transform: scaleY(1);
-			opacity: 1;
-		}
-	}
+  .ant-menu-submenu.dendron-ant-menu-submenu-selected {
+    > .ant-menu-submenu-title {
+      background-color: rgb(
+        230,
+        240,
+        225
+      ); // antd's @menu-item-active-bg with ich @primary-1
+    }
+
+    > .ant-menu-submenu-title:after {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
 }


### PR DESCRIPTION
- Replace runtime CSS rules on DendronLayout with layout components
- Move footer over the navbar [[scratch.2021.11.08.151528.move-footer-over-to-navbar]]

**Improvements**
- The layout takes the full width on screens < 1320px (See [docusaurus](https://docusaurus.io/docs))
- Remove the content layout shifting when the page is being resized.
- Remove runtime calculations

Attachment

https://user-images.githubusercontent.com/989826/141357288-34e36897-4028-41d2-867d-f795101989b1.mov


