### PR TITLE
fix(views): encapsulate webviews

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -45,6 +45,10 @@ import { ALL_COMMANDS } from "./commands";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";
 import { ReloadIndexCommand } from "./commands/ReloadIndex";
+import {
+  SeedBrowseCommand,
+  WebViewPanelFactory,
+} from "./commands/SeedBrowseCommand";
 import { ShowNoteGraphCommand } from "./commands/ShowNoteGraph";
 import { ShowPreviewCommand } from "./commands/ShowPreview";
 import { ShowSchemaGraphCommand } from "./commands/ShowSchemaGraph";
@@ -1064,6 +1068,22 @@ async function _setupCommands(
           await new ShowNoteGraphCommand(
             NoteGraphPanelFactory.create(ws)
           ).run();
+        })
+      )
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.SEED_BROWSE.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.SEED_BROWSE.key,
+        sentryReportingCallback(async () => {
+          const panel = WebViewPanelFactory.create(
+            ws.workspaceService!.seedService
+          );
+          const cmd = new SeedBrowseCommand(panel);
+
+          return cmd.run();
         })
       )
     );

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -45,6 +45,12 @@ import { ALL_COMMANDS } from "./commands";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";
 import { ReloadIndexCommand } from "./commands/ReloadIndex";
+import { ShowNoteGraphCommand } from "./commands/ShowNoteGraph";
+import { ShowPreviewCommand } from "./commands/ShowPreview";
+import { ShowSchemaGraphCommand } from "./commands/ShowSchemaGraph";
+import { NoteGraphPanelFactory } from "./components/views/NoteGraphViewFactory";
+import { PreviewPanelFactory } from "./components/views/PreviewViewFactory";
+import { SchemaGraphViewFactory } from "./components/views/SchemaGraphViewFactory";
 import {
   CONFIG,
   DendronContext,
@@ -318,7 +324,7 @@ export async function _activate(
     });
 
     // Setup the commands
-    _setupCommands(context);
+    _setupCommands(ws, context);
     _setupLanguageFeatures(context);
 
     // Need to recompute this for tests, because the instance of DendronExtension doesn't get re-created.
@@ -954,7 +960,10 @@ export function shouldDisplayLapsedUserMsg(): boolean {
   );
 }
 
-async function _setupCommands(context: vscode.ExtensionContext) {
+async function _setupCommands(
+  ws: DendronExtension,
+  context: vscode.ExtensionContext
+) {
   const existingCommands = await vscode.commands.getCommands();
 
   ALL_COMMANDS.map((Cmd) => {
@@ -1018,6 +1027,43 @@ async function _setupCommands(context: vscode.ExtensionContext) {
             useSameVault: true,
             ...args,
           });
+        })
+      )
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.SHOW_PREVIEW.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.SHOW_PREVIEW.key,
+        sentryReportingCallback(async () => {
+          await new ShowPreviewCommand(PreviewPanelFactory.create(ws)).run();
+        })
+      )
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.SHOW_SCHEMA_GRAPH.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.SHOW_SCHEMA_GRAPH.key,
+        sentryReportingCallback(async () => {
+          await new ShowSchemaGraphCommand(
+            SchemaGraphViewFactory.create(ws)
+          ).run();
+        })
+      )
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key,
+        sentryReportingCallback(async () => {
+          await new ShowNoteGraphCommand(
+            NoteGraphPanelFactory.create(ws)
+          ).run();
         })
       )
     );

--- a/packages/plugin-core/src/commands/SeedBrowseCommand.ts
+++ b/packages/plugin-core/src/commands/SeedBrowseCommand.ts
@@ -4,12 +4,11 @@ import {
   SeedBrowserMessage,
   SeedBrowserMessageType,
 } from "@dendronhq/common-all";
-import _ from "lodash";
+import { SeedService } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WebViewUtils } from "../views/utils";
-import { getExtension } from "../workspace";
 import { SeedAddCommand } from "./SeedAddCommand";
 import { SeedCommandBase } from "./SeedCommandBase";
 
@@ -17,77 +16,99 @@ type CommandOpts = {};
 
 type CommandOutput = void;
 
+export class WebViewPanelFactory {
+  private static panel: vscode.WebviewPanel | undefined = undefined;
+
+  static create(svc: SeedService): vscode.WebviewPanel {
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        "dendronIframe",
+        "Seed Registry",
+        {
+          viewColumn: ViewColumn.Active,
+          preserveFocus: false,
+        },
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          enableFindWidget: true,
+        }
+      );
+
+      this.panel.webview.onDidReceiveMessage(
+        async (msg: SeedBrowserMessage) => {
+          switch (msg.type) {
+            case SeedBrowserMessageType.onSeedAdd: {
+              const cmd = new SeedAddCommand();
+              const resp = await cmd.execute({ seedId: msg.data.data });
+
+              // Error should already be logged within SeedAddCommand()
+              if (!resp.error) {
+                this.panel?.webview.postMessage({
+                  type: SeedBrowserMessageType.onSeedStateChange,
+                  data: {
+                    msg: svc.getSeedsInWorkspace(),
+                  },
+                  source: "vscode",
+                });
+              }
+
+              break;
+            }
+            case SeedBrowserMessageType.onOpenUrl: {
+              vscode.env.openExternal(vscode.Uri.parse(msg.data.data));
+              break;
+            }
+            case DMessageEnum.MESSAGE_DISPATCHER_READY: {
+              this.panel?.webview.postMessage({
+                type: SeedBrowserMessageType.onSeedStateChange,
+                data: {
+                  msg: svc.getSeedsInWorkspace(),
+                },
+                source: "vscode",
+              });
+              break;
+            }
+
+            default:
+              break;
+          }
+        }
+      );
+
+      this.panel.onDidDispose(() => {
+        this.panel = undefined;
+      });
+    }
+
+    return this.panel;
+  }
+}
+
 export class SeedBrowseCommand extends SeedCommandBase<
   CommandOpts,
   CommandOutput
 > {
+  _panel: vscode.WebviewPanel;
+
+  constructor(panel: vscode.WebviewPanel) {
+    super();
+    this._panel = panel;
+  }
+
   key = DENDRON_COMMANDS.SEED_BROWSE.key;
   async gatherInputs(): Promise<any> {
     return {};
   }
+
   async execute() {
-    const existingPanel = getExtension().getWebView(
-      DendronEditorViewKey.SEED_BROWSER
-    );
-
-    if (!_.isUndefined(existingPanel)) {
-      existingPanel.reveal();
-      return;
-    }
-
-    // If panel does not exist
-    const panel = vscode.window.createWebviewPanel(
-      "dendronIframe",
-      "Seed Registry",
-      {
-        viewColumn: ViewColumn.Active,
-        preserveFocus: false,
-      },
-      {
-        enableScripts: true,
-        retainContextWhenHidden: true,
-        enableFindWidget: true,
-      }
-    );
-
     const resp = await WebViewUtils.genHTMLForWebView({
       title: "Seed Browser",
       view: DendronEditorViewKey.SEED_BROWSER,
     });
 
-    panel.webview.html = resp;
+    this._panel.webview.html = resp;
 
-    panel.webview.onDidReceiveMessage(async (msg: SeedBrowserMessage) => {
-      switch (msg.type) {
-        case SeedBrowserMessageType.onSeedAdd: {
-          const cmd = new SeedAddCommand();
-          const resp = await cmd.execute({ seedId: msg.data.data });
-
-          // Error should already be logged within SeedAddCommand()
-          if (!resp.error) {
-            this.postSeedStateToWebview();
-          }
-
-          break;
-        }
-        case SeedBrowserMessageType.onOpenUrl: {
-          vscode.env.openExternal(vscode.Uri.parse(msg.data.data));
-          break;
-        }
-        case DMessageEnum.MESSAGE_DISPATCHER_READY: {
-          this.postSeedStateToWebview();
-          break;
-        }
-
-        default:
-          break;
-      }
-    });
-
-    getExtension().setWebView(DendronEditorViewKey.SEED_BROWSER, panel);
-
-    panel.onDidDispose(() => {
-      getExtension().setWebView(DendronEditorViewKey.SEED_BROWSER, undefined);
-    });
+    this._panel.reveal();
   }
 }

