### PR TITLE
DRAFT: scroll sync from editor to preview

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -102,6 +102,25 @@ export class WebViewCommonUtils {
         document.head.appendChild(link);
     }
       ${acquireVsCodeApi}
+    
+    
+     window.addEventListener('message', event => {
+        const targetText = event.data.text;
+        const targetOffset = event.data.elementOffset;
+        
+        const allElements = document.querySelectorAll('*');
+        
+        var myElements = [];
+        for (var i = 0; i < allElements.length; i++) { 
+            if (allElements[i].innerHTML.includes(targetText)) {
+                myElements.push(allElements[i]);
+            }
+        }
+        
+        const lastElement = myElements[targetOffset];
+        lastElement.scrollIntoView();        
+    });
+    
     </script>
 
     <body onload="onload()" class="vscode-${initialTheme || "light"}">

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -470,6 +470,13 @@
         "enablement": "dendron:pluginActive"
       },
       {
+        "command": "dendron.syncPreview",
+        "title": "Dendron: Sync Preview",
+        "desc": "Sync Preview With Editor",
+        "docLink": "dendron.topic.commands.md",
+        "docPreview": ""
+      },
+      {
         "command": "dendron.pasteFile",
         "title": "Dendron: Paste File",
         "desc": "Paste file"
@@ -877,6 +884,11 @@
         "windows": "windows+ctrl+p",
         "mac": "cmd+ctrl+p",
         "when": "dendron:pluginActive"
+      },
+      {
+        "command": "dendron.syncPreview",
+        "windows": "ctrl+windows+s",
+        "mac": "ctrl+cmd+s"
       }
     ],
     "markdown.previewStyles": [

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -291,6 +291,9 @@ export const handleLink = async ({
   }
 };
 
+// eslint-disable-next-line import/no-mutable-exports
+export let UI_SHOW_PREVIEW_CMD: ShowPreviewCommand | undefined;
+
 export class ShowPreviewCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
@@ -301,6 +304,23 @@ export class ShowPreviewCommand extends BasicCommand<
   constructor(previewPanel: vscode.WebviewPanel) {
     super();
     this._panel = previewPanel;
+
+    if (UI_SHOW_PREVIEW_CMD === undefined) {
+      UI_SHOW_PREVIEW_CMD = this;
+    }
+  }
+
+  async syncEditorToPreviewPlacement(
+    cleanedText: string,
+    elementOffset: number
+  ) {
+    if (this._panel && this._panel.webview) {
+      this._panel.webview.postMessage({
+        type: "sync-editor-to-preview",
+        text: cleanedText,
+        elementOffset,
+      });
+    }
   }
 
   async sanityCheck() {

--- a/packages/plugin-core/src/commands/SyncPreviewCommand.ts
+++ b/packages/plugin-core/src/commands/SyncPreviewCommand.ts
@@ -1,0 +1,100 @@
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+import { VSCodeUtils } from "../vsCodeUtils";
+import * as vscode from "vscode";
+import { TextEditor } from "vscode";
+import { Logger } from "../logger";
+import { UI_SHOW_PREVIEW_CMD } from "./ShowPreview";
+
+type CommandOpts = {};
+
+type CommandInput = {};
+
+type CommandOutput = void;
+
+const ctx = `SyncPreviewCommand`;
+
+export class ScrollSyncUtil {
+  // https://regex101.com/r/zI1Qdy/1
+  static headerDetectorRegEx = new RegExp("^##* ");
+
+  // https://regex101.com/r/wjwqXm/1
+  static listStarDetectorRegEx = new RegExp("^\\s*\\*\\s");
+
+  static replaceTextForMatch(text: string): string {
+    if (this.headerDetectorRegEx.test(text)) {
+      // Example '# header-val'. We want to take value after the space
+      return text.substring(text.indexOf(" ") + 1);
+    } else if (this.listStarDetectorRegEx.test(text)) {
+      // We want the space after the star to be our starting point
+      return text.substring(text.indexOf("*") + 2);
+    }
+    return text;
+  }
+}
+
+export class EditorToPreviewSyncer {
+  static async sync(editor: TextEditor) {
+    if (UI_SHOW_PREVIEW_CMD === undefined) return;
+
+    Logger.info({ ctx, msg: `Activated editor to Preview sync.` });
+
+    const currentCursor = editor.selection.active;
+
+    const cursorLine = editor.document.lineAt(currentCursor.line);
+    const textRange = new vscode.Range(
+      cursorLine.range.start,
+      cursorLine.range.end
+    );
+    const cleanedText = ScrollSyncUtil.replaceTextForMatch(
+      editor.document.getText(textRange)
+    );
+
+    // We should find our element at least once which would increment the offset to 0
+    let elementOffset = -1;
+    for (let i = 0; i <= currentCursor.line; i += 1) {
+      // Find out how many matches for the given text content exist in
+      // in the document so we can figure out which of the element to
+      // take within the HTML preview.
+      const textLine = editor.document.lineAt(i);
+
+      if (textLine.text.includes(cleanedText)) {
+        elementOffset += 1;
+      }
+    }
+
+    if (elementOffset === -1) {
+      Logger.warn({
+        msg: `'cleanText' must have not matched up with original element setting offset to '0'`,
+      });
+      elementOffset = 0;
+    }
+
+    console.log(
+      `Scroll sync activated text: '${cleanedText}', offset: '${elementOffset}'`
+    );
+
+    await UI_SHOW_PREVIEW_CMD.syncEditorToPreviewPlacement(
+      cleanedText,
+      elementOffset
+    );
+  }
+}
+
+export class SyncPreviewCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.SYNC_PREVIEW.key;
+
+  async gatherInputs(): Promise<CommandInput | undefined> {
+    return {};
+  }
+
+  async execute() {
+    const editor = VSCodeUtils.getActiveTextEditor();
+    if (editor !== undefined) {
+      await EditorToPreviewSyncer.sync(editor);
+    }
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -58,6 +58,7 @@ import { SeedRemoveCommand } from "./SeedRemoveCommand";
 import { SetupWorkspaceCommand } from "./SetupWorkspace";
 import { ShowHelpCommand } from "./ShowHelp";
 import { ShowLegacyPreviewCommand } from "./ShowLegacyPreview";
+import { SyncPreviewCommand } from "./SyncPreviewCommand";
 import { SignInCommand } from "./SignIn";
 import { SignUpCommand } from "./SignUp";
 import { SnapshotVaultCommand } from "./SnapshotVault";
@@ -120,6 +121,7 @@ const ALL_COMMANDS = [
   SetupWorkspaceCommand,
   ShowHelpCommand,
   ShowLegacyPreviewCommand,
+  SyncPreviewCommand,
   SignInCommand,
   SignUpCommand,
   PublishExportCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -867,6 +867,18 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     docPreview: "",
     enablement: "dendron:pluginActive",
   },
+  SYNC_PREVIEW: {
+    key: "dendron.syncPreview",
+    title: `${CMD_PREFIX} Sync Preview`,
+    group: "notes",
+    keybindings: {
+      windows: "ctrl+windows+s",
+      mac: "ctrl+cmd+s",
+    },
+    desc: "Sync Preview With Editor",
+    docLink: "dendron.topic.commands.md",
+    docPreview: "",
+  },
   PASTE_FILE: {
     key: "dendron.pasteFile",
     title: `${CMD_PREFIX} Paste File`,

--- a/packages/plugin-core/src/logger.ts
+++ b/packages/plugin-core/src/logger.ts
@@ -144,6 +144,16 @@ export class Logger {
     });
   }
 
+  static warn(payload: any, show?: boolean): void {
+    Logger.log(payload, "warn", { show });
+
+    Sentry.addBreadcrumb({
+      category: "plugin",
+      message: customStringify(payload),
+      level: Sentry.Severity.Warning,
+    });
+  }
+
   static info(payload: any, show?: boolean): void {
     Logger.log(payload, "info", { show });
 

--- a/packages/plugin-core/src/test/suite-integ/SyncPreviewCommandTest.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncPreviewCommandTest.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "mocha";
+import { expect } from "../testUtilsv2";
+import { ScrollSyncUtil } from "../../commands/SyncPreviewCommand";
+
+suite("SyncPreviewCommand tests", () => {
+  describe(`ScrollSyncUtil tests:`, () => {
+    describe(`replaceTextForMatch`, () => {
+      it(`WHEN no special chars THEN keep as is`, () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("hi world")).toEqual(
+          "hi world"
+        );
+      });
+
+      it("WHEN starts with star space THEN remove the star", () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("* hi world")).toEqual(
+          "hi world"
+        );
+      });
+
+      it("WHEN starts with space star space THEN remove the star", () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("  * hi world")).toEqual(
+          "hi world"
+        );
+      });
+
+      it("WHEN starts with star without space THEN keep the star", () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("*hi world")).toEqual(
+          "*hi world"
+        );
+      });
+
+      it("WHEN starts # and space THEN remove the #", () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("# hi")).toEqual("hi");
+      });
+
+      it("WHEN starts with two # and space THEN remove the #", () => {
+        expect(ScrollSyncUtil.replaceTextForMatch("## hi")).toEqual("hi");
+      });
+    });
+  });
+});

