### PR TITLE
enhance(views): Support new config to automatically show preview

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -252,13 +252,17 @@
         },
         "bubbleUpCreateNew": {
           "type": "boolean"
+        },
+        "fuzzThreshold": {
+          "type": "number"
         }
       },
       "required": [
         "selectionMode",
         "confirmVaultOnCreate",
         "leaveTrace",
-        "bubbleUpCreateNew"
+        "bubbleUpCreateNew",
+        "fuzzThreshold"
       ],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  NoteLookupCommand }"
@@ -425,6 +429,9 @@
         "maxNoteLength": {
           "type": "number"
         },
+        "enableEditorDecorations": {
+          "type": "boolean"
+        },
         "feedback": {
           "type": "boolean"
         },
@@ -446,7 +453,8 @@
         "enableUserTags",
         "enableHashTags",
         "maxPreviewsCached",
-        "maxNoteLength"
+        "maxNoteLength",
+        "enableEditorDecorations"
       ],
       "additionalProperties": false,
       "description": "Namespace for configurations that affect the workspace"
@@ -773,6 +781,9 @@
         },
         "enableKatex": {
           "type": "boolean"
+        },
+        "automaticallyShowPreview": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -780,7 +791,8 @@
         "enableNoteTitleForLink",
         "enableMermaid",
         "enablePrettyRefs",
-        "enableKatex"
+        "enableKatex",
+        "automaticallyShowPreview"
       ],
       "additionalProperties": false,
       "description": "Namespace for all preview related configurations"

--- a/packages/common-all/src/constants/configs/preview.ts
+++ b/packages/common-all/src/constants/configs/preview.ts
@@ -14,4 +14,8 @@ export const PREVIEW: DendronConfigEntryCollection<DendronPreviewConfig> = {
   enableMermaid: ENABLE_MERMAID("preview"),
   enablePrettyRefs: ENABLE_PRETTY_REFS("preview"),
   enableKatex: ENABLE_KATEX("preview"),
+  automaticallyShowPreview: {
+    label: "Automatically Show Preview",
+    desc: "Automatically show preview when opening VSCode and switching between notes.",
+  },
 };

