### PR TITLE
chore: clean up abstractions used in CLI command

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -217,6 +217,16 @@ export function assertInvalidState(msg: string): never {
 
 /** Utility class for helping to correctly construct common errors. */
 export class ErrorFactory {
+  /**
+   * Not found
+   */
+  static create404Error({ url }: { url: string }): DendronError {
+    return new DendronError({
+      message: `resource at ${url} did not exist`,
+      severity: ERROR_SEVERITY.FATAL,
+    });
+  }
+
   static createUnexpectedEventError({ event }: { event: any }): DendronError {
     return new DendronError({
       message: `unexpected event: '${this.safeStringify(event)}'`,

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -195,11 +195,11 @@ export interface RespV2<T> {
  */
 export type RespV3<T> =
   | {
-      hasError: true;
       error: IDendronError;
+      data?: never;
     }
   | {
-      hasError: false;
+      error?: never;
       data: T;
     };
 

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -190,6 +190,19 @@ export interface RespV2<T> {
   error: IDendronError | null;
 }
 
+/**
+ * This lets us use a discriminate union to see if result has error or data
+ */
+export type RespV3<T> =
+  | {
+      hasError: true;
+      error: IDendronError;
+    }
+  | {
+      hasError: false;
+      data: T;
+    };
+
 export type BooleanResp =
   | { data: true; error: null }
   | { data: false; error: DendronError };
@@ -676,7 +689,7 @@ export type NoteViewMessage = DMessage<
   { id?: string; href?: string }
 >;
 
-export type NoteViewMessageType = DMessageEnum | NoteViewMessageEnum
+export type NoteViewMessageType = DMessageEnum | NoteViewMessageEnum;
 
 export type SeedBrowserMessage = DMessage<
   SeedBrowserMessageType | DMessageEnum,

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -5,6 +5,7 @@ import {
   NoteUtils,
   SchemaModuleProps,
   SchemaUtils,
+  DNodePropsQuickInputV2,
 } from "@dendronhq/common-all";
 import {
   file2Note,
@@ -16,7 +17,6 @@ import {
 } from "@dendronhq/common-server";
 import _ from "lodash";
 import path from "path";
-import { DNodePropsQuickInputV2 } from "@dendronhq/common-all";
 
 export type CreateNoteOptsV4 = {
   vault: DVault;
@@ -54,7 +54,7 @@ export class TestNoteFactory {
   }
 
   async createForFName(fname: string): Promise<NoteProps> {
-    return await NoteTestUtilsV4.createNote({
+    return NoteTestUtilsV4.createNote({
       fname,
       ...this._defaults,
     });
@@ -62,7 +62,9 @@ export class TestNoteFactory {
 
   async createForFNames(fnames: string[]): Promise<NoteProps[]> {
     const noteProps: NoteProps[] = [];
+    // eslint-disable-next-line no-plusplus
     for (let i = 0; i < fnames.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
       noteProps.push(await this.createForFName(fnames[i]));
     }
     return noteProps;
@@ -142,7 +144,7 @@ export class NoteTestUtilsV4 {
     const npath = path.join(vault2Path({ vault, wsRoot }), fname + ".md");
     const note = file2Note(npath, vault);
     const newNote = cb(note);
-    return await note2File({ note: newNote, vault, wsRoot });
+    return note2File({ note: newNote, vault, wsRoot });
   }
 
   static async modifySchemaByPath(
@@ -154,6 +156,6 @@ export class NoteTestUtilsV4 {
     const npath = path.join(vpath, fname + ".schema.yml");
     const schema = await file2Schema(npath, wsRoot);
     const newSchema = cb(schema);
-    return await schemaModuleProps2File(newSchema, vpath, fname);
+    return schemaModuleProps2File(newSchema, vpath, fname);
   }
 }

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -76,10 +76,8 @@ export const NOTE_PRESETS_V4 = {
   }),
   NOTE_WITH_CUSTOM_ATT: CreateNoteFactory({
     fname: "foo",
-    props: {
-      custom: {
-        bond: 42,
-      },
+    custom: {
+      bond: 42,
     },
   }),
   NOTE_DOMAIN_NAMESPACE: CreateNoteFactory({ fname: "pro" }),

--- a/packages/common-test-utils/src/presets/utils.ts
+++ b/packages/common-test-utils/src/presets/utils.ts
@@ -15,7 +15,7 @@ export class NotePresetsUtils {
       rootName: fname,
     });
     await NodeTestUtilsV2.createSchemaModuleOpts({
-      vaultDir: vaultDir,
+      vaultDir,
       rootName: fname,
     });
   }

--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -116,7 +116,7 @@ export abstract class CLICommand<
       this.opts.quiet = true;
     }
     const opts = await this.enrichArgs(args);
-    if (opts.hasError) {
+    if (opts.error) {
       this.L.error(opts.error);
       return { error: opts.error };
     }

--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -1,4 +1,9 @@
-import { DendronError, isDendronResp, CLIEvents } from "@dendronhq/common-all";
+import {
+  CLIEvents,
+  DendronError,
+  isDendronResp,
+  RespV3,
+} from "@dendronhq/common-all";
 import {
   createLogger,
   getDurationMilliseconds,
@@ -91,7 +96,7 @@ export abstract class CLICommand<
    * Converts CLI flags into {@link TOpts}
    * @param args
    */
-  abstract enrichArgs(args: any): Promise<TOpts>;
+  abstract enrichArgs(args: any): Promise<RespV3<TOpts>>;
 
   eval = async (args: any) => {
     const start = process.hrtime();
@@ -100,6 +105,7 @@ export abstract class CLICommand<
     if (!args.wsRoot) {
       const configPath = WorkspaceUtils.findWSRoot();
       if (_.isUndefined(configPath) && !this.wsRootOptional) {
+        // eslint-disable-next-line no-console
         console.log("no workspace detected. --wsRoot must be set");
         process.exit(1);
       } else {
@@ -110,12 +116,12 @@ export abstract class CLICommand<
       this.opts.quiet = true;
     }
     const opts = await this.enrichArgs(args);
-    if (opts.error) {
+    if (opts.hasError) {
       this.L.error(opts.error);
       return { error: opts.error };
     }
 
-    const out = await this.execute(opts);
+    const out = await this.execute(opts.data);
     if (isDendronResp(out) && out.error) {
       this.L.error(out.error);
     }
@@ -139,6 +145,7 @@ export abstract class CLICommand<
 
   print(obj: any) {
     if (!this.opts.quiet) {
+      // eslint-disable-next-line no-console
       console.log(obj);
     }
   }

--- a/packages/dendron-cli/src/commands/build-site-v2.ts
+++ b/packages/dendron-cli/src/commands/build-site-v2.ts
@@ -65,7 +65,7 @@ export class BuildSiteV2CLICommand extends CLICommand<
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     const engineArgs = await setupEngine(args);
     this.L.info({ msg: `connecting to engine on port: ${engineArgs.port}` });
     // add site specific notes
@@ -77,7 +77,7 @@ export class BuildSiteV2CLICommand extends CLICommand<
         engineArgs.engine.notes[ent.id] = ent;
       });
     }
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts) {

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -131,9 +131,9 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd });
-    return { ...args };
+    return { data: { ...args } };
   }
 
   async generateJSONSchemaFromConfig() {

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -153,10 +153,10 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     return uniqueCandidates;
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ action: args.action });
     const engineArgs = await setupEngine(args);
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {
@@ -179,19 +179,19 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     const engineWrite = dryRun
       ? () => {}
       : throttle(_.bind(engine.writeNote, engine), 300, {
-        // @ts-ignore
+          // @ts-ignore
           leading: true,
         });
     const engineDelete = dryRun
       ? () => {}
       : throttle(_.bind(engine.deleteNote, engine), 300, {
-        // @ts-ignore
+          // @ts-ignore
           leading: true,
         });
     const engineGetNoteByPath = dryRun
       ? () => {}
       : throttle(_.bind(engine.getNoteByPath, engine), 300, {
-        // @ts-ignore
+          // @ts-ignore
           leading: true,
         });
 
@@ -201,7 +201,7 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         console.log(
           "the CLI currently doesn't support this action. please run this using the plugin"
         );
-        return { exit }
+        return { exit };
       }
       // eslint-disable-next-line no-fallthrough
       case DoctorActions.H1_TO_TITLE: {

--- a/packages/dendron-cli/src/commands/exportPod.ts
+++ b/packages/dendron-cli/src/commands/exportPod.ts
@@ -34,7 +34,7 @@ export class ExportPodCLICommand extends CLICommand<
     setupPodArgs(args);
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ podId: args.podId });
     return enrichPodArgs({ pods: getAllExportPods(), podType: "export" })(args);
   }

--- a/packages/dendron-cli/src/commands/importPod.ts
+++ b/packages/dendron-cli/src/commands/importPod.ts
@@ -47,7 +47,6 @@ export class ImportPodCLICommand extends CLICommand<
     const { podClass: PodClass, config, wsRoot, engine, server } = opts;
     const vaults = engine.vaults;
     const pod = new PodClass();
-    console.log("running pod...", config);
     await pod.execute({
       wsRoot,
       config,
@@ -65,7 +64,8 @@ export class ImportPodCLICommand extends CLICommand<
                     ? true
                     : `Enter either Yes or No`,
               })
-            : console.log("Note is already in sync with the google doc");
+            : // eslint-disable-next-line no-console
+              console.log("Note is already in sync with the google doc");
 
         return resp;
       },
@@ -81,7 +81,6 @@ export class ImportPodCLICommand extends CLICommand<
         }
         resolve({});
       });
-      console.log("done");
     });
   }
 }

