### PR TITLE
enhance: strip out theming on copy and paste from preview

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -63,16 +63,16 @@ export class WebViewCommonUtils {
       var theme = 'unknown';
 
       function onload() {
-          console.log("calling onLoad");
-          applyTheme(document.body.className);
-      
-          var observer = new MutationObserver(function(mutations) {
-              mutations.forEach(function(mutationRecord) {
-                  applyTheme(mutationRecord.target.className);
-              });    
-          });
-          var target = document.body;
-          observer.observe(target, { attributes : true, attributeFilter : ['class'] });
+        console.log("calling onLoad");
+        applyTheme(document.body.className);
+    
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutationRecord) {
+                applyTheme(mutationRecord.target.className);
+            });    
+        });
+        var target = document.body;
+        observer.observe(target, { attributes : true, attributeFilter : ['class'] });
       }
 
       function applyTheme(newTheme) {
@@ -100,10 +100,71 @@ export class WebViewCommonUtils {
         link.setAttribute('rel', 'stylesheet');
         link.setAttribute('href', themeMap[newTheme]);
         document.head.appendChild(link);
-    }
+      }
       ${acquireVsCodeApi}
     </script>
-
+     
+    <!-- Javascript to handle copy event: to take the html of the copy without taking the theming. -->
+    <script type="text/javascript">
+      document.addEventListener('copy', (e) => {
+        const htmlSelection = getHTMLOfSelection();
+        
+        if (htmlSelection !== undefined){
+          copyToClipboard(htmlSelection);            
+        }  
+      });
+      
+      /** 
+       * Based off of: https://stackoverflow.com/a/5084044/7858768
+       * */
+      function getHTMLOfSelection () {
+        let range;
+        if (document.selection && document.selection.createRange) {
+          range = document.selection.createRange();
+          return range.htmlText;
+        }
+        else if (window.getSelection) {
+          const selection = window.getSelection();
+          if (selection.rangeCount > 0) {
+            range = selection.getRangeAt(0);
+            const clonedSelection = range.cloneContents();
+            const div = document.createElement('div');
+            div.appendChild(clonedSelection);
+            return div.innerHTML;
+          }
+          else {
+            return undefined;
+          }
+        }
+        else {
+          return undefined;
+        }
+      }
+      
+      /**
+      Based off of: 
+      * https://stackoverflow.com/a/64711198/7858768
+      * https://stackoverflow.com/a/57279336/7858768
+      */
+      function copyToClipboard(html) {
+        const container = document.createElement('div');
+        container.innerHTML = html;
+        container.style.position = 'fixed';
+        container.style.pointerEvents = 'none';
+        container.style.opacity = 0;
+        
+        const blob = new Blob([html], {type: "text/html"});
+        const item = new ClipboardItem({"text/html": blob});
+ 
+        navigator.clipboard.write([item]).then(function() {
+          console.log("Copied to clipboard successfully!");
+        }, function(error) {
+          console.error("Unable to write to clipboard. Error:");
+          console.log(error);
+        });
+      }
+    </script>
+    
     <body onload="onload()" class="vscode-${initialTheme || "light"}">
       <div id="main-content-wrap" class="main-content-wrap">
         <div id="main-content" class="main-content">

--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -63,7 +63,6 @@ export class WebViewCommonUtils {
       var theme = 'unknown';
 
       function onload() {
-        console.log("calling onLoad");
         applyTheme(document.body.className);
     
         var observer = new MutationObserver(function(mutations) {
@@ -157,7 +156,7 @@ export class WebViewCommonUtils {
         const item = new ClipboardItem({"text/html": blob});
  
         navigator.clipboard.write([item]).then(function() {
-          console.log("Copied to clipboard successfully!");
+          
         }, function(error) {
           console.error("Unable to write to clipboard. Error:");
           console.log(error);

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -87,6 +87,9 @@ export class WebViewUtils {
       port,
       wsRoot,
       browser: false,
+      // acquireVsCodeApi() Documentation: This function can only be invoked once per session.
+      // You must hang onto the instance of the VS Code API returned by this method,
+      // and hand it out to any other functions that need to use it.
       acquireVsCodeApi: `const vscode = acquireVsCodeApi(); window.vscode = vscode;`,
       themeMap,
     });

--- a/test-workspace/vault/dendron.preview.md
+++ b/test-workspace/vault/dendron.preview.md
@@ -1,0 +1,17 @@
+---
+id: ILP9zHbwAltPWMfvIXtds
+title: Preview
+desc: ''
+updated: 1638194999578
+created: 1638194914915
+---
+
+## Copies text as plain text
+1. Show preview on this note
+1. Select few lines of text.
+1. Copy it
+1. Paste it into GMAIL/Google Docs (or some other theme supprting tool)
+
+EXPECTED: text is pasted as plain text.
+
+

--- a/test-workspace/vault/foo.md
+++ b/test-workspace/vault/foo.md
@@ -2,9 +2,19 @@
 id: foo
 title: Foo
 desc: ""
-updated: 1608147429954
+updated: 1638882358581
 created: 1595170096361
 published: true
 ---
 
+## Foo Header
 This is the foo note
+
+[goog](https://www.google.com/) [bing](https://www.bing.com/)
+
+## Header Value
+* [goog](https://www.google.com/)
+* [bing](https://www.bing.com/)
+* [yahoo](https://www.yahoo.com/)
+
+non-link-value


### PR DESCRIPTION
# Pull Request Checklist

Note as mentioned in the comments using the clipboard readText() already strips out the theming. However, that means the headers are written as plain text. 

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows