### PR TITLE
fix: add workspace root to workspace folders for Code Workspaces

### DIFF
--- a/packages/engine-server/src/workspace/vscode.ts
+++ b/packages/engine-server/src/workspace/vscode.ts
@@ -109,12 +109,16 @@ export class WorkspaceConfig {
     });
     const jsonBody: WorkspaceSettings = _.merge(
       {
-        folders: cleanOpts.vaults
-          ? cleanOpts.vaults.map((ent) => ({
-              path: ent.fsPath,
-              name: ent.name,
-            }))
-          : [],
+        folders: [
+          {
+            path: wsRoot,
+            name: "workspace",
+          },
+          ...(cleanOpts.vaults || []).map((vault) => ({
+            path: vault.fsPath,
+            name: vault.name,
+          })),
+        ],
         settings: Settings.defaults(),
         extensions: Extensions.defaults(),
       },


### PR DESCRIPTION
Adds the workspace root to the Code Workspace template. The reasoning behind it is that people tend to get confused that they can't find `dendron.yml` in their workspace when they initialize it.

I remember talking about making this change a few months ago, but I don't remember if we decided not to add it.

Here's a screenshot of what the explorer looks like with a default workspace initialized:
![Screenshot_20211119_041308](https://user-images.githubusercontent.com/1008124/142598131-49e043be-a34d-4919-81f1-a761fbbd9947.png)

This also might be a little confusing since the vaults are shown both in their own sections and also under root. I couldn't figure out a way to hide them without potentially also hiding other folders in the workspace. What are your thoughts on doing it this way versus how it was before?