--- a/test-workspace/vault/dendron.links.heading-anchors.md
+++ b/test-workspace/vault/dendron.links.heading-anchors.md
@@ -2,7 +2,7 @@
 id: FSi3bKWQeQXYTjE1PoTB0
 title: Heading Anchors
 desc: ''
-updated: 1633004714929
+updated: 1639388362455
 created: 1632988925249
 ---
 
@@ -35,6 +35,51 @@ created: 1632988925249
 * content-1
 * content-1
 * content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+* content-1
+
 
 ## heading-2
 * content-2


### PR DESCRIPTION
## DRAFT: scroll sync from editor to preview

Main related note: ![[dendron://private/task.preview.scroll-in-sync-with-markdown]]
(At the bottom section: ![[dendron://private/task.preview.scroll-in-sync-with-markdown#user-triggered-sync,1:#*]] there is info on different steps of approach).

Good note to test this is ![[dendron.links.heading-anchors#heading-2,1]] in test workspace.

The approach is attempting to get cleaned version of the text from text editor focus and find the offset (how many elements in editor exist with such text) then find the offset element with the preview. However, the current challenge is that the links get rendered very differently (with diffrent text) which throws off this approach. 

Looking for suggestions if someone has a better approach to this problem or whether we should continue down this road and attempt to parse the links etc.. further for higher likelehood of correct match of offset of the element. 