### PR TITLE
Add links to dendron vault for a few dendron components

### DIFF
--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -63,6 +63,9 @@ interface DebouncedFunc<T extends (...args: any[]) => any> {
   flush(): ReturnType<T> | undefined;
 }
 
+/**
+ * See [[Workspace Watcher|dendron://dendron.docs/pkg.plugin-core.ref.workspace-watcher]] for more docs
+ */
 export class WorkspaceWatcher {
   /** The documents that have been opened during this session that have not been viewed yet in the editor. */
   private _openedDocuments: Map<string, TextDocument>;

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -114,6 +114,7 @@ export const debouncedUpdateDecorations = debounceAsyncUntilComplete({
   trailing: true,
 });
 
+// see [[Decorations|dendron://dendron.docs/pkg.plugin-core.ref.decorations]] for further docs
 export async function updateDecorations(editor: TextEditor): Promise<{
   allDecorations?: Map<TextEditorDecorationType, DecorationOptions[]>;
   allWarnings?: Diagnostic[];

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -44,7 +44,7 @@ const getFrontmatterPosition = (
 };
 
 /**
- * Keep notes on disk in sync with engine
+ * See [[Note Sync Service|dendron://dendron.docs/pkg.plugin-core.ref.note-sync-service]] for docs
  */
 export class NoteSyncService {
   static instance() {
@@ -166,6 +166,9 @@ export class NoteSyncService {
     return noteClean;
   }
 
+  /**
+   * Update note metadata (eg. links and anchors)
+   */
   static async updateNoteMeta({
     note,
     fmChangeOnly,

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -21,6 +21,10 @@ const context = (scope: string) => {
   const ROOT_CTX = "WindowWatcher";
   return ROOT_CTX + ":" + scope;
 };
+
+/**
+ * See [[Window Watcher|dendron://dendron.docs/pkg.plugin-core.ref.window-watcher]] for docs
+ */
 export class WindowWatcher {
   private _previewProxy: PreviewProxy;
 
@@ -35,6 +39,7 @@ export class WindowWatcher {
   activate(context: ExtensionContext) {
     const extension = getExtension();
 
+    // provide logging whenever window changes
     extension.addDisposable(
       window.onDidChangeVisibleTextEditors(
         sentryReportingCallback((editors: TextEditor[]) => {
@@ -84,10 +89,13 @@ export class WindowWatcher {
         this.triggerUpdateDecorations(editor);
         this.triggerNotePreviewUpdate(editor);
 
+        // other components can register handlers for window watcher
+        // those handlers get called here
         this.onDidChangeActiveTextEditorHandlers.forEach((value) =>
           value.call(this, editor)
         );
 
+        // we have custom logic for newly opened documents
         if (
           getExtension().workspaceWatcher?.getNewlyOpenedDocument(
             editor.document


### PR DESCRIPTION
Now that we have the ability to document both in the code and also in Dendron, the question is what to put where.

The pattern I've been using: 
- details should be put in code as regular comments
- high level overviews should be put in Dendron. these details currently are in the form of reference notes of existing packages. See docs [here](https://github.com/dendronhq/dendron-docs/commit/f49a192ad8f58824989bbba7feece38a57704e0f)

The reference notes for these packages can be found [here](https://github.com/dendronhq/dendron-docs/commit/dafc752b99b33697c8872eedf0bf0c195a6c17ed)

One outstanding issue:
- the `Summary` section overlaps with the docstring for a given module. see below for an example. potential solution: use block embeding from file to note to generate summary 

```ts
/**
 * Creates instances of `FooWidget`
 */
class FooWidgetFactory {
}
```

```md
## Summary
Creates instances of `FooWidget`
```

This is just the beginning - there's a lot more that can be had but in interest of iteration, starting with module references as a simple starting point that we can build on.
