### PR TITLE
fix(lookup): full length word matches should be case insensitive

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -368,10 +368,12 @@ export class FuseEngine {
       // with a super low score of '0.03' but we don't want to display all the journal
       // dates with the same length. Hence whenever the length of our query is equal
       // or longer than the query results, we want to create a new note, not show those results.
+
+      const lowerCaseQueryString = queryString.toLowerCase();
       results = results.filter(
         (r) =>
           r.item.fname.length > queryString.length ||
-          r.item.fname === queryString
+          r.item.fname.toLowerCase() === lowerCaseQueryString
       );
     }
 

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -309,6 +309,22 @@ describe("Fuse Engine tests with dummy data", () => {
         assertHasFName(queryResults, "some.note.name.with.big-o");
       });
     });
+
+    describe(`WHEN querying for full length word`, () => {
+      it("AND case matches THEN should get the note", () => {
+        const queryResults = fuseEngine.queryNote({
+          qs: "some.note.name.with.big-o",
+        });
+        assertHasFName(queryResults, "some.note.name.with.big-o");
+      });
+
+      it("AND case does NOT match THEN should get the note", () => {
+        const queryResults = fuseEngine.queryNote({
+          qs: "SOME.note.NAME.with.big-o",
+        });
+        assertHasFName(queryResults, "some.note.name.with.big-o");
+      });
+    });
   });
 });
 

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -277,6 +277,35 @@ describe("Fuse Engine tests with dummy data", () => {
       });
     });
 
+    describe('WHEN querying for "NOTE" (case mismatch)', () => {
+      let queryResult: NoteIndexProps[];
+      beforeAll(() => {
+        queryResult = fuseEngine.queryNote({ qs: "NOTE" });
+      });
+
+      it("THEN include note-1", () => {
+        assertHasFName(queryResult, "note-1");
+      });
+
+      it("THEN include note-2", () => {
+        assertHasFName(queryResult, "note-1");
+      });
+
+      it("THEN notes with same matching score should be ordered by update time", () => {
+        expect(queryResult[0].fname).toEqual("note-3");
+        expect(queryResult[1].fname).toEqual("note-2");
+        expect(queryResult[2].fname).toEqual("note-1");
+      });
+
+      it('THEN include "parent.new-note-1"', () => {
+        assertHasFName(queryResult, "parent.new-note-1");
+      });
+
+      it('THEN exclude "user.tim.test"', () => {
+        assertDoesNotHaveFName(queryResult, "user.tim.test");
+      });
+    });
+
     describe('WHEN querying for "note-1"', () => {
       let queryResults: NoteIndexProps[];
 


### PR DESCRIPTION
# fix(lookup): full length word matches should be case insensitive



## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [ ] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [ ] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows
