### PR TITLE
enhance(pods): better-support for github Issue and task Notes

### DIFF
--- a/test-workspace/vault/github.issues.31-lorem-ipsum-101-test.md
+++ b/test-workspace/vault/github.issues.31-lorem-ipsum-101-test.md
@@ -1,0 +1,14 @@
+---
+id: RKHQLGSbFJiyDRm5jbjF9
+title: 31 Lorem Ipsum 101 Test
+desc: ''
+updated: 1639736164072
+created: 1639735640344
+tags:
+  - scope.pod
+url: 'https://github.com/Harshita-mindfire/graphQL/issues/31'
+status: 'CLOSED'
+issueID: I_kwDOGFRkSc5Ajp_J
+author: 'https://github.com/Harshita-mindfire'
+---
+Testing API


### PR DESCRIPTION
This PR adds an `aliasMapping` field in GitHub publish config to support interoperability of github-publish and airtable export pod. 
For Eg config could be: 
```
aliasMapping: {
  assignees: { value: {kevin: 'kevinslin'}, alias: 'owner'},
  status: { value: {x: 'CLOSED'}}
}
```
- Config for our task Note mappings : [[Pod Configuration|dendron://private/area.team.sop.publish-github-issue#pod-configuration]]
- [loom video](https://www.loom.com/share/a29980086c4b4f8cb1556cacb32f4123)