--- a/packages/plugin-core/src/commands/SeedCommandBase.ts
+++ b/packages/plugin-core/src/commands/SeedCommandBase.ts
@@ -1,9 +1,4 @@
-import {
-  DendronError,
-  DendronEditorViewKey,
-  ERROR_SEVERITY,
-  SeedBrowserMessageType,
-} from "@dendronhq/common-all";
+import { DendronError, ERROR_SEVERITY } from "@dendronhq/common-all";
 import { SeedService } from "@dendronhq/engine-server";
 import { commands } from "vscode";
 import { WORKSPACE_ACTIVATION_CONTEXT } from "../constants";
@@ -45,20 +40,6 @@ export abstract class SeedCommandBase<
     }
 
     return this.seedSvc;
-  }
-
-  protected postSeedStateToWebview() {
-    const existingPanel = getExtension().getWebView(
-      DendronEditorViewKey.SEED_BROWSER
-    );
-
-    existingPanel?.webview.postMessage({
-      type: SeedBrowserMessageType.onSeedStateChange,
-      data: {
-        msg: this.getSeedSvc().getSeedsInWorkspace(),
-      },
-      source: "vscode",
-    });
   }
 
   protected async onUpdatingWorkspace() {

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -1,23 +1,10 @@
-import {
-  DendronEditorViewKey,
-  DMessageEnum,
-  GraphViewMessage,
-  GraphViewMessageType,
-  NoteProps,
-} from "@dendronhq/common-all";
-import _ from "lodash";
-import { commands, ViewColumn, window } from "vscode";
+import { DendronEditorViewKey } from "@dendronhq/common-all";
+import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { GraphStyleService } from "../styles";
-import { VSCodeUtils } from "../vsCodeUtils";
 import { WebViewUtils } from "../views/utils";
-import { getEngine, getExtension } from "../workspace";
 import { BasicCommand } from "./base";
-import { GotoNoteCommand } from "./GotoNote";
-import { WSUtils } from "../WSUtils";
 
 type CommandOpts = {};
-
 type CommandOutput = void;
 
 export class ShowNoteGraphCommand extends BasicCommand<
@@ -25,117 +12,25 @@ export class ShowNoteGraphCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key;
+
+  private _panel;
+
+  constructor(panel: vscode.WebviewPanel) {
+    super();
+    this._panel = panel;
+  }
   async gatherInputs(): Promise<any> {
     return {};
   }
-  static refresh(note: NoteProps) {
-    const panel = getExtension().getWebView(DendronEditorViewKey.NOTE_GRAPH);
-    if (panel) {
-      // panel.title = `${title} ${note.fname}`;
-      panel.webview.postMessage({
-        type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-        data: {
-          note,
-          sync: true,
-        },
-        source: "vscode",
-      });
-    }
-  }
+
   async execute() {
-    const title = "Note Graph";
-
-    // Get workspace information
-    const ext = getExtension();
-
-    // If panel already exists
-    const existingPanel = ext.getWebView(DendronEditorViewKey.NOTE_GRAPH);
-
-    if (!_.isUndefined(existingPanel)) {
-      try {
-        // If error, panel disposed and needs to be recreated
-        existingPanel.reveal();
-        return;
-      } catch (error) {
-        console.error(error);
-      }
-    }
-
-    // If panel does not exist
-    const panel = window.createWebviewPanel(
-      "dendronIframe", // Identifies the type of the webview. Used internally
-      title, // Title of the panel displayed to the user
-      {
-        viewColumn: ViewColumn.Beside,
-        preserveFocus: true,
-      }, // Editor column to show the new webview panel in.
-      {
-        enableScripts: true,
-        retainContextWhenHidden: true,
-        enableFindWidget: true,
-      }
-    );
-
     const resp: string = await WebViewUtils.genHTMLForWebView({
       title: "Dendron Graph",
       view: DendronEditorViewKey.NOTE_GRAPH,
     });
 
-    panel.webview.html = resp;
+    this._panel.webview.html = resp;
 
-    // Listener
-    panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
-      switch (msg.type) {
-        case GraphViewMessageType.onSelect: {
-          const note = getEngine().notes[msg.data.id];
-          await commands.executeCommand(
-            "workbench.action.focusFirstEditorGroup"
-          );
-          await new GotoNoteCommand().execute({
-            qs: note.fname,
-            vault: note.vault,
-          });
-          break;
-        }
-        case GraphViewMessageType.onGetActiveEditor: {
-          const activeTextEditor = VSCodeUtils.getActiveTextEditor();
-          const note =
-            activeTextEditor &&
-            WSUtils.getNoteFromDocument(activeTextEditor.document);
-          if (note) {
-            ShowNoteGraphCommand.refresh(note);
-          }
-          break;
-        }
-        case GraphViewMessageType.onRequestGraphStyle: {
-          // Set graph styles
-          const styles = GraphStyleService.getParsedStyles();
-          if (styles) {
-            panel.webview.postMessage({
-              type: "onGraphStyleLoad",
-              data: {
-                styles,
-              },
-              source: "vscode",
-            });
-          }
-          break;
-        }
-        // case GraphViewMessageType.onReady: {
-        //   const profile = getDurationMilliseconds(start);
-        //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });
-        //   AnalyticsUtils.track(VSCodeEvents.TreeView_Ready, {
-        //     duration: profile,
-        //   });
-        //   break;
-        // }
-        default:
-          console.log("got data", msg);
-          break;
-      }
-    });
-
-    // Update workspace-wide graph panel
-    ext.setWebView(DendronEditorViewKey.NOTE_GRAPH, panel);
+    this._panel.reveal();
   }
 }

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -310,7 +310,6 @@ export class ShowPreviewCommand extends BasicCommand<
   }
 
   async execute(_opts?: CommandOpts) {
-    // const ctx = "ShowPreview";
     const ext = getExtension();
     const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
     const preserveFocus = true;

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -1,8 +1,5 @@
 import {
-  assertUnreachable,
   DendronError,
-  DendronEditorViewKey,
-  DMessageEnum,
   DNoteAnchor,
   ErrorFactory,
   ERROR_STATUS,
@@ -10,9 +7,7 @@ import {
   NotePropsDict,
   NoteUtils,
   NoteViewMessage,
-  NoteViewMessageEnum,
   VaultUtils,
-  getWebEditorViewEntry,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import _ from "lodash";
@@ -22,10 +17,9 @@ import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
 import { QuickPickUtil } from "../utils/quickPick";
-import { PreviewUtils, WebViewUtils } from "../views/utils";
+import { WebViewUtils } from "../views/utils";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getEngine, getExtension } from "../workspace";
-import { WSUtils } from "../WSUtils";
 import { BasicCommand } from "./base";
 import { GotoNoteCommand } from "./GotoNote";
 
@@ -82,28 +76,6 @@ export enum LinkType {
   MARKDOWN = "MARKDOWN",
   UNKNOWN = "UNKNOWN",
 }
-
-const classifyLink = ({ href }: NoteViewMessage["data"]): LinkType => {
-  if (href && href.startsWith("vscode-webview") && href.includes("/assets/")) {
-    // Note: currently even when the wiki link is fully vault qualified as example
-    // of [[dendron://assets/note-in-asset-vault]] When it is clicked within the preview
-    // the href will look along the lines of:
-    // `vscode-webview://72db5b4c-61f8-400b-808c-771184cb3d7f/r68Zw7OChUZWvbD10qqmY`
-    // href will contain the id of the note but it will NOT contain the vault
-    // hence we should avoid the issue of parsing 'assets' vault name even if someone names their
-    // vault 'assets'.
-    return LinkType.ASSET;
-  } else if (href && href.startsWith("vscode-webview")) {
-    return LinkType.WIKI;
-  } else if (
-    href &&
-    (href.startsWith("http://") || href.startsWith("https://"))
-  ) {
-    return LinkType.WEBSITE;
-  } else {
-    return LinkType.UNKNOWN;
-  }
-};
 
 /** This wrapper class is mostly here to allow easier stubbing for testing. */
 export class ShowPreviewNoteUtil {
@@ -324,6 +296,12 @@ export class ShowPreviewCommand extends BasicCommand<
 > {
   key = DENDRON_COMMANDS.SHOW_PREVIEW.key;
 
+  _panel: vscode.WebviewPanel;
+  constructor(previewPanel: vscode.WebviewPanel) {
+    super();
+    this._panel = previewPanel;
+  }
+
   async sanityCheck() {
     if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
       return "No document open";
@@ -332,110 +310,26 @@ export class ShowPreviewCommand extends BasicCommand<
   }
 
   async execute(_opts?: CommandOpts) {
-    const ctx = "ShowPreview";
+    // const ctx = "ShowPreview";
     const ext = getExtension();
-    const existingPanel = ext.getWebView(DendronEditorViewKey.NOTE_PREVIEW);
     const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
     const preserveFocus = true;
     const port = ext.port!;
     const wsRoot = ext.getEngine().wsRoot;
 
-    // show existing panel if exist
-    if (!_.isUndefined(existingPanel)) {
-      Logger.info({ ctx, msg: "reveal existing" });
-      try {
-        // If error, panel disposed and needs to be recreated
-        existingPanel.reveal(viewColumn, preserveFocus);
-        return;
-      } catch (error: any) {
-        Logger.error({ ctx, error });
-      }
-    }
-    Logger.info({ ctx, msg: "creating new" });
-
-    const { bundleName: name, label } = getWebEditorViewEntry(
-      DendronEditorViewKey.NOTE_PREVIEW
-    );
-    const panel = vscode.window.createWebviewPanel(
-      name,
-      label,
-      {
-        viewColumn,
-        preserveFocus,
-      },
-      {
-        enableScripts: true,
-        retainContextWhenHidden: true,
-        enableFindWidget: true,
-        localResourceRoots: WebViewUtils.getLocalResourceRoots(ext.context),
-      }
-    );
+    const name = "notePreview";
 
     const webViewAssets = WebViewUtils.getJsAndCss(name);
-    panel.webview.onDidReceiveMessage(async (msg: NoteViewMessage) => {
-      const ctx = "ShowPreview:onDidReceiveMessage";
-      Logger.debug({ ctx, msgType: msg.type });
-      switch (msg.type) {
-        case DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR:
-        case DMessageEnum.INIT: {
-          // do nothing
-          break;
-        }
-        case DMessageEnum.MESSAGE_DISPATCHER_READY: {
-          // if ready, get current note
-          const note = WSUtils.getActiveNote();
-          if (note) {
-            Logger.debug({
-              ctx,
-              msg: "got active note",
-              note: NoteUtils.toLogObj(note),
-            });
-            PreviewUtils.refresh(note);
-          }
-          break;
-        }
-        case NoteViewMessageEnum.onClick: {
-          const { data } = msg;
-          const linkType = classifyLink(data);
-          await handleLink({
-            linkType,
-            data,
-            wsRoot: getEngine().wsRoot,
-          });
-          break;
-        }
-        case NoteViewMessageEnum.onGetActiveEditor: {
-          // only entered on "init" in `plugin-core/src/views/utils.ts:87`
-          Logger.debug({ ctx, "msg.type": "onGetActiveEditor" });
-          const activeTextEditor = VSCodeUtils.getActiveTextEditor();
-          const maybeNote = !_.isUndefined(activeTextEditor)
-            ? WSUtils.tryGetNoteFromDocument(activeTextEditor?.document)
-            : undefined;
-          if (!_.isUndefined(maybeNote)) PreviewUtils.refresh(maybeNote);
-          break;
-        }
-        default:
-          assertUnreachable(msg.type);
-      }
-    });
 
     const html = WebViewUtils.getWebviewContent({
       ...webViewAssets,
       port,
       wsRoot,
-      panel,
+      panel: this._panel,
     });
-    panel.webview.html = html;
 
-    // Update workspace-wide panel
-    ext.setWebView(DendronEditorViewKey.NOTE_PREVIEW, panel);
+    this._panel.webview.html = html;
 
-    // remove webview from workspace when user closes it
-    // this prevents throwing `Uncaught Error: Webview is disposed` in `ShowPreviewCommand#refresh`
-    panel.onDidDispose(() => {
-      const ctx = "ShowPreview:onDidDispose";
-      Logger.debug({ ctx, state: "dispose preview" });
-      ext.setWebView(DendronEditorViewKey.NOTE_PREVIEW, undefined);
-    });
+    this._panel.reveal(viewColumn, preserveFocus);
   }
 }

--- a/packages/plugin-core/src/commands/ShowSchemaGraph.ts
+++ b/packages/plugin-core/src/commands/ShowSchemaGraph.ts
@@ -1,16 +1,7 @@
-import {
-  DendronEditorViewKey,
-  GraphViewMessage,
-  GraphViewMessageType,
-  VaultUtils,
-} from "@dendronhq/common-all";
-import _ from "lodash";
-import path from "path";
-import vscode, { Uri, ViewColumn, window } from "vscode";
+import { DendronEditorViewKey } from "@dendronhq/common-all";
+import vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { VSCodeUtils } from "../vsCodeUtils";
 import { WebViewUtils } from "../views/utils";
-import { getExtension, getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -22,123 +13,24 @@ export class ShowSchemaGraphCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.SHOW_SCHEMA_GRAPH.key;
+
+  _panel: vscode.WebviewPanel;
+
+  constructor(panel: vscode.WebviewPanel) {
+    super();
+    this._panel = panel;
+  }
+
   async gatherInputs(): Promise<any> {
     return {};
   }
+
   async execute() {
-    const title = "Schema Graph";
-
-    // Get workspace information
-    const ext = getExtension();
-
-    // If panel already exists
-    const existingPanel = ext.getWebView(DendronEditorViewKey.SCHEMA_GRAPH);
-
-    if (!_.isUndefined(existingPanel)) {
-      try {
-        // If error, panel disposed and needs to be recreated
-        existingPanel.reveal();
-        return;
-      } catch (error) {
-        console.error(error);
-      }
-    }
-
-    // If panel does not exist
-    const panel = window.createWebviewPanel(
-      "dendronIframe", // Identifies the type of the webview. Used internally
-      title, // Title of the panel displayed to the user
-      {
-        viewColumn: ViewColumn.Beside,
-        preserveFocus: true,
-      }, // Editor column to show the new webview panel in.
-      {
-        enableScripts: true,
-        retainContextWhenHidden: true,
-        enableFindWidget: true,
-      }
-    );
-
     const resp: string = await WebViewUtils.genHTMLForWebView({
       title: "Schema Graph",
       view: DendronEditorViewKey.SCHEMA_GRAPH,
     });
 
-    panel.webview.html = resp;
-
-    // Listener
-    panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
-      switch (msg.type) {
-        case GraphViewMessageType.onSelect: {
-          const engine = getExtension().getEngine();
-          const schema = engine.schemas[msg.data.id];
-
-          const { wsRoot } = getDWorkspace();
-
-          await vscode.commands.executeCommand(
-            "workbench.action.focusFirstEditorGroup"
-          );
-          if (msg.data.vault && wsRoot) {
-            const vaults = engine.vaults.filter(
-              (v) => VaultUtils.getName(v) === msg.data.vault
-            );
-            if (_.isEmpty(vaults)) return;
-
-            const schemaPath = path.join(
-              wsRoot,
-              vaults[0].fsPath,
-              `root.schema.yml`
-            );
-            const uri = Uri.file(schemaPath);
-
-            await VSCodeUtils.openFileInEditor(uri);
-          } else if (schema && wsRoot) {
-            const fname = schema.fname;
-            // const vault = schema.vault;
-
-            const schemaPath = path.join(
-              wsRoot,
-              schema.vault.fsPath,
-              `${fname}.schema.yml`
-            );
-            const uri = Uri.file(schemaPath);
-
-            await VSCodeUtils.openFileInEditor(uri);
-          }
-          break;
-        }
-        // case GraphViewMessageType.onGetActiveEditor: {
-        //   const document = VSCodeUtils.getActiveTextEditor()?.document;
-        //   if (document) {
-        //     if (
-        //       !getExtension().workspaceService?.isPathInWorkspace(document.uri.fsPath)
-        //     ) {
-        //       // not in workspace
-        //       return;
-        //     }
-        //     const note = WSUtils.getNoteFromDocument(document);
-        //     if (note) {
-        //       // refresh note
-        //       this.refresh(note);
-        //     }
-        //   }
-        //   break;
-        // }
-        // case GraphViewMessageType.onReady: {
-        //   const profile = getDurationMilliseconds(start);
-        //   Logger.info({ ctx, msg: "treeViewLoaded", profile, start });
-        //   AnalyticsUtils.track(VSCodeEvents.TreeView_Ready, {
-        //     duration: profile,
-        //   });
-        //   break;
-        // }
-        default:
-          console.log("got data", msg);
-          break;
-      }
-    });
-
-    // Update workspace-wide graph panel
-    ext.setWebView(DendronEditorViewKey.SCHEMA_GRAPH, panel);
+    this._panel.webview.html = resp;
   }
 }

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -14,9 +14,9 @@ import { CopyNoteRefCommand } from "./CopyNoteRef";
 import { CopyNoteURLCommand } from "./CopyNoteURL";
 import { CreateDailyJournalCommand } from "./CreateDailyJournal";
 import { CreateHookCommand } from "./CreateHookCommand";
+import { CreateNoteWithUserDefinedTrait } from "./CreateNoteWithUserDefinedTrait";
 import { CreateSchemaFromHierarchyCommand } from "./CreateSchemaFromHierarchyCommand";
 import { CreateTaskCommand } from "./CreateTask";
-import { CreateNoteWithUserDefinedTrait } from "./CreateNoteWithUserDefinedTrait";
 import { DeleteHookCommand } from "./DeleteHookCommand";
 import { DeleteNodeCommand } from "./DeleteNodeCommand";
 import { DiagnosticsReportCommand } from "./DiagnosticsReport";
@@ -54,14 +54,10 @@ import { RestoreVaultCommand } from "./RestoreVault";
 import { RunMigrationCommand } from "./RunMigrationCommand";
 import { SchemaLookupCommand } from "./SchemaLookupCommand";
 import { SeedAddCommand } from "./SeedAddCommand";
-import { SeedBrowseCommand } from "./SeedBrowseCommand";
 import { SeedRemoveCommand } from "./SeedRemoveCommand";
 import { SetupWorkspaceCommand } from "./SetupWorkspace";
 import { ShowHelpCommand } from "./ShowHelp";
 import { ShowLegacyPreviewCommand } from "./ShowLegacyPreview";
-import { ShowNoteGraphCommand } from "./ShowNoteGraph";
-import { ShowPreviewCommand } from "./ShowPreview";
-import { ShowSchemaGraphCommand } from "./ShowSchemaGraph";
 import { SignInCommand } from "./SignIn";
 import { SignUpCommand } from "./SignUp";
 import { SnapshotVaultCommand } from "./SnapshotVault";
@@ -71,6 +67,10 @@ import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
 
+/**
+ * Note: this does not contain commands that have parametered constructors, as
+ * those cannot be cast to the CodeCommandConstructor interface.
+ */
 const ALL_COMMANDS = [
   AddAndCommit,
   ArchiveHierarchyCommand,
@@ -119,10 +119,7 @@ const ALL_COMMANDS = [
   RestoreVaultCommand,
   SetupWorkspaceCommand,
   ShowHelpCommand,
-  ShowNoteGraphCommand,
-  ShowSchemaGraphCommand,
   ShowLegacyPreviewCommand,
-  ShowPreviewCommand,
   SignInCommand,
   SignUpCommand,
   PublishExportCommand,
@@ -139,7 +136,6 @@ const ALL_COMMANDS = [
   SeedAddCommand,
   SeedRemoveCommand,
   RunMigrationCommand,
-  SeedBrowseCommand,
   CreateTaskCommand,
   RegisterNoteTraitCommand,
   CreateNoteWithUserDefinedTrait,

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -1,0 +1,128 @@
+import {
+  assertUnreachable,
+  DMessageEnum,
+  GraphViewMessage,
+  GraphViewMessageType,
+  OnDidChangeActiveTextEditorMsg,
+} from "@dendronhq/common-all";
+import * as vscode from "vscode";
+import { commands, ViewColumn, window } from "vscode";
+import { GotoNoteCommand } from "../../commands/GotoNote";
+import { Logger } from "../../logger";
+import { GraphStyleService } from "../../styles";
+import { sentryReportingCallback } from "../../utils/analytics";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { DendronExtension, getEngine } from "../../workspace";
+import { WSUtils } from "../../WSUtils";
+
+export class NoteGraphPanelFactory {
+  private static _panel: vscode.WebviewPanel | undefined = undefined;
+  private static _vsCodeCallback: vscode.Disposable | undefined = undefined;
+
+  static create(ext: DendronExtension): vscode.WebviewPanel {
+    if (!this._panel) {
+      this._panel = window.createWebviewPanel(
+        "dendronIframe", // Identifies the type of the webview. Used internally
+        "Note Graph", // Title of the panel displayed to the user
+        {
+          viewColumn: ViewColumn.Beside,
+          preserveFocus: true,
+        }, // Editor column to show the new webview panel in.
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          enableFindWidget: true,
+        }
+      );
+
+      this._panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
+        const ctx = "ShowSchemaGraph:onDidReceiveMessage";
+        Logger.debug({ ctx, msgType: msg.type });
+
+        switch (msg.type) {
+          case GraphViewMessageType.onSelect: {
+            const note = getEngine().notes[msg.data.id];
+            await commands.executeCommand(
+              "workbench.action.focusFirstEditorGroup"
+            );
+            await new GotoNoteCommand().execute({
+              qs: note.fname,
+              vault: note.vault,
+            });
+            break;
+          }
+          case GraphViewMessageType.onGetActiveEditor: {
+            const activeTextEditor = VSCodeUtils.getActiveTextEditor();
+            const note =
+              activeTextEditor &&
+              WSUtils.getNoteFromDocument(activeTextEditor.document);
+            if (note) {
+              this._panel!.webview.postMessage({
+                type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+                data: {
+                  note,
+                  sync: true,
+                },
+                source: "vscode",
+              });
+            }
+            break;
+          }
+          case GraphViewMessageType.onRequestGraphStyle: {
+            // Set graph styles
+            const styles = GraphStyleService.getParsedStyles();
+            if (styles) {
+              this._panel!.webview.postMessage({
+                type: "onGraphStyleLoad",
+                data: {
+                  styles,
+                },
+                source: "vscode",
+              });
+            }
+            break;
+          }
+
+          default:
+            assertUnreachable();
+        }
+      });
+
+      this._vsCodeCallback = vscode.window.onDidChangeActiveTextEditor(
+        sentryReportingCallback((editor: vscode.TextEditor | undefined) => {
+          if (
+            NoteGraphPanelFactory._panel &&
+            NoteGraphPanelFactory._panel.visible
+          ) {
+            if (!editor) {
+              return;
+            }
+
+            const note = WSUtils.getNoteFromDocument(editor.document);
+
+            NoteGraphPanelFactory._panel.webview.postMessage({
+              type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+              data: {
+                note,
+                sync: true,
+              },
+              source: "vscode",
+            } as OnDidChangeActiveTextEditorMsg);
+          }
+        })
+      );
+
+      ext.addDisposable(this._vsCodeCallback);
+
+      this._panel.onDidDispose(() => {
+        this._panel = undefined;
+
+        if (this._vsCodeCallback) {
+          this._vsCodeCallback.dispose();
+          this._vsCodeCallback = undefined;
+        }
+      });
+    }
+    return this._panel;
+  }
+}

--- a/packages/plugin-core/src/components/views/PreviewViewFactory.ts
+++ b/packages/plugin-core/src/components/views/PreviewViewFactory.ts
@@ -1,0 +1,211 @@
+import {
+  assertUnreachable,
+  DMessageEnum,
+  NoteProps,
+  NoteUtils,
+  NoteViewMessage,
+  NoteViewMessageEnum,
+  OnDidChangeActiveTextEditorMsg,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+import * as vscode from "vscode";
+import { handleLink, LinkType } from "../../commands/ShowPreview";
+import { Logger } from "../../logger";
+import { sentryReportingCallback } from "../../utils/analytics";
+import { WebViewUtils } from "../../views/utils";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { DendronExtension } from "../../workspace";
+import { WSUtils } from "../../WSUtils";
+
+/**
+ * Proxy for the Preview Panel
+ */
+export interface PreviewProxy {
+  /**
+   * Method to update the preview with the passed in NoteProps.
+   * @param note Note Props to update the preview contents with
+   */
+  updateForNote(note: NoteProps): void;
+}
+
+export class PreviewPanelFactory {
+  private static _panel: vscode.WebviewPanel | undefined = undefined;
+  private static _vsCodeCallback: vscode.Disposable | undefined = undefined;
+
+  private static sendRefreshMessage(
+    panel: vscode.WebviewPanel,
+    note: NoteProps
+  ) {
+    panel.webview.postMessage({
+      type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+      data: {
+        note,
+        syncChangedNote: true,
+      },
+      source: "vscode",
+    } as OnDidChangeActiveTextEditorMsg);
+  }
+
+  private static classifyLink({ href }: NoteViewMessage["data"]): LinkType {
+    if (
+      href &&
+      href.startsWith("vscode-webview") &&
+      href.includes("/assets/")
+    ) {
+      // Note: currently even when the wiki link is fully vault qualified as example
+      // of [[dendron://assets/note-in-asset-vault]] When it is clicked within the preview
+      // the href will look along the lines of:
+      // `vscode-webview://72db5b4c-61f8-400b-808c-771184cb3d7f/r68Zw7OChUZWvbD10qqmY`
+      // href will contain the id of the note but it will NOT contain the vault
+      // hence we should avoid the issue of parsing 'assets' vault name even if someone names their
+      // vault 'assets'.
+      return LinkType.ASSET;
+    } else if (href && href.startsWith("vscode-webview")) {
+      return LinkType.WIKI;
+    } else if (
+      href &&
+      (href.startsWith("http://") || href.startsWith("https://"))
+    ) {
+      return LinkType.WEBSITE;
+    } else {
+      return LinkType.UNKNOWN;
+    }
+  }
+
+  static getProxy(): PreviewProxy {
+    return {
+      updateForNote(note) {
+        if (PreviewPanelFactory._panel) {
+          PreviewPanelFactory._panel.webview.postMessage({
+            type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+            data: {
+              note,
+              syncChangedNote: true,
+            },
+            source: "vscode",
+          } as OnDidChangeActiveTextEditorMsg);
+        }
+      },
+    };
+  }
+
+  static create(ext: DendronExtension): vscode.WebviewPanel {
+    const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
+    const preserveFocus = true;
+
+    if (this._panel) {
+      return this._panel;
+    }
+
+    const name = "notePreview";
+
+    this._panel = vscode.window.createWebviewPanel(
+      name,
+      "Dendron Preview",
+      {
+        viewColumn,
+        preserveFocus,
+      },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        enableFindWidget: true,
+        localResourceRoots: WebViewUtils.getLocalResourceRoots(ext.context),
+      }
+    );
+
+    this._panel.webview.onDidReceiveMessage(async (msg: NoteViewMessage) => {
+      const ctx = "ShowPreview:onDidReceiveMessage";
+      Logger.debug({ ctx, msgType: msg.type });
+      switch (msg.type) {
+        case DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR:
+        case DMessageEnum.INIT: {
+          // do nothing
+          break;
+        }
+        case DMessageEnum.MESSAGE_DISPATCHER_READY: {
+          // if ready, get current note
+          const note = WSUtils.getActiveNote();
+          if (note) {
+            Logger.debug({
+              ctx,
+              msg: "got active note",
+              note: NoteUtils.toLogObj(note),
+            });
+            PreviewPanelFactory.sendRefreshMessage(this._panel!, note);
+          }
+          break;
+        }
+        case NoteViewMessageEnum.onClick: {
+          const { data } = msg;
+          const linkType = PreviewPanelFactory.classifyLink(data);
+          await handleLink({
+            linkType,
+            data,
+            wsRoot: ext.getEngine().wsRoot,
+          });
+          break;
+        }
+        case NoteViewMessageEnum.onGetActiveEditor: {
+          Logger.debug({ ctx, "msg.type": "onGetActiveEditor" });
+          const activeTextEditor = VSCodeUtils.getActiveTextEditor();
+          const maybeNote = !_.isUndefined(activeTextEditor)
+            ? WSUtils.tryGetNoteFromDocument(activeTextEditor?.document)
+            : undefined;
+
+          if (!_.isUndefined(maybeNote)) {
+            PreviewPanelFactory.sendRefreshMessage(this._panel!, maybeNote);
+          }
+          break;
+        }
+        default:
+          assertUnreachable(msg.type);
+      }
+    });
+
+    this._vsCodeCallback = vscode.window.onDidChangeActiveTextEditor(
+      sentryReportingCallback((editor: vscode.TextEditor | undefined) => {
+        if (
+          !editor ||
+          editor.document.uri.fsPath !==
+            vscode.window.activeTextEditor?.document.uri.fsPath
+        ) {
+          return;
+        }
+
+        const uri = editor.document.uri;
+        if (!ext.workspaceService?.isPathInWorkspace(uri.fsPath)) {
+          return;
+        }
+
+        const maybeNote = WSUtils.tryGetNoteFromDocument(editor.document);
+
+        if (!maybeNote) {
+          return;
+        }
+
+        this._panel!.webview.postMessage({
+          type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+          data: {
+            note: maybeNote,
+            syncChangedNote: true,
+          },
+          source: "vscode",
+        } as OnDidChangeActiveTextEditorMsg);
+      })
+    );
+
+    ext.addDisposable(this._vsCodeCallback);
+
+    this._panel.onDidDispose(() => {
+      this._panel = undefined;
+
+      if (this._vsCodeCallback) {
+        this._vsCodeCallback.dispose();
+        this._vsCodeCallback = undefined;
+      }
+    });
+
+    return this._panel;
+  }
+}

--- a/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
@@ -1,0 +1,133 @@
+import {
+  DMessageEnum,
+  GraphViewMessage,
+  GraphViewMessageType,
+  OnDidChangeActiveTextEditorMsg,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+import path from "path";
+import * as vscode from "vscode";
+import { Uri, ViewColumn, window } from "vscode";
+import { Logger } from "../../logger";
+import { sentryReportingCallback } from "../../utils/analytics";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { DendronExtension } from "../../workspace";
+import { WSUtils } from "../../WSUtils";
+
+export class SchemaGraphViewFactory {
+  private static _panel: vscode.WebviewPanel | undefined = undefined;
+  private static _vsCodeCallback: vscode.Disposable | undefined = undefined;
+
+  //TODO: Limit scope of parameter from DendronExtension to only what's needed
+  static create(ext: DendronExtension): vscode.WebviewPanel {
+    if (this._panel) {
+      return this._panel;
+    }
+    const title = "Schema Graph";
+
+    this._panel = window.createWebviewPanel(
+      "dendronIframe", // Identifies the type of the webview. Used internally
+      title, // Title of the panel displayed to the user
+      {
+        viewColumn: ViewColumn.Beside,
+        preserveFocus: true,
+      }, // Editor column to show the new webview panel in.
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        enableFindWidget: true,
+      }
+    );
+
+    // Listener
+    this._panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
+      const ctx = "ShowSchemaGraph:onDidReceiveMessage";
+      Logger.debug({ ctx, msgType: msg.type });
+
+      switch (msg.type) {
+        case GraphViewMessageType.onSelect: {
+          const engine = ext.getEngine();
+          const schema = engine.schemas[msg.data.id];
+
+          const wsRoot = ext.getEngine().wsRoot;
+
+          await vscode.commands.executeCommand(
+            "workbench.action.focusFirstEditorGroup"
+          );
+          if (msg.data.vault && wsRoot) {
+            const vaults = engine.vaults.filter(
+              (v) => VaultUtils.getName(v) === msg.data.vault
+            );
+            if (_.isEmpty(vaults)) return;
+
+            const schemaPath = path.join(
+              wsRoot,
+              vaults[0].fsPath,
+              `root.schema.yml`
+            );
+            const uri = Uri.file(schemaPath);
+
+            await VSCodeUtils.openFileInEditor(uri);
+          } else if (schema && wsRoot) {
+            const fname = schema.fname;
+            // const vault = schema.vault;
+
+            const schemaPath = path.join(
+              wsRoot,
+              schema.vault.fsPath,
+              `${fname}.schema.yml`
+            );
+            const uri = Uri.file(schemaPath);
+
+            await VSCodeUtils.openFileInEditor(uri);
+          }
+          break;
+        }
+        default:
+          Logger.error({
+            ctx,
+            msg: "Unexpected message type from SchemaGraph Webview: " + msg,
+          });
+          break;
+      }
+    });
+
+    this._vsCodeCallback = vscode.window.onDidChangeActiveTextEditor(
+      sentryReportingCallback((editor: vscode.TextEditor | undefined) => {
+        if (
+          SchemaGraphViewFactory._panel &&
+          SchemaGraphViewFactory._panel.visible
+        ) {
+          if (!editor) {
+            return;
+          }
+
+          const note = WSUtils.getNoteFromDocument(editor.document);
+
+          SchemaGraphViewFactory._panel.webview.postMessage({
+            type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+            data: {
+              note,
+              sync: true,
+            },
+            source: "vscode",
+          } as OnDidChangeActiveTextEditorMsg);
+        }
+      })
+    );
+
+    ext.addDisposable(this._vsCodeCallback);
+
+    this._panel.onDidDispose(() => {
+      this._panel = undefined;
+
+      if (this._vsCodeCallback) {
+        this._vsCodeCallback.dispose();
+        this._vsCodeCallback = undefined;
+      }
+    });
+
+    return this._panel;
+  }
+}

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -17,8 +17,8 @@ import _ from "lodash";
 import path from "path";
 import visit from "unist-util-visit";
 import * as vscode from "vscode";
