### PR TITLE
enhance: add fuzzy threshold configuration

### DIFF
--- a/packages/common-all/src/constants/configs/commands.ts
+++ b/packages/common-all/src/constants/configs/commands.ts
@@ -61,6 +61,10 @@ const NOTE: DendronConfigEntryCollection<NoteLookupConfig> = {
     label: "Bubble Up Create New",
     desc: "Put `Create New` at the top of the lookup result.",
   },
+  fuzzThreshold: {
+    label: "Fuzziness threshold for lookup",
+    desc: "Sets the fuzziness level of lookups 0=exact matches only, 1=max fuzziness.",
+  },
 };
 
 /**

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -28,43 +28,6 @@ export const FuseExtendedSearchConstants = {
   PrefixExactMatch: "^",
 };
 
-/**
- * Experimentally set.
- *
- * At the time of testing:
- *
- * At previous threshold of 0.5 string 'dendron' matched
- * 'scratch.2021.06.15.104331.make-sure-seeds-are-initialized-on-startup' with score 0.42.
- * Which is too fuzzy of a match.
- *
- * 'rename' fuzzy matches 'dendron.scratch.2020.11.07.publish-under-original-filenames' with 0.16.
- *
- * For reference
- * 'dendron rename' matches 'dendron.dev.design.commands.rename' with 0.001.
- *
- * Having this score too high gets too unrelated matches which pushes the
- * 'Create New' entry out of the view.
- * --------------------------------------------------------------------------------
- *
- * Note if you are going to be tweaking this value it is highly suggested to add a
- * temporary piece of code To be able to see the all the results that are matched by
- * fuse engine along with their scores, inside {@link FuseEngine.queryNote}
- * */
-//       const dir = `<YOUR-DIR>/${qs}`;
-//       try{
-//         require('fs').mkdirSync(dir)
-//       }catch (e){
-//       }
-//       const data = JSON.stringify(
-//         {
-//           qs: qs,
-//           fuseQueryString: fuseQueryString,
-//           results:results
-//         });
-//       const path = `${dir}/${THRESHOLD_VALUE}_${new Date().getTime()}.json`;
-//       require('fs').writeFile(path, data, ()=>{});
-export const DEFAULT_THRESHOLD_VALUE = 0.2;
-
 function createFuse<T>(
   initList: T[],
   opts: Fuse.IFuseOptions<T> & {
@@ -133,18 +96,16 @@ export type SerializedFuseIndex = ReturnType<
 type FuseEngineOpts = {
   mode?: DEngineMode;
   /** If specified must be within 0-1 range. */
-  fuzzThreshold?: number;
+  fuzzThreshold: number;
 };
 
-export const getThresholdValue = (configThreshold?: number) => {
-  let threshold = DEFAULT_THRESHOLD_VALUE;
-  if (
-    !_.isUndefined(configThreshold) &&
-    configThreshold >= 0 &&
-    configThreshold <= 1
-  ) {
+export const getThresholdValue = (configThreshold: number) => {
+  // Setting it to fallback threshold value in case configuration is incorrect.
+  let threshold = 0.2;
+  if (configThreshold >= 0 && configThreshold <= 1) {
     threshold = configThreshold;
   }
+
   return threshold;
 };
 

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -63,7 +63,7 @@ export const FuseExtendedSearchConstants = {
 //         });
 //       const path = `${dir}/${THRESHOLD_VALUE}_${new Date().getTime()}.json`;
 //       require('fs').writeFile(path, data, ()=>{});
-const THRESHOLD_VALUE = 0.2;
+export const DEFAULT_THRESHOLD_VALUE = 0.2;
 
 function createFuse<T>(
   initList: T[],
@@ -132,6 +132,20 @@ export type SerializedFuseIndex = ReturnType<
 
 type FuseEngineOpts = {
   mode?: DEngineMode;
+  /** If specified must be within 0-1 range. */
+  fuzzThreshold?: number;
+};
+
+export const getThresholdValue = (configThreshold?: number) => {
+  let threshold = DEFAULT_THRESHOLD_VALUE;
+  if (
+    !_.isUndefined(configThreshold) &&
+    configThreshold >= 0 &&
+    configThreshold <= 1
+  ) {
+    threshold = configThreshold;
+  }
+  return threshold;
 };
 
 export class FuseEngine {
@@ -159,7 +173,8 @@ export class FuseEngine {
   private readonly threshold: number;
 
   constructor(opts: FuseEngineOpts) {
-    this.threshold = opts.mode === "exact" ? 0.0 : THRESHOLD_VALUE;
+    this.threshold =
+      opts.mode === "exact" ? 0.0 : getThresholdValue(opts.fuzzThreshold);
 
     this.notesIndex = createFuse<NoteProps>([], {
       preset: "note",

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -11,6 +11,7 @@ import {
   NoteUtils,
   DNodeUtils,
   DEngineClient,
+  ConfigUtils,
 } from ".";
 import { DVault } from "./types";
 
@@ -99,14 +100,14 @@ type FuseEngineOpts = {
   fuzzThreshold: number;
 };
 
-export const getThresholdValue = (configThreshold: number) => {
-  // Setting it to fallback threshold value in case configuration is incorrect.
-  let threshold = 0.2;
-  if (configThreshold >= 0 && configThreshold <= 1) {
-    threshold = configThreshold;
+export const getCleanThresholdValue = (configThreshold: number) => {
+  if (configThreshold < 0 || configThreshold > 1) {
+    // Setting threshold to fallback threshold value in case configuration is incorrect.
+    return ConfigUtils.getLookup(ConfigUtils.genDefaultConfig()).note
+      .fuzzThreshold;
   }
 
-  return threshold;
+  return configThreshold;
 };
 
 export class FuseEngine {
@@ -135,7 +136,7 @@ export class FuseEngine {
 
   constructor(opts: FuseEngineOpts) {
     this.threshold =
-      opts.mode === "exact" ? 0.0 : getThresholdValue(opts.fuzzThreshold);
+      opts.mode === "exact" ? 0.0 : getCleanThresholdValue(opts.fuzzThreshold);
 
     this.notesIndex = createFuse<NoteProps>([], {
       preset: "note",

--- a/packages/common-all/src/types/configs/commands/lookup.ts
+++ b/packages/common-all/src/types/configs/commands/lookup.ts
@@ -27,6 +27,7 @@ export type NoteLookupConfig = {
   confirmVaultOnCreate: boolean;
   leaveTrace: boolean;
   bubbleUpCreateNew: boolean;
+  fuzzThreshold?: number;
 };
 
 /**

--- a/packages/common-all/src/types/configs/commands/lookup.ts
+++ b/packages/common-all/src/types/configs/commands/lookup.ts
@@ -27,7 +27,7 @@ export type NoteLookupConfig = {
   confirmVaultOnCreate: boolean;
   leaveTrace: boolean;
   bubbleUpCreateNew: boolean;
-  fuzzThreshold?: number;
+  fuzzThreshold: number;
 };
 
 /**
@@ -41,6 +41,29 @@ export function genDefaultLookupConfig(): LookupConfig {
       confirmVaultOnCreate: false,
       leaveTrace: false,
       bubbleUpCreateNew: true,
+      /**
+       * Experimentally set.
+       *
+       * At the time of testing:
+       *
+       * At previous threshold of 0.5 string 'dendron' matched
+       * 'scratch.2021.06.15.104331.make-sure-seeds-are-initialized-on-startup' with score 0.42.
+       * Which is too fuzzy of a match.
+       *
+       * 'rename' fuzzy matches 'dendron.scratch.2020.11.07.publish-under-original-filenames' with 0.16.
+       *
+       * For reference
+       * 'dendron rename' matches 'dendron.dev.design.commands.rename' with 0.001.
+       *
+       * Having this score too high gets too unrelated matches which pushes the
+       * 'Create New' entry out of the view.
+       * --------------------------------------------------------------------------------
+       *
+       * Note if you are going to be tweaking this value it is highly suggested to add a
+       * temporary piece of code To be able to see the all the results that are matched by
+       * fuse engine along with their scores, inside {@link FuseEngine.queryNote}
+       * */
+      fuzzThreshold: 0.2,
     },
   };
 }

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -116,7 +116,6 @@ export class DendronEngineClient implements DEngineClient {
     this.notes = {};
     this.schemas = {};
     this.links = [];
-    this.fuseEngine = new FuseEngine({});
     this.vaults = vaults;
     this.wsRoot = ws;
     this.ws = ws;
@@ -125,6 +124,9 @@ export class DendronEngineClient implements DEngineClient {
     this.logger = logger || createLogger();
     const cpath = DConfig.configPath(ws);
     this.config = readYAML(cpath) as IntermediateDendronConfig;
+    this.fuseEngine = new FuseEngine({
+      fuzzThreshold: ConfigUtils.getLookup(this.config).note.fuzzThreshold,
+    });
     this.store = new FileStorage({
       engine: this,
       logger: this.logger,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -143,7 +143,9 @@ export class DendronEngineV2 implements DEngine {
     this.configRoot = props.wsRoot;
     this.logger = props.logger;
     this.props = props;
-    this.fuseEngine = new FuseEngine({});
+    this.fuseEngine = new FuseEngine({
+      fuzzThreshold: ConfigUtils.getLookup(props.config).note.fuzzThreshold,
+    });
     this.links = [];
     this.config = props.config;
     this._vaults = props.vaults;

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -5,10 +5,7 @@ import {
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import Fuse from "fuse.js";
-import {
-  DEFAULT_THRESHOLD_VALUE,
-  getThresholdValue,
-} from "@dendronhq/common-all/src";
+import { getThresholdValue } from "@dendronhq/common-all";
 
 type TestData = {
   fname: string;
@@ -51,7 +48,7 @@ function assertDoesNotHaveFName(queryResult: NoteIndexProps[], fname: string) {
 }
 
 async function initializeFuseEngine(testData: TestData[]): Promise<FuseEngine> {
-  const fuseEngine = new FuseEngine({});
+  const fuseEngine = new FuseEngine({ fuzzThreshold: 0.2 });
   const notePropsDict: NotePropsDict = await testDataToNotePropsDict(testData);
   await fuseEngine.updateNotesIndex(notePropsDict);
   return fuseEngine;
@@ -78,19 +75,15 @@ const queryTestV1 = ({
 
 describe("Fuse utility function tests", () => {
   describe(`getThresholdValue`, () => {
-    it("WHEN val is not specified THEN use default", () => {
-      expect(getThresholdValue()).toEqual(DEFAULT_THRESHOLD_VALUE);
+    it("WHEN val is specified but too small THEN use fallback", () => {
+      expect(getThresholdValue(-1)).toEqual(0.2);
     });
 
-    it("WHEN val is specified but too small THEN use default", () => {
-      expect(getThresholdValue(-1)).toEqual(DEFAULT_THRESHOLD_VALUE);
+    it("WHEN val is specified but too large THEN use fallback", () => {
+      expect(getThresholdValue(1.1)).toEqual(0.2);
     });
 
-    it("WHEN val is specified but too large THEN use default", () => {
-      expect(getThresholdValue(1.1)).toEqual(DEFAULT_THRESHOLD_VALUE);
-    });
-
-    it("WHEN val is specified and within range THEN use the configured value", () => {
+    it("WHEN val is within range THEN use the configured value", () => {
       expect(getThresholdValue(0.1234)).toEqual(0.1234);
     });
   });

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -5,6 +5,10 @@ import {
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import Fuse from "fuse.js";
+import {
+  DEFAULT_THRESHOLD_VALUE,
+  getThresholdValue,
+} from "@dendronhq/common-all/src";
 
 type TestData = {
   fname: string;
@@ -73,6 +77,24 @@ const queryTestV1 = ({
 };
 
 describe("Fuse utility function tests", () => {
+  describe(`getThresholdValue`, () => {
+    it("WHEN val is not specified THEN use default", () => {
+      expect(getThresholdValue()).toEqual(DEFAULT_THRESHOLD_VALUE);
+    });
+
+    it("WHEN val is specified but too small THEN use default", () => {
+      expect(getThresholdValue(-1)).toEqual(DEFAULT_THRESHOLD_VALUE);
+    });
+
+    it("WHEN val is specified but too large THEN use default", () => {
+      expect(getThresholdValue(1.1)).toEqual(DEFAULT_THRESHOLD_VALUE);
+    });
+
+    it("WHEN val is specified and within range THEN use the configured value", () => {
+      expect(getThresholdValue(0.1234)).toEqual(0.1234);
+    });
+  });
+
   describe(`doesContainSpecialQueryChars`, () => {
     test.each([
       // Fuse doesn't treat * specially but we map * to ' ' hence we treat it as special character.

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import Fuse from "fuse.js";
-import { getThresholdValue } from "@dendronhq/common-all";
+import { getCleanThresholdValue } from "@dendronhq/common-all";
 
 type TestData = {
   fname: string;
@@ -74,17 +74,17 @@ const queryTestV1 = ({
 };
 
 describe("Fuse utility function tests", () => {
-  describe(`getThresholdValue`, () => {
+  describe(`getCleanThresholdValue`, () => {
     it("WHEN val is specified but too small THEN use fallback", () => {
-      expect(getThresholdValue(-1)).toEqual(0.2);
+      expect(getCleanThresholdValue(-1)).toEqual(0.2);
     });
 
     it("WHEN val is specified but too large THEN use fallback", () => {
-      expect(getThresholdValue(1.1)).toEqual(0.2);
+      expect(getCleanThresholdValue(1.1)).toEqual(0.2);
     });
 
     it("WHEN val is within range THEN use the configured value", () => {
-      expect(getThresholdValue(0.1234)).toEqual(0.1234);
+      expect(getCleanThresholdValue(0.1234)).toEqual(0.1234);
     });
   });
 

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -42,6 +42,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -173,6 +174,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -298,6 +300,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -388,6 +391,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -493,6 +497,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -36,6 +36,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -167,6 +168,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -292,6 +294,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -382,6 +385,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -487,6 +491,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -597,6 +602,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates
@@ -696,6 +702,7 @@ commands:
             confirmVaultOnCreate: false
             leaveTrace: false
             bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
     randomNote: {}
     insertNote:
         initialValue: templates

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -1,4 +1,10 @@
-import { FuseEngine, NoteProps, NotePropsDict } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  FuseEngine,
+  IntermediateDendronConfig,
+  NoteProps,
+  NotePropsDict,
+} from "@dendronhq/common-all";
 import { verifyEngineSliceState } from "@dendronhq/common-frontend";
 import { Grid } from "antd";
 import _ from "lodash";
@@ -52,12 +58,17 @@ export function useDendronRouter() {
  * @param setNoteIndex
  */
 export function useDendronLookup() {
-  const [noteIndex, setNoteIndex] =
-    React.useState<FuseEngine | undefined>(undefined);
+  const engine = useEngineAppSelector((state) => state.engine);
+  const config = engine.config as IntermediateDendronConfig;
+  const fuzzThreshold = ConfigUtils.getLookup(config).note.fuzzThreshold;
+
+  const [noteIndex, setNoteIndex] = React.useState<FuseEngine | undefined>(
+    undefined
+  );
   React.useEffect(() => {
     fetchNotes().then(async (noteData) => {
       const { notes } = noteData;
-      const noteIndex = new FuseEngine({ mode: "fuzzy" });
+      const noteIndex = new FuseEngine({ mode: "fuzzy", fuzzThreshold });
       noteIndex.updateNotesIndex(notes);
       setNoteIndex(noteIndex);
     });

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -255,6 +255,7 @@ suite("Extension", function () {
                 confirmVaultOnCreate: false,
                 leaveTrace: false,
                 bubbleUpCreateNew: true,
+                fuzzThreshold: 0.2,
               },
             },
             randomNote: {},


### PR DESCRIPTION
# enhance: add fuzzy threshold configuration

Allows users to configure the fuzziness threshodl of lookups. 

PR doc: https://github.com/dendronhq/dendron-site/pull/303/files

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
  * Tested with configuration
  * Tested without adding new configuration
  * Tested with note configuration entirely.
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
