### PR TITLE
chore: adding additional tests for including inline schema in regular schema

### DIFF
--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
@@ -252,6 +252,28 @@ describe(`schemaParser tests:`, () => {
       expect(payload.errors).toEqual(null);
     });
 
+    describe(`AND parsing non line part of schema which uses local child id`, () => {
+      let plainSchema: SchemaProps;
+
+      beforeAll(() => {
+        plainSchema = inlined.schemas["plain_schema"];
+      });
+
+      it("THEN schema is found and has child schema", () => {
+        expect(plainSchema.children[0]).toEqual("plain_schema_child");
+      });
+
+      it("THEN child of plain schema has a valid template", () => {
+        expect(
+          inlined.schemas[plainSchema.children[0]].data?.template?.id
+        ).toEqual("templates.example");
+      });
+
+      it("THEN plain schema is able to have inline schema as a child", () => {
+        expect(plainSchema.children[1]).toEqual("daily");
+      });
+    });
+
     describe(`AND parsing non inline part of schema which contains imported id`, () => {
       let foosParent: SchemaProps;
 
@@ -270,14 +292,14 @@ describe(`schemaParser tests:`, () => {
 
     describe(`AND inline schema is parsed`, () => {
       it(`THEN inlined root has daily id`, () => {
-        expect(inlined.root.id).toEqual("daily");
+        expect(inlined.schemas["daily"]).toBeDefined();
       });
 
       describe(`AND daily has journal child`, () => {
         let journal: SchemaProps;
 
         beforeAll(() => {
-          journal = inlined.schemas[inlined.root.children[0]];
+          journal = inlined.schemas["journal"];
         });
 
         it(`THEN patternless journal id is equal to journal`, () => {

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -344,6 +344,11 @@ version: 1
 imports: 
   - foo
 schemas:
+  - id: plain_schema
+    parent: root
+    children:
+      - plain_schema_child
+      - daily
   - id: daily
     parent: root
     children:
@@ -367,6 +372,8 @@ schemas:
     children:
       - pattern: has_untyped_template
         template: templates.untyped
+  - id: plain_schema_child
+    template: templates.example
 `
   );
 
@@ -374,6 +381,13 @@ schemas:
     wsRoot,
     body: "Template text",
     fname: "templates.day",
+    vault: vault1,
+  });
+
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    body: "Template text",
+    fname: "templates.example",
     vault: vault1,
   });
 

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -61,7 +61,7 @@ runSuiteButSkipForWindows()(
           const testNote = engine.notes["foo"];
           expect(testNote).toBeTruthy();
 
-          const opened = await WSUtils.openSchema(engine.schemas.daily);
+          const opened = await WSUtils.openSchema(engine.schemas.plain_schema);
 
           expect(doesSchemaExist("new_schema")).toBeFalsy();
 


### PR DESCRIPTION
# chore: adding additional tests for including inline schema in regular schema

Appears as we are able to add inline schema under non inline schema. 

## Attempt to reproduce
Created a new template in test workspace (there is already note foo.one so named it baz)
```yaml
version: 1
imports: []
schemas:
  - id: baz
    parent: root
    children: 
      - one
      - journal
  - id: one
    template: templates.hi
  - id: journal
    pattern: "[0-2][0-9][0-9][0-9]"
    children:
      - pattern: "[0-1][0-9]"
        children:
          - pattern: "[0-3][0-9]"
            template: templates.hi 
```
Was able to create note `baz.one` which showed schema icon and created a note with template https://www.loom.com/share/b1ba56eb56d7488281b513bcd9f8f002 

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
