### PR TITLE
enhance(markdown): add `depth` metadata to header anchors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     browser: true,
     es6: true,
     jest: true,
-    "cypress/globals": true
+    "cypress/globals": true,
   },
   extends: ["plugin:react/recommended", "airbnb", "airbnb/hooks", "prettier"],
   globals: {
@@ -36,22 +36,24 @@ module.exports = {
     "prefer-template": "off",
     "consistent-return": "off",
     // less restrictive airbnb
-    'no-restricted-syntax': [
-      'error',
+    "no-restricted-syntax": [
+      "error",
       {
-        selector: 'ForInStatement',
-        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+        selector: "ForInStatement",
+        message:
+          "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.",
       },
       {
-        selector: 'WithStatement',
-        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+        selector: "WithStatement",
+        message:
+          "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
       },
     ],
-    'no-continue': 'off',
+    "no-continue": "off",
     // don't agree with
     "dot-notation": "off",
     // Less restrictive version of airbnb
-    'no-labels': ['error', { allowLoop: true, allowSwitch: false }],
+    "no-labels": ["error", { allowLoop: true, allowSwitch: false }],
     // prettier
     indent: "off",
     quotes: "off",
@@ -83,11 +85,14 @@ module.exports = {
     "import/no-cycle": "off",
     // --- React
     "react/prop-types": "off",
-    // we use 'logger' inside of hooks, gets flagged 
+    // we use 'logger' inside of hooks, gets flagged
     "react-hooks/exhaustive-deps": "off",
     // suppress errors for missing 'import React' in files
     "react/react-in-jsx-scope": "off",
-    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "react/jsx-filename-extension": [
+      1,
+      { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+    ],
     "react/destructuring-assignment": "off",
     "react/jsx-curly-newline": "off",
     "react/jsx-props-no-spreading": "off",

--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -96,7 +96,6 @@
     "workbench.editor.showTabs": true,
     "editor.snippetSuggestions": "none",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "liveFrame.url": "http://localhost:3000/proto",
     "[typescript]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -47,13 +47,24 @@ export type DNoteLoc = {
   anchorHeader?: string;
 };
 
-export type DNoteAnchor = {
-  /**
-   * In the future, we could have ID based anchors
-   */
-  type: "header" | "block";
+export type DNoteAnchor = DNoteBlockAnchor | DNoteHeaderAnchor;
+/**
+ * Anchor without {@link DNoteHeaderAnchor.depth} info
+ */
+export type DNoteAnchorBasic =
+  | DNoteBlockAnchor
+  | Omit<DNoteHeaderAnchor, "depth">;
+
+export type DNoteBlockAnchor = {
+  type: "block";
   text?: string; //original text for the anchor
   value: string;
+};
+export type DNoteHeaderAnchor = {
+  type: "header";
+  text?: string; //original text for the anchor
+  value: string;
+  depth: number;
 };
 
 export type DNoteAnchorPositioned = DNoteAnchor & {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -48,8 +48,10 @@ export type DNoteLoc = {
 };
 
 export type DNoteAnchor = DNoteBlockAnchor | DNoteHeaderAnchor;
+
 /**
  * Anchor without {@link DNoteHeaderAnchor.depth} info
+ * @todo see migration [[DNoteAnchorBasic|dendron://dendron.docs/dev.changelog#dnoteanchorbasic]]
  */
 export type DNoteAnchorBasic =
   | DNoteBlockAnchor
@@ -60,6 +62,13 @@ export type DNoteBlockAnchor = {
   text?: string; //original text for the anchor
   value: string;
 };
+
+/**
+ * This represents a markdown header
+ * ```md
+ * # H1
+ * ```
+ */
 export type DNoteHeaderAnchor = {
   type: "header";
   text?: string; //original text for the anchor

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -30,6 +30,7 @@ import {
   DVault,
   USERS_HIERARCHY_BASE,
   TAGS_HIERARCHY_BASE,
+  DNoteAnchorBasic,
 } from "@dendronhq/common-all";
 import _ from "lodash";
 import type {
@@ -782,8 +783,9 @@ export class AnchorUtils {
 
     const { line, column } = node.position.start;
     if (node.type === DendronASTTypes.HEADING) {
-      const text = this.headerText(node as Heading);
-      const value = slugger.slug(this.headerText(node as Heading));
+      const headerNode = node as Heading;
+      const text = this.headerText(headerNode);
+      const value = slugger.slug(this.headerText(headerNode));
       return [
         value,
         {
@@ -792,6 +794,7 @@ export class AnchorUtils {
           value,
           line: line - 1,
           column: column - 1,
+          depth: headerNode.depth,
         },
       ];
     } else if (node.type === DendronASTTypes.BLOCK_ANCHOR) {
@@ -837,10 +840,10 @@ export class AnchorUtils {
     }
   }
 
-  static anchor2string(anchor: DNoteAnchor): string {
+  static anchor2string(anchor: DNoteAnchor | DNoteAnchorBasic): string {
     if (anchor.type === "block") return `^${anchor.value}`;
     if (anchor.type === "header") return anchor.value;
-    assertUnreachable(anchor.type);
+    assertUnreachable(anchor);
   }
 }
 

--- a/packages/plugin-core/.eslintrc.json
+++ b/packages/plugin-core/.eslintrc.json
@@ -8,5 +8,11 @@
   "plugins": ["@typescript-eslint"],
   "env": {
     "mocha": true
+  },
+  "rules": {
+    // 1. allow anonymous functions inside of mocha tests
+    "prefer-arrow-callback": 0,
+    "func-names": "off"
+    // 1. end
   }
 }

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -151,7 +151,7 @@ export class GotoNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     });
     if (nonNote) {
       opts.qs = nonNote.fullPath;
-      opts.vault = null;
+      opts.vault = undefined;
     }
     return opts;
   }

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -1,6 +1,6 @@
 import {
   assertUnreachable,
-  DNoteAnchor,
+  DNoteAnchorBasic,
   DVault,
   getSlugger,
   NoteProps,
@@ -23,8 +23,8 @@ import { BasicCommand } from "./base";
 
 type CommandOpts = {
   qs?: string;
-  vault?: DVault | null;
-  anchor?: DNoteAnchor;
+  vault?: DVault;
+  anchor?: DNoteAnchorBasic;
   overrides?: Partial<NoteProps>;
   /**
    * What {@link vscode.ViewColumn} to open note in
@@ -43,14 +43,14 @@ type CommandOutput =
   | undefined;
 
 export const findAnchorPos = (opts: {
-  anchor: DNoteAnchor;
+  anchor: DNoteAnchorBasic;
   note: NoteProps;
 }): Position => {
   const { anchor: findAnchor, note } = opts;
   let key: string;
   if (findAnchor.type === "header") key = getSlugger().slug(findAnchor.value);
   else if (findAnchor.type === "block") key = `^${findAnchor.value}`;
-  else assertUnreachable(findAnchor.type);
+  else assertUnreachable(findAnchor);
 
   const found = note.anchors[key];
 

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -37,6 +37,7 @@ export const extractHeaderAnchorIfExists = (
     return {
       type: "header",
       value: anchorValue,
+      depth: tokens.length - 1,
     };
   }
 };

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -1,4 +1,4 @@
-import { SurveyEvents } from "@dendronhq/common-all";
+import { getStage, SurveyEvents } from "@dendronhq/common-all";
 import { AnalyticsUtils } from "./utils/analytics";
 import * as vscode from "vscode";
 import _ from "lodash";
@@ -623,6 +623,9 @@ export class SurveyUtils {
    * Asks three questions about background, use case, and prior tools used.
    */
   static async showInitialSurvey() {
+    if (getStage() === "test") {
+      return;
+    }
     AnalyticsUtils.track(SurveyEvents.InitialSurveyPrompted);
     vscode.window
       .showInformationMessage(
@@ -683,6 +686,9 @@ export class SurveyUtils {
   }
 
   static async showLapsedUserSurvey() {
+    if (getStage() === "test") {
+      return;
+    }
     AnalyticsUtils.track(SurveyEvents.LapsedUserSurveyPrompted);
     await vscode.window
       .showInformationMessage(
@@ -749,6 +755,10 @@ export class SurveyUtils {
   }
 
   static async showInactiveUserSurvey() {
+    // do not show in test
+    if (getStage() === "test") {
+      return;
+    }
     AnalyticsUtils.track(SurveyEvents.InactiveUserSurveyPrompted);
     await vscode.window
       .showInformationMessage(

--- a/packages/plugin-core/src/test/suite-integ/DeleteHookCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DeleteHookCommand.test.ts
@@ -4,7 +4,6 @@ import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import { describe } from "mocha";
 import path from "path";
-import * as vscode from "vscode";
 import { CreateHookCommand } from "../../commands/CreateHookCommand";
 import { DeleteHookCommand } from "../../commands/DeleteHookCommand";
 import { DENDRON_COMMANDS } from "../../constants";
@@ -12,8 +11,7 @@ import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite(DENDRON_COMMANDS.DELETE_HOOK.key, function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this);
+  const ctx = setupBeforeAfter(this);
   describe("main", () => {
     test("basic", (done) => {
       const hookName = "foo";

--- a/packages/plugin-core/src/test/suite-integ/DeleteNodeCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DeleteNodeCommand.test.ts
@@ -17,7 +17,7 @@ import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import { window } from "vscode";
 import { WSUtils } from "../../WSUtils";
 
-suite("notes", function () {
+suite("DeleteNodeCommand", function () {
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this);
 
   test("basic", (done) => {
@@ -97,7 +97,7 @@ suite("notes", function () {
             ],
             (ent) => {
               if (!_.isEqual(ent.actual, ent.expected)) {
-                throw `issue with ${JSON.stringify(ent)}`;
+                throw new Error(`issue with ${JSON.stringify(ent)}`);
               }
               return true;
             }

--- a/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
@@ -103,6 +103,7 @@ suite("ShowPreview utility methods", () => {
       expect(actual.anchor).toEqual({
         type: "header",
         value: "anch-val-1",
+        depth: 1,
       });
     });
 

--- a/packages/plugin-core/src/test/suite-integ/md.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/md.test.ts
@@ -1,0 +1,54 @@
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import * as vscode from "vscode";
+import { getReferenceAtPosition } from "../../utils/md";
+import { getDWorkspace } from "../../workspace";
+import { WSUtils } from "../../WSUtils";
+import { expect } from "../testUtilsv2";
+import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+
+suite("WHEN getReferenceAtPosition", function () {
+  const ctx = setupBeforeAfter(this);
+  const activeNoteName = "active";
+
+  describeMultiWS(
+    "AND WHEN header anchor is present",
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        return NoteTestUtilsV4.createNote({
+          fname: activeNoteName,
+          vault: vaults[0],
+          wsRoot,
+          body: "[[foo#foo1]]",
+        });
+      },
+      ctx,
+    },
+    () => {
+      test("THEN initializes correctly", async () => {
+        // You can access the workspace inside the test like this:
+        const { engine } = getDWorkspace();
+        const activeNote = engine.notes[activeNoteName];
+        const editor = await WSUtils.openNote(activeNote);
+        const pos = new vscode.Position(7, 0);
+        const reference = getReferenceAtPosition(editor.document, pos);
+        expect(reference).toEqual({
+          anchorEnd: undefined,
+          anchorStart: {
+            type: "header",
+            value: "foo1",
+          },
+          label: "",
+          range: new vscode.Range(
+            new vscode.Position(7, 0),
+            new vscode.Position(7, 12)
+          ),
+          ref: "foo",
+          refText: "foo#foo1",
+          refType: undefined,
+          vaultName: undefined,
+        });
+        return;
+      });
+    }
+  );
+});


### PR DESCRIPTION
Header anchors would be parsed and `depth` data for headers would be dropped. That means the following header

```md
## Use Cases
```

would be represented as

```json
"use-cases": {
    "type": "header",
    "text": "Use Cases",
    "value": "use-cases",
    "line": 24,
    "column": 0
}
```

This adds the depth data in.
```diff
"use-cases": {
    "type": "header",
    "text": "Use Cases",
    "value": "use-cases",
    "line": 24,
    "column": 0,
+   "depth": 2,
}
```

Currently, this effects the output of the [[JSON Pod|pkg.pods-core.ref.json]].

This PR also fixes a few test issues and updates our eslint config to work better with mocha
- chore: update eslint rules to for mocha tests
- chore: remove unused option in workspace
- add depth to header
- fix issues with tests


# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [ ] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [ ] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

#### Special Cases
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing 

### Docs
- [ ] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [ ] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

Example PR Description
```markdown
# feat: capitalize all foos

This changes capitalizes all occurrences of `foo` to `Foo` 

Docs PR: <URL_TO_DOCS_PR>
```

## Special Cases

### First Time PR
- [ ] Sign the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) which will be prompted by our github bot after you submit the PR
- [ ] Add your [discord](https://discord.gg/AE3NRw9) alias in the review so that we can give you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) badge in our community

### Git
- [ ] Make sure your branch names adhere to our commit style [[#^6zdCscSXs1MM]]
    - All PRs should start with `[feat|fix|enhance|]/[{description-of-pr-in-kebab-case}]`
        - `eg. feat/add-thisthing`

### Analytics
- [ ] If you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Github Issue
- [ ] If this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
- [ ] If the resolution comes with a document update, link the docs PR to the issue as well.
