### PR TITLE
chore(build): Use in memory verdaccio to speed up local publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,334 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **cli:** workspace info prints message to CLI ([6d512e2](https://github.com/dendronhq/dendron/commit/6d512e21f2542515b802a188fcf5edc75e21f8fd))
+* **commands:** allow creation of new notes when move header destination doesn't exist yet ([#1646](https://github.com/dendronhq/dendron/issues/1646)) ([90a47e4](https://github.com/dendronhq/dendron/commit/90a47e4779b0d9209aa95f209688a42f20497990))
+* **commands:** move header command modifying unrelated note content ([#1574](https://github.com/dendronhq/dendron/issues/1574)) ([46cad20](https://github.com/dendronhq/dendron/commit/46cad20c089fd4bcc22513a2dfc60bed8197e7f6))
+* **dev:** fix some typos in the GitHub templates ([#1546](https://github.com/dendronhq/dendron/issues/1546)) ([87dd69c](https://github.com/dendronhq/dendron/commit/87dd69cd15b81655cc5e407e616f7a0d2211ec0b))
+* **lookup:** disappearing vaults in vault selection quickpick ([#1717](https://github.com/dendronhq/dendron/issues/1717)) ([7e2333a](https://github.com/dendronhq/dendron/commit/7e2333ae8b6dd5bcd10f29d6bf61931e206830ec))
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **lookup:** re-enable lookup commands ([e780cd1](https://github.com/dendronhq/dendron/commit/e780cd10f7c6ae17b1ad83666322677329b34f32))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** github import pod handle deleted authors ([#1660](https://github.com/dendronhq/dendron/issues/1660)) ([eb11440](https://github.com/dendronhq/dendron/commit/eb11440e255b889e546cd7f67fcb970692c52989))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** optimize nextjs publishing search ([#1519](https://github.com/dendronhq/dendron/issues/1519)) ([d06dd25](https://github.com/dendronhq/dendron/commit/d06dd25e292532a4ea66d1aa469a27c00b424ad6))
+* **publish:** remove .next dir if it exists in publish init ([#1548](https://github.com/dendronhq/dendron/issues/1548)) ([3ffd87a](https://github.com/dendronhq/dendron/commit/3ffd87a606d2251991319e81ba7292989dac427f))
+* **publish:** remove duplicate CSS ([#1707](https://github.com/dendronhq/dendron/issues/1707)) ([9574009](https://github.com/dendronhq/dendron/commit/9574009f03441abae6209920f4c076ed46af73ad))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **publish:** Title parts duplicated in Next publishing search ([#1573](https://github.com/dendronhq/dendron/issues/1573)) ([59de1a4](https://github.com/dendronhq/dendron/commit/59de1a486be980c1e6b16753478c62b03c38e018))
+* **publish:** unslugify titles in toc ([292a46b](https://github.com/dendronhq/dendron/commit/292a46b14287f2e649a7929516ed97144e9fd2d6))
+* **publish:** verbose logging when building notes ([136cbec](https://github.com/dendronhq/dendron/commit/136cbec7c10d6c42b79ecce0f21955d546ba1f9e))
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* **workspace:** remove trailing whitespace in note ([#1736](https://github.com/dendronhq/dendron/issues/1736)) ([d1f0117](https://github.com/dendronhq/dendron/commit/d1f01177390e206fe75f235caa7ef10eebe43732))
+* ajv warning messages printed to console ([#1722](https://github.com/dendronhq/dendron/issues/1722)) ([1aae27b](https://github.com/dendronhq/dendron/commit/1aae27bb0924f649af131ca7664da3f914044c31))
+* circular dependency with logger ([5f3f958](https://github.com/dendronhq/dendron/commit/5f3f9587516a6abfd0cde4810839b900cb0ff0b9))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* Change Workspace command recognizes native workspaces ([#1621](https://github.com/dendronhq/dendron/issues/1621)) ([d120934](https://github.com/dendronhq/dendron/commit/d1209348577437d6df1780ff2955849dabf7fbc9))
+* mistyped analytics event name ([#1678](https://github.com/dendronhq/dendron/issues/1678)) ([13086c2](https://github.com/dendronhq/dendron/commit/13086c2c9dc995f7feeea3cfed66fddb54ca52a9))
+* **publish:** table of contents layout ([#1649](https://github.com/dendronhq/dendron/issues/1649)) ([dbae739](https://github.com/dendronhq/dendron/commit/dbae739ad0650c75a72dd51821b3a5d4ab556839))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **server:** improving error response on api server ([#1645](https://github.com/dendronhq/dendron/issues/1645)) ([8936fb6](https://github.com/dendronhq/dendron/commit/8936fb690045022487fb46aafd661581b60deab1))
+* file watcher updates backlinks ([#1618](https://github.com/dendronhq/dendron/issues/1618)) ([1e0b776](https://github.com/dendronhq/dendron/commit/1e0b776c8fe9af90f56a0df4a57002982a4d834c))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* handle undefined and null properties of old command configs in migration ([#1508](https://github.com/dendronhq/dendron/issues/1508)) ([6782b54](https://github.com/dendronhq/dendron/commit/6782b54231e30c6fc6298f1c3a826469dd6548ec))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* lock ua-parser-js to 0.7.28 due to https://github.com/faisalman/ua-parser-js/issues/536 ([7b697d2](https://github.com/dendronhq/dendron/commit/7b697d26be6fe3912ed51c1ca0753b0cac8e8c70))
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* notes getting edited issue ([#1559](https://github.com/dendronhq/dendron/issues/1559)) ([6810a9a](https://github.com/dendronhq/dendron/commit/6810a9a1564750b2fd31da7b6ab44f062ed779f5))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* require statement path ([#1561](https://github.com/dendronhq/dendron/issues/1561)) ([6a7be61](https://github.com/dendronhq/dendron/commit/6a7be61db3ec7e6fab61871b30ec215c47f1cb59))
+* **workspace:** error when init native workspace ([e74d492](https://github.com/dendronhq/dendron/commit/e74d492186489d06aa584dd9c78d82ad27017e85))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+* **workspace:** possible error if open note is changed quickly after edit ([#1486](https://github.com/dendronhq/dendron/issues/1486)) ([e21f92e](https://github.com/dendronhq/dendron/commit/e21f92e528f19ad44643fb63fe0e817f33bffea7))
+
+
+### Features Dendron
+
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **workspace:** added contextual ui menu option for wrapping link ([#1677](https://github.com/dendronhq/dendron/issues/1677)) ([732108c](https://github.com/dendronhq/dendron/commit/732108c848eb05e5f2c9cf1fc8ecdd02fa377c6e))
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** hide default markdown preview button ([#1636](https://github.com/dendronhq/dendron/issues/1636)) ([ce182b2](https://github.com/dendronhq/dendron/commit/ce182b278008ded4ffe0de02b12b70ef4f948dc4))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+### Reverts
+
+* Revert "chore(build): add sleep after publish to build step" ([e8e20ee](https://github.com/dendronhq/dendron/commit/e8e20ee54d2bda97b2092954334874379623f9a8))
+* Revert "fix: add workspace root to workspace folders for Code Workspaces" ([09b3ad5](https://github.com/dendronhq/dendron/commit/09b3ad58fb3c872acfa7a71c64e7e9c9b27a8ded))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* fix journal note creation ([#1465](https://github.com/dendronhq/dendron/issues/1465)) ([18a5f27](https://github.com/dendronhq/dendron/commit/18a5f273183cd084a1eaf288ed2c48ad7a092a1e))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+* **commands:** move header command compile noterefs ([#1458](https://github.com/dendronhq/dendron/issues/1458)) ([acc15d6](https://github.com/dendronhq/dendron/commit/acc15d6614194404dc5610d2ae9ffbe689013fc0))
+* **lookup:** vault selection use wrong label ([#1463](https://github.com/dendronhq/dendron/issues/1463)) ([2767be7](https://github.com/dendronhq/dendron/commit/2767be78a458548c72d0ada194abb15263b52a1f))
+* **publish:** bad seo props setter ([373d933](https://github.com/dendronhq/dendron/commit/373d9331aba3b3385632f01661dd6c80835ec5ac))
+* **publish:** nextjs search note snippets ([#1433](https://github.com/dendronhq/dendron/issues/1433)) ([0cb8f38](https://github.com/dendronhq/dendron/commit/0cb8f38fc9cb5e45af682fc5524ff5eb7ba44ce7))
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* **workspace:** highlighting for wildcard note refs with header offsets ([#1460](https://github.com/dendronhq/dendron/issues/1460)) ([a4722da](https://github.com/dendronhq/dendron/commit/a4722daaff33b25667c0b431cc919f898401ca31))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* add ovsx dev dep ([0080b8f](https://github.com/dendronhq/dendron/commit/0080b8fa0faf1c63630ea72fa78d2e4afb0fdf22))
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+* **lookup:** picked schema matching name was not creating the expected note ([#1425](https://github.com/dendronhq/dendron/issues/1425)) ([76cf5e1](https://github.com/dendronhq/dendron/commit/76cf5e1b2e7929a65fcdcf060e52242abc6991fa))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* **publish:** footer show on first load ([#1413](https://github.com/dendronhq/dendron/issues/1413)) ([00d32cc](https://github.com/dendronhq/dendron/commit/00d32cc830ca6da3160a9cee86386e50b3a35fd6))
+* no-op on hover provider if dendron non active ([#1398](https://github.com/dendronhq/dendron/issues/1398)) ([61949f1](https://github.com/dendronhq/dendron/commit/61949f187d1a6c5a1d3ed3f63f9695b51bacdc7a))
+* **workspace:** next gen views in remote workspaces ([#1401](https://github.com/dendronhq/dendron/issues/1401)) ([c9cb2e0](https://github.com/dendronhq/dendron/commit/c9cb2e0381c258b34e355bb89d53b3624ff3962e))
+
+
+### Features Dendron
+
+* **publish:** add popover for long title in menu ([#1408](https://github.com/dendronhq/dendron/issues/1408)) ([b94b223](https://github.com/dendronhq/dendron/commit/b94b2235f337b2e54bcbf8658e5f4f371804c5f9))
+* **publish:** mobile navigation ([#1407](https://github.com/dendronhq/dendron/issues/1407)) ([3487213](https://github.com/dendronhq/dendron/commit/34872138131f030f460dc4cd8e81c65fe7654524))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+* **workspace:** notes added outside Dendron are missed ([#1406](https://github.com/dendronhq/dendron/issues/1406)) ([1a34940](https://github.com/dendronhq/dendron/commit/1a349407718d65e94dfdc86104af587e00344264))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** prevent malformed keybinding.json ([#1403](https://github.com/dendronhq/dendron/issues/1403)) ([2a221ab](https://github.com/dendronhq/dendron/commit/2a221ab5ad2ddd9cf93b27edf4a145941fca1915))
+* **workspace:** regression with hover preview ([5e8079a](https://github.com/dendronhq/dendron/commit/5e8079a9532d0dbc395ea9a7aaab640b6212b368))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* no-op completion provider when dendron isn't active ([#1392](https://github.com/dendronhq/dendron/issues/1392)) ([8136b9c](https://github.com/dendronhq/dendron/commit/8136b9c6bad293ac77aae78a9426c3b27c4d38d3))
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+* selection2link doesn't update note with link ([#1383](https://github.com/dendronhq/dendron/issues/1383)) ([737d584](https://github.com/dendronhq/dendron/commit/737d584c42a8033131437085ff5b2e4db3f18e8a))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+* **preview:** button for toggle local/global graph ([#1386](https://github.com/dendronhq/dendron/issues/1386)) ([31d905b](https://github.com/dendronhq/dendron/commit/31d905bb57294e268aa64c28b3a0a176d4839b41))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** add force close timeout ([ebbe51f](https://github.com/dendronhq/dendron/commit/ebbe51f0aad37e5ecf4b319405e6c719f1e14dc5))
+* **publish:** dangling connection when publishing via 11ty using github action ([c08117d](https://github.com/dendronhq/dendron/commit/c08117dd41fe250b6aa9f29f1b61879a7f9b56ce))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* creating scratch when text is selected within a note SHOULD not match scratches just due to prefix ([#1292](https://github.com/dendronhq/dendron/issues/1292)) ([cea4568](https://github.com/dendronhq/dendron/commit/cea456809b0da327bff5e06c1a796323d3eb257f))
+* decorations for erased tags persist ([#1291](https://github.com/dendronhq/dendron/issues/1291)) ([e3284f6](https://github.com/dendronhq/dendron/commit/e3284f6449fe36edb81deb2ae4c97612fdf2b8de))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* disallow toggling of vault selection behavior in move note ([#1296](https://github.com/dendronhq/dendron/issues/1296)) ([4dc7ca4](https://github.com/dendronhq/dendron/commit/4dc7ca4547bc0c7bcb8eb3e27f64ad7236ef4fd5))
+* do not show multi select button on note rename ([#1293](https://github.com/dendronhq/dendron/issues/1293)) ([bd283c1](https://github.com/dendronhq/dendron/commit/bd283c1427f5b1f611885dd8499b2bd5b5bf98c3))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* fix move note to have exact match ([#1331](https://github.com/dendronhq/dendron/issues/1331)) ([a5f4f9b](https://github.com/dendronhq/dendron/commit/a5f4f9b5220d67621e508a68ad2386cd481db21f))
+* fixing cmd tab typo in tutorial.2 ([#1234](https://github.com/dendronhq/dendron/issues/1234)) ([6e0543d](https://github.com/dendronhq/dendron/commit/6e0543d5077d40f2e9fc12325d3e111cad7e9a01))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* highlight same file wikilinks, wildcard references, links with anchors ([#1306](https://github.com/dendronhq/dendron/issues/1306)) ([956aa2a](https://github.com/dendronhq/dendron/commit/956aa2a7079eaa93acd2a66ace3c44f3f874c0f8))
+* hover provider shouldn't recommend Ctrl+click for missing notes unless configured ([#1276](https://github.com/dendronhq/dendron/issues/1276)) ([cc037b6](https://github.com/dendronhq/dendron/commit/cc037b6e53c21389be8507e8088dc65bff0d7259))
+* Ignore lookupConfirm if dailyVault is set ([#1311](https://github.com/dendronhq/dendron/issues/1311)) ([1c734da](https://github.com/dendronhq/dendron/commit/1c734daa45cc1e655638d754267c6bdf5bdcab90))
+* issue with init workspace ([94d05c8](https://github.com/dendronhq/dendron/commit/94d05c8f1b6856c769d0cd2964d1dece9decb37c))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+* make package public ([#1225](https://github.com/dendronhq/dendron/issues/1225)) ([b6832ce](https://github.com/dendronhq/dendron/commit/b6832ceab281826c5009a451df63f9607366b72d))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+* unhandled error in insert note link ([#1192](https://github.com/dendronhq/dendron/issues/1192)) ([a73420c](https://github.com/dendronhq/dendron/commit/a73420cd0f3d9f933256be43b839226b15b1e837))
+* update links on frontmatter tags changes ([#1214](https://github.com/dendronhq/dendron/issues/1214)) ([4d344fe](https://github.com/dendronhq/dendron/commit/4d344fe40701a259e3ac4399899dab4099c8614f))
+* update vs code compat version + husky hook check ([#1346](https://github.com/dendronhq/dendron/issues/1346)) ([1ae3fc6](https://github.com/dendronhq/dendron/commit/1ae3fc6da41084adc1e19f4c09b3a75d00ca0cb3))
+* workspace fix ([4f4bfab](https://github.com/dendronhq/dendron/commit/4f4bfab336862b43da226aa75db9f446e60ba1a2))
+
+
+### Features Dendron
+
+* **publish:** notice for dev mode ([#1354](https://github.com/dendronhq/dendron/issues/1354)) ([e3f9fc9](https://github.com/dendronhq/dendron/commit/e3f9fc9d81dc51fbaec5f4bbccb2f6c1dffb1afb))
+* Add smart vault selection to NoteLookupCommand ([#1174](https://github.com/dendronhq/dendron/issues/1174)) ([742cab6](https://github.com/dendronhq/dendron/commit/742cab6c683bb14b6baff6c786957a5cc7228894))
+* additional styling for nextjs ([f8e7972](https://github.com/dendronhq/dendron/commit/f8e797231b586c20ac4d2e1fa1813982cc282375))
+* consolidate dendron configs ([#1295](https://github.com/dendronhq/dendron/issues/1295)) ([177ac92](https://github.com/dendronhq/dendron/commit/177ac925a5442471f041ce5d991da52cecee6c9b))
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* run migration command ([#1177](https://github.com/dendronhq/dendron/issues/1177)) ([98bd000](https://github.com/dendronhq/dendron/commit/98bd000236e8c3a7def6b6895fa8d24315c54cf2))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+* tag colors in graph ([#1227](https://github.com/dendronhq/dendron/issues/1227)) ([cc95d0a](https://github.com/dendronhq/dendron/commit/cc95d0a1ae1f611f9162149db6163660b06fdfeb))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* force update picker item on button trigger even when value hasn't changed ([#1176](https://github.com/dendronhq/dendron/issues/1176)) ([46449a4](https://github.com/dendronhq/dendron/commit/46449a44009913af6340b26660fd5b5b2a79d57f))
+* horizontal rule not rendering ([#1156](https://github.com/dendronhq/dendron/issues/1156)) ([a95b615](https://github.com/dendronhq/dendron/commit/a95b6157512cda56ce98fd3944dc439570182e5b))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+### Features Dendron
+
+* make breadcrumbs clickable ([#1164](https://github.com/dendronhq/dendron/issues/1164)) ([a386fc3](https://github.com/dendronhq/dendron/commit/a386fc3dd42769207f58259f292216be51f0a15b))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* properly log error stack ([485e220](https://github.com/dendronhq/dendron/commit/485e220f8ffa6cd63210e106e846ff305b920b77))
+* regression with move note command ([5e357b8](https://github.com/dendronhq/dendron/commit/5e357b8995ff335aa36ad48777a96ee56b196c01))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* accept splitType argument in lookup v2 ([#1102](https://github.com/dendronhq/dendron/issues/1102)) ([a1120e4](https://github.com/dendronhq/dendron/commit/a1120e449af9776a14d2bcbb47f8d877ebd1227b))
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* CopyNoteRef respects noXVaultWikiLink option ([#1085](https://github.com/dendronhq/dendron/issues/1085)) ([b4b3da3](https://github.com/dendronhq/dendron/commit/b4b3da3306e2c5621c3c79a53b9f6e4cc31856c6)), closes [#1072](https://github.com/dendronhq/dendron/issues/1072)
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* extension readme getting started link ([#1084](https://github.com/dendronhq/dendron/issues/1084)) ([d3f5b7d](https://github.com/dendronhq/dendron/commit/d3f5b7dc49873cbbb9e44ce1ff473cd4d95e1214))
+* FM tags with quoted strings & with spaces ([1a16689](https://github.com/dendronhq/dendron/commit/1a1668914f70b48a4e74a218bd43521df226de38))
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+* highlighting is not displayed ([#1083](https://github.com/dendronhq/dendron/issues/1083)) ([86ead9b](https://github.com/dendronhq/dendron/commit/86ead9b7ec66a51712a265f263a515c624f2861c))
+* issue with direct child filter partially omitting values in quickpick ([#1123](https://github.com/dendronhq/dendron/issues/1123)) ([fbabab4](https://github.com/dendronhq/dendron/commit/fbabab4b61c91f3ebbe62def339efb32e1815178))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+* lookupv3 selection issue ([#1130](https://github.com/dendronhq/dendron/issues/1130)) ([c807e88](https://github.com/dendronhq/dendron/commit/c807e88a82217e5a04dfddb5a24259a50bea4813))
+* patch `getOrCreate` to inherit from default values ([#1126](https://github.com/dendronhq/dendron/issues/1126)) ([512b476](https://github.com/dendronhq/dendron/commit/512b476e8ac986887f25bc9a21bf7b189ea19ce9))
+* **calendar-view:** header selection throws error ([#1122](https://github.com/dendronhq/dendron/issues/1122)) ([5bc8ca1](https://github.com/dendronhq/dendron/commit/5bc8ca1a256328bd6d05f7d351e2c7ae7042580c)), closes [/ant.design/changelog#4](https://github.com//ant.design/changelog/issues/4)
+* properly debounce picker update ([#1111](https://github.com/dendronhq/dendron/issues/1111)) ([ae12e1e](https://github.com/dendronhq/dendron/commit/ae12e1ec39e6d75c9c47e27eff7f96418984da4a))
+* renaming frontmatter tags adds # ([223d9f5](https://github.com/dendronhq/dendron/commit/223d9f50430569b440e45567ffc71a7fff81f96f))
+* skip delayed decoration update if note is closed ([2d91164](https://github.com/dendronhq/dendron/commit/2d9116489b2d1f4d5ccd6d22c022af2da9984817))
+* undefined tags breaks note serialization ([b1d784c](https://github.com/dendronhq/dendron/commit/b1d784c8df18b3b45999f01c14793436ff669a3f))
+* uninstall hook force flush ([#1087](https://github.com/dendronhq/dendron/issues/1087)) ([386aac2](https://github.com/dendronhq/dendron/commit/386aac2b8036cd58c190da99609cef2d3ed2467f))
+
+
+### Features Dendron
+
+* add journal title override to NoteLookupCommand ([#1140](https://github.com/dendronhq/dendron/issues/1140)) ([173b0c9](https://github.com/dendronhq/dendron/commit/173b0c95d7ca9593e72e2cd1c39e4fdcf31fa64a))
+* **calendar:** enable webui by default ([#1127](https://github.com/dendronhq/dendron/issues/1127)) ([3ce8be0](https://github.com/dendronhq/dendron/commit/3ce8be05f50c0fef784eef1b6d02e4816e1bf44a))
+* add remaining modifiers to NoteLookup ([#1056](https://github.com/dendronhq/dendron/issues/1056)) ([49c6005](https://github.com/dendronhq/dendron/commit/49c6005d2a2c8fd422eb653977e926084e743d6a)), closes [#1045](https://github.com/dendronhq/dendron/issues/1045) [#1046](https://github.com/dendronhq/dendron/issues/1046)
+* add schema suggestion to NoteLookupCommand ([#1113](https://github.com/dendronhq/dendron/issues/1113)) ([7dbd03f](https://github.com/dendronhq/dendron/commit/7dbd03f20586d5174c13a40ed50eecfd8b4c788d))
+* add schema templating feature to NoteLookupCommand ([#1118](https://github.com/dendronhq/dendron/issues/1118)) ([8a4cd2b](https://github.com/dendronhq/dendron/commit/8a4cd2b337521abcc25df61e145ef6868c50ea0f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* re-engage lapsed users with prompt ([#1086](https://github.com/dendronhq/dendron/issues/1086)) ([f4e6dc5](https://github.com/dendronhq/dendron/commit/f4e6dc563aafdfc0b46966e74d9b38920aee1207))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* render frontmatter tags in HTML ([86f798a](https://github.com/dendronhq/dendron/commit/86f798a3c72ca405922945b835119aa0e0b1c3d9))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -11,6 +11,9 @@ store:
     limit: 5000
 web:
   title: Verdaccio
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
 packages:
   "@*/*":
     access: $all

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -1,0 +1,5 @@
+max_body_size: 1000mb
+logs: { type: stdout, format: pretty, level: http }
+store:
+  memory:
+    limit: 5000

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -1,4 +1,10 @@
 max_body_size: 1000mb
+auth:
+  auth-memory:
+    users:
+      foo:
+        name: dendron
+        password: temporarydendronpassword
 logs: { type: stdout, format: pretty, level: http }
 store:
   memory:

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -16,7 +16,7 @@ packages:
     access: $all
     publish: $all
     unpublish: $all
-    # proxy: npmjs
+    proxy: npmjs
 
   "**":
     # allow all users (including non-authenticated users) to read and
@@ -32,4 +32,4 @@ packages:
     unpublish: $all
 
     # if package is not available locally, proxy requests to 'npmjs' registry
-    # proxy: npmjs
+    proxy: npmjs

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -14,9 +14,9 @@ web:
 packages:
   "@*/*":
     access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
+    publish: $all
+    unpublish: $all
+    # proxy: npmjs
 
   "**":
     # allow all users (including non-authenticated users) to read and
@@ -28,8 +28,8 @@ packages:
 
     # allow all known users to publish/publish packages
     # (anyone can register by default, remember?)
-    publish: $authenticated
-    unpublish: $authenticated
+    publish: $all
+    unpublish: $all
 
     # if package is not available locally, proxy requests to 'npmjs' registry
-    proxy: npmjs
+    # proxy: npmjs

--- a/bootstrap/data/verdaccio/config.yaml
+++ b/bootstrap/data/verdaccio/config.yaml
@@ -9,3 +9,27 @@ logs: { type: stdout, format: pretty, level: http }
 store:
   memory:
     limit: 5000
+web:
+  title: Verdaccio
+packages:
+  "@*/*":
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+  "**":
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish/publish packages
+    # (anyone can register by default, remember?)
+    publish: $authenticated
+    unpublish: $authenticated
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -6,7 +6,7 @@ if [ $PUBLISH_ENDPOINT = "local" ] && [ -z $FAST ] ; then
 	sleep 3
 fi
 if [ $PUBLISH_ENDPOINT = "local" ] && [ $FAST ] ; then
-	echo "start verdaccio in fast mode"
+	echo "starting verdaccio with in-memory cache to speed up build time"
 	verdaccio -c ./bootstrap/data/verdaccio/config.yaml > verdaccio.log 2>&1 &
 	FOO_PID=$!
 	echo "$FOO_PID"

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -16,12 +16,14 @@ fi
 
 SCRIPT_BUILD_ENV=${BUILD_ENV:-local}
 echo "building... upgrade: $UPGRADE_TYPE, endpoint: $PUBLISH_ENDPOINT build environment: $SCRIPT_BUILD_ENV"
-if [ $PUBLISH_ENDPOINT = "local" ]; then
-	echo "npm login with local account"
-	yarn setup:npmlogin:local
-elif [ $PUBLISH_ENDPOINT = "remote" ]; then
-	echo "npm login with remote npm registry account"
-	yarn setup:npmlogin:remote
+if [ $SCRIPT_BUILD_ENV = "ci" ]; then
+  if [ $PUBLISH_ENDPOINT = "local" ]; then
+  	echo "npm login with local account"
+	  yarn setup:npmlogin:local
+	elif [ $PUBLISH_ENDPOINT = "remote" ]; then
+  	echo "npm login with remote npm registry account"
+	  yarn setup:npmlogin:remote
+	fi
 fi
 
 DENDRON_CLI=dendron

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -1,16 +1,16 @@
 if [ $PUBLISH_ENDPOINT = "local" ] && [ -z $FAST ] ; then
 	echo "start verdaccio"
-	verdaccio -c ../data/verdaccio/config.yaml > verdaccio.log 2>&1 &
+	verdaccio > verdaccio.log 2>&1 &
 	FOO_PID=$!
 	echo "$FOO_PID"
 	sleep 3
 fi
 if [ $PUBLISH_ENDPOINT = "local" ] && [ $FAST ] ; then
 	echo "start verdaccio in fast mode"
-	verdaccio -c ../data/verdaccio/config.yaml > verdaccio.log 2>&1 &
+	verdaccio -c ./bootstrap/data/verdaccio/config.yaml > verdaccio.log 2>&1 &
 	FOO_PID=$!
 	echo "$FOO_PID"
-	sleep 3
+	sleep 1
 fi
 
 

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -16,14 +16,12 @@ fi
 
 SCRIPT_BUILD_ENV=${BUILD_ENV:-local}
 echo "building... upgrade: $UPGRADE_TYPE, endpoint: $PUBLISH_ENDPOINT build environment: $SCRIPT_BUILD_ENV"
-if [ $SCRIPT_BUILD_ENV = "ci" ]; then
-  if [ $PUBLISH_ENDPOINT = "local" ]; then
-  	echo "npm login with local account"
-	  yarn setup:npmlogin:local
-	elif [ $PUBLISH_ENDPOINT = "remote" ]; then
-  	echo "npm login with remote npm registry account"
-	  yarn setup:npmlogin:remote
-	fi
+if [ $PUBLISH_ENDPOINT = "local" ]; then
+	echo "npm login with local account"
+	yarn setup:npmlogin:local
+elif [ $PUBLISH_ENDPOINT = "remote" ]; then
+	echo "npm login with remote npm registry account"
+	yarn setup:npmlogin:remote
 fi
 
 DENDRON_CLI=dendron

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -1,10 +1,18 @@
-if [ $PUBLISH_ENDPOINT = "local" ]; then
+if [ $PUBLISH_ENDPOINT = "local" ] && [ -z $FAST ] ; then
 	echo "start verdaccio"
-	verdaccio > verdaccio.log 2>&1 &
+	verdaccio -c ../data/verdaccio/config.yaml > verdaccio.log 2>&1 &
 	FOO_PID=$!
 	echo "$FOO_PID"
 	sleep 3
 fi
+if [ $PUBLISH_ENDPOINT = "local" ] && [ $FAST ] ; then
+	echo "start verdaccio in fast mode"
+	verdaccio -c ../data/verdaccio/config.yaml > verdaccio.log 2>&1 &
+	FOO_PID=$!
+	echo "$FOO_PID"
+	sleep 3
+fi
+
 
 SCRIPT_BUILD_ENV=${BUILD_ENV:-local}
 echo "building... upgrade: $UPGRADE_TYPE, endpoint: $PUBLISH_ENDPOINT build environment: $SCRIPT_BUILD_ENV"

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "0.69.2"
+  "version": "0.69.3-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "cross-env": "^7.0.3",
     "execa": "^5.0.0",
     "github-slugger": "^1.3.0",
-    "typescript": "^4.1.5"
+    "typescript": "^4.1.5",
+    "verdaccio-memory": "^10.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier": "^2.0.4",
     "standard-version": "^8.0.0",
     "verdaccio": "^5.1.3",
+    "verdaccio-auth-memory": "^10.0.1",
     "vsce": "^1.96.1"
   },
   "scripts": {

--- a/packages/api-server/CHANGELOG.md
+++ b/packages/api-server/CHANGELOG.md
@@ -3,6 +3,69 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **server:** improving error response on api server ([#1645](https://github.com/dendronhq/dendron/issues/1645)) ([8936fb6](https://github.com/dendronhq/dendron/commit/8936fb690045022487fb46aafd661581b60deab1))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/api-server",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -57,9 +57,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
     "@sentry/integrations": "^6.13.1",
     "@sentry/node": "^6.13.1",
     "cors": "^2.8.5",

--- a/packages/common-all/CHANGELOG.md
+++ b/packages/common-all/CHANGELOG.md
@@ -3,6 +3,158 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+
+
+### Features Dendron
+
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* **publish:** bad seo props setter ([373d933](https://github.com/dendronhq/dendron/commit/373d9331aba3b3385632f01661dd6c80835ec5ac))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+
+
+### Features Dendron
+
+* consolidate dendron configs ([#1295](https://github.com/dendronhq/dendron/issues/1295)) ([177ac92](https://github.com/dendronhq/dendron/commit/177ac925a5442471f041ce5d991da52cecee6c9b))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* properly log error stack ([485e220](https://github.com/dendronhq/dendron/commit/485e220f8ffa6cd63210e106e846ff305b920b77))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* undefined tags breaks note serialization ([b1d784c](https://github.com/dendronhq/dendron/commit/b1d784c8df18b3b45999f01c14793436ff669a3f))
+
+
+### Features Dendron
+
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-all",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "common-all",
   "license": "GPLv3",
   "repository": {

--- a/packages/common-assets/CHANGELOG.md
+++ b/packages/common-assets/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-assets",
   "private": true,
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "main": "index.js",
   "license": "GPLv3",
   "scripts": {

--- a/packages/common-frontend/CHANGELOG.md
+++ b/packages/common-frontend/CHANGELOG.md
@@ -3,6 +3,94 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+### Features Dendron
+
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Features Dendron
+
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-frontend",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "common-frontend",
   "license": "GPLv3",
   "repository": {
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
-    "@dendronhq/common-all": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
     "@reduxjs/toolkit": "^1.5.1",
     "@types/lodash": "^4.14.161",
     "@types/node": "^14.11.2",

--- a/packages/common-server/CHANGELOG.md
+++ b/packages/common-server/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* ajv warning messages printed to console ([#1722](https://github.com/dendronhq/dendron/issues/1722)) ([1aae27b](https://github.com/dendronhq/dendron/commit/1aae27bb0924f649af131ca7664da3f914044c31))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+
+
+### Features Dendron
+
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-server",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "common-server",
   "license": "GPLv3",
   "repository": {
@@ -36,7 +36,7 @@
     "test:watch": "echo nop"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
     "@sentry/integrations": "^6.13.3",
     "@sentry/node": "^6.13.3",
     "@types/analytics-node": "^3.1.6",

--- a/packages/common-test-utils/CHANGELOG.md
+++ b/packages/common-test-utils/CHANGELOG.md
@@ -3,6 +3,83 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+
+
+### Features Dendron
+
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-test-utils",
   "private": true,
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -50,9 +50,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/pods-core": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/pods-core": "^0.69.3-alpha.0",
     "@types/sinon": "^9.0.9",
     "fs-extra": "^9.0.1",
     "lodash": "^4.17.20",

--- a/packages/dendron-11ty/CHANGELOG.md
+++ b/packages/dendron-11ty/CHANGELOG.md
@@ -3,6 +3,72 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** remove duplicate CSS ([#1707](https://github.com/dendronhq/dendron/issues/1707)) ([9574009](https://github.com/dendronhq/dendron/commit/9574009f03441abae6209920f4c076ed46af73ad))
+* lock ua-parser-js to 0.7.28 due to https://github.com/faisalman/ua-parser-js/issues/536 ([7b697d2](https://github.com/dendronhq/dendron/commit/7b697d26be6fe3912ed51c1ca0753b0cac8e8c70))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/dendron-11ty/package.json
+++ b/packages/dendron-11ty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-11ty-legacy",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "main": "index.js",
   "license": "AGPLv3",
   "files": [
@@ -29,10 +29,10 @@
   "dependencies": {
     "@11ty/eleventy": "^0.11.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
     "@dendronhq/eleventy-plugin-seo": "^0.6.0",
-    "@dendronhq/engine-server": "^0.69.2",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
     "@fec/eleventy-plugin-remark": "^2.1.0",
     "eleventy-xml-plugin": "^0.1.0",
     "fs-extra": "^9.0.1",

--- a/packages/dendron-cli/CHANGELOG.md
+++ b/packages/dendron-cli/CHANGELOG.md
@@ -3,6 +3,105 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **cli:** workspace info prints message to CLI ([6d512e2](https://github.com/dendronhq/dendron/commit/6d512e21f2542515b802a188fcf5edc75e21f8fd))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** remove .next dir if it exists in publish init ([#1548](https://github.com/dendronhq/dendron/issues/1548)) ([3ffd87a](https://github.com/dendronhq/dendron/commit/3ffd87a606d2251991319e81ba7292989dac427f))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+
+
+### Features Dendron
+
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+### Reverts
+
+* Revert "chore(build): add sleep after publish to build step" ([e8e20ee](https://github.com/dendronhq/dendron/commit/e8e20ee54d2bda97b2092954334874379623f9a8))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** add force close timeout ([ebbe51f](https://github.com/dendronhq/dendron/commit/ebbe51f0aad37e5ecf4b319405e6c719f1e14dc5))
+* **publish:** dangling connection when publishing via 11ty using github action ([c08117d](https://github.com/dendronhq/dendron/commit/c08117dd41fe250b6aa9f29f1b61879a7f9b56ce))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+
+
+### Features Dendron
+
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+
+
+### Features Dendron
+
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-cli",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "dendron-cli",
   "license": "GPLv3",
   "repository": {
@@ -40,11 +40,11 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.69.2",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
-    "@dendronhq/pods-core": "^0.69.2",
+    "@dendronhq/api-server": "^0.69.3-alpha.0",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
+    "@dendronhq/pods-core": "^0.69.3-alpha.0",
     "@jcoreio/async-throttle": "^1.3.2",
     "@types/prompts": "^2.0.14",
     "fs-extra": "^9.0.1",

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -228,7 +228,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           }
           try {
             this.setEndpoint(opts.publishEndpoint);
-            LernaUtils.publishVersion(opts.publishEndpoint);
+            await LernaUtils.publishVersion(opts.publishEndpoint);
           } finally {
             if (opts.publishEndpoint === PublishEndpoint.LOCAL) {
               BuildUtils.setRegRemote();
@@ -339,7 +339,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     this.bumpVersion(opts);
 
     this.print("publish version...");
-    LernaUtils.publishVersion(opts.publishEndpoint);
+    await LernaUtils.publishVersion(opts.publishEndpoint);
 
     this.print("sync assets...");
     await this.syncAssets(opts);

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -228,7 +228,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           }
           try {
             this.setEndpoint(opts.publishEndpoint);
-            await LernaUtils.publishVersion(opts.publishEndpoint);
+            LernaUtils.publishVersion(opts.publishEndpoint);
           } finally {
             if (opts.publishEndpoint === PublishEndpoint.LOCAL) {
               BuildUtils.setRegRemote();
@@ -339,7 +339,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     this.bumpVersion(opts);
 
     this.print("publish version...");
-    await LernaUtils.publishVersion(opts.publishEndpoint);
+    LernaUtils.publishVersion(opts.publishEndpoint);
 
     this.print("sync assets...");
     await this.syncAssets(opts);

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { DendronError, error2PlainObject } from "@dendronhq/common-all";
 import { createLogger, findUpTo } from "@dendronhq/common-server";
 import execa from "execa";
@@ -474,7 +475,7 @@ export class BuildUtils {
   }
 
   static async publish({ cwd, osvxKey }: { cwd: string; osvxKey: string }) {
-    return await Promise.all([
+    return Promise.all([
       $("vsce publish", { cwd }),
       $("ovsx publish", {
         cwd,

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -72,9 +72,9 @@ export class LernaUtils {
     console.log("---");
     $(`node bootstrap/scripts/genMeta.js`);
     // HACK: packages are not immediately available after publishing to local npm
-    return new Promise(() => {
-      setTimeout((resolve) => {
-        resolve();
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(undefined);
       }, 3000);
     });
   }

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { DendronError, error2PlainObject } from "@dendronhq/common-all";
 import { createLogger, findUpTo } from "@dendronhq/common-server";
 import execa from "execa";
@@ -475,7 +476,7 @@ export class BuildUtils {
   }
 
   static async publish({ cwd, osvxKey }: { cwd: string; osvxKey: string }) {
-    return await Promise.all([
+    return Promise.all([
       $("vsce publish", { cwd }),
       $("ovsx publish", {
         cwd,

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -71,6 +71,12 @@ export class LernaUtils {
     console.log(cmd.stderr);
     console.log("---");
     $(`node bootstrap/scripts/genMeta.js`);
+    // HACK: packages are not immediately available after publishing to local npm
+    return new Promise(() => {
+      setTimeout((resolve) => {
+        resolve();
+      }, 3000);
+    });
   }
 }
 

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { DendronError, error2PlainObject } from "@dendronhq/common-all";
 import { createLogger, findUpTo } from "@dendronhq/common-server";
 import execa from "execa";
@@ -72,12 +71,6 @@ export class LernaUtils {
         : REMOTE_NPM_ENDPOINT;
     await $$(`lerna publish from-package --ignore-scripts --registry ${url}`);
     $(`node bootstrap/scripts/genMeta.js`);
-    // HACK: packages are not immediately available after publishing to local npm
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(undefined);
-      }, 10000);
-    });
   }
 }
 
@@ -482,7 +475,7 @@ export class BuildUtils {
   }
 
   static async publish({ cwd, osvxKey }: { cwd: string; osvxKey: string }) {
-    return Promise.all([
+    return await Promise.all([
       $("vsce publish", { cwd }),
       $("ovsx publish", {
         cwd,

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -75,7 +75,7 @@ export class LernaUtils {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(undefined);
-      }, 3000);
+      }, 10000);
     });
   }
 }

--- a/packages/dendron-cli/storage/.verdaccio-db.json
+++ b/packages/dendron-cli/storage/.verdaccio-db.json
@@ -1,4 +1,0 @@
-{
-  "list": ["@dendronhq/mume"],
-  "secret": "3ae67407c003c3c3dd09c7a040a1bd0b96b44db6f1861cdad932dd79b8a1446e"
-}

--- a/packages/dendron-next-server/CHANGELOG.md
+++ b/packages/dendron-next-server/CHANGELOG.md
@@ -3,6 +3,112 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+
+
+### Features Dendron
+
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Features Dendron
+
+* **preview:** button for toggle local/global graph ([#1386](https://github.com/dendronhq/dendron/issues/1386)) ([31d905b](https://github.com/dendronhq/dendron/commit/31d905bb57294e268aa64c28b3a0a176d4839b41))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+
+
+### Features Dendron
+
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* tag colors in graph ([#1227](https://github.com/dendronhq/dendron/issues/1227)) ([cc95d0a](https://github.com/dendronhq/dendron/commit/cc95d0a1ae1f611f9162149db6163660b06fdfeb))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* horizontal rule not rendering ([#1156](https://github.com/dendronhq/dendron/issues/1156)) ([a95b615](https://github.com/dendronhq/dendron/commit/a95b6157512cda56ce98fd3944dc439570182e5b))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* **calendar-view:** header selection throws error ([#1122](https://github.com/dendronhq/dendron/issues/1122)) ([5bc8ca1](https://github.com/dendronhq/dendron/commit/5bc8ca1a256328bd6d05f7d351e2c7ae7042580c)), closes [/ant.design/changelog#4](https://github.com//ant.design/changelog/issues/4)
+
+
+### Features Dendron
+
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/dendron-next-server/package.json
+++ b/packages/dendron-next-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/dendron-next-server",
   "private": true,
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "license": "GPLv3",
   "repository": {
     "type": "git",
@@ -36,9 +36,9 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.2",
     "@chakra-ui/react": "^1.0.0",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-frontend": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-frontend": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
     "@next/bundle-analyzer": "^11.1.2",

--- a/packages/dendron-plugin-views/CHANGELOG.md
+++ b/packages/dendron-plugin-views/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-plugin-views",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "private": true,
   "workspaces": {
     "nohoist": [
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-frontend": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-frontend": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -3,6 +3,182 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** verbose logging when building notes ([136cbec](https://github.com/dendronhq/dendron/commit/136cbec7c10d6c42b79ecce0f21955d546ba1f9e))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* **workspace:** remove trailing whitespace in note ([#1736](https://github.com/dendronhq/dendron/issues/1736)) ([d1f0117](https://github.com/dendronhq/dendron/commit/d1f01177390e206fe75f235caa7ef10eebe43732))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* handle undefined and null properties of old command configs in migration ([#1508](https://github.com/dendronhq/dendron/issues/1508)) ([6782b54](https://github.com/dendronhq/dendron/commit/6782b54231e30c6fc6298f1c3a826469dd6548ec))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+
+
+### Features Dendron
+
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+### Reverts
+
+* Revert "fix: add workspace root to workspace folders for Code Workspaces" ([09b3ad5](https://github.com/dendronhq/dendron/commit/09b3ad58fb3c872acfa7a71c64e7e9c9b27a8ded))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+
+
+### Features Dendron
+
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** regression with hover preview ([5e8079a](https://github.com/dendronhq/dendron/commit/5e8079a9532d0dbc395ea9a7aaab640b6212b368))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* workspace fix ([4f4bfab](https://github.com/dendronhq/dendron/commit/4f4bfab336862b43da226aa75db9f446e60ba1a2))
+
+
+### Features Dendron
+
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+* patch `getOrCreate` to inherit from default values ([#1126](https://github.com/dendronhq/dendron/issues/1126)) ([512b476](https://github.com/dendronhq/dendron/commit/512b476e8ac986887f25bc9a21bf7b189ea19ce9))
+* renaming frontmatter tags adds # ([223d9f5](https://github.com/dendronhq/dendron/commit/223d9f50430569b440e45567ffc71a7fff81f96f))
+
+
+### Features Dendron
+
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* render frontmatter tags in HTML ([86f798a](https://github.com/dendronhq/dendron/commit/86f798a3c72ca405922945b835119aa0e0b1c3d9))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/engine-server",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "dendron-engine",
   "license": "GPLv3",
   "repository": {
@@ -37,8 +37,8 @@
     "test:unit:debug": "echo nop"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
     "@dendronhq/remark-mermaid": "^0.2.0",
     "@mapbox/rehype-prism": "^0.5.0",
     "@types/fs-extra": "^9.0.1",

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -3,6 +3,163 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+
+
+### Features Dendron
+
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+
+
+### Features Dendron
+
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+
+
+### Features Dendron
+
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/engine-test-utils",
   "private": true,
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -59,14 +59,14 @@
     "preset": "ts-jest"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.69.2",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-frontend": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/common-test-utils": "^0.69.2",
-    "@dendronhq/dendron-cli": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
-    "@dendronhq/pods-core": "^0.69.2",
+    "@dendronhq/api-server": "^0.69.3-alpha.0",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-frontend": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/common-test-utils": "^0.69.3-alpha.0",
+    "@dendronhq/dendron-cli": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
+    "@dendronhq/pods-core": "^0.69.3-alpha.0",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/devCLICommand.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/devCLICommand.spec.ts
@@ -44,7 +44,9 @@ describe("build", () => {
 
         const typecheckStub = stub(BuildUtils, "runTypeCheck").returns();
         const bumpVersionStub = stub(LernaUtils, "bumpVersion").returns();
-        const publishVersionStub = stub(LernaUtils, "publishVersion").returns();
+        const publishVersionStub = stub(LernaUtils, "publishVersion").returns(
+          Promise.resolve()
+        );
         const buildNextServerStub = stub(
           BuildUtils,
           "buildNextServer"

--- a/packages/nextjs-template/CHANGELOG.md
+++ b/packages/nextjs-template/CHANGELOG.md
@@ -3,6 +3,120 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** optimize nextjs publishing search ([#1519](https://github.com/dendronhq/dendron/issues/1519)) ([d06dd25](https://github.com/dendronhq/dendron/commit/d06dd25e292532a4ea66d1aa469a27c00b424ad6))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **publish:** table of contents layout ([#1649](https://github.com/dendronhq/dendron/issues/1649)) ([dbae739](https://github.com/dendronhq/dendron/commit/dbae739ad0650c75a72dd51821b3a5d4ab556839))
+* **publish:** Title parts duplicated in Next publishing search ([#1573](https://github.com/dendronhq/dendron/issues/1573)) ([59de1a4](https://github.com/dendronhq/dendron/commit/59de1a486be980c1e6b16753478c62b03c38e018))
+* **publish:** unslugify titles in toc ([292a46b](https://github.com/dendronhq/dendron/commit/292a46b14287f2e649a7929516ed97144e9fd2d6))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* **publish:** nextjs search note snippets ([#1433](https://github.com/dendronhq/dendron/issues/1433)) ([0cb8f38](https://github.com/dendronhq/dendron/commit/0cb8f38fc9cb5e45af682fc5524ff5eb7ba44ce7))
+
+
+### Features Dendron
+
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* **publish:** footer show on first load ([#1413](https://github.com/dendronhq/dendron/issues/1413)) ([00d32cc](https://github.com/dendronhq/dendron/commit/00d32cc830ca6da3160a9cee86386e50b3a35fd6))
+
+
+### Features Dendron
+
+* **publish:** add popover for long title in menu ([#1408](https://github.com/dendronhq/dendron/issues/1408)) ([b94b223](https://github.com/dendronhq/dendron/commit/b94b2235f337b2e54bcbf8658e5f4f371804c5f9))
+* **publish:** mobile navigation ([#1407](https://github.com/dendronhq/dendron/issues/1407)) ([3487213](https://github.com/dendronhq/dendron/commit/34872138131f030f460dc4cd8e81c65fe7654524))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+
+
+### Features Dendron
+
+* **publish:** notice for dev mode ([#1354](https://github.com/dendronhq/dendron/issues/1354)) ([e3f9fc9](https://github.com/dendronhq/dendron/commit/e3f9fc9d81dc51fbaec5f4bbccb2f6c1dffb1afb))
+* additional styling for nextjs ([f8e7972](https://github.com/dendronhq/dendron/commit/f8e797231b586c20ac4d2e1fa1813982cc282375))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Features Dendron
+
+* make breadcrumbs clickable ([#1164](https://github.com/dendronhq/dendron/issues/1164)) ([a386fc3](https://github.com/dendronhq/dendron/commit/a386fc3dd42769207f58259f292216be51f0a15b))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "license": "Apache-2.0",
   "private": true,
   "repository": {
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.7",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-frontend": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-frontend": "^0.69.3-alpha.0",
     "antd": "^4.15.5",
     "html-react-parser": "^1.3.0",
     "lodash": "^4.17.21",

--- a/packages/plugin-core/.vscodeignore
+++ b/packages/plugin-core/.vscodeignore
@@ -13,3 +13,5 @@ build
 scripts/**
 fixtures/**
 dist/extension.jsbak
+tmp
+CHANGELOG.md

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -3,6 +3,232 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **commands:** allow creation of new notes when move header destination doesn't exist yet ([#1646](https://github.com/dendronhq/dendron/issues/1646)) ([90a47e4](https://github.com/dendronhq/dendron/commit/90a47e4779b0d9209aa95f209688a42f20497990))
+* **commands:** move header command modifying unrelated note content ([#1574](https://github.com/dendronhq/dendron/issues/1574)) ([46cad20](https://github.com/dendronhq/dendron/commit/46cad20c089fd4bcc22513a2dfc60bed8197e7f6))
+* **lookup:** disappearing vaults in vault selection quickpick ([#1717](https://github.com/dendronhq/dendron/issues/1717)) ([7e2333a](https://github.com/dendronhq/dendron/commit/7e2333ae8b6dd5bcd10f29d6bf61931e206830ec))
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **lookup:** re-enable lookup commands ([e780cd1](https://github.com/dendronhq/dendron/commit/e780cd10f7c6ae17b1ad83666322677329b34f32))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* circular dependency with logger ([5f3f958](https://github.com/dendronhq/dendron/commit/5f3f9587516a6abfd0cde4810839b900cb0ff0b9))
+* **workspace:** error when init native workspace ([e74d492](https://github.com/dendronhq/dendron/commit/e74d492186489d06aa584dd9c78d82ad27017e85))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* Change Workspace command recognizes native workspaces ([#1621](https://github.com/dendronhq/dendron/issues/1621)) ([d120934](https://github.com/dendronhq/dendron/commit/d1209348577437d6df1780ff2955849dabf7fbc9))
+* file watcher updates backlinks ([#1618](https://github.com/dendronhq/dendron/issues/1618)) ([1e0b776](https://github.com/dendronhq/dendron/commit/1e0b776c8fe9af90f56a0df4a57002982a4d834c))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* mistyped analytics event name ([#1678](https://github.com/dendronhq/dendron/issues/1678)) ([13086c2](https://github.com/dendronhq/dendron/commit/13086c2c9dc995f7feeea3cfed66fddb54ca52a9))
+* notes getting edited issue ([#1559](https://github.com/dendronhq/dendron/issues/1559)) ([6810a9a](https://github.com/dendronhq/dendron/commit/6810a9a1564750b2fd31da7b6ab44f062ed779f5))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* require statement path ([#1561](https://github.com/dendronhq/dendron/issues/1561)) ([6a7be61](https://github.com/dendronhq/dendron/commit/6a7be61db3ec7e6fab61871b30ec215c47f1cb59))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* **workspace:** possible error if open note is changed quickly after edit ([#1486](https://github.com/dendronhq/dendron/issues/1486)) ([e21f92e](https://github.com/dendronhq/dendron/commit/e21f92e528f19ad44643fb63fe0e817f33bffea7))
+
+
+### Features Dendron
+
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **workspace:** added contextual ui menu option for wrapping link ([#1677](https://github.com/dendronhq/dendron/issues/1677)) ([732108c](https://github.com/dendronhq/dendron/commit/732108c848eb05e5f2c9cf1fc8ecdd02fa377c6e))
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** hide default markdown preview button ([#1636](https://github.com/dendronhq/dendron/issues/1636)) ([ce182b2](https://github.com/dendronhq/dendron/commit/ce182b278008ded4ffe0de02b12b70ef4f948dc4))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* fix journal note creation ([#1465](https://github.com/dendronhq/dendron/issues/1465)) ([18a5f27](https://github.com/dendronhq/dendron/commit/18a5f273183cd084a1eaf288ed2c48ad7a092a1e))
+* **commands:** move header command compile noterefs ([#1458](https://github.com/dendronhq/dendron/issues/1458)) ([acc15d6](https://github.com/dendronhq/dendron/commit/acc15d6614194404dc5610d2ae9ffbe689013fc0))
+* **lookup:** vault selection use wrong label ([#1463](https://github.com/dendronhq/dendron/issues/1463)) ([2767be7](https://github.com/dendronhq/dendron/commit/2767be78a458548c72d0ada194abb15263b52a1f))
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* **workspace:** highlighting for wildcard note refs with header offsets ([#1460](https://github.com/dendronhq/dendron/issues/1460)) ([a4722da](https://github.com/dendronhq/dendron/commit/a4722daaff33b25667c0b431cc919f898401ca31))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* add ovsx dev dep ([0080b8f](https://github.com/dendronhq/dendron/commit/0080b8fa0faf1c63630ea72fa78d2e4afb0fdf22))
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+* **lookup:** picked schema matching name was not creating the expected note ([#1425](https://github.com/dendronhq/dendron/issues/1425)) ([76cf5e1](https://github.com/dendronhq/dendron/commit/76cf5e1b2e7929a65fcdcf060e52242abc6991fa))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* no-op on hover provider if dendron non active ([#1398](https://github.com/dendronhq/dendron/issues/1398)) ([61949f1](https://github.com/dendronhq/dendron/commit/61949f187d1a6c5a1d3ed3f63f9695b51bacdc7a))
+* **workspace:** next gen views in remote workspaces ([#1401](https://github.com/dendronhq/dendron/issues/1401)) ([c9cb2e0](https://github.com/dendronhq/dendron/commit/c9cb2e0381c258b34e355bb89d53b3624ff3962e))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** notes added outside Dendron are missed ([#1406](https://github.com/dendronhq/dendron/issues/1406)) ([1a34940](https://github.com/dendronhq/dendron/commit/1a349407718d65e94dfdc86104af587e00344264))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** prevent malformed keybinding.json ([#1403](https://github.com/dendronhq/dendron/issues/1403)) ([2a221ab](https://github.com/dendronhq/dendron/commit/2a221ab5ad2ddd9cf93b27edf4a145941fca1915))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* no-op completion provider when dendron isn't active ([#1392](https://github.com/dendronhq/dendron/issues/1392)) ([8136b9c](https://github.com/dendronhq/dendron/commit/8136b9c6bad293ac77aae78a9426c3b27c4d38d3))
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* selection2link doesn't update note with link ([#1383](https://github.com/dendronhq/dendron/issues/1383)) ([737d584](https://github.com/dendronhq/dendron/commit/737d584c42a8033131437085ff5b2e4db3f18e8a))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* creating scratch when text is selected within a note SHOULD not match scratches just due to prefix ([#1292](https://github.com/dendronhq/dendron/issues/1292)) ([cea4568](https://github.com/dendronhq/dendron/commit/cea456809b0da327bff5e06c1a796323d3eb257f))
+* decorations for erased tags persist ([#1291](https://github.com/dendronhq/dendron/issues/1291)) ([e3284f6](https://github.com/dendronhq/dendron/commit/e3284f6449fe36edb81deb2ae4c97612fdf2b8de))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* disallow toggling of vault selection behavior in move note ([#1296](https://github.com/dendronhq/dendron/issues/1296)) ([4dc7ca4](https://github.com/dendronhq/dendron/commit/4dc7ca4547bc0c7bcb8eb3e27f64ad7236ef4fd5))
+* do not show multi select button on note rename ([#1293](https://github.com/dendronhq/dendron/issues/1293)) ([bd283c1](https://github.com/dendronhq/dendron/commit/bd283c1427f5b1f611885dd8499b2bd5b5bf98c3))
+* fix move note to have exact match ([#1331](https://github.com/dendronhq/dendron/issues/1331)) ([a5f4f9b](https://github.com/dendronhq/dendron/commit/a5f4f9b5220d67621e508a68ad2386cd481db21f))
+* fixing cmd tab typo in tutorial.2 ([#1234](https://github.com/dendronhq/dendron/issues/1234)) ([6e0543d](https://github.com/dendronhq/dendron/commit/6e0543d5077d40f2e9fc12325d3e111cad7e9a01))
+* highlight same file wikilinks, wildcard references, links with anchors ([#1306](https://github.com/dendronhq/dendron/issues/1306)) ([956aa2a](https://github.com/dendronhq/dendron/commit/956aa2a7079eaa93acd2a66ace3c44f3f874c0f8))
+* hover provider shouldn't recommend Ctrl+click for missing notes unless configured ([#1276](https://github.com/dendronhq/dendron/issues/1276)) ([cc037b6](https://github.com/dendronhq/dendron/commit/cc037b6e53c21389be8507e8088dc65bff0d7259))
+* Ignore lookupConfirm if dailyVault is set ([#1311](https://github.com/dendronhq/dendron/issues/1311)) ([1c734da](https://github.com/dendronhq/dendron/commit/1c734daa45cc1e655638d754267c6bdf5bdcab90))
+* issue with init workspace ([94d05c8](https://github.com/dendronhq/dendron/commit/94d05c8f1b6856c769d0cd2964d1dece9decb37c))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+* unhandled error in insert note link ([#1192](https://github.com/dendronhq/dendron/issues/1192)) ([a73420c](https://github.com/dendronhq/dendron/commit/a73420cd0f3d9f933256be43b839226b15b1e837))
+* update links on frontmatter tags changes ([#1214](https://github.com/dendronhq/dendron/issues/1214)) ([4d344fe](https://github.com/dendronhq/dendron/commit/4d344fe40701a259e3ac4399899dab4099c8614f))
+* update vs code compat version + husky hook check ([#1346](https://github.com/dendronhq/dendron/issues/1346)) ([1ae3fc6](https://github.com/dendronhq/dendron/commit/1ae3fc6da41084adc1e19f4c09b3a75d00ca0cb3))
+
+
+### Features Dendron
+
+* Add smart vault selection to NoteLookupCommand ([#1174](https://github.com/dendronhq/dendron/issues/1174)) ([742cab6](https://github.com/dendronhq/dendron/commit/742cab6c683bb14b6baff6c786957a5cc7228894))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* run migration command ([#1177](https://github.com/dendronhq/dendron/issues/1177)) ([98bd000](https://github.com/dendronhq/dendron/commit/98bd000236e8c3a7def6b6895fa8d24315c54cf2))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* force update picker item on button trigger even when value hasn't changed ([#1176](https://github.com/dendronhq/dendron/issues/1176)) ([46449a4](https://github.com/dendronhq/dendron/commit/46449a44009913af6340b26660fd5b5b2a79d57f))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* regression with move note command ([5e357b8](https://github.com/dendronhq/dendron/commit/5e357b8995ff335aa36ad48777a96ee56b196c01))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* accept splitType argument in lookup v2 ([#1102](https://github.com/dendronhq/dendron/issues/1102)) ([a1120e4](https://github.com/dendronhq/dendron/commit/a1120e449af9776a14d2bcbb47f8d877ebd1227b))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* CopyNoteRef respects noXVaultWikiLink option ([#1085](https://github.com/dendronhq/dendron/issues/1085)) ([b4b3da3](https://github.com/dendronhq/dendron/commit/b4b3da3306e2c5621c3c79a53b9f6e4cc31856c6)), closes [#1072](https://github.com/dendronhq/dendron/issues/1072)
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* extension readme getting started link ([#1084](https://github.com/dendronhq/dendron/issues/1084)) ([d3f5b7d](https://github.com/dendronhq/dendron/commit/d3f5b7dc49873cbbb9e44ce1ff473cd4d95e1214))
+* FM tags with quoted strings & with spaces ([1a16689](https://github.com/dendronhq/dendron/commit/1a1668914f70b48a4e74a218bd43521df226de38))
+* highlighting is not displayed ([#1083](https://github.com/dendronhq/dendron/issues/1083)) ([86ead9b](https://github.com/dendronhq/dendron/commit/86ead9b7ec66a51712a265f263a515c624f2861c))
+* issue with direct child filter partially omitting values in quickpick ([#1123](https://github.com/dendronhq/dendron/issues/1123)) ([fbabab4](https://github.com/dendronhq/dendron/commit/fbabab4b61c91f3ebbe62def339efb32e1815178))
+* lookupv3 selection issue ([#1130](https://github.com/dendronhq/dendron/issues/1130)) ([c807e88](https://github.com/dendronhq/dendron/commit/c807e88a82217e5a04dfddb5a24259a50bea4813))
+* properly debounce picker update ([#1111](https://github.com/dendronhq/dendron/issues/1111)) ([ae12e1e](https://github.com/dendronhq/dendron/commit/ae12e1ec39e6d75c9c47e27eff7f96418984da4a))
+* skip delayed decoration update if note is closed ([2d91164](https://github.com/dendronhq/dendron/commit/2d9116489b2d1f4d5ccd6d22c022af2da9984817))
+* uninstall hook force flush ([#1087](https://github.com/dendronhq/dendron/issues/1087)) ([386aac2](https://github.com/dendronhq/dendron/commit/386aac2b8036cd58c190da99609cef2d3ed2467f))
+
+
+### Features Dendron
+
+* add journal title override to NoteLookupCommand ([#1140](https://github.com/dendronhq/dendron/issues/1140)) ([173b0c9](https://github.com/dendronhq/dendron/commit/173b0c95d7ca9593e72e2cd1c39e4fdcf31fa64a))
+* **calendar:** enable webui by default ([#1127](https://github.com/dendronhq/dendron/issues/1127)) ([3ce8be0](https://github.com/dendronhq/dendron/commit/3ce8be05f50c0fef784eef1b6d02e4816e1bf44a))
+* add remaining modifiers to NoteLookup ([#1056](https://github.com/dendronhq/dendron/issues/1056)) ([49c6005](https://github.com/dendronhq/dendron/commit/49c6005d2a2c8fd422eb653977e926084e743d6a)), closes [#1045](https://github.com/dendronhq/dendron/issues/1045) [#1046](https://github.com/dendronhq/dendron/issues/1046)
+* add schema suggestion to NoteLookupCommand ([#1113](https://github.com/dendronhq/dendron/issues/1113)) ([7dbd03f](https://github.com/dendronhq/dendron/commit/7dbd03f20586d5174c13a40ed50eecfd8b4c788d))
+* add schema templating feature to NoteLookupCommand ([#1118](https://github.com/dendronhq/dendron/issues/1118)) ([8a4cd2b](https://github.com/dendronhq/dendron/commit/8a4cd2b337521abcc25df61e145ef6868c50ea0f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* re-engage lapsed users with prompt ([#1086](https://github.com/dendronhq/dendron/issues/1086)) ([f4e6dc5](https://github.com/dendronhq/dendron/commit/f4e6dc563aafdfc0b46966e74d9b38920aee1207))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchal note taking tool that grows as you do. ",
   "publisher": "dendron",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "engines": {
     "vscode": "^1.54.0"
   },
@@ -868,8 +868,8 @@
     "rimraf": "npx rimraf"
   },
   "devDependencies": {
-    "@dendronhq/common-test-utils": "^0.69.2",
-    "@dendronhq/engine-test-utils": "^0.69.2",
+    "@dendronhq/common-test-utils": "^0.69.3-alpha.0",
+    "@dendronhq/engine-test-utils": "^0.69.3-alpha.0",
     "@sentry/webpack-plugin": "^1.17.1",
     "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0.1",
@@ -904,12 +904,12 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.69.2",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/dendron-cli": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
-    "@dendronhq/pods-core": "^0.69.2",
+    "@dendronhq/api-server": "^0.69.3-alpha.0",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/dendron-cli": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
+    "@dendronhq/pods-core": "^0.69.3-alpha.0",
     "@sentry/integrations": "^6.13.1",
     "@sentry/node": "^6.13.1",
     "@types/vscode": "1.58",

--- a/packages/pods-core/CHANGELOG.md
+++ b/packages/pods-core/CHANGELOG.md
@@ -3,6 +3,96 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.69.3-alpha.0](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.3-alpha.0) (2021-11-22)
+
+
+### Bug Fixes
+
+* **pods:** github import pod handle deleted authors ([#1660](https://github.com/dendronhq/dendron/issues/1660)) ([eb11440](https://github.com/dendronhq/dendron/commit/eb11440e255b889e546cd7f67fcb970692c52989))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+
+
+### Features Dendron
+
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+
+
+
+
+
 ## [0.69.2](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.69.2) (2021-11-19)
 
 

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/pods-core",
-  "version": "0.69.2",
+  "version": "0.69.3-alpha.0",
   "description": "pods-core",
   "license": "GPLv3",
   "repository": {
@@ -50,9 +50,9 @@
   },
   "dependencies": {
     "@dendronhq/airtable": "^0.11.1",
-    "@dendronhq/common-all": "^0.69.2",
-    "@dendronhq/common-server": "^0.69.2",
-    "@dendronhq/engine-server": "^0.69.2",
+    "@dendronhq/common-all": "^0.69.3-alpha.0",
+    "@dendronhq/common-server": "^0.69.3-alpha.0",
+    "@dendronhq/engine-server": "^0.69.3-alpha.0",
     "@instantish/martian": "^1.0.3",
     "@notionhq/client": "^0.1.9",
     "@octokit/graphql": "^4.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25767,6 +25767,13 @@ verdaccio-audit@10.0.2:
     https-proxy-agent "5.0.0"
     node-fetch "2.6.1"
 
+verdaccio-auth-memory@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/verdaccio-auth-memory/-/verdaccio-auth-memory-10.0.1.tgz#a4ace3767e954c9ade81bdbe5adb6db82a3417d1"
+  integrity sha512-Y3ZPTHCIW/jD5eACaswBIoJWe6VmOWcOnKZwggqoK/utl1M88KGDypLgQbzmBi+TkZuF3+LsqyDlNYjVd3NqGA==
+  dependencies:
+    "@verdaccio/commons-api" "10.0.1"
+
 verdaccio-htpasswd@10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-10.0.0.tgz#7a7f44e8ed4db40c53deef0f5101f2a16dce4ff1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17660,18 +17660,18 @@ memoizee@0.4.15:
     next-tick "^1.1.0"
     timers-ext "^0.1.7"
 
-memory-fs@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
-  integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
+memory-fs@0.5.0, memory-fs@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
+  integrity sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-memory-fs@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
-  integrity sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
+memory-fs@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
@@ -25777,6 +25777,15 @@ verdaccio-htpasswd@10.0.0:
     bcryptjs "2.4.3"
     http-errors "1.8.0"
     unix-crypt-td-js "1.1.4"
+
+verdaccio-memory@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.npmjs.org/verdaccio-memory/-/verdaccio-memory-10.0.1.tgz#6ea1b6ed8bd434712a0469b942fdfce9a6fb453c"
+  integrity sha512-2jHB3H6XJk9HwMmoNfOXspMkik/MdRUT5sN80tyIgdT7a6FNpFl9wgKb43Ne69yMTb1lc4tRcvlGLezIummVyw==
+  dependencies:
+    "@verdaccio/commons-api" "10.0.1"
+    "@verdaccio/streams" "10.0.0"
+    memory-fs "0.5.0"
 
 verdaccio@^5.1.3:
   version "5.2.0"


### PR DESCRIPTION
- NOTE: in memory verdaccio is much faster but doesn't persist contents after shutdown which makes it insuitable for publishing in pipeline (where building and pulling are in two different steps)

- chore(build): add sleep after publish to build step
- update build
- update timeout
- better lerna output
- update verdaccio config
- add local auth provider
- update patch script
- udpate verdaccio
- update verdaccio
- restore old buildPatch
- add npm proxy back
- Revert "chore(build): add sleep after publish to build step"
- add await
- update uplinks
- update buildPatch