--- a/packages/common-all/src/types/configs/preview/preview.ts
+++ b/packages/common-all/src/types/configs/preview/preview.ts
@@ -7,6 +7,7 @@ export type DendronPreviewConfig = {
   enableMermaid: boolean;
   enablePrettyRefs: boolean;
   enableKatex: boolean;
+  automaticallyShowPreview: boolean;
 };
 
 /**
@@ -20,5 +21,6 @@ export function genDefaultPreviewConfig(): DendronPreviewConfig {
     enableMermaid: true,
     enablePrettyRefs: true,
     enableKatex: true,
+    automaticallyShowPreview: false,
   };
 }

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -252,13 +252,17 @@
         },
         "bubbleUpCreateNew": {
           "type": "boolean"
+        },
+        "fuzzThreshold": {
+          "type": "number"
         }
       },
       "required": [
         "selectionMode",
         "confirmVaultOnCreate",
         "leaveTrace",
-        "bubbleUpCreateNew"
+        "bubbleUpCreateNew",
+        "fuzzThreshold"
       ],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  NoteLookupCommand }"
@@ -425,6 +429,9 @@
         "maxNoteLength": {
           "type": "number"
         },
+        "enableEditorDecorations": {
+          "type": "boolean"
+        },
         "feedback": {
           "type": "boolean"
         },
@@ -446,7 +453,8 @@
         "enableUserTags",
         "enableHashTags",
         "maxPreviewsCached",
-        "maxNoteLength"
+        "maxNoteLength",
+        "enableEditorDecorations"
       ],
       "additionalProperties": false,
       "description": "Namespace for configurations that affect the workspace"
@@ -773,6 +781,9 @@
         },
         "enableKatex": {
           "type": "boolean"
+        },
+        "automaticallyShowPreview": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -780,7 +791,8 @@
         "enableNoteTitleForLink",
         "enableMermaid",
         "enablePrettyRefs",
-        "enableKatex"
+        "enableKatex",
+        "automaticallyShowPreview"
       ],
       "additionalProperties": false,
       "description": "Namespace for all preview related configurations"

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -113,6 +113,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -249,6 +250,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -360,6 +362,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -454,6 +457,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -561,6 +565,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -107,6 +107,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -243,6 +244,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -354,6 +356,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -448,6 +451,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -555,6 +559,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -673,6 +678,7 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;
 
@@ -774,5 +780,6 @@ preview:
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
+    automaticallyShowPreview: false
 "
 `;

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -736,6 +736,11 @@ export async function _activate(
         source: "extension",
         action: "activate",
       });
+      const note = WSUtils.getActiveNote();
+      if (note) {
+        PreviewPanelFactory.getProxy().showPreviewAndUpdate(note);
+      }
+
       return true;
     }
     return false;

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -736,6 +736,7 @@ export async function _activate(
         source: "extension",
         action: "activate",
       });
+      // If automaticallyShowPreview = true, display preview panel on start up
       const note = WSUtils.getActiveNote();
       if (note) {
         PreviewPanelFactory.getProxy().showPreviewAndUpdate(note);

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -161,7 +161,7 @@ export class NoteSyncService {
     const noteClean = await engine.updateNote(note);
 
     // Temporary workaround until NoteSyncService is no longer a singleton
-    PreviewPanelFactory.getProxy().updateForNote(noteClean);
+    PreviewPanelFactory.getProxy().showPreviewAndUpdate(noteClean);
 
     return noteClean;
   }

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1,10 +1,10 @@
 import {
+  ConfigUtils,
   CONSTANTS,
   InstallStatus,
   isNotUndefined,
   Time,
   VaultUtils,
-  ConfigUtils,
   WorkspaceType,
 } from "@dendronhq/common-all";
 import {
@@ -332,6 +332,7 @@ suite("Extension", function () {
             enableMermaid: true,
             enablePrettyRefs: true,
             enableKatex: true,
+            automaticallyShowPreview: false,
           },
         });
 

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -1,36 +1,43 @@
-import { NoteUtils } from "@dendronhq/common-all";
+import { ConfigUtils, NoteUtils, WorkspaceOpts } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
+import { PreviewPanelFactory } from "../../components/views/PreviewViewFactory";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WindowWatcher } from "../../windowWatcher";
-import { getExtension } from "../../workspace";
+import { getDWorkspace, getExtension } from "../../workspace";
 import { WorkspaceWatcher } from "../../WorkspaceWatcher";
 import { WSUtils } from "../../WSUtils";
 import { expect, runSingleVaultTest } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  describeSingleWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
-suite("WindowWatcher", function () {
+const setupBasic = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    fname: "bar",
+    body: "bar body",
+    vault: vaults[0],
+    wsRoot,
+  });
+};
+
+suite("WindowWatcher: GIVEN the dendron extension is running", function () {
   let watcher: WindowWatcher;
 
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
-  describe("onDidChange", () => {
+  describe("WHEN onDidChangeActiveTextEditor is triggered", () => {
     test("basic", (done) => {
       runSingleVaultTest({
         ctx,
-        postSetupHook: async ({ vaults, wsRoot }) => {
-          const vault = vaults[0];
-          await NoteTestUtilsV4.createNote({
-            fname: "bar",
-            body: "bar body",
-            vault,
-            wsRoot,
-          });
-        },
+        postSetupHook: setupBasic,
         onInit: async ({ vault, wsRoot }) => {
           const vaultPath = vault.fsPath;
           watcher = new WindowWatcher();
@@ -43,6 +50,63 @@ suite("WindowWatcher", function () {
         },
       });
     });
+
+    describeSingleWS(
+      "AND WHEN automaticallyShowPreview is set to false",
+      {
+        postSetupHook: setupBasic,
+        ctx,
+        modConfigCb: (config) => {
+          ConfigUtils.setPreviewProps(
+            config,
+            "automaticallyShowPreview",
+            false
+          );
+          return config;
+        },
+      },
+      () => {
+        test("THEN preview panel is not shown", async () => {
+          const { wsRoot, vaults } = getDWorkspace();
+          const vaultPath = vaults[0].fsPath;
+          watcher = new WindowWatcher();
+          const notePath = path.join(wsRoot, vaultPath, "bar.md");
+          const uri = vscode.Uri.file(notePath);
+          const editor = await VSCodeUtils.openFileInEditor(uri);
+          await watcher.triggerNotePreviewUpdate(editor!);
+
+          const maybePanel = PreviewPanelFactory.getProxy().getPanel();
+          expect(maybePanel).toBeFalsy();
+        });
+      }
+    );
+
+    describeSingleWS(
+      "AND WHEN automaticallyShowPreview is set to true",
+      {
+        postSetupHook: setupBasic,
+        ctx,
+        modConfigCb: (config) => {
+          ConfigUtils.setPreviewProps(config, "automaticallyShowPreview", true);
+          return config;
+        },
+      },
+      () => {
+        test("THEN preview panel is shown", async () => {
+          const { wsRoot, vaults } = getDWorkspace();
+          const vaultPath = vaults[0].fsPath;
+          watcher = new WindowWatcher();
+          const notePath = path.join(wsRoot, vaultPath, "bar.md");
+          const uri = vscode.Uri.file(notePath);
+          const editor = await VSCodeUtils.openFileInEditor(uri);
+          await watcher.triggerNotePreviewUpdate(editor!);
+
+          const maybePanel = PreviewPanelFactory.getProxy().getPanel();
+          expect(maybePanel).toBeTruthy();
+          expect(maybePanel?.active).toBeTruthy();
+        });
+      }
+    );
   });
 
   // NOTE: flaky tests

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -27,7 +27,9 @@ const setupBasic = async (opts: WorkspaceOpts) => {
 };
 
 suite("WindowWatcher: GIVEN the dendron extension is running", function () {
-  let watcher: WindowWatcher;
+  const watcher: WindowWatcher = new WindowWatcher(
+    PreviewPanelFactory.getProxy()
+  );
 
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
@@ -40,7 +42,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         postSetupHook: setupBasic,
         onInit: async ({ vault, wsRoot }) => {
           const vaultPath = vault.fsPath;
-          watcher = new WindowWatcher();
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           const editor = await VSCodeUtils.openFileInEditor(uri);
@@ -69,7 +70,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         test("THEN preview panel is not shown", async () => {
           const { wsRoot, vaults } = getDWorkspace();
           const vaultPath = vaults[0].fsPath;
-          watcher = new WindowWatcher();
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           const editor = await VSCodeUtils.openFileInEditor(uri);
@@ -95,7 +95,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         test("THEN preview panel is shown", async () => {
           const { wsRoot, vaults } = getDWorkspace();
           const vaultPath = vaults[0].fsPath;
-          watcher = new WindowWatcher();
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           const editor = await VSCodeUtils.openFileInEditor(uri);
@@ -127,7 +126,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
 
           getExtension().workspaceWatcher = new WorkspaceWatcher();
           getExtension().workspaceWatcher?.activate(ctx);
-          watcher = new WindowWatcher();
           watcher.activate(ctx);
           // Open a note
           await WSUtils.openNote(
@@ -153,7 +151,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           await VSCodeUtils.closeAllEditors();
           getExtension().workspaceWatcher = new WorkspaceWatcher();
           getExtension().workspaceWatcher?.activate(ctx);
-          watcher = new WindowWatcher();
 
           watcher.activate(ctx);
           // Open a note

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -9,7 +9,7 @@ import {
   TextEditorVisibleRangesChangeEvent,
   window,
 } from "vscode";
-import { PreviewPanelFactory } from "./components/views/PreviewViewFactory";
+import { PreviewProxy } from "./components/views/PreviewViewFactory";
 import { debouncedUpdateDecorations } from "./features/windowDecorations";
 import { Logger } from "./logger";
 import { sentryReportingCallback } from "./utils/analytics";
@@ -22,6 +22,12 @@ const context = (scope: string) => {
   return ROOT_CTX + ":" + scope;
 };
 export class WindowWatcher {
+  private _previewProxy: PreviewProxy;
+
+  constructor(previewProxy: PreviewProxy) {
+    this._previewProxy = previewProxy;
+  }
+
   private onDidChangeActiveTextEditorHandlers: ((
     e: TextEditor | undefined
   ) => void)[] = [];
@@ -130,8 +136,9 @@ export class WindowWatcher {
    */
   async triggerNotePreviewUpdate({ document }: TextEditor) {
     const maybeNote = WSUtils.tryGetNoteFromDocument(document);
-    if (maybeNote)
-      PreviewPanelFactory.getProxy().showPreviewAndUpdate(maybeNote);
+    if (maybeNote) {
+      this._previewProxy.showPreviewAndUpdate(maybeNote);
+    }
 
     return;
   }

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -30,6 +30,7 @@ import _ from "lodash";
 import path from "path";
 import * as vscode from "vscode";
 import { Uri } from "vscode";
+import { PreviewPanelFactory } from "./components/views/PreviewViewFactory";
 import {
   DendronContext,
   extensionQualifiedId,
@@ -642,7 +643,7 @@ export class DendronExtension {
       throw new Error(`rootDir not set when activating Watcher`);
     }
 
-    const windowWatcher = new WindowWatcher();
+    const windowWatcher = new WindowWatcher(PreviewPanelFactory.getProxy());
 
     windowWatcher.activate(this.context);
     for (const editor of vscode.window.visibleTextEditors) {


### PR DESCRIPTION
- Introduce new config automaticallyShowPreview
- When window changes (ie switching between notes), show preview if config is set to true
- When workspace is launched, show preview if config is set to true
- Default to false

Testing
- Manually verified preview behavior against test workspace
- Updated test cases for WindowWatcher.test.ts
