### PR TITLE
fix: extension crash in non-Dendron workspaces when there's many files

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -777,7 +777,7 @@
         },
         "dendron.watchForNativeWorkspace": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "When enabled, Dendron will watch non-Dendron workspaces to detect when one is created, and will automatically initialize itself. Otherwise, you may need to reload VSCode after creating a native workspace."
         }
       }

--- a/packages/plugin-core/src/commands/SetupWorkspace.ts
+++ b/packages/plugin-core/src/commands/SetupWorkspace.ts
@@ -184,9 +184,7 @@ export class SetupWorkspaceCommand extends BasicCommand<
       rootDirRaw: rootDir,
       skipOpenWs,
       workspaceType,
-    } = _.defaults(opts, {
-      skipOpenWs: opts?.workspaceType === WorkspaceType.NATIVE,
-    });
+    } = _.defaults(opts, {});
     Logger.info({ ctx, rootDir, skipOpenWs, workspaceType });
 
     if (
@@ -218,11 +216,16 @@ export class SetupWorkspaceCommand extends BasicCommand<
       });
     }
 
-    if (!opts.skipOpenWs) {
+    if (!skipOpenWs) {
       vscode.window.showInformationMessage("opening dendron workspace");
-      VSCodeUtils.openWS(
-        vscode.Uri.file(path.join(rootDir, CONSTANTS.DENDRON_WS_NAME)).fsPath
-      );
+      if (workspaceType === WorkspaceType.CODE) {
+        VSCodeUtils.openWS(
+          vscode.Uri.file(path.join(rootDir, CONSTANTS.DENDRON_WS_NAME)).fsPath
+        );
+      } else if (workspaceType === WorkspaceType.NATIVE) {
+        // For native workspaces, we just need to reload the existing workspace because we want to keep the same workspace.
+        VSCodeUtils.reloadWindow();
+      }
     }
     return vaults;
   }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1223,7 +1223,7 @@ export const CONFIG: { [key: string]: ConfigEntry } = {
   WATCH_FOR_NATIVE_WS: {
     key: "dendron.watchForNativeWorkspace",
     type: "boolean",
-    default: true,
+    default: false,
     description:
       "When enabled, Dendron will watch non-Dendron workspaces to detect when one is created, and will automatically initialize itself. Otherwise, you may need to reload VSCode after creating a native workspace.",
   },


### PR DESCRIPTION
When there's a lot of files in non-Dendron workspaces, the native workspace creation watcher would cause Dendron to crash.
This PR disables the watcher by default, and instead simply reloads the workspace when a native workspace is created.

#1312
