### PR TITLE
fix: ajv warning messages printed to console

### DIFF
--- a/packages/common-server/src/parser.ts
+++ b/packages/common-server/src/parser.ts
@@ -22,9 +22,17 @@ import { createLogger, DLogger } from "./logger";
 import Ajv from "ajv";
 import AjvErrors from "ajv-errors";
 
-const ajv = new Ajv({ allErrors: true });
-// Allows custom error messages to be specified within the ajv-schema definition.
-AjvErrors(ajv);
+class AJVProvider {
+  static ajv: Ajv;
+  static getAjv() {
+    if (this.ajv === undefined) {
+      this.ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
+      // Allows custom error messages to be specified within the ajv-schema definition.
+      AjvErrors(this.ajv);
+    }
+    return this.ajv;
+  }
+}
 
 let _LOGGER: DLogger | undefined;
 
@@ -209,7 +217,7 @@ export class SchemaParserV2 extends ParserBaseV2 {
   private static validateSchemaOptsPreCreation(
     opts: (SchemaOpts | SchemaRaw) & { vault: DVault }
   ) {
-    const validator = ajv.compile(AJV_SCHEMAS.SCHEMA_OBJ);
+    const validator = AJVProvider.getAjv().compile(AJV_SCHEMAS.SCHEMA_OBJ);
     const isValid = validator(opts);
     if (!isValid) {
       let message = "";


### PR DESCRIPTION
# fix: ajv warning messages printed to console

Fixed the warning message, and added encapsulation for the ajv to only get instantiated for the first time that its used for good measure. 

## General

### Quality Assurance
- [] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
   - parser.spec.ts already has a test which indirectly tests the changes in the code, made sure that if validaton is commented out parser.spec.ts does not pass. 
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
