### PR TITLE
chore(internal): Pass Extension into Plugin Command

### DIFF
--- a/packages/engine-server/src/markdown/remark/hierarchies.ts
+++ b/packages/engine-server/src/markdown/remark/hierarchies.ts
@@ -64,6 +64,7 @@ function footnoteDef2html(definition: FootnoteDefinition) {
 }
 
 /** Adds the "Children", "Tags", and "Footnotes" items to the end of the note. Also renders footnotes. */
+// eslint-disable-next-line func-names
 const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
   const proc = this;
   const hierarchyDisplayTitle = opts?.hierarchyDisplayTitle || "Children";

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1005,7 +1005,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.RELOAD_INDEX.key,
         sentryReportingCallback(async (silent?: boolean) => {
-          const out = await new ReloadIndexCommand().run({ silent });
+          const out = await new ReloadIndexCommand(ws).run({ silent });
           if (!silent) {
             vscode.window.showInformationMessage(`finish reload`);
           }
@@ -1021,7 +1021,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.GO_NEXT_HIERARCHY.key,
         sentryReportingCallback(async () => {
-          await new GoToSiblingCommand().execute({ direction: "next" });
+          await new GoToSiblingCommand(ws).execute({ direction: "next" });
         })
       )
     );
@@ -1031,7 +1031,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.GO_PREV_HIERARCHY.key,
         sentryReportingCallback(async () => {
-          await new GoToSiblingCommand().execute({ direction: "prev" });
+          await new GoToSiblingCommand(ws).execute({ direction: "prev" });
         })
       )
     );
