### PR TITLE
chore: analytics for native workspaces that were actually code workspaces

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -566,6 +566,9 @@ export async function _activate(
 
       MetadataService.instance().setDendronWorkspaceActivated();
 
+      const codeWorkspacePresent = await fs.pathExists(
+        path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME)
+      );
       AnalyticsUtils.identify();
       AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, {
         duration: durationReloadWorkspace,
@@ -573,6 +576,7 @@ export async function _activate(
         numNotes,
         numVaults: _.size(getEngine().vaults),
         workspaceType: ws.type,
+        codeWorkspacePresent,
       });
       if (stage !== "test") {
         await ws.activateWatchers();


### PR DESCRIPTION
We now collect analytics when a native workspace is initialized that was really a code workspace.

Docs: https://github.com/dendronhq/dendron-site/pull/309