### PR TITLE
fix(schema): When applying a schema template, do not override the body but append to the end to it

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1262,8 +1262,13 @@ export class SchemaUtils {
       }
       const tempNoteProps = _.pick(tempNote, this.TEMPLATE_COPY_PROPS);
       _.forEach(tempNoteProps, (v, k) => {
-        // @ts-ignore
-        note[k] = v;
+        // If note body exists, append template's body instead of overriding
+        if (k === "body" && note[k] !== "") {
+          note[k] += `\n${v}`;
+        } else {
+          // @ts-ignore
+          note[k] = v;
+        }
       });
       return true;
     }

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1241,7 +1241,6 @@ type SchemaMatchResult = {
 export class SchemaUtils {
   /** The props of a template note that will get copied over when the template is applied. */
   static TEMPLATE_COPY_PROPS: readonly (keyof NoteProps)[] = [
-    "body",
     "desc",
     "custom",
     "color",
@@ -1262,14 +1261,15 @@ export class SchemaUtils {
       }
       const tempNoteProps = _.pick(tempNote, this.TEMPLATE_COPY_PROPS);
       _.forEach(tempNoteProps, (v, k) => {
-        // If note body exists, append template's body instead of overriding
-        if (k === "body" && note[k] !== "") {
-          note[k] += `\n${v}`;
-        } else {
-          // @ts-ignore
-          note[k] = v;
-        }
+        // @ts-ignore
+        note[k] = v;
       });
+      // If note body exists, append template's body instead of overriding
+      if (note.body) {
+        note.body += `\n${tempNote.body}`;
+      } else {
+        note.body = tempNote.body;
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
* Updated tests for dnode.ts
* Minor lint fixes in dnode.spec.ts
* Append template note's body if current note's body is not empty
* See https://github.com/dendronhq/dendron/issues/1675

Unit Test
*  ./node_modules/.bin/jest /Users/tulingma/workspace/dendron/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts

Manual Test
* Run "Run:Extension Local (plugin-core) against test workspace
* Test creating note with template
* Test creating note with template with selection extract