### PR TITLE
enhance: adding telemetry to CreateSchemaFromHierarchyCommand

### DIFF
--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -83,6 +83,7 @@ export abstract class BaseCommand<
     let resp: TOut | undefined;
 
     try {
+      // TODO: Add sanity check failure to analytics payload.
       const out = await this.sanityCheck();
       if (out === "cancel") {
         return;

--- a/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateSchemaFromHierarchyCommand.test.ts
@@ -3,6 +3,7 @@ import {
   HierarchyLevel,
   SchemaCandidate,
   SchemaCreator,
+  StopReason,
   UserQueries,
 } from "../../commands/CreateSchemaFromHierarchyCommand";
 import { TestNoteFactory } from "@dendronhq/common-test-utils";
@@ -51,6 +52,10 @@ async function createTestSchemaCandidatesDefault() {
   ];
 
   return createSchemaCandidates(fnames);
+}
+
+function buildCmd() {
+  return new CreateSchemaFromHierarchyCommand();
 }
 
 suite("CreateSchemaFromHierarchyCommand tests", () => {
@@ -217,6 +222,34 @@ schemas:
           expect(
             schemaCandidates.some((cand) => cand.label === "h1.*.h3a")
           ).toBeTruthy();
+        });
+      });
+    });
+
+    describe(`addAnalyticsPayload tests`, () => {
+      it(`WHEN successfully created THEN format success`, () => {
+        const actual = buildCmd().addAnalyticsPayload(
+          { isHappy: true },
+          { successfullyCreated: true }
+        );
+        expect(actual).toEqual({ successfullyCreated: true });
+      });
+
+      it(`WHEN input was not happy THEN format the stop reason`, () => {
+        const actual = buildCmd().addAnalyticsPayload({
+          isHappy: false,
+          stopReason: StopReason.DID_NOT_PICK_SCHEMA_FILE_NAME,
+        });
+        expect(actual).toEqual({
+          successfullyCreated: false,
+          stopReason: StopReason.DID_NOT_PICK_SCHEMA_FILE_NAME,
+        });
+      });
+
+      it("WHEN stop reason is not present but create is not happy THEN format create not happy", () => {
+        const actual = buildCmd().addAnalyticsPayload({ isHappy: false });
+        expect(actual).toEqual({
+          successfullyCreated: false,
         });
       });
     });


### PR DESCRIPTION
# enhance: adding telemetry to CreateSchemaFromHierarchyCommand



## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
Print out of analytics payload from base command in different use cases:
```
Payload: '{"stopReason":"CANCELLED_PATTERN_SELECTION","successfullyCreated":false}'
Payload: '{"stopReason":"DID_NOT_PICK_HIERARCHY_LEVEL","successfullyCreated":false}'
Payload: '{"stopReason":"UNSELECTED_ALL_PATTERNS","successfullyCreated":false}'
Payload: '{"stopReason":"DID_NOT_PICK_SCHEMA_FILE_NAME","successfullyCreated":false}'
Payload: '{"successfullyCreated":true}'
// Example of empty payload is when sanity check is invoked.
Payload: '{}'
Payload: '{"stopReason":"SCHEMA_WITH_TOP_ID_ALREADY_EXISTS","successfullyCreated":false}'
```


- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