@@ -1043,7 +1043,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.RENAME_NOTE.key,
         sentryReportingCallback(async (args: any) => {
-          await new MoveNoteCommand().run({
+          await new MoveNoteCommand(ws).run({
             allowMultiselect: false,
             useSameVault: true,
             ...args,

--- a/packages/plugin-core/src/commands/ArchiveHierarchy.ts
+++ b/packages/plugin-core/src/commands/ArchiveHierarchy.ts
@@ -1,6 +1,7 @@
 import { NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 import { RefactorHierarchyCommandV2 } from "./RefactorHierarchyV2";
@@ -22,8 +23,8 @@ export class ArchiveHierarchyCommand extends BasicCommand<
   key = DENDRON_COMMANDS.ARCHIVE_HIERARCHY.key;
   private refactorCmd: RefactorHierarchyCommandV2;
 
-  constructor(name?: string) {
-    super(name);
+  constructor(extension: IDendronExtension, name?: string) {
+    super(extension, name);
     this.refactorCmd = new RefactorHierarchyCommandV2();
   }
 

--- a/packages/plugin-core/src/commands/ConfigurePodCommand.ts
+++ b/packages/plugin-core/src/commands/ConfigurePodCommand.ts
@@ -13,6 +13,7 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { showPodQuickPickItemsV4 } from "../utils/pods";
 import { getExtension } from "../workspace";
 import { BasicCommand } from "./base";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -27,8 +28,8 @@ export class ConfigurePodCommand extends BasicCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.CONFIGURE_POD.key;
 
-  constructor(_name?: string) {
-    super(_name);
+  constructor(extension: IDendronExtension, _name?: string) {
+    super(extension, _name);
     this.pods = getAllExportPods();
   }
 

--- a/packages/plugin-core/src/commands/ExportPod.ts
+++ b/packages/plugin-core/src/commands/ExportPod.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/pods";
 import { getExtension, getDWorkspace } from "../workspace";
 import { BaseCommand } from "./base";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -30,8 +31,8 @@ export class ExportPodCommand extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.EXPORT_POD.key;
 
-  constructor(_name?: string) {
-    super(_name);
+  constructor(extension: IDendronExtension, _name?: string) {
+    super(extension, _name);
     this.pods = getAllExportPods();
   }
 

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -62,7 +62,7 @@ export class GotoNoteCommand extends BasicCommand<
   GoToNoteCommandOutput
 > {
   key = DENDRON_COMMANDS.GOTO_NOTE.key;
-  private extension: IDendronExtension;
+  protected extension: IDendronExtension;
   private wsUtils: IWSUtilsV2;
 
   constructor(extension: IDendronExtension) {

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -10,6 +10,7 @@ import {
 import _ from "lodash";
 import { ProgressLocation, Uri, window } from "vscode";
 import { DENDRON_COMMANDS, Oauth2Pods } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import {
   getGlobalState,
   launchGoogleOAuthFlow,
@@ -39,8 +40,8 @@ export class ImportPodCommand extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.IMPORT_POD.key;
 
-  constructor(_name?: string) {
-    super(_name);
+  constructor(extension: IDendronExtension, _name?: string) {
+    super(extension, _name);
     this.pods = getAllImportPods();
   }
 

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -60,6 +60,7 @@ import { BaseCommand } from "./base";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { AutoCompleter } from "../utils/autoCompleter";
 import { AutoCompletable } from "../utils/AutoCompletable";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 export type CommandRunOpts = {
   initialValue?: string;
@@ -129,8 +130,8 @@ export class NoteLookupCommand
   protected _provider: ILookupProviderV3 | undefined;
   protected _quickPick: DendronQuickPickerV2 | undefined;
 
-  constructor() {
-    super("LookupCommandV3");
+  constructor(extension?: IDendronExtension, _name?: string) {
+    super(extension, "LookupCommandV3");
   }
 
   protected get controller(): LookupControllerV3 {

--- a/packages/plugin-core/src/commands/PublishDevCommand.ts
+++ b/packages/plugin-core/src/commands/PublishDevCommand.ts
@@ -9,6 +9,7 @@ import fs from "fs-extra";
 import _ from "lodash";
 import { window } from "vscode";
 import { DENDRON_EMOJIS } from "@dendronhq/common-all";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = {
   pid: number;
@@ -16,6 +17,12 @@ type CommandOutput = {
 
 export class PublishDevCommand extends BasicCommand<CommandOutput> {
   key = DENDRON_COMMANDS.PUBLISH_DEV.key;
+  protected extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    super(extension);
+    this.extension = extension;
+  }
 
   async gatherInputs(): Promise<any> {
     return {};
@@ -33,7 +40,9 @@ export class PublishDevCommand extends BasicCommand<CommandOutput> {
     const ctx = "PublishDevCommand";
     this.L.info({ ctx, msg: "enter" });
 
-    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod();
+    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod(
+      this.extension
+    );
     const { enrichedOpts, wsRoot, cmd, nextPath } = prepareOut;
     this.L.info({ ctx, msg: "prepare", enrichedOpts, nextPath });
 

--- a/packages/plugin-core/src/commands/PublishExportCommand.ts
+++ b/packages/plugin-core/src/commands/PublishExportCommand.ts
@@ -6,6 +6,7 @@ import { DENDRON_COMMANDS } from "../constants";
 import { checkPreReq, NextJSPublishUtils } from "../utils/site";
 import { BasicCommand } from "./base";
 import { VSCodeUtils } from "../vsCodeUtils";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOpts = void;
 
@@ -19,6 +20,13 @@ export class PublishExportCommand extends BasicCommand<
 > {
   key = DENDRON_COMMANDS.PUBLISH_EXPORT.key;
 
+  protected extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    super(extension);
+    this.extension = extension;
+  }
+
   async gatherInputs(): Promise<any> {
     return {};
   }
@@ -31,7 +39,9 @@ export class PublishExportCommand extends BasicCommand<
     const ctx = "PublishExportCommand";
     this.L.info({ ctx, msg: "enter" });
 
-    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod();
+    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod(
+      this.extension
+    );
     const { enrichedOpts, wsRoot, cmd, nextPath } = prepareOut;
     this.L.info({ ctx, msg: "prepare", enrichedOpts, nextPath });
 

--- a/packages/plugin-core/src/commands/Refactor.ts
+++ b/packages/plugin-core/src/commands/Refactor.ts
@@ -3,6 +3,7 @@ import { createLogger, getAllFiles } from "@dendronhq/common-server";
 import fs, { Dirent } from "fs-extra";
 import _ from "lodash";
 import path from "path";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { BasicCommand } from "./base";
 
 const L = createLogger("dendron");
@@ -45,8 +46,12 @@ export abstract class RefactorBaseCommand<
 > extends BasicCommand<RefactorCommandOpts> {
   public props: Required<RefactorCommandOpts>;
 
-  constructor(name: string, opts: RefactorCommandOpts) {
-    super(name);
+  constructor(
+    extension: IDendronExtension,
+    name: string,
+    opts: RefactorCommandOpts
+  ) {
+    super(extension, name);
     this.props = this.cleanOpts(opts);
   }
 

--- a/packages/plugin-core/src/commands/SchemaLookupCommand.ts
+++ b/packages/plugin-core/src/commands/SchemaLookupCommand.ts
@@ -21,6 +21,7 @@ import {
 import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { OldNewLocation, PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
 import { getDWorkspace } from "../workspace";
@@ -65,8 +66,8 @@ export class SchemaLookupCommand extends BaseCommand<
   protected _controller: LookupControllerV3 | undefined;
   protected _provider: ILookupProviderV3 | undefined;
 
-  constructor() {
-    super("SchemaLookupCommand");
+  constructor(extension: IDendronExtension) {
+    super(extension, "SchemaLookupCommand");
   }
 
   protected get controller(): LookupControllerV3 {

--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -50,8 +50,11 @@ export abstract class BaseCommand<
   TRunOpts = TOpts
 > {
   public L: DLogger;
+  protected extension?: IDendronExtension;
 
-  constructor(_name?: string) {
+  // TODO: this should be a required variable
+  constructor(extension?: IDendronExtension, _name?: string) {
+    this.extension = extension;
     this.L = Logger;
   }
 

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -21,6 +21,7 @@ import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getEngine, getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
@@ -36,17 +37,18 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.airtableexport";
 
-  public constructor() {
-    super(new QuickPickHierarchySelector());
+  public constructor(extension: IDendronExtension) {
+    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
   }
 
   public createPod(
     config: RunnableAirtableV2PodConfig
   ): ExportPodV2<AirtableExportReturnType> {
-    return new AirtableExportPodV2(
-      new Airtable({ apiKey: config.apiKey }),
-      config
-    );
+    return new AirtableExportPodV2({
+      airtable: new Airtable({ apiKey: config.apiKey }),
+      config,
+      engine: this.extension!.getEngine(),
+    });
   }
 
   public getRunnableSchema(): JSONSchemaType<RunnableAirtableV2PodConfig> {

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -16,6 +16,7 @@ import {
 import path from "path";
 import * as vscode from "vscode";
 import { HierarchySelector } from "../../components/lookup/HierarchySelector";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getDWorkspace, getExtension } from "../../workspace";
 import { BaseCommand } from "../base";
@@ -49,9 +50,16 @@ export abstract class BaseExportPodCommand<
    * hierarchy to export. Should use {@link QuickPickHierarchySelector} by
    * default
    */
-  constructor(hierarchySelector: HierarchySelector) {
+  constructor({
+    hierarchySelector,
+    extension,
+  }: {
+    hierarchySelector: HierarchySelector;
+    extension: IDendronExtension;
+  }) {
     super();
     this.hierarchySelector = hierarchySelector;
+    this.extension = extension;
   }
 
   /**

--- a/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
+++ b/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
@@ -2,6 +2,7 @@ import { getAllExportPods, PodClassEntryV4 } from "@dendronhq/pods-core";
 import { PodCommandFactory } from "../../components/pods/PodCommandFactory";
 import { PodUIControls } from "../../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../../constants";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { BaseCommand, CodeCommandInstance } from "../base";
 
 type CommandOutput = void;
@@ -21,8 +22,8 @@ export class ExportPodV2Command extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.EXPORT_POD_V2.key;
 
-  constructor(_name?: string) {
-    super(_name);
+  constructor(extension: IDendronExtension, _name?: string) {
+    super(extension, _name);
     this.pods = getAllExportPods();
   }
 
@@ -32,9 +33,13 @@ export class ExportPodV2Command extends BaseCommand<
    * undefined if the user didn't select anything.
    */
   async gatherInputs(podId: string): Promise<CommandInput | undefined> {
+    const extension = this.extension!;
     // If a podId is passed in, use this instead of prompting the user
     if (podId) {
-      return PodCommandFactory.createPodCommandForStoredConfig({ podId });
+      return PodCommandFactory.createPodCommandForStoredConfig(
+        { podId },
+        extension
+      );
     }
 
     const exportChoice = await PodUIControls.promptForExportConfigOrNewExport();
@@ -47,9 +52,12 @@ export class ExportPodV2Command extends BaseCommand<
       if (!podType) {
         return;
       }
-      return PodCommandFactory.createPodCommandForPodType(podType);
+      return PodCommandFactory.createPodCommandForPodType(podType, extension);
     } else {
-      return PodCommandFactory.createPodCommandForStoredConfig(exportChoice);
+      return PodCommandFactory.createPodCommandForStoredConfig(
+        exportChoice,
+        extension
+      );
     }
   }
 

--- a/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
@@ -20,6 +20,7 @@ import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { clipboard } from "../../utils";
 import { launchGoogleOAuthFlow } from "../../utils/pods";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -37,8 +38,8 @@ export class GoogleDocsExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.googledocsexport";
 
-  public constructor() {
-    super(new QuickPickHierarchySelector());
+  public constructor(extension: IDendronExtension) {
+    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
   }
 
   public createPod(

--- a/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
@@ -15,6 +15,7 @@ import path from "path";
 import * as vscode from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getDWorkspace, getEngine, getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
@@ -30,8 +31,8 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.markdownexportv2";
 
-  public constructor() {
-    super(new QuickPickHierarchySelector());
+  public constructor(extension: IDendronExtension) {
+    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
   }
 
   public async gatherInputs(

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -9,6 +9,7 @@ import { CodeCommandInstance } from "../../commands/base";
 import { AirtableExportPodCommand } from "../../commands/pods/AirtableExportPodCommand";
 import { GoogleDocsExportPodCommand } from "../../commands/pods/GoogleDocsExportPodCommand";
 import { MarkdownExportPodCommand } from "../../commands/pods/MarkdownExportPodCommand";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { getExtension } from "../../workspace";
 
 export class PodCommandFactory {
@@ -19,7 +20,8 @@ export class PodCommandFactory {
    * @returns A pod command configured with the found configuration
    */
   public static createPodCommandForStoredConfig(
-    configId: Pick<ExportPodConfigurationV2, "podId">
+    configId: Pick<ExportPodConfigurationV2, "podId">,
+    extension: IDendronExtension
   ): CodeCommandInstance {
     const storedConfig = PodV2ConfigManager.getPodConfigById({
       podsDir: path.join(getExtension().podsDir, "custom"),
@@ -36,7 +38,7 @@ export class PodCommandFactory {
 
     switch (storedConfig.podType) {
       case PodV2Types.AirtableExportV2: {
-        const airtableCmd = new AirtableExportPodCommand();
+        const airtableCmd = new AirtableExportPodCommand(extension);
         cmdWithArgs = {
           key: airtableCmd.key,
           run(): Promise<void> {
@@ -46,7 +48,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand();
+        const cmd = new MarkdownExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -56,7 +58,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand();
+        const cmd = new GoogleDocsExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -81,11 +83,12 @@ export class PodCommandFactory {
    * @returns
    */
   public static createPodCommandForPodType(
-    podType: PodV2Types
+    podType: PodV2Types,
+    extension: IDendronExtension
   ): CodeCommandInstance {
     switch (podType) {
       case PodV2Types.AirtableExportV2: {
-        const cmd = new AirtableExportPodCommand();
+        const cmd = new AirtableExportPodCommand(extension);
 
         return {
           key: cmd.key,
@@ -96,7 +99,7 @@ export class PodCommandFactory {
       }
 
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand();
+        const cmd = new MarkdownExportPodCommand(extension);
 
         return {
           key: cmd.key,
@@ -106,7 +109,7 @@ export class PodCommandFactory {
         };
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand();
+        const cmd = new GoogleDocsExportPodCommand(extension);
         return {
           key: cmd.key,
           run(): Promise<void> {

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -17,6 +17,7 @@ import { launchGoogleOAuthFlow } from "../../utils/pods";
 import { getExtension } from "../../workspace";
 import { PodCommandFactory } from "./PodCommandFactory";
 import { assertUnreachable } from "@dendronhq/common-all";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 
 /**
  * Contains VSCode UI controls for common Pod UI operations
@@ -154,16 +155,16 @@ export class PodUIControls {
    * Prompt user to pick a pod (v2) type
    * @returns a runnable code command for the selected pod
    */
-  public static async promptForPodTypeForCommand(): Promise<
-    CodeCommandInstance | undefined
-  > {
+  public static async promptForPodTypeForCommand(
+    extension: IDendronExtension
+  ): Promise<CodeCommandInstance | undefined> {
     const picked = await PodUIControls.promptForPodType();
 
     if (!picked) {
       return;
     }
 
-    return PodCommandFactory.createPodCommandForPodType(picked);
+    return PodCommandFactory.createPodCommandForPodType(picked, extension);
   }
 
   /**

--- a/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
@@ -7,20 +7,20 @@ import {
 } from "@dendronhq/pods-core";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
 import { ConfigurePodCommand } from "../../commands/ConfigurePodCommand";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  getFakeExtensionForTest,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
 suite("ConfigurePod", function () {
   let root: DirResult;
-  let ctx: vscode.ExtensionContext;
   let podsDir: string;
 
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {
       root = tmpDir();
       podsDir = path.join(root.name, "pods");
@@ -31,8 +31,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async ({}) => {
-        const cmd = new ConfigurePodCommand();
+      onInit: async () => {
+        const cmd = new ConfigurePodCommand(getFakeExtensionForTest());
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         cmd.gatherInputs = async () => {
           return { podClass: podChoice.podClass };
@@ -52,8 +52,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async ({}) => {
-        const cmd = new ConfigurePodCommand();
+      onInit: async () => {
+        const cmd = new ConfigurePodCommand(getFakeExtensionForTest());
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         const podClass = podChoice.podClass;
         cmd.gatherInputs = async () => {

--- a/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
@@ -8,16 +8,16 @@ import {
 } from "@dendronhq/pods-core";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
 import { ImportPodCommand } from "../../commands/ImportPod";
 import { getDWorkspace } from "../../workspace";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  getFakeExtensionForTest,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
 suite("ImportPod", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
@@ -39,7 +39,7 @@ suite("ImportPod", function () {
               ensureDirSync(path.dirname(configPath));
               writeYAML(configPath, config);
 
-              const cmd = new ImportPodCommand();
+              const cmd = new ImportPodCommand(getFakeExtensionForTest());
               const podChoice = podClassEntryToPodItemV4(JSONImportPod);
               // @ts-ignore
               cmd.gatherInputs = async () => {

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -65,6 +65,7 @@ import { WSUtils } from "../../WSUtils";
 import { createMockQuickPick, getActiveEditorBasename } from "../testUtils";
 import { expect, resetCodeWorkspace } from "../testUtilsv2";
 import {
+  getFakeExtensionForTest,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
   withConfig,
@@ -204,7 +205,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const opts = await cmd.gatherInputs();
           const out = cmd.enrichInputs(opts);
           expect(
@@ -234,7 +235,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -262,7 +263,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -281,7 +282,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -304,7 +305,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -330,7 +331,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -366,7 +367,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -392,7 +393,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await WSUtils.openNote(engine.notes["foo"]);
           const opts = (await cmd.run({ noConfirm: true }))!;
@@ -412,7 +413,7 @@ suite("NoteLookupCommand", function () {
           fs.removeSync(path.join(vpath, "foo.ch1.md"));
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller, provider, quickpick } = await cmd.gatherInputs({
@@ -468,7 +469,7 @@ suite("NoteLookupCommand", function () {
         await ENGINE_HOOKS.setupHierarchyForLookupTests({ wsRoot, vaults });
       },
       onInit: async () => {
-        const cmd = new NoteLookupCommand();
+        const cmd = new NoteLookupCommand(getFakeExtensionForTest());
 
         const out: CommandOutput = (await cmd.run({
           noConfirm: true,
@@ -579,7 +580,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -612,7 +613,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults, engine, wsRoot }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const vault = TestEngineUtils.vault1(vaults);
           stubVaultPick(vaults);
           const opts = (await cmd.run({
@@ -636,7 +637,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -660,7 +661,7 @@ suite("NoteLookupCommand", function () {
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults, wsRoot }) => {
           const vault = _.find(vaults, { fsPath: "vault2" });
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           sinon.stub(PickerUtilsV2, "getVaultForOpenEditor").returns(vault!);
 
           const opts = (await cmd.run({
@@ -703,7 +704,7 @@ suite("NoteLookupCommand", function () {
 
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE_OTHER.fname;
           const vault = _.find(vaults, { fsPath: "vault2" });
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           sinon
             .stub(PickerUtilsV2, "promptVault")
             .returns(Promise.resolve(vault));
@@ -733,7 +734,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await cmd.run({
             initialValue: "bar.ch1",
@@ -757,7 +758,7 @@ suite("NoteLookupCommand", function () {
         },
 
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           await cmd.run({
             initialValue: "foo.",
@@ -782,7 +783,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({
             initialValue: "daily.journal.2021.08.10",
@@ -816,7 +817,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const spyFetchPickerResultsNoInput = sinon.spy(
             NotePickerUtils,
@@ -846,7 +847,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -861,7 +862,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -878,7 +879,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -895,7 +896,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "gamma" });
           expect(promptVaultSpy.calledOnce).toBeTruthy();
@@ -913,7 +914,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           // with journal note modifier enabled,
           await WSUtils.openNote(engine.notes["foo"]);
@@ -951,7 +952,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -983,7 +984,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -1016,7 +1017,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -1041,7 +1042,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           // with journal note modifier enabled,
           await WSUtils.openNote(engine.notes["foo"]);
@@ -1079,7 +1080,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1117,7 +1118,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1155,7 +1156,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1195,7 +1196,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1261,7 +1262,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({});
           const { selection2linkBtn, selectionExtractBtn } =
@@ -1280,7 +1281,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({
             selectionType: LookupSelectionTypeEnum.none,
@@ -1301,7 +1302,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({});
           const { selection2linkBtn, selectionExtractBtn } =
@@ -1320,7 +1321,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1360,7 +1361,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1401,7 +1402,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1443,7 +1444,7 @@ suite("NoteLookupCommand", function () {
             },
             { wsRoot }
           );
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1478,7 +1479,7 @@ suite("NoteLookupCommand", function () {
       runLegacyMultiWorkspaceTest({
         ctx,
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           // open and create a file outside of vault.
@@ -1520,7 +1521,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1559,7 +1560,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1610,7 +1611,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           // close all editors before running.
@@ -1645,7 +1646,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1678,7 +1679,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
           const out = await cmd.run({
             initialValue: "foo",
@@ -1697,7 +1698,7 @@ suite("NoteLookupCommand", function () {
 
   describe("journal + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand();
+      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -1843,7 +1844,7 @@ suite("NoteLookupCommand", function () {
 
   describe("scratch + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand();
+      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -1987,7 +1988,7 @@ suite("NoteLookupCommand", function () {
 
   describe("task + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand();
+      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -2119,7 +2120,7 @@ suite("NoteLookupCommand", function () {
 
   describe("note modifiers + selectionExtract interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine, noteType }: any) => {
-      const cmd = new NoteLookupCommand();
+      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -2201,7 +2202,7 @@ suite("NoteLookupCommand", function () {
       engine,
       opts,
     }: any) => {
-      const cmd = new NoteLookupCommand();
+      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
       const notesToSelect = ["foo.ch1", "bar", "lorem", "ipsum"].map(
         (fname) => engine.notes[fname]
       );
@@ -2343,6 +2344,7 @@ suite("stateService", function () {
   let homeDirStub: SinonStub;
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: async (ctx) => {
+      // eslint-disable-next-line no-new
       new StateService(ctx);
       await resetCodeWorkspace();
       homeDirStub = TestEngineUtils.mockHomeDir();
@@ -2360,7 +2362,7 @@ suite("stateService", function () {
         onInit: async ({ vaults }) => {
           VSCodeUtils.closeAllEditors();
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           let metaData = MetadataService.instance().getMeta();
@@ -2387,7 +2389,7 @@ suite("stateService", function () {
         onInit: async ({ vaults }) => {
           VSCodeUtils.closeAllEditors();
 
-          const cmd = new NoteLookupCommand();
+          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
           stubVaultPick(vaults);
 
           await cmd.run({

--- a/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
@@ -13,6 +13,7 @@ import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import {
   describeSingleWS,
+  getFakeExtensionForTest,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
 } from "../testUtilsV3";
@@ -28,7 +29,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new SchemaLookupCommand();
+          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
 
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           const editor = VSCodeUtils.getActiveTextEditor();
@@ -50,7 +51,7 @@ suite("SchemaLookupCommand", function () {
       () => {
         test("THEN proper information message is shown", async () => {
           const windowSpy = sinon.spy(vscode.window, "showInformationMessage");
-          const cmd = new SchemaLookupCommand();
+          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
 
           await cmd.run({ noConfirm: true, initialValue: "foo.test" });
           const infoMsg = windowSpy.getCall(0).args[0];
@@ -69,7 +70,7 @@ suite("SchemaLookupCommand", function () {
             await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           },
           onInit: async () => {
-            const cmd = new SchemaLookupCommand();
+            const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
             const { quickpick } = (await cmd.run({
               noConfirm: true,
               initialValue: "*",
@@ -88,7 +89,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new SchemaLookupCommand();
+          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
 
           await cmd.run({ noConfirm: true, initialValue: "baz" });
           const editor = VSCodeUtils.getActiveTextEditor();
@@ -108,7 +109,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const cmd = new SchemaLookupCommand();
+          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
           const fooNote = engine.notes["foo"];
           await WSUtils.openNote(fooNote);
           await cmd.run({ noConfirm: true, initialValue: "baz" });
@@ -131,7 +132,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const cmd = new SchemaLookupCommand();
+          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
           const gatherOut = await cmd.gatherInputs({
             noConfirm: true,
           });

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -3,7 +3,6 @@ import { vault2Path } from "@dendronhq/common-server";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { PodExportScope } from "@dendronhq/pods-core";
 import { after, describe } from "mocha";
-import { IDendronExtension } from "packages/plugin-core/src/dendronExtensionInterface";
 import path from "path";
 import sinon from "sinon";
 import * as vscode from "vscode";
@@ -13,6 +12,7 @@ import { expect } from "../../../testUtilsv2";
 import {
   describeMultiWS,
   describeSingleWS,
+  getFakeExtensionForTest,
   setupBeforeAfter,
 } from "../../../testUtilsV3";
 import { TestExportPodCommand } from "./TestExportCommand";
@@ -22,7 +22,7 @@ suite("BaseExportPodCommand", function () {
     beforeHook: () => {},
   });
   // not using this right now for tests
-  const extension = {} as IDendronExtension;
+  const extension = getFakeExtensionForTest();
 
   describe("GIVEN a BaseExportPodCommand implementation", () => {
     describeSingleWS(

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -1,8 +1,13 @@
+import { NoteProps } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { PodExportScope } from "@dendronhq/pods-core";
-import { describe, after } from "mocha";
+import { after, describe } from "mocha";
+import { IDendronExtension } from "packages/plugin-core/src/dendronExtensionInterface";
 import path from "path";
+import sinon from "sinon";
 import * as vscode from "vscode";
+import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { getDWorkspace } from "../../../../workspace";
 import { expect } from "../../../testUtilsv2";
 import {
@@ -10,16 +15,14 @@ import {
   describeSingleWS,
   setupBeforeAfter,
 } from "../../../testUtilsV3";
-import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { TestExportPodCommand } from "./TestExportCommand";
-import { NoteProps } from "@dendronhq/common-all";
-import sinon from "sinon";
-import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 
 suite("BaseExportPodCommand", function () {
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
+  // not using this right now for tests
+  const extension = {} as IDendronExtension;
 
   describe("GIVEN a BaseExportPodCommand implementation", () => {
     describeSingleWS(
@@ -28,7 +31,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand();
+        const cmd = new TestExportPodCommand(extension);
 
         test("THEN clipboard contents should be in the export payload", async () => {
           vscode.env.clipboard.writeText("test");
@@ -47,7 +50,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand();
+        const cmd = new TestExportPodCommand(extension);
 
         test("THEN selection contents should be undefined if nothing is highlighted", async () => {
           const payload = await cmd.enrichInputs({
@@ -67,7 +70,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand();
+        const cmd = new TestExportPodCommand(extension);
 
         test("THEN selection contents should be in the export payload", async () => {
           const { wsRoot, vaults } = getDWorkspace();
@@ -95,7 +98,7 @@ suite("BaseExportPodCommand", function () {
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand();
+        const cmd = new TestExportPodCommand(extension);
 
         test("THEN hierarchy note props should be in the export payload", async () => {
           const payload = await cmd.enrichInputs({
@@ -119,7 +122,7 @@ suite("BaseExportPodCommand", function () {
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand();
+        const cmd = new TestExportPodCommand(extension);
 
         test("THEN workspace note props should be in the export payload", async () => {
           const payload = await cmd.enrichInputs({

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -9,6 +9,7 @@ import {
 } from "@dendronhq/pods-core";
 import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
 import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
+import { getExtension } from "packages/plugin-core/src/workspace";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.
@@ -31,7 +32,10 @@ export class TestExportPodCommand extends BaseExportPodCommand<
   };
 
   public constructor() {
-    super(TestExportPodCommand.mockedSelector);
+    super({
+      hierarchySelector: TestExportPodCommand.mockedSelector,
+      extension: getExtension(),
+    });
   }
 
   /**

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -7,9 +7,9 @@ import {
   PodExportScope,
   RunnablePodConfigV2,
 } from "@dendronhq/pods-core";
-import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
+import { IDendronExtension } from "packages/plugin-core/src/dendronExtensionInterface";
 import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
-import { getExtension } from "packages/plugin-core/src/workspace";
+import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.
@@ -31,10 +31,10 @@ export class TestExportPodCommand extends BaseExportPodCommand<
     },
   };
 
-  public constructor() {
+  public constructor(extension: IDendronExtension) {
     super({
       hierarchySelector: TestExportPodCommand.mockedSelector,
-      extension: getExtension(),
+      extension,
     });
   }
 

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -7,9 +7,9 @@ import {
   PodExportScope,
   RunnablePodConfigV2,
 } from "@dendronhq/pods-core";
-import { IDendronExtension } from "packages/plugin-core/src/dendronExtensionInterface";
 import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
 import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
+import { IDendronExtension } from "../../../../../src/dendronExtensionInterface";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -49,6 +49,7 @@ import {
   SetupWorkspaceOpts,
 } from "../commands/SetupWorkspace";
 import { VaultAddCommand } from "../commands/VaultAddCommand";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { StateService } from "../services/stateService";
 import { WorkspaceConfig } from "../settings";
@@ -515,4 +516,11 @@ export function stubCancellationToken(): CancellationToken {
       };
     },
   };
+}
+
+/**
+ * TODO: used as part of refactoring commands
+ */
+export function getFakeExtensionForTest() {
+  return {} as IDendronExtension;
 }

--- a/packages/plugin-core/src/utils/site.ts
+++ b/packages/plugin-core/src/utils/site.ts
@@ -18,6 +18,7 @@ import _ from "lodash";
 import path from "path";
 import { ProgressLocation, window } from "vscode";
 import { ExportPodCommand } from "../commands/ExportPod";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace } from "../workspace";
 
@@ -146,11 +147,11 @@ export const getSiteRootDirPath = () => {
 };
 
 export class NextJSPublishUtils {
-  static async prepareNextJSExportPod() {
-    const ws = getDWorkspace();
+  static async prepareNextJSExportPod(extension: IDendronExtension) {
+    const ws = extension.getWorkspaceImplOrThrow();
     const wsRoot = ws.wsRoot;
     const engine = ws.engine;
-    const cmd = new ExportPodCommand();
+    const cmd = new ExportPodCommand(extension);
 
     let nextPath = NextjsExportPodUtils.getNextRoot(wsRoot);
     const podConfig: NextjsExportConfig = {

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -43,6 +43,7 @@ export class AirtableExportPodV2
 {
   private _config: RunnableAirtableV2PodConfig;
   private _airtableBase: Base;
+  // @ts-ignore
   private _engine: DEngineClient;
 
   constructor({

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -2,6 +2,7 @@ import Airtable, { Base, FieldSet, Records } from "@dendronhq/airtable";
 import {
   DendronCompositeError,
   DendronError,
+  DEngineClient,
   NoteProps,
   ResponseUtil,
   RespV2,
@@ -42,10 +43,20 @@ export class AirtableExportPodV2
 {
   private _config: RunnableAirtableV2PodConfig;
   private _airtableBase: Base;
+  private _engine: DEngineClient;
 
-  constructor(airtable: Airtable, config: RunnableAirtableV2PodConfig) {
+  constructor({
+    airtable,
+    config,
+    engine,
+  }: {
+    airtable: Airtable;
+    config: RunnableAirtableV2PodConfig;
+    engine: DEngineClient;
+  }) {
     this._airtableBase = airtable.base(config.baseId);
     this._config = config;
+    this._engine = engine;
   }
 
   async exportNote(input: NoteProps): Promise<AirtableExportReturnType> {


### PR DESCRIPTION
Since we deprecated `getExtension`, we need a way for commands to get an instance of the extension.
This is necessary to access engine specific variables in the airtable pod. 
