### PR TITLE
feat: Goto Note can open links to non-note files

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -70,6 +70,11 @@ export function isBlockAnchor(anchor?: string): boolean {
   return !!anchor && anchor[0] === "^";
 }
 
+export function isFileAnchor(anchor?: string): boolean {
+  // not undefined, not an empty string, and the first character is L, and is followed by numbers
+  return !!anchor && /L\d+/.test(anchor);
+}
+
 /** A type guard for things that are not undefined.
  *
  * This is equivalent to !_.isUndefined(), except that it provides a type guard

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -113,7 +113,7 @@ export class VaultUtils {
     return vault;
   }
 
-  static getVaultByNotePath({
+  static getVaultByFilePath({
     vaults,
     wsRoot,
     fsPath,

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -467,7 +467,7 @@ export async function fileExists(path: string) {
  *
  * @param fpath A file name or relative path that we are searching inside vaults.
  */
-async function findFileVault({
+async function findFileInVault({
   fpath,
   wsRoot,
   vaults,
@@ -479,7 +479,7 @@ async function findFileVault({
   // Assets from later vaults will overwrite earlier ones.
   vaults = [...vaults].reverse();
   for (const vault of vaults) {
-    const fullPath = path.join(wsRoot, vault.fsPath, fpath);
+    const fullPath = path.join(wsRoot, VaultUtils.getRelPath(vault), fpath);
     // Doing this sequentially to simulate how publishing handles conflicting assets.
     // eslint-disable-next-line no-await-in-loop
     if (await fileExists(fullPath)) {
@@ -499,7 +499,7 @@ export async function findNonNoteFile(opts: {
   fpath = _.trim(fpath, "/\\");
   // Check if this is an asset first
   if (fpath.startsWith("assets")) {
-    const out = await findFileVault(opts);
+    const out = await findFileInVault(opts);
     if (out !== undefined) return out;
   }
   // If not an asset, or if we couldn't find it in assets, then check from wsRoot for out-of-vault files

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -7,6 +7,8 @@ import {
   SchemaUtils,
   DNodePropsQuickInputV2,
   NotePropsDict,
+  DEngineClient,
+  EngineWriteOptsV2,
 } from "@dendronhq/common-all";
 import {
   file2Note,
@@ -152,6 +154,24 @@ export class NoteTestUtilsV4 {
     }
     return note;
   };
+
+  /** This is like `createNote`, except it will make sure the engine is updated with the note.
+   *
+   * Prefer this over `createNote` if you are creating a note when the engine is
+   * already active. For example, when you are using `describeMultiWs` or
+   * `describeSingleWs` where the engine is already active inside the block.
+   *
+   * Avoid using this to update an existing note, this may cause issues.
+   */
+  static async createNoteWithEngine(
+    opts: Omit<CreateNoteOptsV4, "noWrite"> & { engine: DEngineClient } & {
+      engineWriteNoteOverride?: EngineWriteOptsV2;
+    }
+  ) {
+    const note = await this.createNote({ ...opts, noWrite: true });
+    await opts.engine.writeNote(note, opts.engineWriteNoteOverride);
+    return note;
+  }
 
   static async createNotePropsInput(
     opts: CreateNoteInputOpts

--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -114,7 +114,7 @@ export class WorkspaceUtils {
     fpath,
   }: { fpath: string } & WorkspaceOpts) {
     try {
-      VaultUtils.getVaultByNotePath({
+      VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: fpath,

--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -104,7 +104,7 @@ export class WSUtils {
   static getVaultFromDocument(document: vscode.TextDocument) {
     const txtPath = document.uri.fsPath;
     const { wsRoot, vaults } = getDWorkspace();
-    const vault = VaultUtils.getVaultByNotePath({
+    const vault = VaultUtils.getVaultByFilePath({
       wsRoot,
       vaults,
       fsPath: txtPath,

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -347,14 +347,14 @@ export class WorkspaceWatcher {
       const files = args.files[0];
       const { vaults, wsRoot } = getDWorkspace();
       const { oldUri, newUri } = files;
-      const oldVault = VaultUtils.getVaultByNotePath({
+      const oldVault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: oldUri.fsPath,
       });
       const oldFname = DNodeUtils.fname(oldUri.fsPath);
 
-      const newVault = VaultUtils.getVaultByNotePath({
+      const newVault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: newUri.fsPath,
@@ -396,7 +396,7 @@ export class WorkspaceWatcher {
       const fname = DNodeUtils.fname(newUri.fsPath);
       const engine = getExtension().getEngine();
       const { vaults, wsRoot } = getDWorkspace();
-      const newVault = VaultUtils.getVaultByNotePath({
+      const newVault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: newUri.fsPath,

--- a/packages/plugin-core/src/commands/GoToSiblingCommand.ts
+++ b/packages/plugin-core/src/commands/GoToSiblingCommand.ts
@@ -46,7 +46,7 @@ export class GoToSiblingCommand extends BasicCommand<
 
     const { vaults, engine, wsRoot } = getDWorkspace();
     if (value === "root") {
-      const vault = VaultUtils.getVaultByNotePath({
+      const vault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: maybeTextEditor.document.uri.fsPath,

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -250,7 +250,9 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
 
     // Non-note files use `qs` for full path, and set vault to null
     if (vault === null) {
-      await VSCodeUtils.openFileInEditor(Uri.parse(qs));
+      await VSCodeUtils.openFileInEditor(
+        Uri.from({ scheme: "file", path: qs })
+      );
       return {
         kind: "nonNote",
         fullPath: qs,

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -116,7 +116,7 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return opts;
   }
 
-  private async getExistingNote(opts: CommandOpts) {
+  private async maybeSetOptsFromExistingNote(opts: CommandOpts) {
     const { engine } = getDWorkspace();
     const notes = NoteUtils.getNotesByFname({
       fname: opts.qs!,
@@ -138,7 +138,7 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return opts;
   }
 
-  private async getExistingNonNoteFile(opts: CommandOpts) {
+  private async maybeSetOptsFromNonNote(opts: CommandOpts) {
     const { vaults, wsRoot } = getDWorkspace().engine;
     const nonNote = await findNonNoteFile({
       fpath: opts.qs!,
@@ -152,7 +152,7 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return opts;
   }
 
-  private async getNewNote(opts: CommandOpts) {
+  private async setOptsFromNewNote(opts: CommandOpts) {
     // Depending on the config, we can either
     // automatically pick the vault or we'll prompt for it.
     const confirmVaultSetting =
@@ -203,16 +203,16 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
 
     // If vault is missing, then we haven't found the note yet. Go through possible options until we find it.
     if (opts.vault === undefined) {
-      const existingNote = await this.getExistingNote(opts);
+      const existingNote = await this.maybeSetOptsFromExistingNote(opts);
       // User cancelled prompt
       if (existingNote === null) return null;
       opts = existingNote;
     }
     if (opts.vault === undefined) {
-      opts = await this.getExistingNonNoteFile(opts);
+      opts = await this.maybeSetOptsFromNonNote(opts);
     }
     if (opts.vault === undefined) {
-      const newNote = await this.getNewNote(opts);
+      const newNote = await this.setOptsFromNewNote(opts);
       // User cancelled prompt
       if (newNote === null) return null;
       opts = newNote;

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -106,7 +106,7 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
           wsRoot,
           VSCodeUtils.getActiveTextEditorOrThrow().document.fileName
         );
-        opts.vault = VaultUtils.getVaultByNotePath({
+        opts.vault = VaultUtils.getVaultByFilePath({
           wsRoot,
           vaults,
           fsPath: opts.qs,

--- a/packages/plugin-core/src/commands/PasteFile.ts
+++ b/packages/plugin-core/src/commands/PasteFile.ts
@@ -69,7 +69,7 @@ export class PasteFileCommand extends BasicCommand<CommandOpts, CommandOutput> {
       Logger.error({ error });
       return { error };
     }
-    const vault = VaultUtils.getVaultByNotePath({
+    const vault = VaultUtils.getVaultByFilePath({
       vaults,
       wsRoot,
       fsPath: uri.fsPath,

--- a/packages/plugin-core/src/commands/RenameNoteV2a.ts
+++ b/packages/plugin-core/src/commands/RenameNoteV2a.ts
@@ -114,7 +114,7 @@ export class RenameNoteV2aCommand extends BaseCommand<
       }
       const engine = ext.getEngine();
       const oldFname = DNodeUtils.fname(oldUri.fsPath);
-      const vault = VaultUtils.getVaultByNotePath({
+      const vault = VaultUtils.getVaultByFilePath({
         fsPath: oldUri.fsPath,
         wsRoot: getDWorkspace().wsRoot,
         vaults: engine.vaults,

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -203,7 +203,7 @@ export abstract class BaseExportPodCommand<
 
     const { vaults, engine, wsRoot } = getDWorkspace();
 
-    const vault = VaultUtils.getVaultByNotePath({
+    const vault = VaultUtils.getVaultByFilePath({
       vaults,
       wsRoot,
       fsPath,

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -384,7 +384,7 @@ export class PickerUtilsV2 {
       )
     ) {
       Logger.info({ ctx, activeDocument: activeDocument.fileName });
-      vault = VaultUtils.getVaultByNotePath({
+      vault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
         fsPath: activeDocument.uri.fsPath,

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -69,7 +69,8 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
           qs: refAtPos.ref,
           anchor: refAtPos.anchorStart,
         });
-        if (_.isUndefined(out)) {
+        if (out?.type !== "note") {
+          // Wasn't able to create, or not a note file
           return;
         }
         const { note, pos } = out;

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -69,7 +69,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
           qs: refAtPos.ref,
           anchor: refAtPos.anchorStart,
         });
-        if (out?.type !== "note") {
+        if (out?.kind !== "note") {
           // Wasn't able to create, or not a note file
           return;
         }

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -110,7 +110,7 @@ export class FileWatcher {
         this.L.debug({ ctx, fsPath, msg: "pre-add-to-engine" });
         const { vaults, engine } = getDWorkspace();
         const { wsRoot } = getDWorkspace();
-        const vault = VaultUtils.getVaultByNotePath({
+        const vault = VaultUtils.getVaultByFilePath({
           vaults,
           fsPath,
           wsRoot,

--- a/packages/plugin-core/src/pluginVaultUtils.ts
+++ b/packages/plugin-core/src/pluginVaultUtils.ts
@@ -22,7 +22,7 @@ export class PluginVaultUtils {
       vaults = getDWorkspace().vaults;
     }
 
-    return VaultUtils.getVaultByNotePath({
+    return VaultUtils.getVaultByFilePath({
       vaults,
       wsRoot,
       fsPath,

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -101,7 +101,7 @@ export class NoteSyncService {
     }
 
     this.L.debug({ ctx, uri: uri.fsPath });
-    const vault = VaultUtils.getVaultByNotePath({
+    const vault = VaultUtils.getVaultByFilePath({
       vaults: engine.vaults,
       wsRoot: getDWorkspace().wsRoot,
       fsPath: uri.fsPath,

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -8,7 +8,7 @@ import {
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
-import { describe } from "mocha";
+import { describe, before } from "mocha";
 import path from "path";
 import sinon from "sinon";
 import * as vscode from "vscode";
@@ -20,7 +20,11 @@ import { WSUtils } from "../../WSUtils";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
 import { getActiveEditorBasename } from "../testUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  describeMultiWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
 const { ANCHOR_WITH_SPECIAL_CHARS, ANCHOR } = GOTO_NOTE_PRESETS;
 suite("GotoNote", function () {
@@ -616,143 +620,143 @@ suite("GotoNote", function () {
       });
     });
 
-    test("non-note file", (done) => {
-      let note: NoteProps;
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NoteTestUtilsV4.createNote({
+    describe("GIVEN non-note files", () => {
+      describeMultiWS("WHEN used on a link to a non-note file", { ctx }, () => {
+        before(async () => {
+          const { wsRoot, vaults } = getDWorkspace();
+          await fs.writeFile(
+            path.join(wsRoot, "test.txt"),
+            "Et voluptatem autem sunt."
+          );
+          await fs.ensureDir(
+            path.join(wsRoot, VaultUtils.getRelPath(vaults[1]), "assets")
+          );
+          await fs.writeFile(
+            path.join(
+              wsRoot,
+              VaultUtils.getRelPath(vaults[1]),
+              "assets",
+              "test.txt"
+            ),
+            "Et hic est voluptatem eum quia quas pariatur."
+          );
+        });
+
+        test("THEN opens the non-note file", async () => {
+          const { vaults, wsRoot, engine } = getDWorkspace();
+          const note = await NoteTestUtilsV4.createNoteWithEngine({
             wsRoot,
             vault: vaults[0],
             fname: "test.note",
             body: "[[/test.txt]]",
+            engine,
           });
-          await fs.writeFile(
-            path.join(wsRoot, "test.txt"),
-            "Et voluptatem autem sunt."
-          );
-        },
-        onInit: async () => {
+
           await WSUtils.openNote(note);
           VSCodeUtils.getActiveTextEditorOrThrow().selection =
             new vscode.Selection(7, 1, 7, 1);
-
           await new GotoNoteCommand().run();
-          // Make sure this took us to the file
+
           expect(getActiveEditorBasename()).toEqual("test.txt");
           expect(
             VSCodeUtils.getActiveTextEditorOrThrow().document.getText().trim()
           ).toEqual("Et voluptatem autem sunt.");
-          done();
-        },
-      });
-    });
+        });
 
-    test("non-note file, without slash in link", (done) => {
-      let note: NoteProps;
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NoteTestUtilsV4.createNote({
-            wsRoot,
-            vault: vaults[0],
-            fname: "test.note",
-            body: "[[test.txt]]",
+        describe("AND the link doesn't include a slash", () => {
+          before(async () => {
+            const { vaults, wsRoot, engine } = getDWorkspace();
+            const note = await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "test.note",
+              body: "[[test.txt]]",
+              engine,
+            });
+
+            await WSUtils.openNote(note);
+            VSCodeUtils.getActiveTextEditorOrThrow().selection =
+              new vscode.Selection(7, 1, 7, 1);
+            await new GotoNoteCommand().run();
           });
-          await fs.writeFile(
-            path.join(wsRoot, "test.txt"),
-            "Et voluptatem autem sunt."
-          );
-        },
-        onInit: async () => {
-          await WSUtils.openNote(note);
-          VSCodeUtils.getActiveTextEditorOrThrow().selection =
-            new vscode.Selection(7, 1, 7, 1);
 
-          await new GotoNoteCommand().run();
-          // Make sure this took us to the file
-          expect(getActiveEditorBasename()).toEqual("test.txt");
-          expect(
-            VSCodeUtils.getActiveTextEditorOrThrow().document.getText().trim()
-          ).toEqual("Et voluptatem autem sunt.");
-          done();
-        },
-      });
-    });
-
-    test("note and non-note file with same name", (done) => {
-      let note: NoteProps;
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NoteTestUtilsV4.createNote({
-            wsRoot,
-            vault: vaults[0],
-            fname: "test.note",
-            body: "[[test.txt]]",
+          test("THEN opens the non-note file", async () => {
+            expect(getActiveEditorBasename()).toEqual("test.txt");
+            expect(
+              VSCodeUtils.getActiveTextEditorOrThrow().document.getText().trim()
+            ).toEqual("Et voluptatem autem sunt.");
           });
-          note = await NoteTestUtilsV4.createNote({
-            wsRoot,
-            vault: vaults[0],
-            fname: "test.txt",
-            body: "Accusantium id et sunt cum esse.",
+        });
+
+        describe("AND the link starts with assets", () => {
+          before(async () => {
+            const { vaults, wsRoot, engine } = getDWorkspace();
+            const note = await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "test.note2",
+              body: "[[assets/test.txt]]",
+              engine,
+            });
+
+            await WSUtils.openNote(note);
+            VSCodeUtils.getActiveTextEditorOrThrow().selection =
+              new vscode.Selection(7, 1, 7, 1);
+            await new GotoNoteCommand().run();
           });
-          await fs.writeFile(
-            path.join(wsRoot, "test.txt"),
-            "Voluptatibus et totam qui eligendi qui quaerat."
-          );
-        },
-        onInit: async () => {
-          await WSUtils.openNote(note);
-          VSCodeUtils.getActiveTextEditorOrThrow().selection =
-            new vscode.Selection(7, 1, 7, 1);
 
-          await new GotoNoteCommand().run();
-          // Make sure this took us to the note, and not the file
-          expect(getActiveEditorBasename()).toEqual("test.txt.md");
-          expect(
-            AssertUtils.assertInString({
-              body: VSCodeUtils.getActiveTextEditorOrThrow().document.getText(),
-              match: ["Accusantium id et sunt cum esse."],
-              nomatch: ["Voluptatibus et totam qui eligendi qui quaerat."],
-            })
-          ).toBeTruthy();
-          done();
-        },
-      });
-    });
-
-    test("non-note asset file", (done) => {
-      let note: NoteProps;
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NoteTestUtilsV4.createNote({
-            wsRoot,
-            vault: vaults[0],
-            fname: "test.note",
-            body: "[[/assets/test.txt]]",
+          test("THEN opens the non-note file inside assets", async () => {
+            expect(getActiveEditorBasename()).toEqual("test.txt");
+            expect(
+              VSCodeUtils.getActiveTextEditorOrThrow().document.getText().trim()
+            ).toEqual("Et hic est voluptatem eum quia quas pariatur.");
           });
-          await fs.ensureDir(path.join(wsRoot, vaults[1].fsPath, "assets"));
-          await fs.writeFile(
-            path.join(wsRoot, vaults[1].fsPath, "assets", "test.txt"),
-            "Et hic est voluptatem eum quia quas pariatur."
-          );
-        },
-        onInit: async () => {
-          await WSUtils.openNote(note);
-          VSCodeUtils.getActiveTextEditorOrThrow().selection =
-            new vscode.Selection(7, 1, 7, 1);
-
-          await new GotoNoteCommand().run();
-          // Make sure this took us to the file
-          expect(getActiveEditorBasename()).toEqual("test.txt");
-          expect(
-            VSCodeUtils.getActiveTextEditorOrThrow().document.getText().trim()
-          ).toEqual("Et hic est voluptatem eum quia quas pariatur.");
-          done();
-        },
+        });
       });
+
+      describeMultiWS(
+        "WHEN there's a note and non-note file with the same name",
+        { ctx },
+        () => {
+          before(async () => {
+            const { wsRoot, vaults, engine } = getDWorkspace();
+            const note = await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "test.note",
+              body: "[[test.txt]]",
+              engine,
+            });
+            await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "test.txt",
+              body: "Accusantium id et sunt cum esse.",
+              engine,
+            });
+            await fs.writeFile(
+              path.join(wsRoot, "test.txt"),
+              "Et voluptatem autem sunt."
+            );
+
+            await WSUtils.openNote(note);
+            VSCodeUtils.getActiveTextEditorOrThrow().selection =
+              new vscode.Selection(7, 1, 7, 1);
+            await new GotoNoteCommand().run();
+          });
+
+          test("THEN opens the note", async () => {
+            expect(getActiveEditorBasename()).toEqual("test.txt.md");
+            expect(
+              AssertUtils.assertInString({
+                body: VSCodeUtils.getActiveTextEditorOrThrow().document.getText(),
+                match: ["Accusantium id et sunt cum esse."],
+                nomatch: ["Voluptatibus et totam qui eligendi qui quaerat."],
+              })
+            ).toBeTruthy();
+          });
+        }
+      );
     });
   });
 });

--- a/packages/plugin-core/src/views/DendronTreeView.ts
+++ b/packages/plugin-core/src/views/DendronTreeView.ts
@@ -213,7 +213,7 @@ export class DendronTreeView {
       return;
     }
     if (basename.endsWith(".md")) {
-      const vault = VaultUtils.getVaultByNotePath({
+      const vault = VaultUtils.getVaultByFilePath({
         fsPath: uri.fsPath,
         wsRoot,
         vaults,

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -126,7 +126,7 @@ export function resolveRelToWSRoot(fpath: string): string {
 /** Given file uri that is within a vault within the current workspace returns the vault. */
 export function getVaultFromUri(fileUri: Uri) {
   const { vaults } = getDWorkspace();
-  const vault = VaultUtils.getVaultByNotePath({
+  const vault = VaultUtils.getVaultByFilePath({
     fsPath: fileUri.fsPath,
     vaults,
     wsRoot: getDWorkspace().wsRoot,


### PR DESCRIPTION
This works by writing relative paths from the `wsRoot` in wikilinks. For example,
`[[/src/index.js]]` will open `${wsRoot}/src/index.js`.

- `[[/src/index.js]]` and `[[src/index.js]]` will function in the same way to maintain compatibility with how Dendron handles wikilinks.
- If the path starts with `/assets`, then it's handled in a special way where we'll instead search for it in `assets` folders within each vault first. This maintains compatibility with how assets work in publishing.
- This only works for existing files, creating non-existing files is not supported.
- If a note and a file with the same name exist (e.g. there's a `file.txt` under `wsRoot` and `file.txt.md` in some vault, and link is `[[file.txt]]`), then the note gets priority to avoid breaking existing links.

Docs: https://github.com/dendronhq/dendron-site/pull/313