--- a/packages/dendron-cli/src/commands/launchEngineServer.ts
+++ b/packages/dendron-cli/src/commands/launchEngineServer.ts
@@ -59,11 +59,11 @@ export class LaunchEngineServerCommand extends CLICommand<
 
   async enrichArgs(args: CommandCLIOpts) {
     const ctx = "enrichArgs";
-    let { wsRoot, port, init, noWritePort } = _.defaults(args, {
+    const { port, init, noWritePort } = _.defaults(args, {
       init: false,
       noWritePort: false,
     });
-    wsRoot = resolvePath(wsRoot, process.cwd());
+    const wsRoot = resolvePath(args.wsRoot, process.cwd());
     const ws = new WorkspaceService({ wsRoot });
     const { dev } = ws.config;
     const vaults = ConfigUtils.getVaults(ws.config);
@@ -94,14 +94,16 @@ export class LaunchEngineServerCommand extends CLICommand<
       await engine.init();
     }
     return {
-      ...args,
-      engine,
-      wsRoot,
-      init,
-      vaults: vaultPaths,
-      port: _port,
-      server,
-      serverSockets,
+      data: {
+        ...args,
+        engine,
+        wsRoot,
+        init,
+        vaults: vaultPaths,
+        port: _port,
+        server,
+        serverSockets,
+      },
     };
   }
 

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -78,10 +78,10 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd, output: args.output });
     const engineArgs = await setupEngine(args);
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts) {

--- a/packages/dendron-cli/src/commands/publishPod.ts
+++ b/packages/dendron-cli/src/commands/publishPod.ts
@@ -1,8 +1,8 @@
-import { DendronError } from "@dendronhq/common-all";
+import { DendronError, RespV3 } from "@dendronhq/common-all";
 import {
   getAllPublishPods,
-  PublishPodConfig,
   PublishPod,
+  PublishPodConfig,
 } from "@dendronhq/pods-core";
 import yargs from "yargs";
 import { CLICommand, CommandCommonProps } from "./base";
@@ -36,11 +36,12 @@ export class PublishPodCLICommand extends CLICommand<
     setupPodArgs(args);
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts): Promise<RespV3<CommandOpts>> {
     this.addArgsToPayload({ podId: args.podId });
-    return enrichPodArgs({ pods: getAllPublishPods(), podType: "publish" })(
-      args
-    );
+    return enrichPodArgs<CommandOpts>({
+      pods: getAllPublishPods(),
+      podType: "publish",
+    })(args);
   }
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {
@@ -49,6 +50,7 @@ export class PublishPodCLICommand extends CLICommand<
     const pod = new PodClass() as PublishPod;
     const resp = await pod.execute({ wsRoot, config, engine, vaults });
     if (config.dest === "stdout") {
+      // eslint-disable-next-line no-console
       console.log(resp);
     }
     return new Promise((resolve) => {

--- a/packages/dendron-cli/src/commands/publishPod.ts
+++ b/packages/dendron-cli/src/commands/publishPod.ts
@@ -38,7 +38,7 @@ export class PublishPodCLICommand extends CLICommand<
 
   async enrichArgs(args: CommandCLIOpts): Promise<RespV3<CommandOpts>> {
     this.addArgsToPayload({ podId: args.podId });
-    return enrichPodArgs<CommandOpts>({
+    return enrichPodArgs({
       pods: getAllPublishPods(),
       podType: "publish",
     })(args);

--- a/packages/dendron-cli/src/commands/seedCLICommand.ts
+++ b/packages/dendron-cli/src/commands/seedCLICommand.ts
@@ -63,7 +63,7 @@ export class SeedCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd, id: args.id, mode: args.mode });
     const engineOpts: SetupEngineCLIOpts = { ...args, init: false };
     if (
@@ -73,7 +73,7 @@ export class SeedCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       engineOpts.wsRoot = process.cwd();
     }
     const engineArgs = await setupEngine(engineOpts);
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {

--- a/packages/dendron-cli/src/commands/utils.ts
+++ b/packages/dendron-cli/src/commands/utils.ts
@@ -59,7 +59,7 @@ export async function setupEngine(
   opts: SetupEngineCLIOpts
 ): Promise<SetupEngineResp> {
   const logger = createLogger();
-  let { wsRoot, enginePort, init, useLocalEngine } = _.defaults(opts, {
+  const { enginePort, init, useLocalEngine } = _.defaults(opts, {
     init: true,
     useLocalEngine: false,
   });
@@ -67,7 +67,7 @@ export async function setupEngine(
   let port: number;
   let server: Server;
   let serverSockets = new Set<Socket>();
-  wsRoot = resolvePath(wsRoot, process.cwd());
+  const wsRoot = resolvePath(opts.wsRoot, process.cwd());
   if (useLocalEngine) {
     const engine = DendronEngineV2.create({ wsRoot, logger });
     await engine.init();
@@ -109,8 +109,8 @@ export async function setupEngine(
     }
   } else {
     logger.info({ ctx: "setupEngine", msg: "initialize new engine" });
-    ({ engine, port, server, serverSockets } =
-      await new LaunchEngineServerCommand().enrichArgs(opts));
+    const resp = await new LaunchEngineServerCommand().enrichArgs(opts);
+    ({ engine, port, server, serverSockets } = resp.data);
     if (init) {
       await engine.init();
     }
@@ -134,4 +134,3 @@ export function setupEngineArgs(args: yargs.Argv) {
     describe: "If set, use in memory engine instead of connecting to a server",
   });
 }
-

--- a/packages/dendron-cli/src/commands/vaultCLICommand.ts
+++ b/packages/dendron-cli/src/commands/vaultCLICommand.ts
@@ -58,10 +58,10 @@ export class VaultCLICommand extends CLICommand<CommandOpts> {
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd });
     const engineArgs = await setupEngine(args);
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts) {

--- a/packages/dendron-cli/src/commands/workspace.ts
+++ b/packages/dendron-cli/src/commands/workspace.ts
@@ -37,10 +37,10 @@ export class WorkspaceCLICommand extends CLICommand<CommandOpts> {
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ action: args.action });
     const engineArgs = await setupEngine({ ...args, init: false });
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
   async execute(opts: CommandOpts) {
     const { action, fromConfig, wsRoot } = _.defaults(opts, {});

--- a/packages/dendron-cli/src/commands/workspaceCLICommand.ts
+++ b/packages/dendron-cli/src/commands/workspaceCLICommand.ts
@@ -53,11 +53,11 @@ export class WorkspaceCLICommand extends CLICommand<
     });
   }
 
-  async enrichArgs(args: CommandCLIOpts): Promise<CommandOpts> {
+  async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd });
     const engineOpts: SetupEngineCLIOpts = _.defaults(args, { init: false });
     const engineArgs = await setupEngine(engineOpts);
-    return { ...args, ...engineArgs };
+    return { data: { ...args, ...engineArgs } };
   }
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {

--- a/packages/engine-test-utils/.vscode/launch.json
+++ b/packages/engine-test-utils/.vscode/launch.json
@@ -10,8 +10,8 @@
       "smartStep": true,
       "cwd": "${workspaceFolder:engine-test-utils}",
       "env": {
-        "LOG_DST": "stdout",
-        "LOG_LEVEL": "info"
+        "LOG_LEVEL": "info",
+        "LOG_DST": "${workspaceFolder}/engine-test-utils-debug.log",
       },
       "args": [
         "--findRelatedTests",

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/base.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/base.spec.ts
@@ -18,8 +18,10 @@ class DummyCLICommand extends CLICommand<any> {
     return opts;
   }
 
+  // @ts-ignore;
   async execute(opts: any) {
-    return opts;
+    // @ts-ignore;
+    return { data: opts };
   }
 }
 
@@ -27,6 +29,7 @@ describe("GIVEN any command, no telemetry set before", () => {
   let dummy: CLICommand;
   beforeEach(() => {
     TestEngineUtils.mockHomeDir();
+    // @ts-ignore;
     dummy = new DummyCLICommand();
   });
 
@@ -48,6 +51,8 @@ describe("GIVEN any command, no telemetry set before", () => {
 
   test("AND telemetry status is set", async () => {
     await dummy.eval({});
-    expect(SegmentClient.getStatus()).toEqual(TelemetryStatus.ENABLED_BY_CLI_DEFAULT);
+    expect(SegmentClient.getStatus()).toEqual(
+      TelemetryStatus.ENABLED_BY_CLI_DEFAULT
+    );
   });
 });

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -37,8 +37,7 @@ import fs from "fs-extra";
 import _ from "lodash";
 import os from "os";
 import path from "path";
-import sinon from "sinon";
-import { SinonStub } from "sinon";
+import sinon, { SinonStub } from "sinon";
 import { ENGINE_HOOKS } from "./presets";
 import { GitTestUtils } from "./utils";
 
@@ -89,10 +88,12 @@ export { DEngineClient, DVault, WorkspaceOpts };
  * @returns
  */
 export async function createServer(opts: WorkspaceOpts & { port?: number }) {
-  return await new LaunchEngineServerCommand().enrichArgs({
-    wsRoot: opts.wsRoot,
-    port: opts.port,
-  });
+  return (
+    await new LaunchEngineServerCommand().enrichArgs({
+      wsRoot: opts.wsRoot,
+      port: opts.port,
+    })
+  ).data;
 }
 
 /**
@@ -120,7 +121,7 @@ export function createSiteConfig(
   opts: Partial<CleanDendronSiteConfig> &
     Required<Pick<CleanDendronSiteConfig, "siteRootDir" | "siteHierarchies">>
 ): CleanDendronSiteConfig {
-  let copts = {
+  const copts = {
     siteNotesDir: "docs",
     siteUrl: "https://localhost:8080",
     ...opts,
@@ -233,7 +234,7 @@ export class TestPresetEntryV5 {
       vaults?: DVault[];
     }
   ) {
-    let {
+    const {
       preSetupHook,
       postSetupHook,
       extraOpts,
@@ -243,15 +244,12 @@ export class TestPresetEntryV5 {
     } = _.defaults(opts, {
       workspaces: [],
     });
-    this.preSetupHook = preSetupHook ? preSetupHook : async () => {};
-    this.postSetupHook = postSetupHook ? postSetupHook : async () => {};
+    this.preSetupHook = preSetupHook || (async () => {});
+    this.postSetupHook = postSetupHook || (async () => {});
     this.testFunc = _.bind(func, this);
     this.extraOpts = extraOpts;
     this.setupTest = setupTest;
-    this.genTestResults = _.bind(
-      genTestResults ? genTestResults : async () => [],
-      this
-    );
+    this.genTestResults = _.bind(genTestResults || (async () => []), this);
     this.workspaces = workspaces;
     this.vaults = opts?.vaults || [
       { fsPath: "vault1" },
@@ -287,8 +285,8 @@ export async function runEngineTestV5(
     addVSWorkspace,
     git,
   } = _.defaults(opts, {
-    preSetupHook: async ({}) => {},
-    postSetupHook: async ({}) => {},
+    preSetupHook: async () => {},
+    postSetupHook: async () => {},
     createEngine: createEngineFromEngine,
     extra: {},
     // third vault has diff name

--- a/packages/engine-test-utils/src/presets/engine-server/index.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/index.ts
@@ -13,6 +13,7 @@ import { ENGINE_RENDER_PRESETS } from "./render";
 import { ENGINE_WRITE_PRESETS, ENGINE_WRITE_PRESETS_MULTI } from "./write";
 import _ from "lodash";
 import { TestPresetEntryV4 } from "@dendronhq/common-test-utils";
+
 export { ENGINE_HOOKS, ENGINE_HOOKS_BASE, ENGINE_HOOKS_MULTI } from "./utils";
 export { ENGINE_RENAME_PRESETS };
 export { ENGINE_QUERY_PRESETS };

--- a/packages/engine-test-utils/src/presets/engine-server/render.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/render.ts
@@ -77,10 +77,8 @@ const NOTES = {
         return NoteTestUtilsV4.createNote({
           ...opts,
           fname: "fm",
-          props: {
-            custom: {
-              foo: "egg",
-            },
+          custom: {
+            foo: "egg",
           },
           vault: opts.vaults[0],
           body: "{{ fm.foo }}\n\ntitle: {{ fm.title }}",

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -57,18 +57,17 @@ export class ImportPodCommand extends BaseCommand<
     const podClass = podChoice.podClass;
     const podsDir = getExtension().podsDir;
     try {
-      const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
-
+      const resp = PodUtils.getConfig({ podsDir, podClass });
+      if (resp.error) {
+        PodUtils.genConfigFile({ podsDir, podClass });
+      }
+      const maybeConfig = resp.data || {};
       // config defined and not just the default placeholder config
       if (
         maybeConfig &&
         (maybeConfig.src !== "TODO" || maybeConfig.vaultName !== "TODO")
       ) {
         return { podChoice, config: maybeConfig };
-      }
-
-      if (!maybeConfig) {
-        PodUtils.genConfigFile({ podsDir, podClass });
       }
 
       const configPath = PodUtils.getConfigPath({ podsDir, podClass });

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -29,6 +29,7 @@ function isTextDecorated(
   return false;
 }
 
+// eslint-disable-next-line func-names
 suite("windowDecorations", function () {
   const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
@@ -184,37 +185,31 @@ suite("windowDecorations", function () {
             fname: "with.all",
             vault: vaults[0],
             wsRoot,
-            props: {
-              custom: {
-                status: "done",
-                owner: "grace",
-                priority: "H",
-                due: "2021.10.29",
-                tags: "foo",
-              },
+            custom: {
+              status: "done",
+              owner: "grace",
+              priority: "H",
+              due: "2021.10.29",
+              tags: "foo",
             },
           });
           await NoteTestUtilsV4.createNote({
             fname: "without.status",
             vault: vaults[0],
             wsRoot,
-            props: {
-              custom: {
-                owner: "grace",
-                priority: "high",
-                tags: ["foo", "bar"],
-              },
+            custom: {
+              owner: "grace",
+              priority: "high",
+              tags: ["foo", "bar"],
             },
           });
           await NoteTestUtilsV4.createNote({
             fname: "without.due",
             vault: vaults[0],
             wsRoot,
-            props: {
-              custom: {
-                status: "",
-                priority: "low",
-              },
+            custom: {
+              status: "",
+              priority: "low",
             },
           });
           await NoteTestUtilsV4.createNote({

--- a/packages/plugin-core/src/utils/site.ts
+++ b/packages/plugin-core/src/utils/site.ts
@@ -71,7 +71,7 @@ export const buildSite = async (opts: BuildSiteV2CLICommandCliOpts) => {
   const cmd = new BuildSiteV2CLICommand();
   const cOpts = await cmd.enrichArgs(opts);
   await cmd.execute({
-    ...cOpts,
+    ...cOpts.data,
     eleventy,
     cwd: eleventyPath,
   });

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -101,7 +101,7 @@ export class AirtableUtils {
   ) {
     const chunks = _.chunk(allRecords, 10);
 
-    let total: number = 0;
+    // let total: number = 0;
     const out = await Promise.all(
       chunks.flatMap(async (record) => {
         // @ts-ignore
@@ -109,7 +109,7 @@ export class AirtableUtils {
         const data = JSON.stringify({ records: record });
         try {
           const _records = await func(record);
-          total += _records.length;
+          // total += _records.length;
           return _records;
         } catch (error) {
           let payload: any = { data };

--- a/packages/pods-core/src/utils.ts
+++ b/packages/pods-core/src/utils.ts
@@ -4,6 +4,8 @@ import {
   genUUIDInsecure,
   ERROR_SEVERITY,
   stringifyError,
+  RespV3,
+  ErrorFactory,
 } from "@dendronhq/common-all";
 import { readYAML } from "@dendronhq/common-server";
 import Ajv, { JSONSchemaType } from "ajv";
@@ -37,13 +39,9 @@ export class PodUtils {
   }: {
     podsDir: string;
     podClass: PodClassEntryV4;
-  }): false | any {
+  }) {
     const podConfigPath = PodUtils.getConfigPath({ podsDir, podClass });
-    if (!fs.existsSync(podConfigPath)) {
-      return false;
-    } else {
-      return readYAML(podConfigPath);
-    }
+    return PodUtils.readPodConfigFromDisk<any>(podConfigPath);
   }
 
   static getConfigPath({
@@ -266,6 +264,18 @@ export class PodUtils {
       configured: true,
       podId: opts.podChoice.id,
     };
+  }
+
+  static readPodConfigFromDisk<T>(podConfigPath: string): RespV3<T> {
+    if (!fs.existsSync(podConfigPath)) {
+      return {
+        error: ErrorFactory.create404Error({ url: podConfigPath }),
+      };
+    } else {
+      return {
+        data: readYAML(podConfigPath),
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
CLI returns a `RespV3` object which is either `data: T` or `DendronError`. 
Use a typescript union to return a type that is either data or error. This results in a stanrad type safe way of checking for errors from any response. 

[Docs](https://github.com/dendronhq/dendron-site/commit/36406061c26b66525497f1ee4f9090b89f0c5b17)

