### PR TITLE
enhance: show stubs at the end of dot ended lookup

### DIFF
--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -888,6 +888,7 @@ function sortForQueryEndingWithDot(
   // l1.l2.with-data.and-child    (data. has partial match 3rd level)
   // level1.level2.data.integer.has-grandchild
   // l1.l2.with-data.and-child.has-grandchild
+  // data.stub (Stub notes come at the end).
   // ```
 
   const itemsWithMetadata = itemsToFilter
@@ -918,8 +919,10 @@ function sortForQueryEndingWithDot(
       const dotsAfterMatch = countDots(
         item.item.fname.substring(item.matchIndex + lowercaseQuery.length)
       );
+      const isStub = item.item.stub;
       const zeroGrandchildren = dotsAfterMatch === 0;
       return {
+        isStub,
         dotsBeforeMatch,
         dotsAfterMatch,
         zeroGrandchildren,
@@ -929,6 +932,7 @@ function sortForQueryEndingWithDot(
     });
 
   const sortOrder: { fieldName: string; order: "asc" | "desc" }[] = [
+    { fieldName: "isStub", order: "desc" },
     { fieldName: "zeroGrandchildren", order: "desc" },
     { fieldName: "isCleanMatch", order: "desc" },
     { fieldName: "dotsAfterMatch", order: "asc" },

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/utils.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/utils.test.ts
@@ -28,11 +28,13 @@ describe(`filterPickerResults`, () => {
   const inputItem = async ({
     fname,
     vaultName,
+    isStub,
   }: {
     fname: string;
     vaultName?: string;
+    isStub?: boolean;
   }): Promise<DNodePropsQuickInputV2> => {
-    return NoteTestUtilsV4.createNotePropsInput({
+    const promise = NoteTestUtilsV4.createNotePropsInput({
       noWrite: true,
       vault: {
         fsPath: "/tmp/vault1",
@@ -41,6 +43,9 @@ describe(`filterPickerResults`, () => {
       wsRoot: "/tmp/ws-root",
       fname,
     });
+    const val = await promise;
+    val.stub = isStub;
+    return val;
   };
 
   describe(`WHEN simplest query possible`, () => {
@@ -67,6 +72,7 @@ describe(`filterPickerResults`, () => {
   describe(`WHEN using dot at the end of the query. ['data.']`, () => {
     it(`THEN filter to items with children AND sort accordingly`, async () => {
       const inputs = [
+        await inputItem({ fname: "data.stub", isStub: true }),
         // Pass in inputs in completely wrong order.
         await inputItem({ fname: "i.completely.do-not.belong" }),
         await inputItem({
@@ -107,6 +113,9 @@ describe(`filterPickerResults`, () => {
         // with partial match.
         "level1.level2.data.integer.has-grandchild",
         "l1.l2.with-data.and-child.has-grandchild",
+
+        // And further down the stub note.
+        "data.stub",
       ];
 
       expect(actual).toEqual(expected);

--- a/test-workspace/vault/data.schema.yml
+++ b/test-workspace/vault/data.schema.yml
@@ -1,0 +1,8 @@
+version: 1
+imports: []
+schemas:
+  - id: data
+    title: data
+    parent: root
+    children:
+      - pattern: stub

--- a/test-workspace/vault/dendron.note-lookup.md
+++ b/test-workspace/vault/dendron.note-lookup.md
@@ -2,7 +2,7 @@
 id: bNkYI2WWK6Jhm2eeVwqrh
 title: Note Lookup
 desc: ''
-updated: 1636555365403
+updated: 1637732673839
 created: 1633501913732
 ---
 
@@ -45,7 +45,9 @@ Should see results with roughly the following order:
 * `languages.with-data.make-sense` 
     * later show matches that are not exact matched `with-data.`
 * `languages.python.data.string.memory` 
-    * lastly show matches that have not just children but grand children etc.
+    * show matches that have not just children but grand children etc.
+* `data.stub` 
+    * show stubs at the end.
 All matches should have `data.` and some value after `data.`
 
 ### Look up with wiki links


### PR DESCRIPTION
# enhance: show stubs at the end of dot ended lookup

Stubs are still visible so they can be easily created, but they are pushed down from the existent notes to interfere less with look up results


<img width="727" alt="Screen Shot 2021-11-24 at 12 41 37 PM" src="https://user-images.githubusercontent.com/4050134/143182938-182ff0cf-0080-49da-8121-21ab9fb7b675.png">


## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
