### PR TITLE
chore: add dendron docs as native ws

### DIFF
--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -1,6 +1,14 @@
 {
   "folders": [
     {
+      "path": "docs/dendron-docs",
+      "name": "dendron-docs"
+    },
+    {
+      "path": "docs/seeds/dendron.dendron-site",
+      "name": "dendron.dendron-site"
+    },
+    {
       "path": ".",
       "name": "root"
     },
@@ -63,9 +71,6 @@
     },
     {
       "path": "test-workspace"
-    },
-    {
-      "path": "docs"
     }
   ],
   "settings": {

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+dendron-docs
+seeds

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-# Contributing to Dendron
-
-Thanks for your interest in contributing to Dendron! ❤️
-
-This project follows the [all-contributors specification](https://allcontributors.org/docs/en/bot/usage). Contributions of any kind welcome! 
-
-Please go [here](https://www.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa.html) to see the contribution docs.

--- a/docs/dendron.yml
+++ b/docs/dendron.yml
@@ -1,0 +1,107 @@
+version: 4
+useFMTitle: true
+useNoteTitleForLink: true
+mermaid: true
+useKatex: false
+dev:
+    enablePreviewV2: true
+    enableWebUI: true
+site:
+    siteHierarchies:
+        - handbook
+    siteRootDir: docs
+    usePrettyRefs: true
+    siteUrl: 'https://wiki.dendron.so'
+    copyAssets: true
+    title: Dendron
+    description: Personal knowledge space
+    siteLastModified: true
+    gh_edit_branch: main
+commands:
+    lookup:
+        note:
+            selectionMode: extract
+            confirmVaultOnCreate: true
+            leaveTrace: false
+            bubbleUpCreateNew: true
+            fuzzThreshold: 0.2
+    randomNote: {}
+    insertNote:
+        initialValue: templates
+    insertNoteLink:
+        aliasMode: none
+        enableMultiSelect: false
+    insertNoteIndex:
+        enableMarker: false
+workspace:
+    dendronVersion: 0.69.3-alpha.1
+    workspaces:
+        dendron-docs:
+            remote:
+                type: git
+                url: 'git@github.com:dendronhq/dendron-docs.git'
+    seeds:
+        dendron.dendron-site:
+            branch: dev
+            site:
+                url: 'https://wiki.dendron.so'
+                index: dendron
+        dendron.templates: {}
+    vaults:
+        -
+            fsPath: vault
+            name: dendron.docs
+            workspace: dendron-docs
+        -
+            fsPath: vault
+            seed: dendron.dendron-site
+            name: dendron.dendron-site
+    journal:
+        dailyDomain: daily
+        name: journal
+        dateFormat: y.MM.dd
+        addBehavior: childOfDomainNamespace
+    scratch:
+        name: scratch
+        dateFormat: y.MM.dd.HHmmss
+        addBehavior: asOwnDomain
+    graph:
+        zoomSpeed: 1
+    enableAutoCreateOnDefinition: false
+    enableXVaultWikiLink: true
+    enableRemoteVaultInit: true
+    workspaceVaultSyncMode: noCommit
+    enableAutoFoldFrontmatter: false
+    maxPreviewsCached: 10
+    maxNoteLength: 204800
+    enableUserTags: true
+    enableHashTags: true
+    task:
+        name: ''
+        dateFormat: ''
+        addBehavior: childOfCurrent
+        statusSymbols:
+            '': ' '
+            wip: w
+            done: x
+            assigned: a
+            moved: m
+            blocked: b
+            delegated: l
+            dropped: d
+            pending: 'y'
+        prioritySymbols:
+            H: high
+            M: medium
+            L: low
+        todoIntegration: false
+        createTaskSelectionType: selection2link
+    enableEditorDecorations: true
+preview:
+    enableFMTitle: true
+    enableNoteTitleForLink: true
+    enableMermaid: true
+    enablePrettyRefs: false
+    enableKatex: false
+usePrettyRefs: false
+noLegacyNoteRef: true


### PR DESCRIPTION
This PR adds Dendron's user documentation and developer documentation as part of the workspace.

**Warning**: There seems to be a few problems with running the development version of the extension while also having the release version extension installed:
- If you open the test workspace as a Native Workspace, the lookup never matches any input. You can still create new notes, and existing notes can be opened if you click on an item in the lookup, but typing something into the bar never matches anything.
- If you open the test workspace as a Code Workspace, you get an error `[dendron.@dendronhq/plugin-core]: Cannot register 'dendron.defaultJournalName'. This property is already registered.`. Otherwise everything seems to work.

I'll look into these issues soon, but otherwise I'll leave it up to the reviewer whether we should merge this right now or after these are fixed.