### PR TITLE
enhance(cli): cli uses separate port file

### DIFF
--- a/bootstrap/.vscode/tasks.json
+++ b/bootstrap/.vscode/tasks.json
@@ -37,10 +37,11 @@
       "command": "./scripts/testAll.sh",
       "options": {
         "env": {
-          "LOG_LEVEL": "error"
+          "LOG_LEVEL": "info",
+          "LOG_DST": "${workspaceFolder}/engine-test-utils.log"
         }
       },
-      "problemMatcher": [],
+      "problemMatcher": []
     },
     {
       "label": "changelog",

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -33,6 +33,7 @@ function launchv2(
   configureLogger({ logPath: LOG_DST });
 
   return new Promise((resolve) => {
+    // eslint-disable-next-line global-require
     const appModule = require("./Server").appModule;
     const app = appModule({
       logPath: LOG_DST,

--- a/packages/dendron-cli/src/commands/launchEngineServer.ts
+++ b/packages/dendron-cli/src/commands/launchEngineServer.ts
@@ -3,6 +3,7 @@ import { launchv2 } from "@dendronhq/api-server";
 import { LogLvl, resolvePath } from "@dendronhq/common-server";
 import {
   DendronEngineClient,
+  EngineUtils,
   WorkspaceService,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
@@ -82,7 +83,7 @@ export class LaunchEngineServerCommand extends CLICommand<
     ws.writeMeta({ version: "dendron-cli" });
 
     if (!noWritePort) {
-      ws.writePort(_port);
+      EngineUtils.writeEnginePortForCLI({ port: _port, wsRoot });
     }
     const engine = DendronEngineClient.create({
       port: _port,

--- a/packages/dendron-cli/src/commands/launchEngineServer.ts
+++ b/packages/dendron-cli/src/commands/launchEngineServer.ts
@@ -69,6 +69,8 @@ export class LaunchEngineServerCommand extends CLICommand<
     const { dev } = ws.config;
     const vaults = ConfigUtils.getVaults(ws.config);
     const vaultPaths = vaults.map((v) => resolvePath(v.fsPath, wsRoot));
+
+    // launches engine server in a separate process
     const {
       port: _port,
       server,

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -46,10 +46,10 @@ import {
 import { createLogger, DLogger, readYAML } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
-import { EngineUtils } from "../lib";
 import { DConfig } from "./config";
 import { FileStorage } from "./drivers/file/storev2";
 import { HistoryService } from "./history";
+import { EngineUtils } from "./utils";
 
 type DendronEngineClientOpts = {
   vaults: DVault[];
@@ -94,7 +94,7 @@ export class DendronEngineClient implements DEngineClient {
   }
 
   static getPort({ wsRoot }: { wsRoot: string }): number {
-    const portFile = EngineUtils.getPortFilePath({ wsRoot });
+    const portFile = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
     if (!fs.pathExistsSync(portFile)) {
       throw new DendronError({ message: "no port file" });
     }

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -46,10 +46,10 @@ import {
 import { createLogger, DLogger, readYAML } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
+import { EngineUtils } from "../lib";
 import { DConfig } from "./config";
 import { FileStorage } from "./drivers/file/storev2";
 import { HistoryService } from "./history";
-import { getPortFilePath } from "./utils";
 
 type DendronEngineClientOpts = {
   vaults: DVault[];
@@ -94,7 +94,7 @@ export class DendronEngineClient implements DEngineClient {
   }
 
   static getPort({ wsRoot }: { wsRoot: string }): number {
-    const portFile = getPortFilePath({ wsRoot });
+    const portFile = EngineUtils.getPortFilePath({ wsRoot });
     if (!fs.pathExistsSync(portFile)) {
       throw new DendronError({ message: "no port file" });
     }

--- a/packages/engine-server/src/markdown/remark/dendronPreview.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPreview.ts
@@ -44,7 +44,12 @@ function handleImage({
     node.url = fpath;
     return;
   }
-  const port = EngineUtils.getEnginePort({ wsRoot });
+  const resp = EngineUtils.getEnginePort({ wsRoot });
+  if (resp.error) {
+    logger.error(resp.error);
+    return;
+  }
+  const port = resp.data;
   const url = EngineUtils.getLocalEngineUrl({ port }) + "/api/assets";
   const params: AssetGetRequest = {
     fpath,

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -545,7 +545,6 @@ export class MDUtilsV5 {
     data: Omit<ProcDataFullOptsV5, "dest">,
     opts?: { flavor?: ProcFlavor }
   ) {
-    console.debug({ ctx: "procRehypeFull" });
     const proc = this._procRehype(
       { mode: ProcMode.FULL, parseOnly: false, flavor: opts?.flavor },
       data

--- a/packages/engine-server/src/topics/connector.ts
+++ b/packages/engine-server/src/topics/connector.ts
@@ -16,14 +16,14 @@ import _ from "lodash";
 import { DConfig } from "../config";
 import { DendronEngineClient } from "../engineClient";
 import {
-  getPortFilePath,
+  EngineUtils,
   getWSMetaFilePath,
   openPortFile,
   openWSMetaFile,
 } from "../utils";
 
 export type EngineConnectorInitOpts = {
-  onReady?: ({}: { ws: EngineConnector }) => Promise<void>;
+  onReady?: (opts: { ws: EngineConnector }) => Promise<void>;
   numRetries?: number;
   portOverride?: number;
   /**
@@ -163,7 +163,7 @@ export class EngineConnector {
   private async _connect(opts: {
     wsRoot: string;
   }): Promise<false | { engine: DendronEngineClient; port: number }> {
-    const portFilePath = getPortFilePath(opts);
+    const portFilePath = EngineUtils.getPortFilePath(opts);
     const metaFpath = getWSMetaFilePath(opts);
     const ctx = "EngineConnector:_connect";
 
@@ -203,11 +203,12 @@ export class EngineConnector {
   async createServerWatcher(opts?: { numRetries?: number; init?: boolean }) {
     const ctx = "EngineConnector:createServerWatcher";
     const { wsRoot } = this;
-    const portFilePath = getPortFilePath({ wsRoot });
+    const portFilePath = EngineUtils.getPortFilePath({ wsRoot });
     this.logger.info({ ctx, msg: "enter", opts });
 
     // try to connect to file
     while (!this.initialized) {
+      // eslint-disable-next-line no-await-in-loop
       await this.connectAndInit({ wsRoot, init: opts?.init });
     }
 

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -136,11 +136,6 @@ export async function getEngine(opts: {
   });
 }
 
-export function getPortFilePath({ wsRoot }: { wsRoot: string }) {
-  const portFile = path.join(wsRoot, CONSTANTS.DENDRON_SERVER_PORT);
-  return portFile;
-}
-
 export function getWSMetaFilePath({ wsRoot }: { wsRoot: string }) {
   const fsPath = path.join(wsRoot, CONSTANTS.DENDRON_WS_META);
   return fsPath;
@@ -319,14 +314,34 @@ export class HierarchyUtils {
 }
 
 export class EngineUtils {
+  static getPortFilePath({ wsRoot }: { wsRoot: string }) {
+    const portFile = path.join(wsRoot, CONSTANTS.DENDRON_SERVER_PORT);
+    return portFile;
+  }
+
+  static getPortFilePathForCLI({ wsRoot }: { wsRoot: string }) {
+    return EngineUtils.getPortFilePath({ wsRoot }) + ".cli";
+  }
+
   static getEnginePort(opts: { wsRoot: string }) {
-    const portFilePath = getPortFilePath(opts);
+    let portFilePath = EngineUtils.getPortFilePath(opts);
+    const port = openPortFile({ fpath: portFilePath });
+    return port;
+  }
+
+  static getEnginePortForCLI(opts: { wsRoot: string }) {
+    const portFilePath = EngineUtils.getPortFilePathForCLI(opts);
     const port = openPortFile({ fpath: portFilePath });
     return port;
   }
 
   static getLocalEngineUrl({ port }: { port: number }) {
     return APIUtils.getLocalEndpoint(port);
+  }
+
+  static writeEnginePortForCLI(opts: { port: number; wsRoot: string }) {
+    const portFilePath = EngineUtils.getPortFilePathForCLI(opts);
+    fs.writeFileSync(portFilePath, _.toString(opts.port), { encoding: "utf8" });
   }
 
   /**

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -45,7 +45,7 @@ import {
 import { SeedService, SeedUtils } from "../seed";
 import { Git } from "../topics/git";
 import {
-  getPortFilePath,
+  EngineUtils,
   getWSMetaFilePath,
   removeCache,
   writeWSMetaFile,
@@ -774,7 +774,7 @@ export class WorkspaceService {
 
   async getVaultRepo(vault: DVault) {
     const vpath = vault2Path({ vault, wsRoot: this.wsRoot });
-    return await GitUtils.getGitRoot(vpath);
+    return GitUtils.getGitRoot(vpath);
   }
 
   async getAllReposVaults(): Promise<Map<string, DVault[]>> {
@@ -1106,7 +1106,7 @@ export class WorkspaceService {
   writePort(port: number) {
     const wsRoot = this.wsRoot;
     // dendron-cli can overwrite port file. anything that needs the port should connect to `portFilePathExtension`
-    const portFilePath = getPortFilePath({ wsRoot });
+    const portFilePath = EngineUtils.getPortFilePath({ wsRoot });
     fs.writeFileSync(portFilePath, _.toString(port), { encoding: "utf8" });
   }
 

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -1106,7 +1106,7 @@ export class WorkspaceService {
   writePort(port: number) {
     const wsRoot = this.wsRoot;
     // dendron-cli can overwrite port file. anything that needs the port should connect to `portFilePathExtension`
-    const portFilePath = EngineUtils.getPortFilePath({ wsRoot });
+    const portFilePath = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
     fs.writeFileSync(portFilePath, _.toString(port), { encoding: "utf8" });
   }
 

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/launchEngineServer.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/launchEngineServer.spec.ts
@@ -1,5 +1,5 @@
 import { LaunchEngineServerCommand } from "@dendronhq/dendron-cli";
-import { getPortFilePath } from "@dendronhq/engine-server";
+import { EngineUtils } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import { runEngineTestV5 } from "../../../engine";
 
@@ -10,8 +10,10 @@ describe("GIVEN LaunchEngineServer cmd", () => {
         async ({ wsRoot }) => {
           const cmd = new LaunchEngineServerCommand();
           await cmd.enrichArgs({ wsRoot });
-          const portFile = getPortFilePath({ wsRoot });
-          expect(fs.existsSync(portFile)).toBeTruthy();
+          const cliPortFile = EngineUtils.getPortFilePathForCLI({ wsRoot });
+          const wsPortFile = EngineUtils.getPortFilePath({ wsRoot });
+          expect(fs.existsSync(cliPortFile)).toBeTruthy();
+          expect(fs.existsSync(wsPortFile)).toBeFalsy();
         },
         {
           expect,
@@ -25,8 +27,8 @@ describe("GIVEN LaunchEngineServer cmd", () => {
           async ({ wsRoot }) => {
             const cmd = new LaunchEngineServerCommand();
             await cmd.enrichArgs({ wsRoot, noWritePort: true });
-            const portFile = getPortFilePath({ wsRoot });
-            expect(fs.existsSync(portFile)).toBeFalsy();
+            const cliPortFile = EngineUtils.getPortFilePathForCLI({ wsRoot });
+            expect(fs.existsSync(cliPortFile)).toBeFalsy();
           },
           {
             expect,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/launchEngineServer.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/launchEngineServer.spec.ts
@@ -11,7 +11,9 @@ describe("GIVEN LaunchEngineServer cmd", () => {
           const cmd = new LaunchEngineServerCommand();
           await cmd.enrichArgs({ wsRoot });
           const cliPortFile = EngineUtils.getPortFilePathForCLI({ wsRoot });
-          const wsPortFile = EngineUtils.getPortFilePath({ wsRoot });
+          const wsPortFile = EngineUtils.getPortFilePathForWorkspace({
+            wsRoot,
+          });
           expect(fs.existsSync(cliPortFile)).toBeTruthy();
           expect(fs.existsSync(wsPortFile)).toBeFalsy();
         },

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/utils/setupEngine.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/utils/setupEngine.spec.ts
@@ -13,6 +13,7 @@ describe("GIVEN setupEngine", () => {
             wsRoot,
             noWritePort: true,
             attach: true,
+            target: "cli",
           });
           expect(resp.engine.notes).toEqual(engine.notes);
           expect(resp.port).toEqual(port);

--- a/packages/plugin-core/src/commands/DiagnosticsReport.ts
+++ b/packages/plugin-core/src/commands/DiagnosticsReport.ts
@@ -37,7 +37,7 @@ export class DiagnosticsReportCommand extends BasicCommand<
 
     const config = JSON.stringify(getDWorkspace().config);
     const wsRoot = getDWorkspace().wsRoot;
-    const port = EngineUtils.getPortFilePath({ wsRoot });
+    const port = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
     const portFromFile = fs.readFileSync(port, { encoding: "utf8" });
 
     const workspaceFile = DendronExtension.workspaceFile().fsPath;

--- a/packages/plugin-core/src/commands/DiagnosticsReport.ts
+++ b/packages/plugin-core/src/commands/DiagnosticsReport.ts
@@ -1,4 +1,4 @@
-import { getPortFilePath } from "@dendronhq/engine-server";
+import { EngineUtils } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import path from "path";
 import { window, workspace } from "vscode";
@@ -37,7 +37,7 @@ export class DiagnosticsReportCommand extends BasicCommand<
 
     const config = JSON.stringify(getDWorkspace().config);
     const wsRoot = getDWorkspace().wsRoot;
-    const port = getPortFilePath({ wsRoot });
+    const port = EngineUtils.getPortFilePath({ wsRoot });
     const portFromFile = fs.readFileSync(port, { encoding: "utf8" });
 
     const workspaceFile = DendronExtension.workspaceFile().fsPath;

--- a/packages/plugin-core/src/test/suite-integ/DiagnosticsReport.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DiagnosticsReport.test.ts
@@ -3,15 +3,13 @@ import { AssertUtils } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import path from "path";
-import * as vscode from "vscode";
 import { DiagnosticsReportCommand } from "../../commands/DiagnosticsReport";
 import { VSCodeUtils } from "../../utils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("DiagnosticsReport", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this);
+  const ctx = setupBeforeAfter(this);
 
   test("basic", (done) => {
     runLegacyMultiWorkspaceTest({
@@ -19,12 +17,12 @@ suite("DiagnosticsReport", function () {
       preSetupHook: async ({ wsRoot, vaults }) => {
         ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
       },
-      onInit: async ({}) => {
-        const log_dst = path.join(
+      onInit: async () => {
+        const logDst = path.join(
           path.dirname(env("LOG_DST")),
           "dendron.server.log"
         );
-        fs.writeFileSync(log_dst, "foobar", { encoding: "utf8" });
+        fs.writeFileSync(logDst, "foobar", { encoding: "utf8" });
         const cmd = new DiagnosticsReportCommand();
         await cmd.execute();
 

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -16,7 +16,7 @@ import {
 } from "@dendronhq/common-server";
 import { toPlainObject } from "@dendronhq/common-test-utils";
 import {
-  getPortFilePath,
+  EngineUtils,
   getWSMetaFilePath,
   MetadataService,
   openWSMetaFile,
@@ -344,7 +344,7 @@ suite("Extension", function () {
           ctx,
           onInit: async ({ wsRoot, vaults, engine }) => {
             // check for meta
-            const port = getPortFilePath({ wsRoot });
+            const port = EngineUtils.getPortFilePath({ wsRoot });
             const fpath = getWSMetaFilePath({ wsRoot });
             const meta = openWSMetaFile({ fpath });
             expect(

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -344,7 +344,7 @@ suite("Extension", function () {
           ctx,
           onInit: async ({ wsRoot, vaults, engine }) => {
             // check for meta
-            const port = EngineUtils.getPortFilePath({ wsRoot });
+            const port = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
             const fpath = getWSMetaFilePath({ wsRoot });
             const meta = openWSMetaFile({ fpath });
             expect(

--- a/packages/plugin-core/src/workspacev2.ts
+++ b/packages/plugin-core/src/workspacev2.ts
@@ -3,7 +3,7 @@ import { createFileWatcher } from "@dendronhq/common-server";
 import {
   DendronEngineClient,
   DEngineClient,
-  getPortFilePath,
+  EngineUtils,
   openPortFile,
 } from "@dendronhq/engine-server";
 import fs, { FSWatcher } from "fs-extra";
@@ -81,7 +81,7 @@ export class DWorkspace {
 
   async createServerWatcher(opts?: { numRetries?: number }) {
     const { wsRoot } = this;
-    const fpath = getPortFilePath({ wsRoot });
+    const fpath = EngineUtils.getPortFilePath({ wsRoot });
     const { watcher } = await createFileWatcher({
       fpath,
       numTries: opts?.numRetries,
@@ -103,7 +103,7 @@ export class DWorkspace {
           Time.DateTime.fromJSDate(fs.statSync(fpath).ctime).toMillis() <
           10e3
       ) {
-        const fpath = getPortFilePath({ wsRoot });
+        const fpath = EngineUtils.getPortFilePath({ wsRoot });
         const port = openPortFile({ fpath });
         this.onChangePort({ port });
       }

--- a/packages/plugin-core/src/workspacev2.ts
+++ b/packages/plugin-core/src/workspacev2.ts
@@ -81,7 +81,7 @@ export class DWorkspace {
 
   async createServerWatcher(opts?: { numRetries?: number }) {
     const { wsRoot } = this;
-    const fpath = EngineUtils.getPortFilePath({ wsRoot });
+    const fpath = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
     const { watcher } = await createFileWatcher({
       fpath,
       numTries: opts?.numRetries,
@@ -103,7 +103,7 @@ export class DWorkspace {
           Time.DateTime.fromJSDate(fs.statSync(fpath).ctime).toMillis() <
           10e3
       ) {
-        const fpath = EngineUtils.getPortFilePath({ wsRoot });
+        const fpath = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
         const port = openPortFile({ fpath });
         this.onChangePort({ port });
       }


### PR DESCRIPTION
The Dendron CLI will create its own instance of an API server for most commands. This engine, when spawned, will write a port file at `.dendron.port` so that other processes can discover the port that the engine server is running on.
The issue is that a running workspace has its own port file which will be overridden. This will make commands like `dendron {cmd} --attach` fail as the port is no longer accurate.

This change causes the dendron-cli to write the engine port at `dendron.port.cli` instead.

- enhance: cli write to own path
- enhance(cli): do not overwrite ws dendron port when activating CLI
