### PR TITLE
fix: fixing navigation to notes from preview that do not have vault specified

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -232,6 +232,7 @@ export class ErrorFactory {
       message: `unexpected event: '${this.safeStringify(event)}'`,
     });
   }
+
   static createInvalidStateError({
     message,
   }: {
@@ -266,6 +267,28 @@ export class ErrorFactory {
       return `Failed to stringify the given object. Due to '${exc.message}'`;
     }
   }
+
+  /** Wraps the error in DendronError WHEN the instance is not already a DendronError. */
+  static wrapIfNeeded(err: any): DendronError {
+    if (err instanceof DendronError) {
+      // If its already a dendron error we don't need to wrap it.
+      return err;
+    } else if (err instanceof Error) {
+      // If its an instance of some other error we will wrap it and keep track
+      // of the inner error which was the cause.
+      return new DendronError({
+        message: err.message,
+        innerError: err,
+      });
+    } else {
+      // Hopefully we aren't reaching this branch but in case someone throws
+      // some object that does not inherit from Error we will attempt to
+      // safe stringify it into message and wrap as DendronError.
+      return new DendronError({
+        message: this.safeStringify(err),
+      });
+    }
+  }
 }
 
 export class ErrorUtils {
@@ -277,6 +300,7 @@ export class ErrorUtils {
     return _.get(error, "name", "") === "DendronError";
   }
 }
+
 export function isTSError(err: any): err is Error {
   return (
     (err as Error).message !== undefined && (err as Error).name !== undefined

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -6,6 +6,7 @@ import {
   SchemaModuleProps,
   SchemaUtils,
   DNodePropsQuickInputV2,
+  NotePropsDict,
 } from "@dendronhq/common-all";
 import {
   file2Note,
@@ -88,6 +89,16 @@ export class TestNoteFactory {
       noteProps.push(await this.createForFName(fnames[i]));
     }
     return noteProps;
+  }
+
+  toNotePropsDict(notes: NoteProps[]): NotePropsDict {
+    const dict: NotePropsDict = {};
+
+    for (const note of notes) {
+      dict[note.id] = note;
+    }
+
+    return dict;
   }
 }
 

--- a/packages/plugin-core/src/test/expect.ts
+++ b/packages/plugin-core/src/test/expect.ts
@@ -41,5 +41,52 @@ export function expect(value: any) {
     toBeFalsy: () => {
       assert.ok(_.isUndefined(value) || !value);
     },
+    /**
+     *  Pass examples:
+     *  <pre>
+     *  await expect(() => { throw new Error(); }).toThrow(); // Passes exception thrown
+     *  await expect(() => { throw new Error(`hi world`); }).toThrow(`hi`); // Passes regex matches
+     *  </pre>
+     *
+     *  Failure examples:
+     *  <pre>
+     *  await expect(() => {  }).toThrow(); // Fails (no exception thrown)
+     *  await expect(() => { throw new Error(`hi`); }).toThrow(`hi world`); // Fails regex does not match
+     *  </pre>
+     * */
+    toThrow: async (regex?: string) => {
+      let threwException = false;
+
+      try {
+        await value();
+      } catch (err) {
+        threwException = true;
+
+        if (regex)
+          if (err instanceof Error) {
+            if (err.message === undefined) {
+              assert.fail(
+                `Regex '${regex}' was specified but thrown error did not have a message`
+              );
+            }
+
+            const matchArr = err.message.match(regex);
+
+            assert.ok(
+              matchArr !== null,
+              `Thrown exception message did NOT match regex:'${regex}' ErrorMessage:'${err.message}'`
+            );
+          } else {
+            assert.fail(
+              `Regex '${regex}' was specified but non Error type was thrown.`
+            );
+          }
+      }
+
+      assert(
+        threwException,
+        `Expected exception to be thrown. None were thrown.`
+      );
+    }
   };
 }

--- a/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
@@ -2,17 +2,18 @@ import { describe, it, beforeEach, afterEach } from "mocha";
 import {
   extractHeaderAnchorIfExists,
   extractNoteIdFromHref,
+  getNavigationTargetNoteForWikiLink,
   handleLink,
   LinkType,
   ShowPreviewAssetOpener,
   ShowPreviewNoteUtil,
 } from "../../commands/ShowPreview";
-import { expect } from "../testUtilsv2";
-import sinon from "sinon";
 import { TestNoteFactory } from "@dendronhq/common-test-utils";
 import path from "path";
 import { NoteProps } from "@dendronhq/common-all";
