### PR TITLE
enhance: add auto completion to GoDown command and CreateTask command

### DIFF
--- a/packages/plugin-core/src/commands/CreateTask.ts
+++ b/packages/plugin-core/src/commands/CreateTask.ts
@@ -4,10 +4,8 @@ import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
 import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
-import {
-  NoteLookupCommand,
-  CommandOutput as NoteLookupOutput,
-} from "./NoteLookupCommand";
+import { CommandOutput as NoteLookupOutput } from "./NoteLookupCommand";
+import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 
 type CommandOpts = {};
 
@@ -33,8 +31,7 @@ export class CreateTaskCommand extends BasicCommand<
     const { config } = getDWorkspace();
     const { createTaskSelectionType } = ConfigUtils.getTask(config);
 
-    const cmd = new NoteLookupCommand();
-    return cmd.run({
+    return AutoCompletableRegistrar.getNoteLookupCmd().run({
       noteType: LookupNoteTypeEnum.task,
       selectionType: createTaskSelectionType,
     });

--- a/packages/plugin-core/src/commands/GoDownCommand.ts
+++ b/packages/plugin-core/src/commands/GoDownCommand.ts
@@ -2,10 +2,8 @@ import path from "path";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
-import {
-  CommandOutput as NoteLookupCommandOut,
-  NoteLookupCommand,
-} from "./NoteLookupCommand";
+import { CommandOutput as NoteLookupCommandOut } from "./NoteLookupCommand";
+import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 
 type CommandOpts = {
   noConfirm?: boolean;
@@ -15,9 +13,11 @@ type CommandOutput = NoteLookupCommandOut;
 
 export class GoDownCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.GO_DOWN_HIERARCHY.key;
+
   async gatherInputs(): Promise<any> {
     return {};
   }
+
   async execute(opts: CommandOpts) {
     const maybeTextEditor = VSCodeUtils.getActiveTextEditor();
     let value = "";
@@ -28,7 +28,7 @@ export class GoDownCommand extends BasicCommand<CommandOpts, CommandOutput> {
       }
     }
 
-    const out = await new NoteLookupCommand().run({
+    const out = await AutoCompletableRegistrar.getNoteLookupCmd().run({
       initialValue: value,
       noConfirm: opts.noConfirm,
     });

--- a/packages/plugin-core/src/test/suite-integ/AutoCompleterRegistrar.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AutoCompleterRegistrar.test.ts
@@ -1,12 +1,32 @@
 import { expect } from "../testUtilsv2";
 import { AutoCompletableRegistrar } from "../../utils/registers/AutoCompletableRegistrar";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { AutoCompletable } from "../../utils/AutoCompletable";
+import { CodeCommandInstance } from "../../commands/base";
 
 suite("AutoCompleterRegistrar tests", function () {
   test(`WHEN accessing registered command THEN retrieve command`, () => {
     const key = "test-key";
-    AutoCompletableRegistrar.register("test-key", new NoteLookupCommand());
-    expect(AutoCompletableRegistrar.getCmd(key)).toBeTruthy();
+    const noteLookupCmd = new NoteLookupCommand();
+
+    const isACommandAndAutoCompletable = (
+      cmd: any
+    ): cmd is CodeCommandInstance & AutoCompletable => {
+      return (
+        (cmd as CodeCommandInstance & AutoCompletable).run !== undefined &&
+        (cmd as CodeCommandInstance & AutoCompletable).onAutoComplete !==
+          undefined
+      );
+    };
+
+    if (isACommandAndAutoCompletable(noteLookupCmd)) {
+      AutoCompletableRegistrar.register("test-key", noteLookupCmd);
+      expect(AutoCompletableRegistrar.getCmd(key)).toBeTruthy();
+    } else {
+      throw new Error(
+        `Could not cast to CodeCommandInstance & AutoCompletable`
+      );
+    }
   });
 
   test(`WHEN accessing unregistered command THEN throw`, () => {

--- a/packages/plugin-core/src/utils/registers/AutoCompletableRegistrar.ts
+++ b/packages/plugin-core/src/utils/registers/AutoCompletableRegistrar.ts
@@ -1,18 +1,41 @@
 import { AutoCompletable } from "../AutoCompletable";
-import { ErrorFactory } from "@dendronhq/common-all";
+import { DendronError, ErrorFactory } from "@dendronhq/common-all";
+import { CodeCommandInstance } from "../../commands/base";
+import { DENDRON_COMMANDS } from "../../constants";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 
 /**
  * Populated during initialization with commands that implement function: cmd.onAutoComplete
  * */
 export class AutoCompletableRegistrar {
-  static _UI_AUTOCOMPLETE_COMMANDS = new Map<string, AutoCompletable>();
+  static _UI_AUTOCOMPLETE_COMMANDS = new Map<
+    string,
+    CodeCommandInstance & AutoCompletable
+  >();
 
-  static register = (key: string, cmd: AutoCompletable) => {
+  static register = (
+    key: string,
+    cmd: CodeCommandInstance & AutoCompletable
+  ) => {
     this._UI_AUTOCOMPLETE_COMMANDS.set(key, cmd);
   };
 
+  static getNoteLookupCmd(): NoteLookupCommand {
+    const isNoteLookup = (cmd: any): cmd is NoteLookupCommand => {
+      return (cmd as NoteLookupCommand).run !== undefined;
+    };
+
+    const noteLookupCmd = this.getCmd(DENDRON_COMMANDS.LOOKUP_NOTE.key);
+
+    if (isNoteLookup(noteLookupCmd)) {
+      return noteLookupCmd;
+    } else {
+      throw new DendronError({ message: `Could not get note lookup command.` });
+    }
+  }
+
   /** Retrieve command instance that is used by UI. */
-  static getCmd = (key: string): AutoCompletable => {
+  static getCmd = (key: string): CodeCommandInstance & AutoCompletable => {
     const cmd = this._UI_AUTOCOMPLETE_COMMANDS.get(key);
 
     if (cmd === undefined) {


### PR DESCRIPTION
# Pull Request Checklist

Instead of creating a new instance of NoteLookupCommand, we are using the UI registered instance of NoteLookupCommand. This allows the OnComplete command to activate.

Note with this change: We are re-using the same instance across multiple commands, appears to work fine, but if there is some tribal knowledge to not do this please comment. 

## General

### Quality Assurance
- [ ] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
