### PR TITLE
chore(build): multiple build optimizations

### DIFF
--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -24,10 +24,10 @@ if [ $SCRIPT_BUILD_ENV = "ci" ]; then
 fi
 
 if [ -z $FAST ]; then
-	LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT
+	LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --quiet
 else
 	echo "running fast mode..."
-	SKIP_SENTRY=1 LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --fast
+	SKIP_SENTRY=1 LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --fast --quiet
 fi
 
 if [ $PUBLISH_ENDPOINT = "local" ]; then

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -249,8 +249,10 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           return { error: null };
         }
         case DevCommands.PACKAGE_PLUGIN: {
-          this.print("install deps...");
-          BuildUtils.installPluginDependencies();
+          if (!opts.fast) {
+            this.print("install deps...");
+            BuildUtils.installPluginDependencies();
+          }
 
           this.print("package deps...");
           BuildUtils.packagePluginDependencies(opts);

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -255,7 +255,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           }
 
           this.print("package deps...");
-          BuildUtils.packagePluginDependencies(opts);
+          await BuildUtils.packagePluginDependencies(opts);
           return { error: null };
         }
         case DevCommands.INSTALL_PLUGIN: {
@@ -351,7 +351,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     BuildUtils.installPluginDependencies();
 
     this.print("package deps...");
-    BuildUtils.packagePluginDependencies(opts);
+    await BuildUtils.packagePluginDependencies(opts);
 
     this.print("setRegRemote...");
     BuildUtils.setRegRemote();

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -196,15 +196,6 @@ export class BuildUtils {
       out.stdout?.pipe(process.stdout);
     }
     await out;
-    // TODO: not sure why this is generated but its not used by extension
-    const extensionBak = path.join(
-      this.getPluginRootPath(),
-      "dist",
-      "extension.jsbak"
-    );
-    if (fs.existsSync(extensionBak)) {
-      fs.removeSync(extensionBak);
-    }
     const out2 = $$(`vsce package --yarn`, {
       cwd: this.getPluginRootPath(),
       env: fast ? { SKIP_SENTRY: "true" } : {},

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -181,12 +181,37 @@ export class BuildUtils {
    * @param param0
    * @returns
    */
-  static packagePluginDependencies({ fast }: { fast?: boolean }) {
-    $(`yarn build:prod`, { cwd: this.getPluginRootPath() });
-    return $(`vsce package --yarn`, {
+  static async packagePluginDependencies({
+    fast,
+    quiet,
+  }: {
+    fast?: boolean;
+    quiet?: boolean;
+  }) {
+    const out = $$(`yarn build:prod`, {
       cwd: this.getPluginRootPath(),
       env: fast ? { SKIP_SENTRY: "true" } : {},
     });
+    if (!quiet) {
+      out.stdout?.pipe(process.stdout);
+    }
+    await out;
+    // TODO: not sure why this is generated but its not used by extension
+    const extensionBak = path.join(
+      this.getPluginRootPath(),
+      "dist",
+      "extension.jsbak"
+    );
+    if (fs.existsSync(extensionBak)) {
+      fs.removeSync(extensionBak);
+    }
+    const out2 = $$(`vsce package --yarn`, {
+      cwd: this.getPluginRootPath(),
+      env: fast ? { SKIP_SENTRY: "true" } : {},
+    });
+    if (!quiet) {
+      out2.stdout?.pipe(process.stdout);
+    }
   }
 
   static async prepPluginPkg(

--- a/packages/plugin-core/.vscodeignore
+++ b/packages/plugin-core/.vscodeignore
@@ -12,3 +12,4 @@ node_modules
 build
 scripts/**
 fixtures/**
+dist/extension.jsbak

--- a/packages/plugin-core/webpack.common.js
+++ b/packages/plugin-core/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
-const TerserPlugin = require("terser-webpack-plugin");
 const BundleAnalyzerPlugin =
   require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 
@@ -75,11 +74,15 @@ const config = {
             ignore: ["node_modules", "webpack.*.js"],
           }),
         ]),
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-      openAnalyzer: false,
-      generateStatsFile: true,
-    }),
+    ...(process.env.ANALYZE_BUNDLE
+      ? [
+          new BundleAnalyzerPlugin({
+            analyzerMode: "static",
+            openAnalyzer: false,
+            generateStatsFile: true,
+          }),
+        ]
+      : []),
   ],
   module: {
     rules: [


### PR DESCRIPTION
This reduces the bundle size of the plugin by +80mb

- chore(build): don't analyze bundle on every build
- chore(build): skip installing dependencies when running `dendron dev prep_package` in `fast` mode
- chore(build): add quiet flag to build step and remove extra build artifact
