### PR TITLE
enahnce(views): mermaid diagrams respect color theme

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -16,9 +16,9 @@ export class NodeJSUtils {
 
 export class WebViewCommonUtils {
   /**
-   * 
-   * @param param0 
-   * @returns 
+   *
+   * @param param0
+   * @returns
    */
   static genVSCodeHTMLIndex = ({
     jsSrc,
@@ -28,19 +28,19 @@ export class WebViewCommonUtils {
     browser,
     acquireVsCodeApi,
     themeMap,
-    initialTheme
+    initialTheme,
   }: {
     jsSrc: string;
     cssSrc: string;
     port: number;
     wsRoot: string;
     browser: boolean;
-    acquireVsCodeApi: string
+    acquireVsCodeApi: string;
     themeMap: {
-      light: string,
-      dark: string 
-    }
-    initialTheme?: string
+      light: string;
+      dark: string;
+    };
+    initialTheme?: string;
   }) => {
     return `<!DOCTYPE html>
   <html lang="en">
@@ -85,6 +85,8 @@ export class WebViewCommonUtils {
         if (newTheme === 'high-contrast') {
             newTheme = 'dark'; // the high-contrast theme seems to be an extreme case of the dark theme
         }
+        // be bale to get current theme using JS;
+        window.currentTheme = newTheme;
     
         if (theme === newTheme) return;
         theme = newTheme;

--- a/packages/dendron-plugin-views/scripts/buildIndex.js
+++ b/packages/dendron-plugin-views/scripts/buildIndex.js
@@ -1,10 +1,9 @@
-const {WebViewCommonUtils} = require("@dendronhq/common-server")
+const { WebViewCommonUtils } = require("@dendronhq/common-server");
 const fs = require("fs-extra");
-const _ = require('lodash');
 const path = require("path");
 
 // Compile Dendron `index.html` template
-let theme = process.env.THEME || "";
+let theme = process.env.THEME || "light";
 
 const out = WebViewCommonUtils.genVSCodeHTMLIndex({
   // dummy, not used. for browser mode, this is added by CRA app
@@ -16,9 +15,10 @@ const out = WebViewCommonUtils.genVSCodeHTMLIndex({
   browser: true,
   acquireVsCodeApi: `window.vscode = {postMessage: ()=>{}};`,
   themeMap: {
-    light: `${path.join("static", "css", "themes", "light.css")}`,
-    dark: `${path.join("static", "css", "themes", "dark.css")}`,
+    light: `${"/" + path.join("static", "css", "themes", "light.css")}`,
+    dark: `${"/" + path.join("static", "css", "themes", "dark.css")}`,
   },
   initialTheme: theme,
 });
+console.log("building index", { theme });
 fs.writeFileSync(path.join("public/index.html"), out);

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -19,8 +19,8 @@ import { useWorkspaceProps } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage, useVSCodeMessage } from "../utils/vscode";
 import "../styles/scss/main.scss";
-import { Layout} from "antd";
-const {Content} = Layout;
+import { Layout } from "antd";
+const { Content } = Layout;
 
 const { useEngineAppSelector, useEngine } = engineHooks;
 
@@ -53,7 +53,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
       source: DMessageSource.webClient,
     });
     logger.info({ ctx, msg: "postVSCodeMessage" });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // register a listener for vscode messages
@@ -96,7 +96,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
 function DendronApp(props: { Component: DendronComponent }) {
   return (
     <Provider store={combinedStore}>
-      <Layout style={{padding: "33px"}}>
+      <Layout style={{ padding: "33px" }}>
         <Content>
           <DendronVSCodeApp {...props} />
         </Content>

--- a/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
@@ -3,15 +3,14 @@ import {
   FOOTNOTE_DEF_CLASS,
   FOOTNOTE_REF_CLASS,
   NoteViewMessageEnum,
-  ThemeType,
 } from "@dendronhq/common-all";
 import { createLogger, DendronNote } from "@dendronhq/common-frontend";
 import _ from "lodash";
+import mermaid from "mermaid";
 import React from "react";
-import { useMermaid, useRenderedNoteBody } from "../hooks";
+import { useCurrentTheme, useMermaid, useRenderedNoteBody } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage } from "../utils/vscode";
-import mermaid from "mermaid";
 
 function isHTMLAnchorElement(element: Element): element is HTMLAnchorElement {
   return element.nodeName === "A";
@@ -96,8 +95,8 @@ const DendronNotePage: DendronComponent = (props) => {
   });
 
   useClickHandler(noteProps?.id);
-  // TODO: dynamiclally set
-  useMermaid({ config, themeType: ThemeType.LIGHT, mermaid, noteRenderedBody });
+  const { currentTheme: themeType } = useCurrentTheme();
+  useMermaid({ config, themeType, mermaid, noteRenderedBody });
 
   if (!noteRenderedBody || !config) {
     return null;

--- a/packages/dendron-plugin-views/src/hooks/index.tsx
+++ b/packages/dendron-plugin-views/src/hooks/index.tsx
@@ -2,7 +2,6 @@ import {
   ConfigUtils,
   IntermediateDendronConfig,
   NoteProps,
-  ThemeType,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -12,6 +11,17 @@ import {
 import { Mermaid } from "mermaid";
 import React from "react";
 import { DendronProps, WorkspaceProps } from "../types";
+
+export const useCurrentTheme = () => {
+  const [currentTheme, setCurrentTheme] = React.useState<"light" | "dark">(
+    "light"
+  );
+  React.useEffect(() => {
+    // @ts-ignore
+    setCurrentTheme(window.currentTheme);
+  }, [setCurrentTheme, currentTheme]);
+  return { currentTheme, setCurrentTheme };
+};
 
 export const useWorkspaceProps = (): [WorkspaceProps] => {
   const elem = window.document.getElementById("root")!;
@@ -73,7 +83,7 @@ export const useMermaid = ({
   noteRenderedBody,
 }: {
   config?: IntermediateDendronConfig;
-  themeType: ThemeType;
+  themeType: "light" | "dark";
   mermaid: Mermaid;
   noteRenderedBody?: string;
 }) => {
@@ -82,19 +92,19 @@ export const useMermaid = ({
     if (config && ConfigUtils.getPreview(config)?.enableMermaid) {
       mermaid.initialize({
         startOnLoad: true,
-        theme: themeType === ThemeType.LIGHT ? "forest" : "dark",
+        theme: themeType === "light" ? "forest" : "dark",
       });
       // use for debugging
       // @ts-ignore
       window._mermaid = mermaid;
       // @ts-ignore
       mermaid.init();
-      logger.info("init mermaid library");
+      logger.info({ msg: "init mermaid library", themeType });
     } else {
       logger.info("skip mermaid library");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [config, noteRenderedBody]);
+  }, [config, noteRenderedBody, themeType]);
 };
 
 /**


### PR DESCRIPTION
Prior, we would default to the light theme which would make dark theme
diagrams hard to read.

Also adds support for setting theme when [[Developing in Browser
Mode|dendron://dendron.dendron-site/pkg.dendron-plugin-views.quickstart#developing-in-browser-mode]].
