### PR TITLE
chore(build): fix asset url

### DIFF
--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -31,12 +31,14 @@ let _MOCK_CONTEXT: undefined | vscode.ExtensionContext;
 export class VSCodeUtils {
   /**
    * In development, this is `packages/plugin-core/assets`
-   * In production, this is `$HOME/$VSCODE_DIR/{path-to-app}/assets
+   * In production, this is `$HOME/$VSCODE_DIR/{path-to-app}/dist/
    * @param context
    * @returns
    */
   static getAssetUri(context: vscode.ExtensionContext) {
-    return VSCodeUtils.joinPath(context.extensionUri, "assets");
+    if (getStage() === "dev")
+      return VSCodeUtils.joinPath(context.extensionUri, "assets");
+    return VSCodeUtils.joinPath(context.extensionUri, "dist");
   }
 
   static closeCurrentFileEditor() {


### PR DESCRIPTION
https://github.com/dendronhq/dendron/pull/1813 removed `assets` directory from the final bundle. Update the assetUrl to reflect this
