### PR TITLE
fix(views): update web uis on note creation

### DIFF
--- a/packages/common-frontend/src/features/engine/hooks.ts
+++ b/packages/common-frontend/src/features/engine/hooks.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { useEffect } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { EngineSliceUtils } from ".";
 import { createLogger } from "../../utils";
 import { EngineState, InitNoteOpts, initNotes } from "./slice";
 import { AppDispatch, RootState } from "./store";
@@ -31,10 +32,7 @@ export const useEngine = ({
     if (engineState.error) {
       return engineState.error;
     }
-    if (
-      (engineState.loading === "idle" && _.isEmpty(engineState.notes)) ||
-      opts.force
-    ) {
+    if (!EngineSliceUtils.hasInitialized(engineState) || opts.force) {
       logger.info({ msg: "dispatch notes", force: opts.force });
       if (_.isUndefined(opts.port)) {
         return;

--- a/packages/common-frontend/src/features/engine/hooks.ts
+++ b/packages/common-frontend/src/features/engine/hooks.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { useEffect } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
-import { EngineSliceUtils } from ".";
+import { engineSliceUtils } from ".";
 import { createLogger } from "../../utils";
 import { EngineState, InitNoteOpts, initNotes } from "./slice";
 import { AppDispatch, RootState } from "./store";
@@ -32,7 +32,7 @@ export const useEngine = ({
     if (engineState.error) {
       return engineState.error;
     }
-    if (!EngineSliceUtils.hasInitialized(engineState) || opts.force) {
+    if (!engineSliceUtils.hasInitialized(engineState) || opts.force) {
       logger.info({ msg: "dispatch notes", force: opts.force });
       if (_.isUndefined(opts.port)) {
         return;

--- a/packages/common-frontend/src/features/engine/index.ts
+++ b/packages/common-frontend/src/features/engine/index.ts
@@ -3,3 +3,4 @@ import * as engineSlice from "./slice";
 export { engineSlice };
 export { store as engineStore, AppDispatch as EngineDispatch } from "./store";
 export * as engineHooks from "./hooks";
+export * from "./utils";

--- a/packages/common-frontend/src/features/engine/index.ts
+++ b/packages/common-frontend/src/features/engine/index.ts
@@ -3,4 +3,4 @@ import * as engineSlice from "./slice";
 export { engineSlice };
 export { store as engineStore, AppDispatch as EngineDispatch } from "./store";
 export * as engineHooks from "./hooks";
-export * from "./utils";
+export * as engineSliceUtils from "./utils";

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -99,17 +99,20 @@ type InitialState = InitializedState;
 type InitializedState = EngineSliceState & {
   notesRendered: { [key: string]: string | undefined };
 };
+const initialState: InitialState = {
+  loading: LoadingStatus.IDLE,
+  currentRequestId: undefined,
+  vaults: [],
+  notes: {},
+  schemas: {},
+  notesRendered: {},
+  error: null,
+};
 
 export type EngineState = InitializedState;
 export const engineSlice = createSlice({
   name: "engine",
-  initialState: {
-    loading: "idle" as const,
-    notes: {},
-    schemas: {},
-    notesRendered: {},
-    error: null,
-  } as InitialState,
+  initialState,
   reducers: {
     setFromInit: (state, action: PayloadAction<DEngineInitPayload>) => {
       const { notes, wsRoot, schemas, vaults, config } = action.payload;
@@ -124,6 +127,18 @@ export const engineSlice = createSlice({
     },
     setError: (state, action: PayloadAction<any>) => {
       state.error = action.payload;
+    },
+    /**
+     * Reset all state
+     */
+    tearDown: (state) => {
+      state.loading = LoadingStatus.IDLE;
+      state.currentRequestId = undefined;
+      state.vaults = [];
+      state.notes = {};
+      state.schemas = {};
+      state.notesRendered = {};
+      state.error = null;
     },
     setRenderNote: (
       state,
@@ -173,15 +188,12 @@ export const engineSlice = createSlice({
   },
 });
 
-export class EngineSliceUtils {
-  static hasInitialized(engine: InitialState) {
-    return (
-      engine.loading === "idle" &&
-      !_.isUndefined(engine.notes) &&
-      !_.isUndefined(engine.vaults)
-    );
-  }
-}
-export const { setNotes, setError, setFromInit, setRenderNote, updateNote } =
-  engineSlice.actions;
+export const {
+  setNotes,
+  setError,
+  setFromInit,
+  setRenderNote,
+  updateNote,
+  tearDown,
+} = engineSlice.actions;
 export const reducer = engineSlice.reducer;

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -5,13 +5,14 @@ import {
   NotePropsDict,
   stringifyError,
   APIUtils,
+  NoteUtils,
 } from "@dendronhq/common-all";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import _ from "lodash";
 import { EngineSliceState, LoadingStatus } from "../../types";
 import { createLogger } from "../../utils";
 // @ts-ignore
-import internal from "@reduxjs/toolkit/node_modules/immer/dist/internal"
+import internal from "@reduxjs/toolkit/node_modules/immer/dist/internal";
 /**
  * Equivalent to engine.init
  */
@@ -135,6 +136,15 @@ export const engineSlice = createSlice({
       const note = action.payload;
       if (!state.notes) {
         state.notes = {};
+      }
+      // this is a new node
+      if (!state.notes[note.id]) {
+        NoteUtils.addParent({
+          note,
+          notesList: _.values(state.notes),
+          createStubs: true,
+          wsRoot: state.wsRoot!,
+        });
       }
       state.notes[note.id] = note;
     },

--- a/packages/common-frontend/src/features/engine/utils.ts
+++ b/packages/common-frontend/src/features/engine/utils.ts
@@ -1,0 +1,12 @@
+import _ from "lodash";
+import { EngineState } from "./slice";
+
+export class EngineSliceUtils {
+  static hasInitialized(engine: EngineState) {
+    return (
+      engine.loading === "idle" &&
+      !_.isUndefined(engine.notes) &&
+      !_.isUndefined(engine.vaults)
+    );
+  }
+}

--- a/packages/common-frontend/src/features/engine/utils.ts
+++ b/packages/common-frontend/src/features/engine/utils.ts
@@ -1,12 +1,10 @@
 import _ from "lodash";
 import { EngineState } from "./slice";
 
-export class EngineSliceUtils {
-  static hasInitialized(engine: EngineState) {
-    return (
-      engine.loading === "idle" &&
-      !_.isUndefined(engine.notes) &&
-      !_.isUndefined(engine.vaults)
-    );
-  }
-}
+export const hasInitialized = (engine: EngineState) => {
+  return (
+    engine.loading === "idle" &&
+    !_.isUndefined(engine.notes) &&
+    !_.isUndefined(engine.vaults)
+  );
+};

--- a/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-next-server/hooks/useSyncGraphWithIDE.tsx
@@ -1,12 +1,9 @@
+import { createLogger, engineSliceUtils } from "@dendronhq/common-frontend";
 import cytoscape from "cytoscape";
 import { useEffect, useState } from "react";
-import { createLogger } from "@dendronhq/common-frontend";
-import { engineSlice } from "@dendronhq/common-frontend";
-import { DendronProps } from "../lib/types";
-import { GraphConfig } from "../lib/graph";
 import { GraphUtils } from "../components/graph";
-
-const EngineSliceUtils = engineSlice.EngineSliceUtils;
+import { GraphConfig } from "../lib/graph";
+import { DendronProps } from "../lib/types";
 
 type Props = DendronProps & {
   graph: cytoscape.Core | undefined;
@@ -17,7 +14,7 @@ const useSyncGraphWithIDE = ({ graph, ide, engine, config }: Props) => {
   const [lastSelectedID, setLastSelectedID] = useState("");
 
   const { noteActive } = ide;
-  const engineInitialized = EngineSliceUtils.hasInitialized(engine);
+  const engineInitialized = engineSliceUtils.hasInitialized(engine);
 
   const logger = createLogger("useSyncGraphWithIDE");
 

--- a/packages/dendron-next-server/pages/vscode/calendar-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/calendar-view.tsx
@@ -7,22 +7,21 @@ import {
 } from "@dendronhq/common-all";
 import {
   createLogger,
-  engineSlice,
+  engineSliceUtils,
   postVSCodeMessage,
 } from "@dendronhq/common-frontend";
 import {
-  CalendarProps as AntdCalendarProps,
-  Spin,
-  Button,
-  Divider,
   Badge,
+  Button,
+  CalendarProps as AntdCalendarProps,
   ConfigProvider,
+  Divider,
+  Spin,
 } from "antd";
-
 import generateCalendar from "antd/lib/calendar/generateCalendar";
 import classNames from "classnames";
 import _ from "lodash";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import luxonGenerateConfig from "../../lib/luxon";
 import { DendronProps } from "../../lib/types";
 
@@ -60,7 +59,6 @@ function getMaybeDatePortion({ fname }: NoteProps, journalName: string) {
 }
 
 const today = luxonGenerateConfig.getNow();
-const { EngineSliceUtils } = engineSlice;
 
 function CalendarView({ engine, ide }: DendronProps) {
   // --- init
@@ -76,7 +74,7 @@ function CalendarView({ engine, ide }: DendronProps) {
 
   const [activeMode, setActiveMode] = useState<CalendarProps["mode"]>("month");
 
-  const engineInitialized = EngineSliceUtils.hasInitialized(engine);
+  const engineInitialized = engineSliceUtils.hasInitialized(engine);
 
   const { notes, config } = engine;
   const { noteActive } = ide;

--- a/packages/dendron-next-server/pages/vscode/tree-view.tsx
+++ b/packages/dendron-next-server/pages/vscode/tree-view.tsx
@@ -17,7 +17,7 @@ import {
 } from "@dendronhq/common-all";
 import {
   createLogger,
-  engineSlice,
+  engineSliceUtils,
   ideHooks,
   postVSCodeMessage,
   TreeViewUtils as CommonTreeViewUtils,
@@ -110,8 +110,6 @@ class TreeViewUtils {
   }
 }
 
-const { EngineSliceUtils } = engineSlice;
-
 function areEqual(prevProps: DendronProps, nextProps: DendronProps) {
   const logger = createLogger("treeViewContainer");
   const isDiff = _.some([
@@ -158,7 +156,7 @@ function TreeViewParent({ engine, ide }: DendronProps) {
       );
     }
   };
-  const engineInitialized = EngineSliceUtils.hasInitialized(engine);
+  const engineInitialized = engineSliceUtils.hasInitialized(engine);
   // what keys shod be open
   const { noteActive } = ide;
   // --- effects


### PR DESCRIPTION
Newly created notes were not synced with the view, leading to components
like tree view not updating when a new view was added
