### PR TITLE
DRAFT-FeedbackRequest: fixing circular dependencies DI

### DIFF
--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -1,11 +1,5 @@
 import { ServerUtils } from "@dendronhq/api-server";
-import {
-  DVault,
-  NoteProps,
-  NoteUtils,
-  SchemaModuleProps,
-  VaultUtils,
-} from "@dendronhq/common-all";
+import { DVault, NoteProps, SchemaModuleProps } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import { HistoryEvent, HistoryService } from "@dendronhq/engine-server";
 import { ExecaChildProcess } from "execa";
@@ -15,7 +9,12 @@ import { DENDRON_COMMANDS } from "./constants";
 import { Logger } from "./logger";
 import { VSCodeUtils } from "./vsCodeUtils";
 import { getDWorkspace, getExtension } from "./workspace";
+import { WSUtilsV2 } from "./WSUtilsV2";
 
+/**
+ * Prefer to use WSUtilsV2 instead of this class to prevent circular dependencies.
+ * (move methods from this file to WSUtilsV2 as needed).
+ * */
 export class WSUtils {
   static handleServerProcess({
     subprocess,
@@ -102,57 +101,17 @@ export class WSUtils {
 
   //moved
   static getVaultFromDocument(document: vscode.TextDocument) {
-    const txtPath = document.uri.fsPath;
-    const { wsRoot, vaults } = getDWorkspace();
-    const vault = VaultUtils.getVaultByFilePath({
-      wsRoot,
-      vaults,
-      fsPath: txtPath,
-    });
-    return vault;
+    return new WSUtilsV2(getExtension()).getVaultFromDocument(document);
   }
 
   static getNoteFromDocument(document: vscode.TextDocument) {
-    const { engine, wsRoot } = getDWorkspace();
-    const txtPath = document.uri.fsPath;
-    const fname = path.basename(txtPath, ".md");
-    let vault: DVault;
-    try {
-      vault = this.getVaultFromDocument(document);
-    } catch (err) {
-      // No vault
-      return undefined;
-    }
-    return NoteUtils.getNoteByFnameV5({
-      fname,
-      vault,
-      wsRoot,
-      notes: engine.notes,
-    });
+    return new WSUtilsV2(getExtension()).getNoteFromDocument(document);
   }
 
   static tryGetNoteFromDocument = (
     document: vscode.TextDocument
   ): NoteProps | undefined => {
-    if (
-      !getExtension().workspaceService?.isPathInWorkspace(document.uri.fsPath)
-    ) {
-      Logger.info({
-        uri: document.uri.fsPath,
-        msg: "not in workspace",
-      });
-      return;
-    }
-    try {
-      const note = WSUtils.getNoteFromDocument(document);
-      return note;
-    } catch (err) {
-      Logger.info({
-        uri: document.uri.fsPath,
-        msg: "not a valid note",
-      });
-    }
-    return;
+    return new WSUtilsV2(getExtension()).tryGetNoteFromDocument(document);
   };
 
   static getActiveNote() {

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -1,0 +1,81 @@
+import { IDendronExtension } from "./dendronExtensionInterface";
+import vscode from "vscode";
+import path from "path";
+import {
+  DVault,
+  NoteProps,
+  NoteUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import { IWSUtilsV2 } from "./WSUtilsV2Interface";
+import { Logger } from "./logger";
+import { VSCodeUtils } from "./vsCodeUtils";
+
+/**
+ *  Non static WSUtils to allow unwinding of our circular dependencies.
+ *   */
+export class WSUtilsV2 implements IWSUtilsV2 {
+  private extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    this.extension = extension;
+  }
+
+  getNoteFromDocument(document: vscode.TextDocument) {
+    const { engine, wsRoot } = this.extension.getDWorkspace();
+    const txtPath = document.uri.fsPath;
+    const fname = path.basename(txtPath, ".md");
+    let vault: DVault;
+    try {
+      vault = this.getVaultFromDocument(document);
+    } catch (err) {
+      // No vault
+      return undefined;
+    }
+    return NoteUtils.getNoteByFnameV5({
+      fname,
+      vault,
+      wsRoot,
+      notes: engine.notes,
+    });
+  }
+
+  getVaultFromDocument(document: vscode.TextDocument) {
+    const txtPath = document.uri.fsPath;
+    const { wsRoot, vaults } = this.extension.getDWorkspace();
+    const vault = VaultUtils.getVaultByFilePath({
+      wsRoot,
+      vaults,
+      fsPath: txtPath,
+    });
+    return vault;
+  }
+
+  tryGetNoteFromDocument(document: vscode.TextDocument): NoteProps | undefined {
+    if (
+      !this.extension.workspaceService?.isPathInWorkspace(document.uri.fsPath)
+    ) {
+      Logger.info({
+        uri: document.uri.fsPath,
+        msg: "not in workspace",
+      });
+      return;
+    }
+    try {
+      const note = this.getNoteFromDocument(document);
+      return note;
+    } catch (err) {
+      Logger.info({
+        uri: document.uri.fsPath,
+        msg: "not a valid note",
+      });
+    }
+    return;
+  }
+
+  getActiveNote() {
+    const editor = VSCodeUtils.getActiveTextEditor();
+    if (editor) return this.getNoteFromDocument(editor.document);
+    return;
+  }
+}

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -1,0 +1,12 @@
+import vscode from "vscode";
+import { NoteProps } from "@dendronhq/common-all";
+
+export interface IWSUtilsV2 {
+  getNoteFromDocument(document: vscode.TextDocument): undefined | NoteProps;
+
+  getVaultFromDocument(document: vscode.TextDocument): unknown;
+
+  tryGetNoteFromDocument(document: vscode.TextDocument): NoteProps | undefined;
+
+  getActiveNote(): any;
+}

--- a/packages/plugin-core/src/WorkspaceWatcherInterface.ts
+++ b/packages/plugin-core/src/WorkspaceWatcherInterface.ts
@@ -1,0 +1,56 @@
+import {
+  ExtensionContext,
+  FileRenameEvent,
+  FileWillRenameEvent,
+  TextDocument,
+  TextDocumentChangeEvent,
+  TextDocumentWillSaveEvent,
+  TextEdit,
+} from "vscode";
+
+export interface IWorkspaceWatcher {
+  activate(context: ExtensionContext): void;
+
+  onDidSaveTextDocument(document: TextDocument): Promise<void>;
+
+  /** This version of `onDidChangeTextDocument` is debounced for a longer time, and is useful for engine changes that should happen more slowly. */
+  onDidChangeTextDocument(event: TextDocumentChangeEvent): Promise<void>;
+
+  /** This version of `onDidChangeTextDocument` is debounced for a shorter time, and is useful for UI updates that should happen quickly. */
+  quickOnDidChangeTextDocument(event: TextDocumentChangeEvent): Promise<void>;
+
+  onDidOpenTextDocument(document: TextDocument): void;
+
+  onWillSaveTextDocument(
+    event: TextDocumentWillSaveEvent
+  ): Promise<{ changes: TextEdit[] }>;
+
+  onWillSaveNote(
+    event: TextDocumentWillSaveEvent
+  ): { changes: any[] } | { changes: TextEdit[] };
+
+  /** Do not use this function, please go to `WindowWatcher.onFirstOpen() instead.`
+   *
+   * Checks if the given document has been opened for the first time during this session, and marks the document as being processed.
+   *
+   * Certain actions (such as folding and adjusting the cursor) need to be done only the first time a document is opened.
+   * While the `WorkspaceWatcher` sees when new documents are opened, the `TextEditor` is not active at that point, and we can not
+   * perform these actions. This code allows `WindowWatcher` to check when an editor becomes active whether that editor belongs to an
+   * newly opened document.
+   *
+   * Mind that this method is not idempotent, checking the same document twice will always return false for the second time.
+   */
+  getNewlyOpenedDocument(document: TextDocument): boolean;
+
+  /**
+   * method to make modifications to the workspace before the file is renamed.
+   * It updates all the references to the oldUri
+   */
+  onWillRenameFiles(args: FileWillRenameEvent): void;
+
+  /**
+   * method to make modifications to the workspace after the file is renamed.
+   * It updates the title of the note wrt the new fname and refreshes tree view
+   */
+  onDidRenameFiles(args: FileRenameEvent): Promise<void>;
+}

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -978,7 +978,8 @@ async function _setupCommands(
   const existingCommands = await vscode.commands.getCommands();
 
   ALL_COMMANDS.map((Cmd) => {
-    const cmd = new Cmd();
+    const cmd = new Cmd(getExtension());
+
     if (!existingCommands.includes(cmd.key))
       context.subscriptions.push(
         vscode.commands.registerCommand(
@@ -1144,6 +1145,7 @@ function updateEngineAPI(port: number | string): void {
   const svc = EngineAPIService.createEngine({
     port,
     enableWorkspaceTrust: vscode.workspace.isTrusted,
+    extension: ext,
   });
   ext.setEngine(svc);
   ext.port = _.toInteger(port);

--- a/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
@@ -14,7 +14,6 @@ import {
   LookupControllerV3CreateOpts,
 } from "../components/lookup/LookupControllerV3";
 import { NoteLookupProvider } from "../components/lookup/LookupProviderV3";
-import { VaultSelectionMode } from "../components/lookup/types";
 import {
   NoteLookupProviderUtils,
   PickerUtilsV2,
@@ -23,6 +22,7 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace, getExtension } from "../workspace";
 import { BaseCommand } from "./base";
 import { GotoNoteCommand } from "./GotoNote";
+import { VaultSelectionMode } from "../components/lookup/typeslight";
 
 export type CommandOpts = {
   fname: string;
@@ -141,7 +141,7 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
       }
     }
 
-    await new GotoNoteCommand().execute({
+    await new GotoNoteCommand(getExtension()).execute({
       qs: fname,
       vault,
       overrides: { title, traits: [this.trait] },

--- a/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
+++ b/packages/plugin-core/src/commands/CreateSchemaFromHierarchyCommand.ts
@@ -15,9 +15,8 @@ import { Uri } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { PluginSchemaUtils } from "../pluginSchemaUtils";
 import { PluginVaultUtils } from "../pluginVaultUtils";
-import { SchemaSyncService } from "../services/SchemaSyncService";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
+import { getDWorkspace, getExtension } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {
@@ -595,7 +594,7 @@ export class CreateSchemaFromHierarchyCommand extends BasicCommand<
 
     fs.writeFileSync(uri!.fsPath, schemaBody);
 
-    await SchemaSyncService.instance().saveSchema({
+    await getExtension().schemaSyncService.saveSchema({
       uri: uri!,
       isBrandNewFile: true,
     });

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -46,10 +46,11 @@ import { DENDRON_COMMANDS } from "../constants";
 import { delayedUpdateDecorations } from "../features/windowDecorations";
 import { EngineAPIService } from "../services/EngineAPIService";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { findReferences, FoundRefT } from "../utils/md";
+import { findReferences } from "../utils/md";
 import { getEngine, getVaultFromUri } from "../workspace";
 import { WSUtils } from "../WSUtils";
 import { BasicCommand } from "./base";
+import { FoundRefT } from "../utils/mdtypes";
 
 type CommandInput =
   | {

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -44,7 +44,6 @@ import {
   LookupSelectionTypeEnum,
   LookupSplitType,
   LookupSplitTypeEnum,
-  VaultSelectionMode,
 } from "../components/lookup/types";
 import {
   node2Uri,
@@ -63,6 +62,7 @@ import {
   AutoCompleter,
   UIAutoCompletableCmds,
 } from "../utils/autoCompleter";
+import { VaultSelectionMode } from "../components/lookup/typeslight";
 
 export type CommandRunOpts = {
   initialValue?: string;

--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -23,7 +23,6 @@ import {
 } from "../components/lookup/LookupProviderV3";
 import { NoteLookupProviderUtils } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
-import { FileWatcher } from "../fileWatcher";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { WSUtils } from "../WSUtils";
 import { getExtension, getDWorkspace } from "../workspace";
@@ -430,7 +429,7 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
         setTimeout(() => {
           if (ext.fileWatcher) {
             ext.fileWatcher.pause = false;
-            FileWatcher.refreshTree();
+            ext.fileWatcher.refreshTree();
           }
           this.L.info({ ctx, msg: "exit" });
         }, 3000);

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -256,7 +256,7 @@ export const handleLink = async ({
           return;
         }
 
-        return new GotoNoteCommand().execute({
+        return new GotoNoteCommand(getExtension()).execute({
           qs: noteData.note.fname,
           vault: noteData.note.vault,
           column: vscode.ViewColumn.One,

--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -4,9 +4,10 @@ import _ from "lodash";
 import { window } from "vscode";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 export type CodeCommandConstructor = {
-  new (): CodeCommandInstance;
+  new (extension: IDendronExtension): CodeCommandInstance;
 };
 export type CodeCommandInstance = {
   key: string;

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -15,7 +15,6 @@ import _ from "lodash";
 import * as vscode from "vscode";
 import { QuickInputButton, ThemeIcon } from "vscode";
 import { EngineAPIService } from "../../services/EngineAPIService";
-import { NoteSyncService } from "../../services/NoteSyncService";
 import { clipboard } from "../../utils";
 import { DendronClientUtilsV2 } from "../../clientUtils";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -28,10 +27,10 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionType,
   LookupSplitType,
-  VaultSelectionMode,
 } from "./types";
 import { NotePickerUtils, PickerUtilsV2 } from "./utils";
 import { WSUtils } from "../../WSUtils";
+import { VaultSelectionMode } from "./typeslight";
 
 export type ButtonType =
   | LookupEffectType
@@ -157,7 +156,7 @@ const selectionToNoteProps = async (opts: {
 
           const currentNote = WSUtils.getNoteFromDocument(editor.document);
           if (currentNote) {
-            await NoteSyncService.instance().updateNoteContents({
+            await getExtension().noteSyncService.updateNoteContents({
               oldNote: currentNote,
               content: editor.document.getText(),
               fmChangeOnly: false,

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -158,24 +158,6 @@ export type LookupSplitType = "horizontal";
 export type LookupEffectType = "copyNoteLink" | "copyNoteRef" | "multiSelect";
 export type LookupNoteExistBehavior = "open" | "overwrite";
 
-export enum VaultSelectionMode {
-  /**
-   * Never prompt the user. Useful for testing
-   */
-  auto,
-
-  /**
-   * Tries to determine the vault automatically, but will prompt the user if
-   * there is ambiguity
-   */
-  smart,
-
-  /**
-   * Always prompt the user if there is more than one vault
-   */
-  alwaysPrompt,
-}
-
 export type TransformedQueryString = {
   /** Transformed query string value.   */
   queryString: string;

--- a/packages/plugin-core/src/components/lookup/typeslight.ts
+++ b/packages/plugin-core/src/components/lookup/typeslight.ts
@@ -1,0 +1,23 @@
+/**
+ * Types that do not carry heavy dependencies (which is currently includes)
+ * Heavy dependencies are currently considered any dependencies that
+ * lead to calling getExtension()
+ */
+
+export enum VaultSelectionMode {
+  /**
+   * Never prompt the user. Useful for testing
+   */
+  auto,
+
+  /**
+   * Tries to determine the vault automatically, but will prompt the user if
+   * there is ambiguity
+   */
+  smart,
+
+  /**
+   * Always prompt the user if there is more than one vault
+   */
+  alwaysPrompt,
+}

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -45,8 +45,8 @@ import {
   DendronQuickPickerV2,
   DendronQuickPickState,
   TransformedQueryString,
-  VaultSelectionMode,
 } from "./types";
+import { VaultSelectionMode } from "./typeslight";
 
 const PAGINATE_LIMIT = 50;
 export const UPDATET_SOURCE = {

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -12,7 +12,7 @@ import { Logger } from "../../logger";
 import { GraphStyleService } from "../../styles";
 import { sentryReportingCallback } from "../../utils/analytics";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { DendronExtension, getEngine } from "../../workspace";
+import { DendronExtension, getEngine, getExtension } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 
 export class NoteGraphPanelFactory {
@@ -45,7 +45,7 @@ export class NoteGraphPanelFactory {
             await commands.executeCommand(
               "workbench.action.focusFirstEditorGroup"
             );
-            await new GotoNoteCommand().execute({
+            await new GotoNoteCommand(getExtension()).execute({
               qs: note.fname,
               vault: note.vault,
             });

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -1,0 +1,80 @@
+import { IDendronTreeViewV2 } from "./views/DendronTreeViewV2Interface";
+import { IFileWatcher } from "./fileWatcherInterface";
+import { WorkspaceService } from "@dendronhq/engine-server";
+import vscode from "vscode";
+import {
+  DWorkspaceV2,
+  WorkspaceSettings,
+  WorkspaceType,
+} from "@dendronhq/common-all";
+import { EngineAPIService } from "./services/EngineAPIService";
+import { IWorkspaceWatcher } from "./WorkspaceWatcherInterface";
+import { DendronWorkspaceSettings } from "./types";
+import { IDendronTreeView } from "./views/DendronTreeViewInterface";
+import { IVaultsResolver } from "./utils/VaultsResolverInterface";
+import { ISchemaSyncService } from "./services/SchemaSyncServiceInterface";
+import { IBacklinksTreeDataProvider } from "./features/BacklinksTreeDataProviderInterface";
+import { IWindowWatcher } from "./windowWatcherInterface";
+import { INoteSyncService } from "./services/NoteSyncServiceInterface";
+import { IWSUtilsV2 } from "./WSUtilsV2Interface";
+
+export interface IDendronExtension {
+  backlinksDataProvider: IBacklinksTreeDataProvider | undefined;
+  dendronTreeView: IDendronTreeView | undefined;
+  dendronTreeViewV2: IDendronTreeViewV2 | undefined;
+  fileWatcher?: IFileWatcher;
+  port?: number;
+  workspaceService?: WorkspaceService;
+  context: vscode.ExtensionContext;
+  windowWatcher?: IWindowWatcher;
+  workspaceWatcher?: IWorkspaceWatcher;
+  serverWatcher?: vscode.FileSystemWatcher;
+  type: WorkspaceType;
+  workspaceImpl?: DWorkspaceV2;
+  vaultsResolver: IVaultsResolver;
+  schemaSyncService: ISchemaSyncService;
+  noteSyncService: INoteSyncService;
+  wsUtils: IWSUtilsV2;
+
+  pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
+
+  getClientAPIRootUrl(): Promise<string>;
+
+  /** Shorthand for previously existing function getWorkspaceImplOrThrow() */
+  getDWorkspace(): DWorkspaceV2;
+
+  getWorkspaceImplOrThrow(): DWorkspaceV2;
+
+  /** For Native workspaces (without .code-workspace file) this will return undefined. */
+  getWorkspaceSettings(): Promise<WorkspaceSettings | undefined>;
+
+  getWorkspaceSettingsSync(): WorkspaceSettings | undefined;
+
+  getDendronWorkspaceSettingsSync(): DendronWorkspaceSettings | undefined;
+
+  getWorkspaceSettingOrDefault({
+    wsConfigKey,
+    dendronConfigKey,
+  }: {
+    wsConfigKey: keyof DendronWorkspaceSettings;
+    dendronConfigKey: string;
+  }): any;
+
+  getEngine(): EngineAPIService;
+
+  setEngine(engine: EngineAPIService): void;
+
+  setupViews(context: vscode.ExtensionContext): Promise<void>;
+
+  addDisposable(disposable: vscode.Disposable): void;
+
+  /**
+   * - get workspace config and workspace folder
+   * - activate workspacespace watchers
+   */
+  activateWatchers(): Promise<void>;
+
+  deactivate(): Promise<void>;
+
+  isActiveV2(_context?: vscode.ExtensionContext): boolean;
+}

--- a/packages/plugin-core/src/features/Backlink.ts
+++ b/packages/plugin-core/src/features/Backlink.ts
@@ -1,0 +1,25 @@
+import vscode from "vscode";
+import { FoundRefT } from "../utils/mdtypes";
+
+export type BacklinkFoundRef = FoundRefT & {
+  parentBacklink: Backlink | undefined;
+};
+
+export class Backlink extends vscode.TreeItem {
+  public refs: BacklinkFoundRef[] | undefined;
+  public parentBacklink: Backlink | undefined;
+
+  constructor(
+    public readonly label: string,
+    refs: FoundRefT[] | undefined,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+  ) {
+    super(label, collapsibleState);
+
+    if (refs) {
+      this.refs = refs.map((r) => ({ ...r, parentBacklink: this }));
+    } else {
+      this.refs = undefined;
+    }
+  }
+}

--- a/packages/plugin-core/src/features/BacklinksTreeDataProviderInterface.ts
+++ b/packages/plugin-core/src/features/BacklinksTreeDataProviderInterface.ts
@@ -1,0 +1,13 @@
+import { Backlink } from "./Backlink";
+import vscode, { ProviderResult } from "vscode";
+
+export interface IBacklinksTreeDataProvider
+  extends vscode.TreeDataProvider<Backlink> {
+  refresh(): void;
+
+  getTreeItem(element: Backlink): Backlink;
+
+  getParent(element: Backlink): ProviderResult<Backlink>;
+
+  getChildren(element?: Backlink): Promise<Backlink[] | undefined>;
+}

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -13,7 +13,7 @@ import {
 } from "../commands/GotoNote";
 import { Logger } from "../logger";
 import { getReferenceAtPosition } from "../utils/md";
-import { DendronExtension, getDWorkspace } from "../workspace";
+import { DendronExtension, getDWorkspace, getExtension } from "../workspace";
 import * as Sentry from "@sentry/node";
 import { findNonNoteFile } from "@dendronhq/common-server";
 
@@ -35,7 +35,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
   }
 
   private async provideForNonNoteFile(nonNoteFile: string) {
-    const out = await new GotoNoteCommand().execute({
+    const out = await new GotoNoteCommand(getExtension()).execute({
       qs: nonNoteFile,
       kind: TargetKind.NON_NOTE,
     });
@@ -53,7 +53,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
     if (noAutoCreateOnDefinition) {
       return;
     }
-    const out = await new GotoNoteCommand().execute({
+    const out = await new GotoNoteCommand(getExtension()).execute({
       qs: refAtPos.ref,
       anchor: refAtPos.anchorStart,
     });

--- a/packages/plugin-core/src/features/codeActionProvider.ts
+++ b/packages/plugin-core/src/features/codeActionProvider.ts
@@ -24,7 +24,7 @@ import { LookupSelectionTypeEnum } from "../components/lookup/types";
 import { sentryReportingCallback } from "../utils/analytics";
 import { getHeaderAt, isBrokenWikilink } from "../utils/editor";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { DendronExtension } from "../workspace";
+import { DendronExtension, getExtension } from "../workspace";
 
 function activate(context: ExtensionContext) {
   context.subscriptions.push(
@@ -119,7 +119,7 @@ export const refactorProvider: CodeActionProvider = {
         isPreferred: true,
         kind: CodeActionKind.RefactorExtract,
         command: {
-          command: new GotoNoteCommand().key,
+          command: new GotoNoteCommand(getExtension()).key,
           title: "Add missing note for wikilink declaration",
           arguments: [{ source: ContextualUIEvents.ContextualUICodeAction }],
         },

--- a/packages/plugin-core/src/fileWatcherInterface.ts
+++ b/packages/plugin-core/src/fileWatcherInterface.ts
@@ -1,0 +1,17 @@
+import { DVault } from "@dendronhq/common-all";
+import { FileWatcherAdapter } from "@dendronhq/engine-server";
+import vscode from "vscode";
+
+export interface IFileWatcher {
+  watchers: { vault: DVault; watcher: FileWatcherAdapter }[];
+
+  pause: boolean;
+
+  activate(context: vscode.ExtensionContext): void;
+
+  onDidCreate(fsPath: string): Promise<void>;
+
+  onDidDelete(fsPath: string): Promise<void>;
+
+  refreshTree(): void;
+}

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -37,7 +37,7 @@ import {
 } from "@dendronhq/common-all";
 import { DendronEngineClient, HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
-import { getDWorkspace } from "../workspace";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 export class EngineAPIService implements DEngineClient {
   private internalEngine: DEngineClient;
@@ -47,11 +47,13 @@ export class EngineAPIService implements DEngineClient {
   static createEngine({
     port,
     enableWorkspaceTrust,
+    extension,
   }: {
     port: number | string;
     enableWorkspaceTrust?: boolean | undefined;
+    extension: IDendronExtension;
   }): EngineAPIService {
-    const { vaults, wsRoot } = getDWorkspace();
+    const { vaults, wsRoot } = extension.getDWorkspace();
     const history = HistoryService.instance();
 
     const api = new DendronAPI({

--- a/packages/plugin-core/src/services/NoteSyncServiceInterface.ts
+++ b/packages/plugin-core/src/services/NoteSyncServiceInterface.ts
@@ -1,0 +1,34 @@
+import vscode from "vscode";
+import { DVault, NoteProps } from "@dendronhq/common-all";
+
+export interface INoteSyncService {
+  /**
+   * Performs tasks that should be run when the note is changed
+   * - update note links
+   * - update note anchors
+   * - trigger engine update
+   * - trigger preview sync
+   * @param uri
+   * @returns
+   */
+  onDidChange(
+    document: vscode.TextDocument,
+    hints?: { contentChanges: readonly vscode.TextDocumentContentChangeEvent[] }
+  ): Promise<NoteProps | undefined>;
+
+  updateNoteContents(opts: {
+    oldNote: NoteProps;
+    content: string;
+    fmChangeOnly: boolean;
+    fname: string;
+    vault: DVault;
+  }): Promise<NoteProps>;
+
+  updateNoteMeta({
+    note,
+    fmChangeOnly,
+  }: {
+    note: NoteProps;
+    fmChangeOnly: boolean;
+  }): Promise<NoteProps>;
+}

--- a/packages/plugin-core/src/services/SchemaSyncService.ts
+++ b/packages/plugin-core/src/services/SchemaSyncService.ts
@@ -2,20 +2,18 @@ import _ from "lodash";
 import { Logger } from "../logger";
 import vscode, { Uri } from "vscode";
 import { SchemaParser } from "@dendronhq/engine-server";
-import { getDWorkspace, getVaultFromUri } from "../workspace";
 import path from "path";
 import { VSCodeUtils } from "../vsCodeUtils";
-
-let SCHEMA_SYNC_SERVICE: SchemaSyncService | undefined;
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { ISchemaSyncService } from "./SchemaSyncServiceInterface";
 
 /** Currently responsible for keeping the engine in sync with schema
  *  changes on disk. */
-export class SchemaSyncService {
-  static instance() {
-    if (_.isUndefined(SCHEMA_SYNC_SERVICE)) {
-      SCHEMA_SYNC_SERVICE = new SchemaSyncService();
-    }
-    return SCHEMA_SYNC_SERVICE;
+export class SchemaSyncService implements ISchemaSyncService {
+  extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    this.extension = extension;
   }
 
   async onDidSave({ document }: { document: vscode.TextDocument }) {
@@ -37,14 +35,14 @@ export class SchemaSyncService {
     isBrandNewFile?: boolean;
   }) {
     const schemaParser = new SchemaParser({
-      wsRoot: getDWorkspace().wsRoot,
+      wsRoot: this.extension.getDWorkspace().wsRoot,
       logger: Logger,
     });
-    const engineClient = getDWorkspace().engine;
+    const engineClient = this.extension.getDWorkspace().engine;
 
     const parsedSchema = await schemaParser.parse(
       [path.basename(uri.fsPath)],
-      getVaultFromUri(uri)
+      this.extension.vaultsResolver.getVaultFromUri(uri)
     );
 
     if (_.isEmpty(parsedSchema.errors)) {

--- a/packages/plugin-core/src/services/SchemaSyncServiceInterface.ts
+++ b/packages/plugin-core/src/services/SchemaSyncServiceInterface.ts
@@ -1,0 +1,13 @@
+import vscode, { Uri } from "vscode";
+
+export interface ISchemaSyncService {
+  onDidSave({ document }: { document: vscode.TextDocument }): Promise<void>;
+
+  saveSchema({
+    uri,
+    isBrandNewFile,
+  }: {
+    uri: Uri;
+    isBrandNewFile?: boolean;
+  }): Promise<void>;
+}

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -11,7 +11,6 @@ import * as vscode from "vscode";
 import { ProviderResult, Uri } from "vscode";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
 import BacklinksTreeDataProvider, {
-  Backlink,
   secondLevelRefsToBacklinks,
 } from "../../features/BacklinksTreeDataProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -19,6 +18,7 @@ import { getDWorkspace } from "../../workspace";
 import { expect, runMultiVaultTest } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import { WSUtils } from "../../WSUtils";
+import { Backlink } from "../../features/Backlink";
 
 type BacklinkWithChildren = Backlink & { children?: Backlink[] | undefined };
 

--- a/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
@@ -10,6 +10,7 @@ import * as vscode from "vscode";
 import { FileWatcher } from "../../fileWatcher";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { getExtension } from "../../workspace";
 
 suite("GIVEN FileWatcher", function () {
   let watcher: FileWatcher;
@@ -34,6 +35,7 @@ suite("GIVEN FileWatcher", function () {
               wsRoot,
               vaults,
               dendronConfig: engine.config,
+              extension: getExtension(),
             });
 
             const notePath = path.join(wsRoot, vaults[0].fsPath, "newbar.md");
@@ -77,6 +79,7 @@ suite("GIVEN FileWatcher", function () {
               wsRoot,
               vaults,
               dendronConfig: engine.config,
+              extension: getExtension(),
             });
 
             const notePath = path.join(wsRoot, vaults[0].fsPath, "newbar.md");

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -15,7 +15,7 @@ import * as vscode from "vscode";
 import { GotoNoteCommand } from "../../commands/GotoNote";
 import { PickerUtilsV2 } from "../../components/lookup/utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace } from "../../workspace";
+import { getDWorkspace, getExtension } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
 import { getActiveEditorBasename } from "../testUtils";
@@ -27,6 +27,11 @@ import {
 } from "../testUtilsV3";
 
 const { ANCHOR_WITH_SPECIAL_CHARS, ANCHOR } = GOTO_NOTE_PRESETS;
+
+function createGoToNotCmd() {
+  return new GotoNoteCommand(getExtension());
+}
+
 suite("GotoNote", function () {
   const ctx = setupBeforeAfter(this, {});
 
@@ -38,7 +43,7 @@ suite("GotoNote", function () {
         onInit: async ({ vaults, engine }) => {
           const vault = vaults[0];
           const note = engine.notes["foo"];
-          const { note: out } = (await new GotoNoteCommand().run({
+          const { note: out } = (await createGoToNotCmd().run({
             qs: "foo",
             vault,
           })) as { note: NoteProps };
@@ -71,7 +76,7 @@ suite("GotoNote", function () {
             stub: true,
           });
 
-          const { note: out } = (await new GotoNoteCommand().run({
+          const { note: out } = (await createGoToNotCmd().run({
             qs: "foo",
             vault,
           })) as { note: NoteProps };
@@ -91,7 +96,7 @@ suite("GotoNote", function () {
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          const { note: out } = (await new GotoNoteCommand().run({
+          const { note: out } = (await createGoToNotCmd().run({
             qs: "foo.ch2",
             vault,
           })) as { note: NoteProps };
@@ -113,7 +118,7 @@ suite("GotoNote", function () {
         },
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             qs: "bar.ch1",
             vault,
           });
@@ -134,7 +139,7 @@ suite("GotoNote", function () {
         },
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             qs: "alpha",
             vault,
             anchor: {
@@ -165,7 +170,7 @@ suite("GotoNote", function () {
         },
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             qs: "target-note",
             vault,
             anchor: {
@@ -192,7 +197,7 @@ suite("GotoNote", function () {
         },
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             qs: "alpha",
             vault,
             anchor: {
@@ -220,7 +225,7 @@ suite("GotoNote", function () {
         },
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             qs: "anchor-target",
             vault,
             anchor: {
@@ -258,7 +263,7 @@ suite("GotoNote", function () {
               new vscode.Position(7, 1),
               new vscode.Position(7, 1)
             );
-          await new GotoNoteCommand().run();
+          await createGoToNotCmd().run();
           // Make sure this took us to the tag note
           expect(getActiveEditorBasename()).toEqual("tags.my.test-0.tag.md");
           done();
@@ -287,7 +292,7 @@ suite("GotoNote", function () {
               new vscode.Position(7, 1),
               new vscode.Position(7, 1)
             );
-          await new GotoNoteCommand().run();
+          await createGoToNotCmd().run();
           // Make sure this took us to the tag note
           expect(getActiveEditorBasename()).toEqual("user.test.mctestface.md");
           done();
@@ -319,7 +324,7 @@ suite("GotoNote", function () {
                 new vscode.Position(6, 8),
                 new vscode.Position(6, 8)
               );
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             // Make sure this took us to the tag note
             expect(getActiveEditorBasename()).toEqual("tags.my.test-0.tag.md");
             done();
@@ -350,7 +355,7 @@ suite("GotoNote", function () {
                 new vscode.Position(6, 8),
                 new vscode.Position(6, 8)
               );
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             // Make sure this took us to the tag note
             expect(getActiveEditorBasename()).toEqual("tags.one.md");
             done();
@@ -381,7 +386,7 @@ suite("GotoNote", function () {
                 new vscode.Position(8, 6),
                 new vscode.Position(8, 6)
               );
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             // Make sure this took us to the tag note
             expect(getActiveEditorBasename()).toEqual("tags.my.test-0.tag.md");
             done();
@@ -425,7 +430,7 @@ suite("GotoNote", function () {
             line: 9,
             char: 23,
           });
-          await new GotoNoteCommand().run();
+          await createGoToNotCmd().run();
           expect(getActiveEditorBasename()).toEqual("test.target.md");
         });
       }
@@ -443,7 +448,7 @@ suite("GotoNote", function () {
           const linkPos = LocationTestUtils.getPresetWikiLinkPosition();
           editor.selection = new vscode.Selection(linkPos, linkPos);
           // foo.ch1.md
-          await new GotoNoteCommand().run({});
+          await createGoToNotCmd().run({});
           const editor2 = VSCodeUtils.getActiveTextEditorOrThrow();
           const suffix =
             path.join(
@@ -473,7 +478,7 @@ suite("GotoNote", function () {
               editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
                 line: 7,
               });
-              await new GotoNoteCommand().run();
+              await createGoToNotCmd().run();
               const openedNote = WSUtils.getNoteFromDocument(
                 VSCodeUtils.getActiveTextEditorOrThrow().document
               );
@@ -502,7 +507,7 @@ suite("GotoNote", function () {
             editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
               line: 8,
             });
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             const openedNote = WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
@@ -527,7 +532,7 @@ suite("GotoNote", function () {
             editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
               line: 9,
             });
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             const openedNote = WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
@@ -552,7 +557,7 @@ suite("GotoNote", function () {
             editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
               line: 10,
             });
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             const openedNote = WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
@@ -578,7 +583,7 @@ suite("GotoNote", function () {
             editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
               line: 11,
             });
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
             const openedNote = WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
@@ -612,7 +617,7 @@ suite("GotoNote", function () {
           const editor = await WSUtils.openNote(note);
           const linkPos = LocationTestUtils.getPresetWikiLinkPosition();
           editor.selection = new vscode.Selection(linkPos, linkPos);
-          await new GotoNoteCommand().run({});
+          await createGoToNotCmd().run({});
           const editor2 = VSCodeUtils.getActiveTextEditorOrThrow();
           const suffix =
             path.join(
@@ -650,7 +655,7 @@ suite("GotoNote", function () {
             new vscode.Position(7, 48)
           );
           // foo.ch1.md
-          await new GotoNoteCommand().run({
+          await createGoToNotCmd().run({
             vault: vaults[0],
           });
           expect(getActiveEditorBasename()).toEqual("foo.ch1.md");
@@ -694,7 +699,7 @@ suite("GotoNote", function () {
           await WSUtils.openNote(note);
           VSCodeUtils.getActiveTextEditorOrThrow().selection =
             new vscode.Selection(7, 1, 7, 1);
-          await new GotoNoteCommand().run();
+          await createGoToNotCmd().run();
 
           expect(getActiveEditorBasename()).toEqual("test.txt");
           expect(
@@ -716,7 +721,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens the non-note file", async () => {
@@ -741,7 +746,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens the non-note file inside assets", async () => {
@@ -781,7 +786,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens the note", async () => {
@@ -823,7 +828,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens the file at that line", async () => {
@@ -864,7 +869,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens that file", async () => {
@@ -901,7 +906,7 @@ suite("GotoNote", function () {
             await WSUtils.openNote(note);
             VSCodeUtils.getActiveTextEditorOrThrow().selection =
               new vscode.Selection(7, 1, 7, 1);
-            await new GotoNoteCommand().run();
+            await createGoToNotCmd().run();
           });
 
           test("THEN opens that file", async () => {

--- a/packages/plugin-core/src/test/suite-integ/NoteSyncService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteSyncService.test.ts
@@ -6,10 +6,10 @@ import { DateTime } from "luxon";
 import { describe } from "mocha";
 import sinon from "sinon";
 import * as vscode from "vscode";
-import { NoteSyncService } from "../../services/NoteSyncService";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { getExtension } from "../../workspace";
 
 async function wait1Millisecond(): Promise<void> {
   return new Promise((resolve) => {
@@ -52,7 +52,7 @@ suite("NoteSyncService tests without time stubbing", function testSuite() {
           });
 
           const beforeStamp = await millisNowAndWait1Milli();
-          const resp = await NoteSyncService.instance().onDidChange(
+          const resp = await getExtension().noteSyncService.onDidChange(
             editor.document,
             {
               contentChanges: [
@@ -119,7 +119,7 @@ suite("NoteSyncService", function testSuite() {
             const selection = new vscode.Selection(pos, pos);
             builder.replace(selection, `Hello`);
           });
-          const resp = await NoteSyncService.instance().onDidChange(
+          const resp = await getExtension().noteSyncService.onDidChange(
             editor.document
           );
           expect(resp?.contentHash).toEqual("465a4f4ebf83fbea836eb7b8e8e040ec");
@@ -153,7 +153,7 @@ suite("NoteSyncService", function testSuite() {
             const pos = new vscode.Position(6, 0);
             builder.insert(pos, `tags: test\n`);
           });
-          await NoteSyncService.instance().onDidChange(editor.document);
+          await getExtension().noteSyncService.onDidChange(editor.document);
 
           // "foo" should have the frontmatter link to "tags.test"
           const updatedFoo = engine.notes["foo"];
@@ -172,7 +172,7 @@ suite("NoteSyncService", function testSuite() {
         onInit: async ({ engine }) => {
           const foo = engine.notes["foo"];
           const editor = await WSUtils.openNote(foo);
-          const resp = await NoteSyncService.instance().onDidChange(
+          const resp = await getExtension().noteSyncService.onDidChange(
             editor.document
           );
           expect(_.isUndefined(resp)).toBeTruthy();

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -28,7 +28,8 @@ const setupBasic = async (opts: WorkspaceOpts) => {
 
 suite("WindowWatcher: GIVEN the dendron extension is running", function () {
   const watcher: WindowWatcher = new WindowWatcher(
-    PreviewPanelFactory.getProxy()
+    PreviewPanelFactory.getProxy(),
+    getExtension()
   );
 
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
@@ -124,7 +125,9 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
 
-          getExtension().workspaceWatcher = new WorkspaceWatcher();
+          getExtension().workspaceWatcher = new WorkspaceWatcher(
+            getExtension()
+          );
           getExtension().workspaceWatcher?.activate(ctx);
           watcher.activate(ctx);
           // Open a note
@@ -149,7 +152,9 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         onInit: async ({ vaults, wsRoot, engine }) => {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
-          getExtension().workspaceWatcher = new WorkspaceWatcher();
+          getExtension().workspaceWatcher = new WorkspaceWatcher(
+            getExtension()
+          );
           getExtension().workspaceWatcher?.activate(ctx);
 
           watcher.activate(ctx);

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -14,7 +14,7 @@ import {
   setupBeforeAfter,
 } from "../testUtilsV3";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
-import { getDWorkspace } from "../../workspace";
+import { getDWorkspace, getExtension } from "../../workspace";
 import { Position } from "vscode";
 import { SchemaSyncService } from "../../services/SchemaSyncService";
 import * as _ from "lodash";
@@ -80,7 +80,7 @@ runSuiteButSkipForWindows()(
           // So for now we will call the instance of SchemaSyncService to make
           // sure at least that is working as expected.
           expect(await opened.document.save()).toBeTruthy();
-          await SchemaSyncService.instance().onDidSave({
+          await getExtension().schemaSyncService.onDidSave({
             document: opened.document,
           });
 
@@ -104,7 +104,7 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
         ctx,
         postSetupHook: setupBasic,
         onInit: async ({ vaults, wsRoot, engine }) => {
-          watcher = new WorkspaceWatcher();
+          watcher = new WorkspaceWatcher(getExtension());
           const oldPath = path.join(wsRoot, vaults[0].fsPath, "oldfile.md");
           const oldUri = vscode.Uri.file(oldPath);
           const newPath = path.join(wsRoot, vaults[0].fsPath, "newfile.md");
@@ -140,7 +140,7 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
         ctx,
         postSetupHook: setupBasic,
         onInit: async ({ vaults, wsRoot, engine }) => {
-          watcher = new WorkspaceWatcher();
+          watcher = new WorkspaceWatcher(getExtension());
           const oldPath = path.join(wsRoot, vaults[0].fsPath, "oldfile.md");
           const oldUri = vscode.Uri.file(oldPath);
           const newPath = path.join(wsRoot, vaults[0].fsPath, "newfile.md");

--- a/packages/plugin-core/src/types.ts
+++ b/packages/plugin-core/src/types.ts
@@ -1,3 +1,6 @@
+import { DVault, IntermediateDendronConfig } from "@dendronhq/common-all";
+import { IDendronExtension } from "./dendronExtensionInterface";
+
 export type EngineFlavor = "note" | "schema";
 export type EngineOpts = {
   flavor: EngineFlavor;
@@ -29,3 +32,29 @@ export type DateTimeFormat =
 export enum CodeConfigKeys {
   DEFAULT_TIMESTAMP_DECORATION_FORMAT = "dendron.defaultTimestampDecorationFormat",
 }
+
+export type DendronWorkspaceSettings = Partial<{
+  "dendron.dailyJournalDomain": string;
+  "dendron.defaultJournalName": string;
+  "dendron.defaultJournalDateFormat": string;
+  "dendron.defaultJournalAddBehavior": string;
+  "dendron.defaultScratchName": string;
+  "dendron.defaultScratchDateFormat": string;
+  "dendron.defaultScratchAddBehavior": string;
+  "dendron.copyNoteUrlRoot": string;
+  "dendron.linkSelectAutoTitleBehavior": string;
+  "dendron.defaultLookupCreateBehavior": string;
+  "dendron.defaultTimestampDecorationFormat": string;
+  "dendron.rootDir": string;
+  "dendron.dendronDir": string;
+  "dendron.logLevel": string;
+  "dendron.trace.server": string;
+  "dendron.serverPort": string;
+}>;
+
+export type WorkspaceOptsV2 = {
+  wsRoot: string;
+  vaults: DVault[];
+  extension: IDendronExtension;
+  dendronConfig?: IntermediateDendronConfig;
+};

--- a/packages/plugin-core/src/utils/VaultsResolver.ts
+++ b/packages/plugin-core/src/utils/VaultsResolver.ts
@@ -1,0 +1,24 @@
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { Uri } from "vscode";
+import { VaultUtils } from "@dendronhq/common-all";
+import { IVaultsResolver } from "./VaultsResolverInterface";
+
+export class VaultsResolver implements IVaultsResolver {
+  private extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    this.extension = extension;
+  }
+
+  getVaultFromUri(fileUri: Uri) {
+    const workspace = this.extension.getDWorkspace();
+    const { vaults } = workspace;
+    const vault = VaultUtils.getVaultByFilePath({
+      fsPath: fileUri.fsPath,
+      vaults,
+      wsRoot: workspace.wsRoot,
+    });
+
+    return vault;
+  }
+}

--- a/packages/plugin-core/src/utils/VaultsResolverInterface.ts
+++ b/packages/plugin-core/src/utils/VaultsResolverInterface.ts
@@ -1,0 +1,6 @@
+import { Uri } from "vscode";
+import { DVault } from "@dendronhq/common-all";
+
+export interface IVaultsResolver {
+  getVaultFromUri(fileUri: Uri): DVault;
+}

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -37,6 +37,7 @@ import vscode, {
 } from "vscode";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace } from "../workspace";
+import { FoundRefT } from "./mdtypes";
 
 export type RefT = {
   label: string;
@@ -45,12 +46,6 @@ export type RefT = {
   anchorStart?: DNoteAnchorBasic;
   anchorEnd?: DNoteAnchorBasic;
   vaultName?: string;
-};
-
-export type FoundRefT = {
-  location: Location;
-  matchText: string;
-  isCandidate?: boolean;
 };
 
 const markdownExtRegex = /\.md$/i;

--- a/packages/plugin-core/src/utils/mdtypes.ts
+++ b/packages/plugin-core/src/utils/mdtypes.ts
@@ -1,0 +1,7 @@
+import { Location } from "vscode";
+
+export type FoundRefT = {
+  location: Location;
+  matchText: string;
+  isCandidate?: boolean;
+};

--- a/packages/plugin-core/src/views/CalendarView.ts
+++ b/packages/plugin-core/src/views/CalendarView.ts
@@ -96,7 +96,7 @@ export class CalendarView implements vscode.WebviewViewProvider {
         let note: NoteProps | undefined;
         // eslint-disable-next-line no-cond-assign
         if (id && (note = getEngine().notes[id])) {
-          await new GotoNoteCommand().execute({
+          await new GotoNoteCommand(getExtension()).execute({
             qs: note.fname,
             vault: note.vault,
           });

--- a/packages/plugin-core/src/views/DendronTreeView.ts
+++ b/packages/plugin-core/src/views/DendronTreeView.ts
@@ -22,7 +22,12 @@ import vscode, {
 import { GotoNoteCommandOpts } from "../commands/GotoNote";
 import { DENDRON_COMMANDS, ICONS } from "../constants";
 import { Logger } from "../logger";
-import { getExtension, getDWorkspace } from "../workspace";
+import { getDWorkspace, getExtension } from "../workspace";
+import {
+  IDendronTreeView,
+  IEngineNoteProvider,
+  ITreeNote,
+} from "./DendronTreeViewInterface";
 
 function createTreeNote(note: NoteProps) {
   const collapsibleState = _.isEmpty(note.children)
@@ -40,7 +45,7 @@ function createTreeNote(note: NoteProps) {
   return tn;
 }
 
-export class TreeNote extends vscode.TreeItem {
+export class TreeNote extends vscode.TreeItem implements ITreeNote {
   public id: string;
   public note: NoteProps;
   public uri: Uri;
@@ -81,7 +86,9 @@ export class TreeNote extends vscode.TreeItem {
   }
 }
 
-export class EngineNoteProvider implements vscode.TreeDataProvider<string> {
+export class EngineNoteProvider
+  implements vscode.TreeDataProvider<string>, IEngineNoteProvider
+{
   private _onDidChangeTreeData: vscode.EventEmitter<string | undefined | void> =
     new vscode.EventEmitter<string | undefined | void>();
   readonly onDidChangeTreeData: vscode.Event<string | undefined | void> =
@@ -167,8 +174,8 @@ export class EngineNoteProvider implements vscode.TreeDataProvider<string> {
   }
 }
 
-export class DendronTreeView {
-  public pause?: boolean;
+export class DendronTreeView implements IDendronTreeView {
+  pause?: boolean;
 
   static register(_context: ExtensionContext) {
     HistoryService.instance().subscribe(

--- a/packages/plugin-core/src/views/DendronTreeViewInterface.ts
+++ b/packages/plugin-core/src/views/DendronTreeViewInterface.ts
@@ -1,0 +1,35 @@
+import vscode, { TextEditor, TreeView, Uri } from "vscode";
+import { NoteProps, NotePropsDict } from "@dendronhq/common-all";
+import { Logger } from "../logger";
+
+export interface ITreeNote {
+  id: string;
+  note: NoteProps;
+  uri: Uri;
+  children: string[];
+  L: typeof Logger;
+}
+
+export interface IEngineNoteProvider {
+  refresh(): void;
+
+  sort(notes: ITreeNote[]): ITreeNote[];
+
+  sortChildren(children: string[], noteDict: NotePropsDict): unknown[];
+
+  getTreeItem(id: string): vscode.TreeItem;
+
+  getChildren(id?: string): Promise<unknown>;
+
+  getParent(id: string): Promise<string | null>;
+
+  parseTree(note: NoteProps, ndict: NotePropsDict): Promise<ITreeNote>;
+}
+
+export interface IDendronTreeView {
+  pause?: boolean;
+  treeView: TreeView<string>;
+  treeProvider: IEngineNoteProvider;
+
+  onOpenTextDocument(editor: TextEditor | undefined): Promise<void>;
+}

--- a/packages/plugin-core/src/views/DendronTreeViewV2Interface.ts
+++ b/packages/plugin-core/src/views/DendronTreeViewV2Interface.ts
@@ -1,0 +1,14 @@
+import vscode from "vscode";
+import { NoteProps } from "@dendronhq/common-all";
+
+export interface IDendronTreeViewV2 {
+  onOpenTextDocument(editor: vscode.TextEditor | undefined): Promise<void>;
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken
+  ): Promise<void>;
+
+  refresh(note: NoteProps): void;
+}

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -8,9 +8,10 @@ import {
 import { findUpTo, WebViewCommonUtils } from "@dendronhq/common-server";
 import path from "path";
 import * as vscode from "vscode";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { DendronExtension, getDWorkspace, getExtension } from "../workspace";
+import { getDWorkspace, getExtension } from "../workspace";
 
 export class WebViewUtils {
   /**
@@ -100,7 +101,7 @@ export class WebViewUtils {
     key,
     webviewView,
   }: {
-    ext: DendronExtension;
+    ext: IDendronExtension;
     key: DendronTreeViewKey;
     webviewView: vscode.WebviewView;
   }) {

--- a/packages/plugin-core/src/windowWatcherInterface.ts
+++ b/packages/plugin-core/src/windowWatcherInterface.ts
@@ -1,0 +1,13 @@
+import { TextEditor } from "vscode";
+
+export interface IWindowWatcher {
+  /**
+   * Decorate wikilinks, user tags etc. as well as warning about some issues like missing frontmatter
+   */
+  triggerUpdateDecorations(editor: TextEditor): Promise<void>;
+
+  /**
+   * Show note preview panel if applicable
+   */
+  triggerNotePreviewUpdate({ document }: TextEditor): Promise<void>;
+}


### PR DESCRIPTION
Started on this since this is blocking other task. 

Publishing a draft before continuing further down this path of introducing interfaces to decouple our circular dependencies.

If we have some shortcut way of fixing circular dependencies we can go that route as well, but if we don't it appears we have to go with introduction of interfaces to be able to untangle concrete implementation couplings that we currently have. 

Using C# interface convention for naming interfaces (prefixing files with `I` to avoid having to rename existing implementaitons) and convention of postfixing `Interface` to the file name to be closer alligned with our file naming. 

In this commit there are 111 circular dependencies left:

```
Processed 1116 files (8.2s) (150 warnings)

1) common-all/lib/types/configs/dendronConfig.d.ts > common-all/lib/types/configs/publishing/publishing.d.ts > common-all/lib/types/workspace.d.ts > common-all/lib/types/intermediateConfigs.d.ts
2) common-all/lib/types/workspace.d.ts > common-all/lib/types/intermediateConfigs.d.ts
3) common-all/lib/types/typesv2.d.ts > common-all/lib/types/foundation.d.ts
4) common-all/lib/types/workspace.d.ts > common-all/lib/types/typesv2.d.ts > common-all/lib/types/foundation.d.ts
5) common-all/lib/types/workspace.d.ts > common-all/lib/types/typesv2.d.ts
6) common-all/lib/fuse.d.ts
7) common-all/src/types/configs/dendronConfig.ts > common-all/src/types/configs/publishing/publishing.ts > common-all/src/types/workspace.ts > common-all/src/types/intermediateConfigs.ts
8) common-all/src/types/workspace.ts > common-all/src/types/intermediateConfigs.ts
9) common-all/src/types/typesv2.ts > common-all/src/types/foundation.ts
10) common-all/src/types/workspace.ts > common-all/src/types/typesv2.ts > common-all/src/types/foundation.ts
11) common-all/src/types/workspace.ts > common-all/src/types/typesv2.ts
12) common-all/src/fuse.ts
13) common-server/src/filesv2.ts > common-server/src/parser.ts
14) dendron-next-server/lib/luxon.ts
15) engine-server/lib/markdown/types.d.ts > engine-server/lib/markdown/remark/dendronPub.d.ts > engine-server/lib/markdown/remark/noteRefs.d.ts > engine-server/lib/markdown/remark/wikiLinks.d.ts > engine-server/lib/markdown/remark/utils.d.ts
16) engine-server/lib/migrations/types.d.ts > engine-server/lib/migrations/service.d.ts
17) engine-server/src/drivers/file/storev2.ts > engine-server/src/drivers/file/noteParser.ts
18) engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/drivers/file/noteParser.ts
19) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts
20) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/backlinks.ts
21) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/backlinks.ts
22) engine-server/src/topics/site.ts > engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/backlinks.ts
23) engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts
24) engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts
25) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts
26) engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts
27) engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts
28) engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts > engine-server/src/markdown/remark/wikiLinks.ts
29) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts > engine-server/src/markdown/remark/wikiLinks.ts
30) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts > engine-server/src/markdown/remark/wikiLinks.ts
31) engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts > engine-server/src/markdown/remark/wikiLinks.ts
32) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts
33) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts
34) engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts > engine-server/src/markdown/remark/noteRefs.ts
35) engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts
36) engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/dendronPreview.ts
37) engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts
38) engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts
39) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/hashtag.ts
40) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/hashtag.ts
41) engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/hashtag.ts
42) engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/noteRefsV2.ts
43) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/noteRefsV2.ts
44) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/noteRefsV2.ts
45) engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/noteRefsV2.ts
46) engine-server/src/topics/site.ts > engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/noteRefsV2.ts
47) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/userTags.ts
48) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts > engine-server/src/markdown/remark/userTags.ts
49) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts
50) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/extendedImage.ts > engine-server/src/markdown/utilsv5.ts
51) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/publishSite.ts
52) engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/publishSite.ts
53) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts > engine-server/src/markdown/remark/transformLinks.ts
54) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts > engine-server/src/markdown/remark/blockAnchors.ts > engine-server/src/markdown/utils.ts
55) engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts
56) engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts
57) engine-server/src/topics/site.ts > engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts > engine-server/src/markdown/types.ts > engine-server/src/markdown/remark/dendronPub.ts
58) engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts > engine-server/src/markdown/remark/utils.ts
59) engine-server/src/utils.ts > engine-server/src/engineClient.ts > engine-server/src/drivers/file/storev2.ts
60) engine-server/src/utils.ts > engine-server/src/engineClient.ts
61) engine-server/src/migrations/migrations.ts > engine-server/src/migrations/types.ts > engine-server/src/migrations/service.ts
62) engine-server/src/migrations/types.ts > engine-server/src/migrations/service.ts
63) nextjs-template/components/DendronGATracking.tsx > nextjs-template/utils/analytics.ts
64) nextjs-template/utils/types.ts > nextjs-template/utils/hooks.ts > nextjs-template/utils/etc.ts
65) nextjs-template/utils/fetchers.ts > nextjs-template/utils/fuse.ts
66) nextjs-template/utils/fuse.ts
67) nextjs-template/utils/types.ts > nextjs-template/utils/hooks.ts > nextjs-template/utils/fetchers.ts
68) plugin-core/.vscode-test/vscode-darwin-1.63.0/Visual Studio Code.app/Contents/Resources/app/extensions/git-base/src/api/api1.ts > plugin-core/.vscode-test/vscode-darwin-1.63.0/Visual Studio Code.app/Contents/Resources/app/extensions/git-base/src/api/extension.ts
69) plugin-core/.vscode-test/vscode-darwin-1.63.2/Visual Studio Code.app/Contents/Resources/app/extensions/git-base/src/api/api1.ts > plugin-core/.vscode-test/vscode-darwin-1.63.2/Visual Studio Code.app/Contents/Resources/app/extensions/git-base/src/api/extension.ts
70) plugin-core/src/dendronExtensionInterface.ts > plugin-core/src/services/EngineAPIService.ts
71) plugin-core/src/types.ts > plugin-core/src/dendronExtensionInterface.ts
72) plugin-core/src/constants.ts > plugin-core/src/types.ts > plugin-core/src/dendronExtensionInterface.ts > plugin-core/src/views/DendronTreeViewInterface.ts > plugin-core/src/logger.ts
73) plugin-core/src/workspace.ts > plugin-core/src/WorkspaceWatcher.ts > plugin-core/src/utils/analytics.ts
74) plugin-core/src/WSUtils.ts > plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts
75) plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts
76) plugin-core/src/WSUtils.ts > plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/buttons.ts
77) plugin-core/src/components/lookup/buttons.ts > plugin-core/src/clientUtils.ts > plugin-core/src/components/lookup/types.ts
78) plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/buttons.ts > plugin-core/src/clientUtils.ts
79) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/buttons.ts > plugin-core/src/clientUtils.ts
80) plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/buttons.ts
81) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/buttons.ts
82) plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts > plugin-core/src/components/lookup/queryStringTransformer.ts
83) plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts
84) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts > plugin-core/src/components/lookup/LookupProviderV3.ts
85) plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts
86) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts > plugin-core/src/components/lookup/LookupControllerV3.ts
87) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/components/lookup/utils.ts
88) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/commands/GotoNote.ts > plugin-core/src/utils/md.ts
89) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/utils/quickPick.ts
90) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts > plugin-core/src/views/utils.ts
91) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts > plugin-core/src/commands/ShowPreview.ts
92) plugin-core/src/workspace.ts > plugin-core/src/components/views/PreviewViewFactory.ts
93) plugin-core/src/workspace.ts > plugin-core/src/services/CommandRegistrar.ts > plugin-core/src/commands/CreateNoteWithTraitCommand.ts
94) plugin-core/src/WSUtils.ts > plugin-core/src/workspace.ts > plugin-core/src/views/CalendarView.ts
95) plugin-core/src/workspace.ts > plugin-core/src/views/CalendarView.ts
96) plugin-core/src/workspace.ts > plugin-core/src/views/DendronTreeView.ts
97) plugin-core/src/workspace.ts > plugin-core/src/views/DendronTreeViewV2.ts
98) plugin-core/src/WSUtils.ts > plugin-core/src/workspace.ts > plugin-core/src/windowWatcher.ts
99) plugin-core/src/WSUtils.ts > plugin-core/src/workspace.ts > plugin-core/src/windowWatcher.ts > plugin-core/src/features/windowDecorations.ts
100) plugin-core/src/workspace.ts > plugin-core/src/windowWatcher.ts > plugin-core/src/features/windowDecorations.ts
101) plugin-core/src/workspace/blankInitializer.ts > plugin-core/src/workspace/workspaceInitializer.ts
102) plugin-core/src/workspace/workspaceInitializer.ts > plugin-core/src/workspace/seedBrowserInitializer.ts
103) plugin-core/src/workspace/blankInitializer.ts > plugin-core/src/workspace/workspaceInitializer.ts > plugin-core/src/workspace/tutorialInitializer.ts
104) plugin-core/src/workspace/workspaceInitializer.ts > plugin-core/src/workspace/tutorialInitializer.ts
105) plugin-core/src/components/doctor/buttons.ts > plugin-core/src/components/doctor/types.ts
106) plugin-core/src/components/pods/PodControls.ts > plugin-core/src/components/pods/PodCommandFactory.ts > plugin-core/src/commands/pods/AirtableExportPodCommand.ts
107) plugin-core/src/components/pods/PodControls.ts > plugin-core/src/components/pods/PodCommandFactory.ts > plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
108) plugin-core/src/components/pods/PodControls.ts > plugin-core/src/components/pods/PodCommandFactory.ts > plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
109) plugin-core/src/test/testUtilsV3.ts > plugin-core/src/test/testUtilsv2.ts
110) pods-core/lib/utils.d.ts
111) pods-core/src/utils.ts
```