-// import { PickerUtilsV2 } from "../../components/lookup/utils";
+import sinon from "sinon";
+import { expect } from "../testUtilsv2";
+import { QuickPickUtil } from "../../utils/quickPick";
 
 suite("ShowPreview utility methods", () => {
   describe(`handleLink`, () => {
@@ -55,6 +56,83 @@ suite("ShowPreview utility methods", () => {
           expect(assetOpenerStub.calledWith(expected)).toBeTruthy();
         });
       });
+    });
+  });
+
+  describe(`getNavigationTargetNoteForWikiLink tests:`, () => {
+    const factory = TestNoteFactory.defaultUnitTestFactory();
+
+    it("WHEN href is missing THEN throw", async () => {
+      await expect(() =>
+        getNavigationTargetNoteForWikiLink({
+          data: {},
+          notes: factory.toNotePropsDict([]),
+        })
+      ).toThrow("href is missing");
+    });
+
+    it("WHEN note can be found by id THEN grab note by id", async () => {
+      const note = await factory.createForFName("foo");
+      note.id = "id-val-1";
+      const dict = factory.toNotePropsDict([note]);
+
+      const actual = await getNavigationTargetNoteForWikiLink({
+        data: {
+          href: `vscode-webview://25d7783e-df29-479c-9838-386c17dbf9b6/id-val-1`,
+        },
+        notes: dict,
+      });
+
+      expect(actual.note).toEqual(note);
+      expect(actual.anchor).toEqual(undefined);
+    });
+
+    it("WHEN note can be found by id with anchor THEN grab note by id and specify anchor", async () => {
+      const note = await factory.createForFName("foo");
+      note.id = "id-val-1";
+      const dict = factory.toNotePropsDict([note]);
+
+      const actual = await getNavigationTargetNoteForWikiLink({
+        data: {
+          href: `vscode-webview://25d7783e-df29-479c-9838-386c17dbf9b6/id-val-1#anch-val-1`,
+        },
+        notes: dict,
+      });
+
+      expect(actual.note).toEqual(note);
+      expect(actual.anchor).toEqual({
+        type: "header",
+        value: "anch-val-1",
+      });
+    });
+
+    it("WHEN note in different vault without vault specified THEN prompt user to choose a note", async () => {
+      const note1 = await factory.createForFName("other-vault-foo");
+      note1.vault = { fsPath: `/tmp/note1vault` };
+      note1.created = 2;
+      const notes = [];
+      notes.push(note1);
+
+      const note2 = await factory.createForFName("other-vault-foo");
+      note2.vault = { fsPath: `/tmp/note2Vault` };
+      note2.created = 1;
+      notes.push(note2);
+
+      sinon
+        .stub(QuickPickUtil, "showChooseNote")
+        .returns(Promise.resolve(note2));
+
+      const dict = factory.toNotePropsDict(notes);
+
+      const noteData = await getNavigationTargetNoteForWikiLink({
+        data: {
+          href: `vscode-webview://25d7783e-df29-479c-9838-386c17dbf9b6/other-vault-foo`,
+        },
+        notes: dict,
+      });
+
+      expect(noteData.note).toEqual(note2);
+      expect(noteData.anchor).toEqual(undefined);
     });
   });
 

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -99,6 +99,7 @@ export function genDefaultConfig() {
     }),
   };
 }
+
 export function genDefaultSettings() {
   return {
     extensions: {
@@ -430,6 +431,7 @@ export class LocationTestUtils {
   static getBasenameFromLocation = (loc: Location) =>
     path.basename(loc.uri.fsPath);
 }
+
 export const stubWorkspaceFile = (wsRoot: string) => {
   const wsPath = path.join(wsRoot, "dendron.code-workspace");
   fs.writeJSONSync(wsPath, {});

--- a/packages/plugin-core/src/utils/quickPick.ts
+++ b/packages/plugin-core/src/utils/quickPick.ts
@@ -1,4 +1,6 @@
 import { VSCodeUtils } from "../utils";
+import { DNodeUtils, NoteProps } from "@dendronhq/common-all";
+import { getDWorkspace } from "../workspace";
 
 export enum ProceedCancel {
   PROCEED = "proceed",
@@ -23,6 +25,31 @@ export class QuickPickUtil {
       return ProceedCancel.PROCEED;
     } else {
       return ProceedCancel.CANCEL;
+    }
+  }
+
+  /**
+   *  Show a quick pick with the given notes as choices. Returns the chosen note
+   *  or undefined if user cancelled the note selection.
+   *  */
+  static async showChooseNote(
+    notes: NoteProps[]
+  ): Promise<NoteProps | undefined> {
+    const inputItems = notes.map((ent) => {
+      const workspace = getDWorkspace();
+      return DNodeUtils.enhancePropForQuickInputV3({
+        wsRoot: workspace.wsRoot,
+        props: ent,
+        schemas: workspace.engine.schemas,
+        vaults: workspace.vaults,
+      });
+    });
+
+    const chosen = await VSCodeUtils.showQuickPick(inputItems);
+    if (chosen === undefined) {
+      return undefined;
+    } else {
+      return chosen;
     }
   }
 }

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1637081758300
+updated: 1638356699074
 created: 1608518909864
 ---
 
@@ -13,6 +13,10 @@ created: 1608518909864
 - [[dendron.ref.figure]]
 - [[same note link to anchor|#unpublished-page]]
 - [[diff note link to anchor|dendron.ref.figure#block]]
+
+## Link in different vault without vault specified
+Should get a quick pick prompt to choose a note to navigate to when clicking on following link in preview. Upon choosing the the note in quick Dendron opens the note. If quick pick is cancelled NO errors should be shown.
+- [[dendron.ref.links.target-different-vault]] 
 
 ## XVault Link
 

--- a/test-workspace/vault2/dendron.ref.links.target-different-vault.md
+++ b/test-workspace/vault2/dendron.ref.links.target-different-vault.md
@@ -1,0 +1,9 @@
+---
+id: vUHPvIxH0mOCxCEOkINkl
+title: Target Different Vault
+desc: ''
+updated: 1638356054182
+created: 1638183067573
+---
+
+Vault2 target (different vault).

--- a/test-workspace/vault3/dendron.ref.links.target-different-vault.md
+++ b/test-workspace/vault3/dendron.ref.links.target-different-vault.md
@@ -1,0 +1,9 @@
+---
+id: RwukeBqun5SaVK8cDEpqT
+title: Target Different Vault
+desc: ''
+updated: 1638356066961
+created: 1638183116472
+---
+
+Vault 3 target different vault.


### PR DESCRIPTION
# fix: fixing navigation to notes from preview that do not have vault specified

Now when clicking on a link in preview that does not specify a vault (but lives in a different) vault we will navigate to the note. IF there are multiple notes in different vaults that match THEN we will choose the note with the oldest create time. 

IF there is a note with same file name in current vault we will choose the note in the same vault above all else. 

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
