### PR TITLE
fix: move auto completable command registration to be done centrally

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -91,6 +91,8 @@ import { DendronCodeWorkspace } from "./workspace/codeWorkspace";
 import { DendronNativeWorkspace } from "./workspace/nativeWorkspace";
 import { WorkspaceInitFactory } from "./workspace/workspaceInitializer";
 import { WSUtils } from "./WSUtils";
+import { AutoCompletableRegistrar } from "./utils/registers/AutoCompletableRegistrar";
+import { isAutoCompletable } from "./utils/AutoCompletable";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -980,6 +982,12 @@ async function _setupCommands(
 
   ALL_COMMANDS.map((Cmd) => {
     const cmd = new Cmd(ws);
+
+    // Register commands that implement on `onAutoComplete` with AutoCompletableRegister
+    // to be able to be invoked with auto completion action.
+    if (isAutoCompletable(cmd)) {
+      AutoCompletableRegistrar.register(cmd.key, cmd);
+    }
 
     if (!existingCommands.includes(cmd.key))
       context.subscriptions.push(

--- a/packages/plugin-core/src/commands/NoteLookupAutoCompleteCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupAutoCompleteCommand.ts
@@ -1,9 +1,6 @@
 import { DENDRON_COMMANDS } from "../constants";
 import { BasicCommand } from "./base";
-import {
-  AUTO_COMPLETABLE_COMMAND_ID,
-  UIAutoCompletableCmds,
-} from "../utils/autoCompleter";
+import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 
 type CommandOpts = {};
 
@@ -22,8 +19,8 @@ export class NoteLookupAutoCompleteCommand extends BasicCommand<
   }
 
   async execute() {
-    await UIAutoCompletableCmds.getCmd(
-      AUTO_COMPLETABLE_COMMAND_ID.NOTE_LOOKUP
+    await AutoCompletableRegistrar.getCmd(
+      DENDRON_COMMANDS.LOOKUP_NOTE.key
     ).onAutoComplete();
   }
 }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -58,11 +58,8 @@ import { AnalyticsUtils, getAnalyticsPayload } from "../utils/analytics";
 import { getDWorkspace, getEngine } from "../workspace";
 import { BaseCommand } from "./base";
 import { VSCodeUtils } from "../vsCodeUtils";
-import {
-  AUTO_COMPLETABLE_COMMAND_ID,
-  AutoCompleter,
-  UIAutoCompletableCmds,
-} from "../utils/autoCompleter";
+import { AutoCompleter } from "../utils/autoCompleter";
+import { AutoCompletable } from "../utils/AutoCompletable";
 
 export type CommandRunOpts = {
   initialValue?: string;
@@ -118,12 +115,15 @@ export { CommandOpts as LookupCommandOptsV3 };
  * Note look up command instance that is used by the UI.
  * */
 
-export class NoteLookupCommand extends BaseCommand<
-  CommandOpts,
-  CommandOutput,
-  CommandGatherOutput,
-  CommandRunOpts
-> {
+export class NoteLookupCommand
+  extends BaseCommand<
+    CommandOpts,
+    CommandOutput,
+    CommandGatherOutput,
+    CommandRunOpts
+  >
+  implements AutoCompletable
+{
   key = DENDRON_COMMANDS.LOOKUP_NOTE.key;
   protected _controller: LookupControllerV3 | undefined;
   protected _provider: ILookupProviderV3 | undefined;
@@ -131,14 +131,6 @@ export class NoteLookupCommand extends BaseCommand<
 
   constructor() {
     super("LookupCommandV3");
-
-    // The first look up command that is created is expected to be created by the UI
-    // upon Dendron initialization hence we will register the instance as
-    // the UI command instance.
-    UIAutoCompletableCmds.registerIfNotRegistered(
-      AUTO_COMPLETABLE_COMMAND_ID.NOTE_LOOKUP,
-      this
-    );
   }
 
   protected get controller(): LookupControllerV3 {

--- a/packages/plugin-core/src/test/suite-integ/AutoCompleterRegistrar.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AutoCompleterRegistrar.test.ts
@@ -1,0 +1,15 @@
+import { expect } from "../testUtilsv2";
+import { AutoCompletableRegistrar } from "../../utils/registers/AutoCompletableRegistrar";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+
+suite("AutoCompleterRegistrar tests", function () {
+  test(`WHEN accessing registered command THEN retrieve command`, () => {
+    const key = "test-key";
+    AutoCompletableRegistrar.register("test-key", new NoteLookupCommand());
+    expect(AutoCompletableRegistrar.getCmd(key)).toBeTruthy();
+  });
+
+  test(`WHEN accessing unregistered command THEN throw`, () => {
+    expect(() => AutoCompletableRegistrar.getCmd("i-dont-exist")).toThrow();
+  });
+});

--- a/packages/plugin-core/src/utils/AutoCompletable.ts
+++ b/packages/plugin-core/src/utils/AutoCompletable.ts
@@ -1,0 +1,24 @@
+/**
+ * Auto Completable is an interface that should be implemented by commands
+ * which are envisioned to support auto complete functionality. It is mostly
+ * geared towards lookup functionality of allowing to auto complete the
+ * lookup results.
+ *
+ * Currently just implementation of this interface does NOT enable auto
+ * complete and a trigger command needs to be setup to actually call the
+ * method of {@link AutoCompletable#onAutoComplete}.
+ *
+ * Commands that do implement this interface will be automatically registered
+ * with AutoCompletableRegistrar during initialization.
+ * */
+export type AutoCompletable = {
+  /**
+   * When auto complete is triggered and calls upon this function the
+   * command should implement the logic for auto completion of current state.
+   * */
+  onAutoComplete: () => Promise<void>;
+};
+
+export const isAutoCompletable = (cmd: any): cmd is AutoCompletable => {
+  return (cmd as AutoCompletable).onAutoComplete !== undefined;
+};

--- a/packages/plugin-core/src/utils/autoCompleter.ts
+++ b/packages/plugin-core/src/utils/autoCompleter.ts
@@ -1,51 +1,10 @@
 /**
  * Responsible for picking out the auto completions.
  * */
-import { ErrorFactory, FuseEngine } from "@dendronhq/common-all";
-import { BaseCommand } from "../commands/base";
+import { FuseEngine } from "@dendronhq/common-all";
 import * as _ from "lodash";
 import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { CREATE_NEW_DETAIL } from "../components/lookup/constants";
-
-type AutoCompletableCmd = BaseCommand<any> & {
-  onAutoComplete: () => Promise<void>;
-};
-
-export enum AUTO_COMPLETABLE_COMMAND_ID {
-  NOTE_LOOKUP = "NOTE_LOOKUP",
-}
-
-export class UIAutoCompletableCmds {
-  static _UI_AUTOCOMPLETE_COMMANDS = new Map<
-    AUTO_COMPLETABLE_COMMAND_ID,
-    AutoCompletableCmd
-  >();
-
-  /**
-   * The first instance that is called with the given id is registered within the map.
-   * */
-  static registerIfNotRegistered = (
-    id: AUTO_COMPLETABLE_COMMAND_ID,
-    cmd: AutoCompletableCmd
-  ) => {
-    if (_.isUndefined(this._UI_AUTOCOMPLETE_COMMANDS.get(id))) {
-      this._UI_AUTOCOMPLETE_COMMANDS.set(id, cmd);
-    }
-  };
-
-  /** Retrieve command instance that is used by UI. */
-  static getCmd = (id: AUTO_COMPLETABLE_COMMAND_ID): AutoCompletableCmd => {
-    const cmd = this._UI_AUTOCOMPLETE_COMMANDS.get(id);
-
-    if (cmd === undefined) {
-      throw ErrorFactory.createInvalidStateError({
-        message: `UI command instance does not exist for '${id}'`,
-      });
-    }
-
-    return cmd;
-  };
-}
 
 export class AutoCompleter {
   /**

--- a/packages/plugin-core/src/utils/registers/AutoCompletableRegistrar.ts
+++ b/packages/plugin-core/src/utils/registers/AutoCompletableRegistrar.ts
@@ -1,0 +1,26 @@
+import { AutoCompletable } from "../AutoCompletable";
+import { ErrorFactory } from "@dendronhq/common-all";
+
+/**
+ * Populated during initialization with commands that implement function: cmd.onAutoComplete
+ * */
+export class AutoCompletableRegistrar {
+  static _UI_AUTOCOMPLETE_COMMANDS = new Map<string, AutoCompletable>();
+
+  static register = (key: string, cmd: AutoCompletable) => {
+    this._UI_AUTOCOMPLETE_COMMANDS.set(key, cmd);
+  };
+
+  /** Retrieve command instance that is used by UI. */
+  static getCmd = (key: string): AutoCompletable => {
+    const cmd = this._UI_AUTOCOMPLETE_COMMANDS.get(key);
+
+    if (cmd === undefined) {
+      throw ErrorFactory.createInvalidStateError({
+        message: `AutoCompletable command is not registered for '${key}'`,
+      });
+    }
+
+    return cmd;
+  };
+}


### PR DESCRIPTION
# Pull Request Checklist
[[dendron://private/task.lookup.2021.12.13.completion-activation-issue]]

Changing to the registration of auto completable commands to make it more robust.

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
