### PR TITLE
enhance(publish): Fallback to default SEO image if no image is set for published pages.

### DIFF
--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -552,7 +552,11 @@ export type DendronSiteConfig = {
   description?: string;
   author?: string;
   twitter?: string;
-  image?: string;
+  /** Default SEO image for published pages */
+  image?: {
+    url: string;
+    alt: string;
+  };
 
   /**
    * Use {@link https://github.com/Nevenall/remark-containers} in published site

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -564,15 +564,6 @@ export class ConfigUtils {
       : ConfigUtils.getPreview(config).enablePrettyRefs;
   }
 
-  static getAutomaticallyShowPreview(
-    config: IntermediateDendronConfig,
-    shouldApplyPublishRules?: boolean
-  ): boolean | undefined {
-    return shouldApplyPublishRules
-      ? ConfigUtils.getProp(config, "useNoteTitleForLink") // TODO fix
-      : ConfigUtils.getPreview(config).automaticallyShowPreview;
-  }
-
   // set
   static setProp<K extends keyof StrictConfigV4>(
     config: IntermediateDendronConfig,

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -388,11 +388,12 @@ export class PublishUtils {
   static getSEOPropsFromConfig(
     config: IntermediateDendronConfig
   ): Partial<SEOProps> {
-    const { title, twitter, description: excerpt } = config.site;
+    const { title, twitter, description: excerpt, image } = config.site;
     return {
       title,
       twitter,
       excerpt,
+      image,
     };
   }
   static getSEOPropsFromNote(note: NoteProps): SEOProps {
@@ -561,6 +562,15 @@ export class ConfigUtils {
     return shouldApplyPublishRules
       ? ConfigUtils.getSite(config).usePrettyRefs
       : ConfigUtils.getPreview(config).enablePrettyRefs;
+  }
+
+  static getAutomaticallyShowPreview(
+    config: IntermediateDendronConfig,
+    shouldApplyPublishRules?: boolean
+  ): boolean | undefined {
+    return shouldApplyPublishRules
+      ? ConfigUtils.getProp(config, "useNoteTitleForLink") // TODO fix
+      : ConfigUtils.getPreview(config).automaticallyShowPreview;
   }
 
   // set

--- a/packages/nextjs-template/components/DendronSEO.tsx
+++ b/packages/nextjs-template/components/DendronSEO.tsx
@@ -1,10 +1,11 @@
 import {
-  IntermediateDendronConfig,
+  ConfigUtils,
   DendronSiteConfig,
+  IntermediateDendronConfig,
   NoteProps,
+  PublishUtils,
   SEOProps,
   Time,
-  PublishUtils,
 } from "@dendronhq/common-all";
 import _ from "lodash";
 import { NextSeo, NextSeoProps } from "next-seo";
@@ -52,6 +53,7 @@ export default function DendronSEO({
 }) {
   const dendronRouter = useDendronRouter();
   const path = dendronRouter.router.asPath;
+  const siteConfig = ConfigUtils.getSite(config);
 
   // don't generate for following pages
   if (
@@ -68,7 +70,8 @@ export default function DendronSEO({
 
   const title = cleanSeoProps.title;
   const description = cleanSeoProps.excerpt;
-  const images = cleanSeoProps?.image ? [cleanSeoProps.image] : [];
+  const defaultImages = siteConfig?.image ? [siteConfig.image] : [];
+  const images = cleanSeoProps?.image ? [cleanSeoProps.image] : defaultImages;
   const canonical = getCanonicalUrl({
     sitePath: path,
     seoProps: cleanSeoProps,

--- a/packages/nextjs-template/components/DendronSEO.tsx
+++ b/packages/nextjs-template/components/DendronSEO.tsx
@@ -1,5 +1,4 @@
 import {
-  ConfigUtils,
   DendronSiteConfig,
   IntermediateDendronConfig,
   NoteProps,
@@ -53,7 +52,6 @@ export default function DendronSEO({
 }) {
   const dendronRouter = useDendronRouter();
   const path = dendronRouter.router.asPath;
-  const siteConfig = ConfigUtils.getSite(config);
 
   // don't generate for following pages
   if (
@@ -70,8 +68,7 @@ export default function DendronSEO({
 
   const title = cleanSeoProps.title;
   const description = cleanSeoProps.excerpt;
-  const defaultImages = siteConfig?.image ? [siteConfig.image] : [];
-  const images = cleanSeoProps?.image ? [cleanSeoProps.image] : defaultImages;
+  const images = cleanSeoProps?.image ? [cleanSeoProps.image] : [];
   const canonical = getCanonicalUrl({
     sitePath: path,
     seoProps: cleanSeoProps,


### PR DESCRIPTION
* Updated image field of DendronSiteConfig to represent default SEO image
* See [[Fallback Seo|dendron://private/task.publish.2021.11.24.fallback-seo]]

Manual Test
* Update dendron.yml to include default image field
* Run NextJs against test workspace. [[Test|dendron://dendron.docs/pkg.nextjs-template.qa.test]]
* Open http://localhost:3000/notes/boy2/ and view page source
* Verified image in meta property="og:image"
