### PR TITLE
enhance: adding last update sort ordering for backlinks

### DIFF
--- a/packages/common-all/src/util/dateFormatUtil.ts
+++ b/packages/common-all/src/util/dateFormatUtil.ts
@@ -1,0 +1,18 @@
+export class DateFormatUtil {
+  /**
+   * Formats the date using short letter description for the month
+   * (Example 'Dec' for 'December), so that there is no ambiguity on the dates
+   * for different locales.
+   *
+   * Ambiguity to avoid: US is month/day/year while most of the world is day/month/year.
+   * */
+  static formatDate(millisSinceEpoch: number) {
+    const date = new Date(millisSinceEpoch);
+
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+}

--- a/packages/common-all/src/util/index.ts
+++ b/packages/common-all/src/util/index.ts
@@ -3,4 +3,5 @@ export * from "./orderedMatchter";
 export * from "./cache";
 export * from "./compat";
 export * from "./regex";
+export * from "./dateFormatUtil";
 export { URI } from "vscode-uri";

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -624,17 +624,17 @@
         {
           "command": "dendron.backlinks.sortByLastUpdated",
           "when": "view == dendron.backlinks && dendron:backlinksSortOrder == PathNames",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "dendron.backlinks.sortByPathNames",
           "when": "view == dendron.backlinks && dendron:backlinksSortOrder == LastUpdated",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "dendron.backlinks.expandAll",
           "when": "view == dendron.backlinks",
-          "group": "navigation"
+          "group": "navigation@2"
         }
       ],
       "explorer/context": [

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -83,6 +83,18 @@
     ],
     "commands": [
       {
+        "command": "dendron.backlinks.sortByLastUpdated",
+        "title": "Sort by last updated (currently sorted by path names)",
+        "icon": "$(list-ordered)",
+        "desc": "Sort the backlinks by when the notes were last updated."
+      },
+      {
+        "command": "dendron.backlinks.sortByPathNames",
+        "title": "Sort by path names (currently sorted by last updated)",
+        "icon": "$(list-ordered)",
+        "desc": "Sort the backlinks by path names of notes."
+      },
+      {
         "command": "dendron.backlinks.expandAll",
         "title": "Expand All",
         "icon": "$(expand-all)",
@@ -609,6 +621,16 @@
         }
       ],
       "view/title": [
+        {
+          "command": "dendron.backlinks.sortByLastUpdated",
+          "when": "view == dendron.backlinks && dendron:backlinksSortOrder == PathNames",
+          "group": "navigation"
+        },
+        {
+          "command": "dendron.backlinks.sortByPathNames",
+          "when": "view == dendron.backlinks && dendron:backlinksSortOrder == LastUpdated",
+          "group": "navigation"
+        },
         {
           "command": "dendron.backlinks.expandAll",
           "when": "view == dendron.backlinks",

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -174,17 +174,17 @@ export const DENDRON_MENUS = {
     {
       command: "dendron.backlinks.sortByLastUpdated",
       when: `view == dendron.backlinks && ${DendronContext.BACKLINKS_SORT_ORDER} == ${BacklinkSortOrder.PathNames}`,
-      group: "navigation",
+      group: "navigation@1",
     },
     {
       command: "dendron.backlinks.sortByPathNames",
       when: `view == dendron.backlinks && ${DendronContext.BACKLINKS_SORT_ORDER} == ${BacklinkSortOrder.LastUpdated}`,
-      group: "navigation",
+      group: "navigation@1",
     },
     {
       command: "dendron.backlinks.expandAll",
       when: "view == dendron.backlinks",
-      group: "navigation",
+      group: "navigation@2",
     },
   ],
   "explorer/context": [

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -3,7 +3,7 @@ import {
   isWebViewEntry,
   TREE_VIEWS,
 } from "@dendronhq/common-all";
-import { CodeConfigKeys } from "./types";
+import { BacklinkSortOrder, CodeConfigKeys } from "./types";
 
 export const extensionQualifiedId = `dendron.dendron`;
 export const DEFAULT_LEGACY_VAULT_NAME = "vault";
@@ -15,6 +15,7 @@ export enum DendronContext {
   HAS_LEGACY_PREVIEW = "dendron:hasLegacyPreview",
   HAS_CUSTOM_MARKDOWN_VIEW = "hasCustomMarkdownPreview",
   NOTE_LOOK_UP_ACTIVE = "dendron:noteLookupActive",
+  BACKLINKS_SORT_ORDER = "dendron:backlinksSortOrder",
 }
 
 const treeViewConfig2VSCodeEntry = (id: DendronTreeViewKey) => {
@@ -165,6 +166,21 @@ export const DENDRON_MENUS = {
     },
   ],
   "view/title": [
+    /**
+     * Sort orders are round-robined, if we add more orders and/or change ordering
+     * of sort order THEN make sure to update the labels of the command since the labels
+     * display the current backlink ordering that is being used.
+     * */
+    {
+      command: "dendron.backlinks.sortByLastUpdated",
+      when: `view == dendron.backlinks && ${DendronContext.BACKLINKS_SORT_ORDER} == ${BacklinkSortOrder.PathNames}`,
+      group: "navigation",
+    },
+    {
+      command: "dendron.backlinks.sortByPathNames",
+      when: `view == dendron.backlinks && ${DendronContext.BACKLINKS_SORT_ORDER} == ${BacklinkSortOrder.LastUpdated}`,
+      group: "navigation",
+    },
     {
       command: "dendron.backlinks.expandAll",
       when: "view == dendron.backlinks",
@@ -212,6 +228,20 @@ export const DENDRON_MENUS = {
 
 export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   // ---
+  BACKLINK_SORT_BY_LAST_UPDATED: {
+    key: "dendron.backlinks.sortByLastUpdated",
+    title: "Sort by last updated (currently sorted by path names)",
+    icon: "$(list-ordered)",
+    desc: "Sort the backlinks by when the notes were last updated.",
+    group: "workspace",
+  },
+  BACKLINK_SORT_BY_PATH_NAMES: {
+    key: "dendron.backlinks.sortByPathNames",
+    title: "Sort by path names (currently sorted by last updated)",
+    icon: "$(list-ordered)",
+    desc: "Sort the backlinks by path names of notes.",
+    group: "workspace",
+  },
   BACKLINK_EXPAND_ALL: {
     key: "dendron.backlinks.expandAll",
     title: "Expand All",

--- a/packages/plugin-core/src/features/BacklinksTreeDataProvider.ts
+++ b/packages/plugin-core/src/features/BacklinksTreeDataProvider.ts
@@ -6,8 +6,12 @@ import {
   FoundRefT,
   sortPaths,
 } from "../utils/md";
-import _ from "lodash";
-import { ICONS } from "../constants";
+import _, { Dictionary } from "lodash";
+import { DendronContext, ICONS } from "../constants";
+import { Logger } from "../logger";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { BacklinkSortOrder } from "../types";
+import { DateFormatUtil } from "@dendronhq/common-all";
 
 export type BacklinkFoundRef = FoundRefT & {
   parentBacklink: Backlink | undefined;
@@ -32,6 +36,14 @@ export class Backlink extends vscode.TreeItem {
   }
 }
 
+function shallowFirstPathSort(
+  referencesByPath: Dictionary<[unknown, ...unknown[]]>
+) {
+  return sortPaths(Object.keys(referencesByPath), {
+    shallowFirst: true,
+  });
+}
+
 /**
  * Given the fsPath of current note, return the list of backlink sources as tree view items.
  * @param fsPath fsPath of current note
@@ -39,7 +51,8 @@ export class Backlink extends vscode.TreeItem {
  */
 const pathsToBacklinkSourceTreeItems = async (
   fsPath: string,
-  isLinkCandidateEnabled: boolean | undefined
+  isLinkCandidateEnabled: boolean | undefined,
+  sortOrder: BacklinkSortOrder
 ) => {
   const fileName = path.parse(fsPath).name;
   const referencesByPath = _.groupBy(
@@ -47,9 +60,39 @@ const pathsToBacklinkSourceTreeItems = async (
     ({ location }) => location.uri.fsPath
   );
 
-  const pathsSorted = sortPaths(Object.keys(referencesByPath), {
-    shallowFirst: true,
-  });
+  let pathsSorted: string[];
+  if (sortOrder === BacklinkSortOrder.PathNames) {
+    pathsSorted = shallowFirstPathSort(referencesByPath);
+  } else if (sortOrder === BacklinkSortOrder.LastUpdated) {
+    pathsSorted = Object.keys(referencesByPath).sort((p1, p2) => {
+      const ref1 = referencesByPath[p1];
+      const ref2 = referencesByPath[p2];
+
+      if (
+        ref1.length === 0 ||
+        ref2.length === 0 ||
+        ref1[0].note === undefined ||
+        ref2[0].note === undefined
+      ) {
+        Logger.error({
+          msg: "Missing info for well formed backlink sort by last updated.",
+        });
+
+        return 0;
+      }
+
+      const ref2Updated = ref2[0].note.updated;
+      const ref1Updated = ref1[0].note.updated;
+
+      // We want to sort in descending order by last updated
+      return ref2Updated - ref1Updated;
+    });
+  } else {
+    Logger.error({
+      msg: `Unsupported sort order: '${sortOrder}' falling back to path sort order.`,
+    });
+    pathsSorted = shallowFirstPathSort(referencesByPath);
+  }
 
   if (!pathsSorted.length) {
     return [];
@@ -109,7 +152,15 @@ export const secondLevelRefsToBacklinks = (
     );
     backlinkTreeItem.parentBacklink = wikilinks[0].parentBacklink;
     backlinkTreeItem.iconPath = new vscode.ThemeIcon(ICONS.WIKILINK);
-    backlinkTreeItem.description = `${wikilinks.length} link(s).`;
+
+    const updatedString =
+      wikilinks[0].note !== undefined
+        ? `, note updated: ${DateFormatUtil.formatDate(
+            wikilinks[0].note.updated
+          )}`
+        : ``;
+
+    backlinkTreeItem.description = `${wikilinks.length} link(s)${updatedString}`;
     out.push(backlinkTreeItem);
   }
   if (isLinkCandidateEnabled) {
@@ -171,6 +222,7 @@ const refsToBacklinkTreeItems = (
 export default class BacklinksTreeDataProvider
   implements vscode.TreeDataProvider<Backlink>
 {
+  private _sortOrder: BacklinkSortOrder = BacklinkSortOrder.PathNames;
   private _onDidChangeTreeData: vscode.EventEmitter<Backlink | undefined> =
     new vscode.EventEmitter<Backlink | undefined>();
   readonly onDidChangeTreeData: vscode.Event<Backlink | undefined> =
@@ -179,6 +231,8 @@ export default class BacklinksTreeDataProvider
 
   constructor(isLinkCandidateEnabled: boolean | undefined) {
     this.isLinkCandidateEnabled = isLinkCandidateEnabled;
+
+    this.updateSortOrder(BacklinkSortOrder.PathNames);
   }
 
   refresh(): void {
@@ -197,6 +251,17 @@ export default class BacklinksTreeDataProvider
     }
   }
 
+  updateSortOrder(sortOrder: BacklinkSortOrder) {
+    this._sortOrder = sortOrder;
+
+    VSCodeUtils.setContextStringValue(
+      DendronContext.BACKLINKS_SORT_ORDER,
+      sortOrder
+    );
+
+    this.refresh();
+  }
+
   public async getChildren(element?: Backlink) {
     const fsPath = vscode.window.activeTextEditor?.document.uri.fsPath;
 
@@ -208,7 +273,8 @@ export default class BacklinksTreeDataProvider
       }
       return pathsToBacklinkSourceTreeItems(
         fsPath,
-        this.isLinkCandidateEnabled
+        this.isLinkCandidateEnabled,
+        this._sortOrder
       );
     } else if (element.label === "Linked" || element.label === "Candidates") {
       // 3rd-level children.

--- a/packages/plugin-core/src/types.ts
+++ b/packages/plugin-core/src/types.ts
@@ -29,3 +29,10 @@ export type DateTimeFormat =
 export enum CodeConfigKeys {
   DEFAULT_TIMESTAMP_DECORATION_FORMAT = "dendron.defaultTimestampDecorationFormat",
 }
+
+export enum BacklinkSortOrder {
+  /** Using path sorted so order with shallow first = true */
+  PathNames = "PathNames",
+
+  LastUpdated = "LastUpdated",
+}

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -51,6 +51,7 @@ export type FoundRefT = {
   location: Location;
   matchText: string;
   isCandidate?: boolean;
+  note?: NoteProps;
 };
 
 const markdownExtRegex = /\.md$/i;
@@ -549,6 +550,7 @@ export const findReferences = async (
       const foundRef: FoundRefT = {
         location,
         matchText: lines.slice(-1)[0],
+        note,
       };
       if (link.type === "linkCandidate") {
         foundRef.isCandidate = true;

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -352,6 +352,10 @@ export class VSCodeUtils {
     vscode.commands.executeCommand("setContext", key, status);
   }
 
+  static setContextStringValue(key: DendronContext, value: string) {
+    vscode.commands.executeCommand("setContext", key, value);
+  }
+
   static showInputBox = vscode.window.showInputBox;
   static showQuickPick = vscode.window.showQuickPick;
   static showWebView = (opts: {

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -33,7 +33,7 @@ import { Uri } from "vscode";
 import { CommandFactory } from "./commandFactory";
 import { ICommandFactory } from "./commandFactoryInterface";
 import { PreviewPanelFactory } from "./components/views/PreviewViewFactory";
-import { DendronContext, GLOBAL_STATE } from "./constants";
+import { DENDRON_COMMANDS, DendronContext, GLOBAL_STATE } from "./constants";
 import {
   DendronWorkspaceSettings,
   IDendronExtension,
@@ -52,7 +52,7 @@ import {
   NoteTraitService,
 } from "./services/NoteTraitService";
 import { UserDefinedTraitV1 } from "./traits/UserDefinedTraitV1";
-import { CodeConfigKeys } from "./types";
+import { BacklinkSortOrder, CodeConfigKeys } from "./types";
 import { DisposableStore } from "./utils";
 import { sentryReportingCallback } from "./utils/analytics";
 import { VersionProvider } from "./versionProvider";
@@ -588,7 +588,23 @@ export class DendronExtension implements IDendronExtension {
     getExtension().backlinksDataProvider = backlinksTreeDataProvider;
 
     vscode.commands.registerCommand(
-      "dendron.backlinks.expandAll",
+      DENDRON_COMMANDS.BACKLINK_SORT_BY_LAST_UPDATED.key,
+      sentryReportingCallback(() => {
+        backlinksTreeDataProvider.updateSortOrder(
+          BacklinkSortOrder.LastUpdated
+        );
+      })
+    );
+
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.BACKLINK_SORT_BY_PATH_NAMES.key,
+      sentryReportingCallback(() => {
+        backlinksTreeDataProvider.updateSortOrder(BacklinkSortOrder.PathNames);
+      })
+    );
+
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.BACKLINK_EXPAND_ALL.key,
       sentryReportingCallback(async () => {
         function expand(backlink: Backlink) {
           backlinkTreeView.reveal(backlink, {

--- a/test-workspace/vault/dendron.backlinks.md
+++ b/test-workspace/vault/dendron.backlinks.md
@@ -1,0 +1,22 @@
+---
+id: QUB1KiYq1NRtwofUFmsJu
+title: Backlinks
+desc: ''
+updated: 1639839454413
+created: 1639839177131
+---
+
+Tests for the `BACKLINKS` panel.
+
+## Ordering Default:
+Default order of the backlinsk to this note should be in lexigraphical order:
+
+* dendron.backlinks.target-A
+* dendron.backlinks.target-B
+* dendron.backlinks.target-C
+
+## Order by laste update time
+Should be the reverse (presuming the update dates on the notes are in such order):
+* dendron.backlinks.target-C
+* dendron.backlinks.target-B
+* dendron.backlinks.target-A

--- a/test-workspace/vault/dendron.backlinks.target-A.md
+++ b/test-workspace/vault/dendron.backlinks.target-A.md
@@ -1,0 +1,9 @@
+---
+id: 8Ig0xWc7dTI1LgvPkbUDJ
+title: target-A
+desc: ''
+updated: 1639839205514
+created: 1639839197765
+---
+
+[[dendron.backlinks]]

--- a/test-workspace/vault/dendron.backlinks.target-B.md
+++ b/test-workspace/vault/dendron.backlinks.target-B.md
@@ -1,0 +1,15 @@
+---
+id: ov6EWXwwYloaW0uwjZRy0
+title: target-B
+desc: ''
+updated: 1640167659599
+created: 1639839211791
+---
+
+[[dendron.backlinks]]
+
+
+[[dendron.backlinks]]
+
+
+[[dendron.backlinks]]

--- a/test-workspace/vault/dendron.backlinks.target-C.md
+++ b/test-workspace/vault/dendron.backlinks.target-C.md
@@ -1,0 +1,11 @@
+---
+id: K9A3l5bIVNpyI9FLBuhzn
+title: target-C
+desc: ''
+updated: 1639839305763
+created: 1639839206587
+---
+
+last modified
+
+[[dendron.backlinks]]


### PR DESCRIPTION
# enhance: adding last update sort ordering for backlinks

Note: VSCode command palette does not seem to respect the ordering. So if anyone knows how to order the commands to show in particular order would be really helpful more info in ![[dendron://private/vscode.command-palette]]

As for the docs: I didnt find a separate backlink panel documentation (besides a mention in links documentation that we have such panel), and really hoping that this is self explanatory from the labels that we have. 

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
    Having alot of issues today with tests, in a different commit tests locally pass but centrally do not. This time the tests keep getting 'stuck' (although unit tests mostly pass, (I have 2 tests that historically fail in unit tests and pass centrally something with GitHub related) Anyway hopefully these plugin tests pass, since I have been able to run backlink provider test successfully. 
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [x] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
