### PR TITLE
fix: auto completer test dependency issue

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupAutoCompleteCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupAutoCompleteCommand.ts
@@ -4,7 +4,6 @@ import {
   AUTO_COMPLETABLE_COMMAND_ID,
   UIAutoCompletableCmds,
 } from "../utils/autoCompleter";
-// import { AUTO_COMPLETABLE_COMMAND_IDS, getUIAutoCompletableUICmd } from "../utils/autoCompleter";
 
 type CommandOpts = {};
 

--- a/packages/plugin-core/src/test/expect.ts
+++ b/packages/plugin-core/src/test/expect.ts
@@ -1,0 +1,45 @@
+import assert from "assert";
+import _ from "lodash";
+
+function safeStringify(obj: any) {
+  try {
+    return JSON.stringify(obj);
+  } catch (err) {
+    return `failed_to_stringify_obj`;
+  }
+}
+
+export function expect(value: any) {
+  return {
+    /**
+     * NOTE: This method currently only works for checking object properties.
+     *
+     * Such as:
+     * var object = { 'user': 'fred', 'age': 40 };
+     * _.isMatch(object, { 'age': 40 });
+     * // => true
+     * _.isMatch(object, { 'age': 36 });
+     * // => false
+     * */
+    toContain: (value2: any) => {
+      assert.ok(
+        _.isMatch(value, value2),
+        `Object:'${safeStringify(value)}' does NOT contain: '${safeStringify(
+          value2
+        )}'`
+      );
+    },
+    toEqual: (value2: any) => {
+      assert.deepStrictEqual(value, value2);
+    },
+    toNotEqual: (value2: any) => {
+      assert.notDeepStrictEqual(value, value2);
+    },
+    toBeTruthy: () => {
+      assert.ok(value);
+    },
+    toBeFalsy: () => {
+      assert.ok(_.isUndefined(value) || !value);
+    },
+  };
+}

--- a/packages/plugin-core/src/test/suite-integ/autoCompleter.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/autoCompleter.test.ts
@@ -1,16 +1,6 @@
-/**
- * File has C_ prefix to move it down in the list of tests.
- * If C_ is removed it bubbles up to the top of the tests and for some reason
- * just using 'expect' starts to trigger the following error:
- * ```
- * Cmd is not a constructor: TypeError: Cmd is not a constructor
- *   at /usr/local/workplace/dendron/packages/plugin-core/out/src/workspace.js:476:25
- * ```
- * Moving the test down in the order of tests appears to resolve this error.
- * */
 import { AutoCompleter } from "../../utils/autoCompleter";
 import { describe, it } from "mocha";
-import { expect } from "../testUtilsv2";
+import { expect } from "../expect";
 
 describe(`Auto Completer tests.`, () => {
   describe(`GIVEN empty file name input`, () => {

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -24,7 +24,6 @@ import {
 } from "@dendronhq/common-test-utils";
 import { DConfig, MetadataService } from "@dendronhq/engine-server";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
-import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -464,45 +463,4 @@ export const stubWorkspace = ({ wsRoot, vaults }: WorkspaceOpts) => {
   stubWorkspaceFolders(wsRoot, vaults);
 };
 
-function safeStringify(obj: any) {
-  try {
-    return JSON.stringify(obj);
-  } catch (err) {
-    return `failed_to_stringify_obj`;
-  }
-}
-
-export function expect(value: any) {
-  return {
-    /**
-     * NOTE: This method currently only works for checking object properties.
-     *
-     * Such as:
-     * var object = { 'user': 'fred', 'age': 40 };
-     * _.isMatch(object, { 'age': 40 });
-     * // => true
-     * _.isMatch(object, { 'age': 36 });
-     * // => false
-     * */
-    toContain: (value2: any) => {
-      assert.ok(
-        _.isMatch(value, value2),
-        `Object:'${safeStringify(value)}' does NOT contain: '${safeStringify(
-          value2
-        )}'`
-      );
-    },
-    toEqual: (value2: any) => {
-      assert.deepStrictEqual(value, value2);
-    },
-    toNotEqual: (value2: any) => {
-      assert.notDeepStrictEqual(value, value2);
-    },
-    toBeTruthy: () => {
-      assert.ok(value);
-    },
-    toBeFalsy: () => {
-      assert.ok(_.isUndefined(value) || !value);
-    },
-  };
-}
+export * from "./expect";


### PR DESCRIPTION
# Pull Request Checklist

Added documentation mention on this issue in ![[dendron://dendron.docs/pkg.plugin-core.dev.errors.cmd-is-not-a-constructor-dependency-issue]] 

## General

### Quality Assurance
- [ ] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