+import { PreviewPanelFactory } from "../components/views/PreviewViewFactory";
 import { Logger } from "../logger";
-import { PreviewUtils } from "../views/utils";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace, getExtension } from "../workspace";
 
@@ -159,7 +159,10 @@ export class NoteSyncService {
 
     this.L.debug({ ctx, fname: note.fname, msg: "exit" });
     const noteClean = await engine.updateNote(note);
-    PreviewUtils.refresh(noteClean);
+
+    // Temporary workaround until NoteSyncService is no longer a singleton
+    PreviewPanelFactory.getProxy().updateForNote(noteClean);
+
     return noteClean;
   }
 

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -12,10 +12,9 @@ import { expect, runSingleVaultTest } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("WindowWatcher", function () {
-  let ctx: vscode.ExtensionContext;
   let watcher: WindowWatcher;
 
-  ctx = setupBeforeAfter(this, {
+  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
@@ -91,6 +90,7 @@ suite("WindowWatcher", function () {
           getExtension().workspaceWatcher = new WorkspaceWatcher();
           getExtension().workspaceWatcher?.activate(ctx);
           watcher = new WindowWatcher();
+
           watcher.activate(ctx);
           // Open a note
           const first = NoteUtils.getNoteByFnameV5({

--- a/packages/plugin-core/src/views/SampleView.ts
+++ b/packages/plugin-core/src/views/SampleView.ts
@@ -1,15 +1,10 @@
 import { DendronTreeViewKey, DMessage } from "@dendronhq/common-all";
 import * as vscode from "vscode";
-import { getExtension } from "../workspace";
 import { WebViewUtils } from "./utils";
 
 export class SampleView implements vscode.WebviewViewProvider {
   public static readonly viewType = DendronTreeViewKey.SAMPLE_VIEW;
   private _view?: vscode.WebviewView;
-
-  constructor() {
-    getExtension().setTreeView(DendronTreeViewKey.SAMPLE_VIEW, this);
-  }
 
   public postMessage(msg: DMessage) {
     this._view?.webview.postMessage(msg);

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -1,21 +1,16 @@
 import {
-  DendronTreeViewKey,
   DendronEditorViewKey,
-  DMessageEnum,
+  DendronTreeViewKey,
   DUtils,
   getStage,
-  NoteProps,
-  OnDidChangeActiveTextEditorMsg,
   getWebTreeViewEntry,
 } from "@dendronhq/common-all";
-import _ from "lodash";
+import { findUpTo, WebViewCommonUtils } from "@dendronhq/common-server";
+import path from "path";
 import * as vscode from "vscode";
 import { Logger } from "../logger";
-import { getExtension, getDWorkspace, DendronExtension } from "../workspace";
-import path from "path";
-import { findUpTo, WebViewCommonUtils } from "@dendronhq/common-server";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { WSUtils } from "../WSUtils";
+import { DendronExtension, getDWorkspace, getExtension } from "../workspace";
 
 export class WebViewUtils {
   /**
@@ -259,32 +254,4 @@ export class WebViewUtils {
      */
     return WebViewUtils.genHTMLForView({ title, view });
   };
-}
-
-/**
- * Utils assisting with the preview
- */
-export class PreviewUtils {
-  static onDidChangeHandler(document: vscode.TextDocument) {
-    const maybeNote = WSUtils.tryGetNoteFromDocument(document);
-    if (!_.isUndefined(maybeNote)) PreviewUtils.refresh(maybeNote);
-  }
-
-  static refresh(note: NoteProps) {
-    const ctx = { ctx: "ShowPreview:refresh", fname: note.fname };
-    const panel = getExtension().getWebView(DendronEditorViewKey.NOTE_PREVIEW);
-    Logger.debug({ ...ctx, state: "enter" });
-    if (panel) {
-      Logger.debug({ ...ctx, state: "panel found" });
-      panel.title = `${note.fname}`;
-      panel.webview.postMessage({
-        type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-        data: {
-          note,
-          syncChangedNote: true,
-        },
-        source: "vscode",
-      } as OnDidChangeActiveTextEditorMsg);
-    }
-  }
 }

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -1,10 +1,4 @@
-import {
-  ConfigUtils,
-  DendronEditorViewKey,
-  DMessageEnum,
-  NoteUtils,
-  OnDidChangeActiveTextEditorMsg,
-} from "@dendronhq/common-all";
+import { ConfigUtils, NoteUtils } from "@dendronhq/common-all";
 import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import visit from "unist-util-visit";
@@ -18,10 +12,8 @@ import {
 import { debouncedUpdateDecorations } from "./features/windowDecorations";
 import { Logger } from "./logger";
 import { sentryReportingCallback } from "./utils/analytics";
-import { PreviewUtils } from "./views/utils";
 import { VSCodeUtils } from "./vsCodeUtils";
 import { getDWorkspace, getExtension } from "./workspace";
-import { WSUtils } from "./WSUtils";
 
 const context = (scope: string) => {
   const ROOT_CTX = "WindowWatcher";
@@ -82,9 +74,6 @@ export class WindowWatcher {
         }
         Logger.info({ ctx, editor: uri.fsPath });
         this.triggerUpdateDecorations(editor);
-        this.triggerNoteGraphViewUpdate();
-        this.triggerSchemaGraphViewUpdate();
-        this.triggerNotePreviewUpdate(editor);
 
         this.onDidChangeActiveTextEditorHandlers.forEach((value) =>
           value.call(this, editor)
@@ -130,66 +119,6 @@ export class WindowWatcher {
     // This may be the active editor, but could be another editor that's open side by side without being selected.
     // Also, debouncing this based on the editor URI so that decoration updates in different editors don't affect each other but updates don't trigger too often for the same editor
     debouncedUpdateDecorations.debouncedFn(editor);
-    return;
-  }
-
-  async triggerNoteGraphViewUpdate() {
-    const noteGraphPanel = getExtension().getWebView(
-      DendronEditorViewKey.NOTE_GRAPH
-    );
-    if (!_.isUndefined(noteGraphPanel)) {
-      if (noteGraphPanel.visible) {
-        // TODO Logic here + test
-
-        const activeEditor = window.activeTextEditor;
-        if (!activeEditor) {
-          return;
-        }
-
-        const note = WSUtils.getNoteFromDocument(activeEditor.document);
-
-        noteGraphPanel.webview.postMessage({
-          type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-          data: {
-            note,
-            sync: true,
-          },
-          source: "vscode",
-        } as OnDidChangeActiveTextEditorMsg);
-      }
-    }
-    return;
-  }
-  async triggerSchemaGraphViewUpdate() {
-    const schemaGraphPanel = getExtension().getWebView(
-      DendronEditorViewKey.SCHEMA_GRAPH
-    );
-    if (!_.isUndefined(schemaGraphPanel)) {
-      if (schemaGraphPanel.visible) {
-        // TODO Logic here + test
-
-        const activeEditor = window.activeTextEditor;
-        if (!activeEditor) {
-          return;
-        }
-
-        const note = WSUtils.getNoteFromDocument(activeEditor.document);
-
-        schemaGraphPanel.webview.postMessage({
-          type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-          data: {
-            note,
-            sync: true,
-          },
-          source: "vscode",
-        } as OnDidChangeActiveTextEditorMsg);
-      }
-    }
-    return;
-  }
-
-  async triggerNotePreviewUpdate({ document }: TextEditor) {
-    PreviewUtils.onDidChangeHandler(document);
     return;
   }
 

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -31,12 +31,7 @@ import path from "path";
 import * as vscode from "vscode";
 import { Uri } from "vscode";
 import {
-  SeedBrowseCommand,
-  WebViewPanelFactory,
-} from "./commands/SeedBrowseCommand";
-import {
   DendronContext,
-  DENDRON_COMMANDS,
   extensionQualifiedId,
   GLOBAL_STATE,
 } from "./constants";
@@ -389,7 +384,6 @@ export class DendronExtension {
     this._traitRegistrar = new NoteTraitManager(new CommandRegistrar(context));
 
     const ctx = "DendronExtension";
-    this.commandRegistrationV2();
     this.L.info({ ctx, msg: "initialized" });
   }
 
@@ -681,25 +675,5 @@ export class DendronExtension {
     const ctx = "deactivateWorkspace";
     this.L.info({ ctx });
     this._disposableStore.dispose();
-  }
-
-  private async commandRegistrationV2() {
-    const existingCommands = await vscode.commands.getCommands();
-
-    if (!existingCommands.includes(DENDRON_COMMANDS.SEED_BROWSE.key)) {
-      this.context.subscriptions.push(
-        vscode.commands.registerCommand(
-          DENDRON_COMMANDS.SEED_BROWSE.key,
-          sentryReportingCallback(async () => {
-            const panel = WebViewPanelFactory.create(
-              this.workspaceService!.seedService
-            );
-            const cmd = new SeedBrowseCommand(panel);
-
-            return cmd.run();
-          })
-        )
-      );
-    }
   }
 }

--- a/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
+++ b/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
@@ -1,9 +1,13 @@
 import { DVault, DWorkspaceV2 } from "@dendronhq/common-all";
 import { WorkspaceService } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
-import { SeedBrowseCommand } from "../commands/SeedBrowseCommand";
+import {
+  SeedBrowseCommand,
+  WebViewPanelFactory,
+} from "../commands/SeedBrowseCommand";
 import { WORKSPACE_ACTIVATION_CONTEXT } from "../constants";
 import { StateService } from "../services/stateService";
+import { getExtension } from "../workspace";
 import { WorkspaceInitializer } from "./workspaceInitializer";
 
 /**
@@ -33,7 +37,11 @@ export class SeedBrowserInitializer implements WorkspaceInitializer {
    * @param _opts
    */
   async onWorkspaceOpen(_opts: { ws: DWorkspaceV2 }): Promise<void> {
-    const cmd = new SeedBrowseCommand();
+    const panel = WebViewPanelFactory.create(
+      getExtension().workspaceService!.seedService
+    );
+
+    const cmd = new SeedBrowseCommand(panel);
     await cmd.execute();
 
     StateService.instance().setActivationContext(

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -12,6 +12,7 @@ import path from "path";
 import rif from "replace-in-file";
 import * as vscode from "vscode";
 import { ShowPreviewCommand } from "../commands/ShowPreview";
+import { PreviewPanelFactory } from "../components/views/PreviewViewFactory";
 import { GLOBAL_STATE, WORKSPACE_ACTIVATION_CONTEXT } from "../constants";
 import { Logger } from "../logger";
 import { StateService } from "../services/stateService";
@@ -84,7 +85,9 @@ export class TutorialInitializer
       if (getStage() !== "test") {
         // TODO: HACK to wait for existing preview to be ready
         setTimeout(() => {
-          new ShowPreviewCommand().execute();
+          new ShowPreviewCommand(
+            PreviewPanelFactory.create(getExtension())
+          ).execute();
         }, 1000);
       }
     } else {


### PR DESCRIPTION
## fix(views): encapsulate webviews

This change encapsulates the webviews in `DendronExtension` for better dependency inversion and removal of circular dependencies

- webviews are no longer exposed in `DendronExtension`
- Note Graph, Schema Graph, and Preview webviews no longer rely on `WorkspaceWatcher` and completely own their own lifecycle, including vs code callback disposables.
- `NoteSyncService` has a static dependency on preview - until that can be refactored from being a singleton, I've exposed a temporary static `PreviewProxy` getter for compatibility.
- Fixed a circ dependency in `SampleView`
- The new view factory methods aren't perfect - they should return something more scoped than the entire `vscode.WebPanelView`, but to reduce churn in the refactor for now I'm leaving most of the code intact.
---

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

#### Special Cases
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurrences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] Sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] Add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community

### Git
- [ ] Make sure your branch names adhere to our commit style [[#^6zdCscSXs1MM]]
    - All PRs should start with `[feat|fix|enhance|]/[{description-of-pr-in-kebab-case}]`
        - `eg. feat/add-thisthing`

### Analytics
- [ ] If you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Github Issue
- [ ] If this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
- [ ] If the resolution comes with a document update, link the docs PR to the issue as well.