### PR TITLE
enhance(schema): Support date variable substitution for templates

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1292,6 +1292,23 @@ export class SchemaUtils {
       } else {
         note.body = tempNote.body;
       }
+
+      // Apply date variable substitution to the body if applicable
+      // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
+      // Use mustache delimiter
+      _.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
+
+      const currentDate = Time.now();
+      const compiledSchemaTemplate = _.template(note.body);
+      note.body = compiledSchemaTemplate({
+        CURRENT_YEAR: currentDate.year,
+        CURRENT_MONTH: currentDate.month,
+        CURRENT_DAY: currentDate.day,
+        CURRENT_HOUR: currentDate.hour,
+        CURRENT_MINUTE: currentDate.minute,
+        CURRENT_SECOND: currentDate.second,
+      });
+
       return true;
     }
     return false;

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -127,6 +127,10 @@ export const NOTE_PRESETS_V4 = {
     fname: "000 Index.md",
     body: "[[alpha]]",
   }),
+  NOTE_WITH_DATE_VARIABLES: CreateNoteFactory({
+    fname: "date-variables",
+    body: "Today is {{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}",
+  }),
   NOTE_WITH_NOTE_REF_SIMPLE: CreateNoteFactory({
     fname: "simple-note-ref",
     body: "![[simple-note-ref.one]]",

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -129,7 +129,10 @@ export const NOTE_PRESETS_V4 = {
   }),
   NOTE_WITH_DATE_VARIABLES: CreateNoteFactory({
     fname: "date-variables",
-    body: "Today is {{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}",
+    body: [
+      "Today is {{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}",
+      "This link goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]",
+    ].join("\n"),
   }),
   NOTE_WITH_NOTE_REF_SIMPLE: CreateNoteFactory({
     fname: "simple-note-ref",

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -287,6 +287,16 @@ export class MDUtilsV5 {
 
     // set options and do validation
     proc = this.setProcOpts(proc, opts);
+
+    // set global date variables
+    const currentDate = DateTime.local();
+    proc = proc.data("CURRENT_YEAR", currentDate.year);
+    proc = proc.data("CURRENT_MONTH", currentDate.month);
+    proc = proc.data("CURRENT_DAY", currentDate.day);
+    proc = proc.data("CURRENT_HOUR", currentDate.hour);
+    proc = proc.data("CURRENT_MINUTE", currentDate.minute);
+    proc = proc.data("CURRENT_SECOND", currentDate.second);
+
     switch (opts.mode) {
       case ProcMode.FULL:
         {

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -288,15 +288,6 @@ export class MDUtilsV5 {
     // set options and do validation
     proc = this.setProcOpts(proc, opts);
 
-    // set global date variables
-    const currentDate = DateTime.local();
-    proc = proc.data("CURRENT_YEAR", currentDate.year);
-    proc = proc.data("CURRENT_MONTH", currentDate.month);
-    proc = proc.data("CURRENT_DAY", currentDate.day);
-    proc = proc.data("CURRENT_HOUR", currentDate.hour);
-    proc = proc.data("CURRENT_MINUTE", currentDate.minute);
-    proc = proc.data("CURRENT_SECOND", currentDate.second);
-
     switch (opts.mode) {
       case ProcMode.FULL:
         {

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -5,6 +5,7 @@ import {
   SchemaOpts,
   NoteProps,
   SchemaTemplate,
+  Time,
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { runEngineTestV5 } from "../../engine";
@@ -126,6 +127,37 @@ describe(`SchemaUtil tests:`, () => {
           {
             expect,
             preSetupHook: ENGINE_HOOKS.setupSchemaPreseet,
+          }
+        );
+      });
+
+      it("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
+        const dateTemplate: SchemaTemplate = {
+          id: "date-variables",
+          type: "note",
+        };
+        await runEngineTestV5(
+          async ({ engine }) => {
+            const resp = SchemaUtils.applyTemplate({
+              template: dateTemplate,
+              note,
+              engine,
+            });
+            expect(resp).toBeTruthy();
+            expect(note.body).not.toEqual(engine.notes["date-variables"].body);
+            expect(note.body.trim()).toEqual(
+              `Today is ${Time.now().year}.${Time.now().month}.${
+                Time.now().day
+              }` +
+                "\n" +
+                `This link goes to [[daily.journal.${Time.now().year}.${
+                  Time.now().month
+                }.${Time.now().day}]]`
+            );
+          },
+          {
+            expect,
+            preSetupHook: ENGINE_HOOKS.setupRefs,
           }
         );
       });

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
@@ -4,7 +4,6 @@ import {
   Processor,
   ProcFlavor,
 } from "@dendronhq/engine-server";
-import { DateTime } from "luxon";
 import os from "os";
 import path from "path";
 import { createEngineFromServer, runEngineTestV5 } from "../../../engine";
@@ -180,40 +179,11 @@ describe("MDUtils.proc", () => {
     },
   });
 
-  const WITH_DATE_VARIABLES = createProcCompileTests({
-    name: "WITH_DATE_VARIABLES",
-    setup: async (opts) => {
-      const { proc } = getOpts(opts);
-      const txt = `{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}`;
-      const resp = await proc.process(txt);
-      return { resp, proc };
-    },
-    verify: {
-      [DendronASTDest.HTML]: {
-        [ProcFlavor.REGULAR]: async ({ extra }) => {
-          const { resp } = extra;
-          await checkString(
-            resp.contents,
-            `${DateTime.local().year}.${DateTime.local().month}.${
-              DateTime.local().day
-            }`
-          );
-        },
-        [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,
-        [ProcFlavor.PUBLISHING]: ProcFlavor.REGULAR,
-      },
-    },
-    preSetupHook: async (opts) => {
-      await ENGINE_HOOKS.setupBasic(opts);
-    },
-  });
-
   const ALL_TEST_CASES = [
     ...WITH_FOOTNOTES,
     ...IMAGE_NO_LEAD_FORWARD_SLASH,
     ...IMAGE_WITH_LEAD_FORWARD_SLASH,
     ...WILDCARD_NOTE_REF_MISSING,
-    ...WITH_DATE_VARIABLES,
   ];
 
   test.each(

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -615,6 +615,11 @@ export const setupRefs: PreSetupHookFunction = async ({ vaults, wsRoot }) => {
     vault,
     wsRoot,
   });
+  // create note with date variables
+  await NOTE_PRESETS_V4.NOTE_WITH_DATE_VARIABLES.create({
+    vault,
+    wsRoot,
+  });
 };
 
 export const ENGINE_HOOKS_BASE = {

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -12,13 +12,7 @@ import {
   VSCodeEvents,
 } from "@dendronhq/common-all";
 import { getDurationMilliseconds } from "@dendronhq/common-server";
-import {
-  DendronASTDest,
-  HistoryService,
-  MDUtilsV5,
-  MetadataService,
-  ProcMode,
-} from "@dendronhq/engine-server";
+import { HistoryService, MetadataService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { Uri } from "vscode";
 import {
@@ -485,20 +479,6 @@ export class NoteLookupCommand extends BaseCommand<
         note: nodeNew,
         engine,
       });
-
-      // Apply any variable substitution to the template before creating new note
-      // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
-      const proc = await MDUtilsV5.procRemarkFull(
-        {
-          fname: nodeNew.fname,
-          engine,
-          dest: DendronASTDest.MD_DENDRON,
-          vault: nodeNew.vault,
-        },
-        { mode: ProcMode.IMPORT }
-      );
-      const resolvedBody = await proc.process(nodeNew.body);
-      nodeNew.body = resolvedBody.toString();
     }
 
     const maybeJournalTitleOverride = this.journalTitleOverride();

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -12,7 +12,13 @@ import {
   VSCodeEvents,
 } from "@dendronhq/common-all";
 import { getDurationMilliseconds } from "@dendronhq/common-server";
-import { HistoryService, MetadataService } from "@dendronhq/engine-server";
+import {
+  DendronASTDest,
+  HistoryService,
+  MDUtilsV5,
+  MetadataService,
+  ProcMode,
+} from "@dendronhq/engine-server";
 import _ from "lodash";
 import { Uri } from "vscode";
 import {
@@ -479,6 +485,20 @@ export class NoteLookupCommand extends BaseCommand<
         note: nodeNew,
         engine,
       });
+
+      // Apply any variable substitution to the template before creating new note
+      // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
+      const proc = await MDUtilsV5.procRemarkFull(
+        {
+          fname: nodeNew.fname,
+          engine,
+          dest: DendronASTDest.MD_DENDRON,
+          vault: nodeNew.vault,
+        },
+        { mode: ProcMode.IMPORT }
+      );
+      const resolvedBody = await proc.process(nodeNew.body);
+      nodeNew.body = resolvedBody.toString();
     }
 
     const maybeJournalTitleOverride = this.journalTitleOverride();
@@ -496,6 +516,7 @@ export class NoteLookupCommand extends BaseCommand<
       Logger.error({ ctx, error: resp.error });
       return;
     }
+
     const uri = NoteUtils.getURI({
       note: nodeNew,
       wsRoot: getDWorkspace().wsRoot,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1,6 +1,5 @@
 import {
   ConfigUtils,
-  DateTime,
   DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
@@ -795,10 +794,14 @@ suite("NoteLookupCommand", function () {
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
           const newNote = WSUtils.getNoteFromDocument(document!);
-          expect(_.trim(newNote!.body)).toEqual(
-            `Today is ${DateTime.local().year}.${DateTime.local().month}.${
-              DateTime.local().day
-            }`
+          expect(newNote!.body.trim()).toEqual(
+            `Today is ${Time.now().year}.${Time.now().month}.${
+              Time.now().day
+            }` +
+              "\n" +
+              `This link goes to [[daily.journal.${Time.now().year}.${
+                Time.now().month
+              }.${Time.now().day}]]`
           );
         });
       }


### PR DESCRIPTION
When applying a schema template, Dendron should support custom date variables.
- Use lodash _.template to apply date variable substitution when we call `applyTemplate`

Testing
- Manually created template with {{ CURRENT_YEAR }}
- Verified new note contains 2021
- Updated unit tests for `applyTemplate` and NoteLookupCommand

See [[Support Custom Date Format When Applying Schema Template|dendron://private/task.2021.11.28.support-custom-date-format-when-applying-schema-template]] for more info
