### PR TITLE
fix: refactor crashes when captured note is a stub

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1107,10 +1107,13 @@ export class NoteUtils {
 
   static serialize(
     props: NoteProps,
-    opts?: { writeHierarchy?: boolean }
+    opts?: { writeHierarchy?: boolean; excludeStub?: boolean }
   ): string {
     const body = props.body;
     let blacklist = ["parent", "children"];
+    if (opts?.excludeStub) {
+      blacklist.push("stub");
+    }
     if (opts?.writeHierarchy) {
       blacklist = [];
     }

--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -4,6 +4,7 @@ import {
   DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
+  NoteUtils,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import fs from "fs-extra";
@@ -277,7 +278,20 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
       return result && !DNodeUtils.isRoot(item);
     });
 
-    return capturedNotes;
+    // filter out notes that are not in fs (virtual stub notes)
+    return capturedNotes.filter((note) => {
+      if (note.stub) {
+        // if a stub is captured, see if it actually exists in the file system.
+        // if it is in the file system, we should include it should be part of the refactor
+        // otherwise, this should be omitted.
+        // as the virtual stubs will automatically be handled by the rename operation.
+        const notePath = NoteUtils.getFullPath({ wsRoot: engine.wsRoot, note });
+        const existsInFileSystem = fs.existsSync(notePath);
+        return existsInFileSystem;
+      } else {
+        return true;
+      }
+    });
   }
 
   getRenameOperations(opts: {


### PR DESCRIPTION
# fix: refactor crashes when captured note is a stub
This PR:
- Fixes an issue with `Dendron: Refactor Hierarchy` where if any note that is captured with the match text is a stub note, the rename operation fails.
  - This only applies to true stub notes (notes that are not in the file system and only virtually exists as a note prop)
  - Notes that are in the file system but has frontmatter `stub` property set to true will still be refactored correctly.

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [~] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

#### Special Cases
- [~] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [~] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## Special Cases

### Git
- [x] Make sure your branch names adhere to our commit style [[#^6zdCscSXs1MM]]
    - All PRs should start with `[feat|fix|enhance|]/[{description-of-pr-in-kebab-case}]`
        - `eg. feat/add-thisthing`

### Analytics
- [~] If you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Github Issue
- [x] If this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
- [~] If the resolution comes with a document update, link the docs PR to the issue as well.