### PR TITLE
enhance: go to definition & hover works for wikilinks inside non-note files

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1118,7 +1118,8 @@ function _setupLanguageFeatures(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(
-      mdLangSelector,
+      // Allows hover provider to work for wikilinks in non-note files
+      anyLangSelector,
       new ReferenceHoverProvider()
     )
   );

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1098,7 +1098,11 @@ async function _setupCommands(
 }
 
 function _setupLanguageFeatures(context: vscode.ExtensionContext) {
-  const mdLangSelector = { language: "markdown", scheme: "*" };
+  const mdLangSelector: vscode.DocumentFilter = {
+    language: "markdown",
+    scheme: "*",
+  };
+  const anyLangSelector: vscode.DocumentFilter = { scheme: "*" };
   context.subscriptions.push(
     vscode.languages.registerReferenceProvider(
       mdLangSelector,
@@ -1107,7 +1111,8 @@ function _setupLanguageFeatures(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider(
-      mdLangSelector,
+      // Allows definition provider to work for wikilinks in non-note files
+      anyLangSelector,
       new DefinitionProvider()
     )
   );

--- a/test-workspace/vault/assets/test.js
+++ b/test-workspace/vault/assets/test.js
@@ -1,0 +1,9 @@
+
+const x = 1;
+const y = [
+    1, 2, 3, 4, 5
+];
+
+// See more about this in [[dendron.journal.2020.07.12.foo]]
+
+y.forEach((i) => console.log(i));

--- a/test-workspace/vault/dendron.journal.2020.07.12.foo.md
+++ b/test-workspace/vault/dendron.journal.2020.07.12.foo.md
@@ -2,8 +2,10 @@
 id: dendron.journal.2020.07.12.foo
 title: dendron.journal.2020.07.12.foo
 desc: ""
-updated: 1598457956604
+updated: 1639780191127
 created: 1598457956604
 ---
 
 Foo content
+
+link to code: [[assets/test.js]]


### PR DESCRIPTION
This PR allows the definition provider and hover provider to work in all files, including non-note files. This allows users to `Ctrl+click` on wikilinks in non-note files, or hover over them.