### PR TITLE
feat: implement goto definition for non-note files

### DIFF
--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -36,7 +36,7 @@ type CommandOpts = {
 };
 export { CommandOpts as GotoNoteCommandOpts };
 
-enum TargetKind {
+export enum TargetKind {
   NOTE = "note",
   NON_NOTE = "nonNote",
 }

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -1,13 +1,73 @@
-import { ConfigUtils, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  DVault,
+  NoteUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
 import _ from "lodash";
 import vscode, { Location, Position, Uri } from "vscode";
-import { findAnchorPos, GotoNoteCommand } from "../commands/GotoNote";
+import {
+  findAnchorPos,
+  GotoNoteCommand,
+  TargetKind,
+} from "../commands/GotoNote";
 import { Logger } from "../logger";
 import { getReferenceAtPosition } from "../utils/md";
 import { DendronExtension, getDWorkspace } from "../workspace";
 import * as Sentry from "@sentry/node";
+import { findNonNoteFile } from "@dendronhq/common-server";
 
 export default class DefinitionProvider implements vscode.DefinitionProvider {
+  private async maybeNonNoteFileDefinition({
+    fpath,
+    vault,
+  }: {
+    fpath: string;
+    vault?: DVault;
+  }) {
+    const { wsRoot, vaults } = getDWorkspace();
+    const file = await findNonNoteFile({
+      fpath,
+      vaults: vault ? [vault] : vaults,
+      wsRoot,
+    });
+    return file?.fullPath;
+  }
+
+  private async provideForNonNoteFile(nonNoteFile: string) {
+    const out = await new GotoNoteCommand().execute({
+      qs: nonNoteFile,
+      kind: TargetKind.NON_NOTE,
+    });
+    // Wasn't able to create
+    if (out?.kind !== TargetKind.NON_NOTE) return;
+    return new Location(Uri.file(out.fullPath), new Position(0, 0));
+  }
+
+  private async provideForNewNote(
+    refAtPos: NonNullable<ReturnType<typeof getReferenceAtPosition>>
+  ) {
+    const config = getDWorkspace().config;
+    const noAutoCreateOnDefinition =
+      !ConfigUtils.getWorkspace(config).enableAutoCreateOnDefinition;
+    if (noAutoCreateOnDefinition) {
+      return;
+    }
+    const out = await new GotoNoteCommand().execute({
+      qs: refAtPos.ref,
+      anchor: refAtPos.anchorStart,
+    });
+    if (out?.kind !== TargetKind.NOTE) {
+      // Wasn't able to create, or not a note file
+      return;
+    }
+    const { note, pos } = out;
+    return new Location(
+      Uri.file(NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })),
+      pos || new Position(0, 0)
+    );
+  }
+
   public async provideDefinition(
     document: vscode.TextDocument,
     position: vscode.Position,
@@ -58,28 +118,14 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
         }
         return loc;
       } else {
-        const config = getDWorkspace().config;
-
-        const noAutoCreateOnDefinition =
-          !ConfigUtils.getWorkspace(config).enableAutoCreateOnDefinition;
-        if (noAutoCreateOnDefinition) {
-          return;
-        }
-        const out = await new GotoNoteCommand().execute({
-          qs: refAtPos.ref,
-          anchor: refAtPos.anchorStart,
+        // if no note exists, check if it's a non-note file
+        const nonNoteFile = await this.maybeNonNoteFileDefinition({
+          fpath: refAtPos.ref,
+          vault,
         });
-        if (out?.kind !== "note") {
-          // Wasn't able to create, or not a note file
-          return;
-        }
-        const { note, pos } = out;
-        return new Location(
-          Uri.file(
-            NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
-          ),
-          pos || new Position(0, 0)
-        );
+
+        if (nonNoteFile) return this.provideForNonNoteFile(nonNoteFile);
+        else return this.provideForNewNote(refAtPos);
       }
     } catch (error) {
       Sentry.captureException(error);

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -38,7 +38,12 @@ import _ from "lodash";
 import { after, afterEach, before, beforeEach, describe } from "mocha";
 import os from "os";
 import sinon from "sinon";
-import { ExtensionContext, Uri, WorkspaceFolder } from "vscode";
+import {
+  ExtensionContext,
+  Uri,
+  WorkspaceFolder,
+  CancellationToken,
+} from "vscode";
 import {
   SetupWorkspaceCommand,
   SetupWorkspaceOpts,
@@ -499,4 +504,15 @@ export function cleanupVSCodeContextSubscriptions(ctx: ExtensionContext) {
   ctx.subscriptions.forEach((disposable) => {
     disposable.dispose();
   });
+}
+
+export function stubCancellationToken(): CancellationToken {
+  return {
+    isCancellationRequested: false,
+    onCancellationRequested: () => {
+      return {
+        dispose: () => {},
+      };
+    },
+  };
 }

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1639211658107
+updated: 1639381655936
 created: 1608518909864
 ---
 
@@ -135,3 +135,7 @@ The following link won't be highlighted since it's inside the code block, but Go
 const x = 1;
 // see more here:[[dendron.ref.links.target-1]]
 ```
+
+## Link to a non-note file
+
+[[/vault/root.schema.yml]]


### PR DESCRIPTION
Allows `Ctrl+Click`ing on a link to a non-note file to navigate to that file. This only works inside notes right now.

I'll work on hover & highlighting inside note files next, then look into definition & hover when inside non-note files.