### PR TITLE
fix/refactor issues

### DIFF
--- a/packages/engine-server/src/markdown/remark/hierarchies.ts
+++ b/packages/engine-server/src/markdown/remark/hierarchies.ts
@@ -64,7 +64,6 @@ function footnoteDef2html(definition: FootnoteDefinition) {
 }
 
 /** Adds the "Children", "Tags", and "Footnotes" items to the end of the note. Also renders footnotes. */
-// eslint-disable-next-line func-names
 const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
   const proc = this;
   const hierarchyDisplayTitle = opts?.hierarchyDisplayTitle || "Children";

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1005,7 +1005,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.RELOAD_INDEX.key,
         sentryReportingCallback(async (silent?: boolean) => {
-          const out = await new ReloadIndexCommand(ws).run({ silent });
+          const out = await new ReloadIndexCommand().run({ silent });
           if (!silent) {
             vscode.window.showInformationMessage(`finish reload`);
           }
@@ -1021,7 +1021,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.GO_NEXT_HIERARCHY.key,
         sentryReportingCallback(async () => {
-          await new GoToSiblingCommand(ws).execute({ direction: "next" });
+          await new GoToSiblingCommand().execute({ direction: "next" });
         })
       )
     );
@@ -1031,7 +1031,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.GO_PREV_HIERARCHY.key,
         sentryReportingCallback(async () => {
-          await new GoToSiblingCommand(ws).execute({ direction: "prev" });
+          await new GoToSiblingCommand().execute({ direction: "prev" });
         })
       )
     );
@@ -1043,7 +1043,7 @@ async function _setupCommands(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.RENAME_NOTE.key,
         sentryReportingCallback(async (args: any) => {
-          await new MoveNoteCommand(ws).run({
+          await new MoveNoteCommand().run({
             allowMultiselect: false,
             useSameVault: true,
             ...args,

--- a/packages/plugin-core/src/commands/ArchiveHierarchy.ts
+++ b/packages/plugin-core/src/commands/ArchiveHierarchy.ts
@@ -1,7 +1,6 @@
 import { NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { DENDRON_COMMANDS } from "../constants";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 import { RefactorHierarchyCommandV2 } from "./RefactorHierarchyV2";
@@ -23,8 +22,8 @@ export class ArchiveHierarchyCommand extends BasicCommand<
   key = DENDRON_COMMANDS.ARCHIVE_HIERARCHY.key;
   private refactorCmd: RefactorHierarchyCommandV2;
 
-  constructor(extension: IDendronExtension, name?: string) {
-    super(extension, name);
+  constructor(name?: string) {
+    super(name);
     this.refactorCmd = new RefactorHierarchyCommandV2();
   }
 

--- a/packages/plugin-core/src/commands/ConfigurePodCommand.ts
+++ b/packages/plugin-core/src/commands/ConfigurePodCommand.ts
@@ -13,7 +13,6 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { showPodQuickPickItemsV4 } from "../utils/pods";
 import { getExtension } from "../workspace";
 import { BasicCommand } from "./base";
-import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -28,8 +27,8 @@ export class ConfigurePodCommand extends BasicCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.CONFIGURE_POD.key;
 
-  constructor(extension: IDendronExtension, _name?: string) {
-    super(extension, _name);
+  constructor(_name?: string) {
+    super(_name);
     this.pods = getAllExportPods();
   }
 

--- a/packages/plugin-core/src/commands/ExportPod.ts
+++ b/packages/plugin-core/src/commands/ExportPod.ts
@@ -15,7 +15,6 @@ import {
 } from "../utils/pods";
 import { getExtension, getDWorkspace } from "../workspace";
 import { BaseCommand } from "./base";
-import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -31,8 +30,8 @@ export class ExportPodCommand extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.EXPORT_POD.key;
 
-  constructor(extension: IDendronExtension, _name?: string) {
-    super(extension, _name);
+  constructor(_name?: string) {
+    super(_name);
     this.pods = getAllExportPods();
   }
 

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -62,7 +62,7 @@ export class GotoNoteCommand extends BasicCommand<
   GoToNoteCommandOutput
 > {
   key = DENDRON_COMMANDS.GOTO_NOTE.key;
-  protected extension: IDendronExtension;
+  private extension: IDendronExtension;
   private wsUtils: IWSUtilsV2;
 
   constructor(extension: IDendronExtension) {

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -10,7 +10,6 @@ import {
 import _ from "lodash";
 import { ProgressLocation, Uri, window } from "vscode";
 import { DENDRON_COMMANDS, Oauth2Pods } from "../constants";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import {
   getGlobalState,
   launchGoogleOAuthFlow,
@@ -40,8 +39,8 @@ export class ImportPodCommand extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.IMPORT_POD.key;
 
-  constructor(extension: IDendronExtension, _name?: string) {
-    super(extension, _name);
+  constructor(_name?: string) {
+    super(_name);
     this.pods = getAllImportPods();
   }
 

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -60,7 +60,6 @@ import { BaseCommand } from "./base";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { AutoCompleter } from "../utils/autoCompleter";
 import { AutoCompletable } from "../utils/AutoCompletable";
-import { IDendronExtension } from "../dendronExtensionInterface";
 
 export type CommandRunOpts = {
   initialValue?: string;
@@ -130,8 +129,8 @@ export class NoteLookupCommand
   protected _provider: ILookupProviderV3 | undefined;
   protected _quickPick: DendronQuickPickerV2 | undefined;
 
-  constructor(extension?: IDendronExtension, _name?: string) {
-    super(extension, "LookupCommandV3");
+  constructor() {
+    super("LookupCommandV3");
   }
 
   protected get controller(): LookupControllerV3 {

--- a/packages/plugin-core/src/commands/PublishDevCommand.ts
+++ b/packages/plugin-core/src/commands/PublishDevCommand.ts
@@ -9,7 +9,6 @@ import fs from "fs-extra";
 import _ from "lodash";
 import { window } from "vscode";
 import { DENDRON_EMOJIS } from "@dendronhq/common-all";
-import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = {
   pid: number;
@@ -17,12 +16,6 @@ type CommandOutput = {
 
 export class PublishDevCommand extends BasicCommand<CommandOutput> {
   key = DENDRON_COMMANDS.PUBLISH_DEV.key;
-  protected extension: IDendronExtension;
-
-  constructor(extension: IDendronExtension) {
-    super(extension);
-    this.extension = extension;
-  }
 
   async gatherInputs(): Promise<any> {
     return {};
@@ -40,9 +33,7 @@ export class PublishDevCommand extends BasicCommand<CommandOutput> {
     const ctx = "PublishDevCommand";
     this.L.info({ ctx, msg: "enter" });
 
-    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod(
-      this.extension
-    );
+    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod();
     const { enrichedOpts, wsRoot, cmd, nextPath } = prepareOut;
     this.L.info({ ctx, msg: "prepare", enrichedOpts, nextPath });
 

--- a/packages/plugin-core/src/commands/PublishExportCommand.ts
+++ b/packages/plugin-core/src/commands/PublishExportCommand.ts
@@ -6,7 +6,6 @@ import { DENDRON_COMMANDS } from "../constants";
 import { checkPreReq, NextJSPublishUtils } from "../utils/site";
 import { BasicCommand } from "./base";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOpts = void;
 
@@ -20,13 +19,6 @@ export class PublishExportCommand extends BasicCommand<
 > {
   key = DENDRON_COMMANDS.PUBLISH_EXPORT.key;
 
-  protected extension: IDendronExtension;
-
-  constructor(extension: IDendronExtension) {
-    super(extension);
-    this.extension = extension;
-  }
-
   async gatherInputs(): Promise<any> {
     return {};
   }
@@ -39,9 +31,7 @@ export class PublishExportCommand extends BasicCommand<
     const ctx = "PublishExportCommand";
     this.L.info({ ctx, msg: "enter" });
 
-    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod(
-      this.extension
-    );
+    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod();
     const { enrichedOpts, wsRoot, cmd, nextPath } = prepareOut;
     this.L.info({ ctx, msg: "prepare", enrichedOpts, nextPath });
 

--- a/packages/plugin-core/src/commands/Refactor.ts
+++ b/packages/plugin-core/src/commands/Refactor.ts
@@ -3,7 +3,6 @@ import { createLogger, getAllFiles } from "@dendronhq/common-server";
 import fs, { Dirent } from "fs-extra";
 import _ from "lodash";
 import path from "path";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import { BasicCommand } from "./base";
 
 const L = createLogger("dendron");
@@ -46,12 +45,8 @@ export abstract class RefactorBaseCommand<
 > extends BasicCommand<RefactorCommandOpts> {
   public props: Required<RefactorCommandOpts>;
 
-  constructor(
-    extension: IDendronExtension,
-    name: string,
-    opts: RefactorCommandOpts
-  ) {
-    super(extension, name);
+  constructor(name: string, opts: RefactorCommandOpts) {
+    super(name);
     this.props = this.cleanOpts(opts);
   }
 

--- a/packages/plugin-core/src/commands/SchemaLookupCommand.ts
+++ b/packages/plugin-core/src/commands/SchemaLookupCommand.ts
@@ -21,7 +21,6 @@ import {
 import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { OldNewLocation, PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
 import { getDWorkspace } from "../workspace";
@@ -66,8 +65,8 @@ export class SchemaLookupCommand extends BaseCommand<
   protected _controller: LookupControllerV3 | undefined;
   protected _provider: ILookupProviderV3 | undefined;
 
-  constructor(extension: IDendronExtension) {
-    super(extension, "SchemaLookupCommand");
+  constructor() {
+    super("SchemaLookupCommand");
   }
 
   protected get controller(): LookupControllerV3 {

--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -50,11 +50,8 @@ export abstract class BaseCommand<
   TRunOpts = TOpts
 > {
   public L: DLogger;
-  protected extension?: IDendronExtension;
 
-  // TODO: this should be a required variable
-  constructor(extension?: IDendronExtension, _name?: string) {
-    this.extension = extension;
+  constructor(_name?: string) {
     this.L = Logger;
   }
 

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -21,6 +21,7 @@ import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getEngine, getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
@@ -43,10 +44,11 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
   public createPod(
     config: RunnableAirtableV2PodConfig
   ): ExportPodV2<AirtableExportReturnType> {
-    return new AirtableExportPodV2(
-      new Airtable({ apiKey: config.apiKey }),
-      config
-    );
+    return new AirtableExportPodV2({
+      airtable: new Airtable({ apiKey: config.apiKey }),
+      config,
+      engine: ExtensionProvider.getEngine(),
+    });
   }
 
   public getRunnableSchema(): JSONSchemaType<RunnableAirtableV2PodConfig> {

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -21,7 +21,6 @@ import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getEngine, getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
@@ -37,18 +36,17 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.airtableexport";
 
-  public constructor(extension: IDendronExtension) {
-    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
+  public constructor() {
+    super(new QuickPickHierarchySelector());
   }
 
   public createPod(
     config: RunnableAirtableV2PodConfig
   ): ExportPodV2<AirtableExportReturnType> {
-    return new AirtableExportPodV2({
-      airtable: new Airtable({ apiKey: config.apiKey }),
-      config,
-      engine: this.extension!.getEngine(),
-    });
+    return new AirtableExportPodV2(
+      new Airtable({ apiKey: config.apiKey }),
+      config
+    );
   }
 
   public getRunnableSchema(): JSONSchemaType<RunnableAirtableV2PodConfig> {

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -16,7 +16,6 @@ import {
 import path from "path";
 import * as vscode from "vscode";
 import { HierarchySelector } from "../../components/lookup/HierarchySelector";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getDWorkspace, getExtension } from "../../workspace";
 import { BaseCommand } from "../base";
@@ -50,16 +49,9 @@ export abstract class BaseExportPodCommand<
    * hierarchy to export. Should use {@link QuickPickHierarchySelector} by
    * default
    */
-  constructor({
-    hierarchySelector,
-    extension,
-  }: {
-    hierarchySelector: HierarchySelector;
-    extension: IDendronExtension;
-  }) {
+  constructor(hierarchySelector: HierarchySelector) {
     super();
     this.hierarchySelector = hierarchySelector;
-    this.extension = extension;
   }
 
   /**

--- a/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
+++ b/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
@@ -2,7 +2,6 @@ import { getAllExportPods, PodClassEntryV4 } from "@dendronhq/pods-core";
 import { PodCommandFactory } from "../../components/pods/PodCommandFactory";
 import { PodUIControls } from "../../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../../constants";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { BaseCommand, CodeCommandInstance } from "../base";
 
 type CommandOutput = void;
@@ -22,8 +21,8 @@ export class ExportPodV2Command extends BaseCommand<
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.EXPORT_POD_V2.key;
 
-  constructor(extension: IDendronExtension, _name?: string) {
-    super(extension, _name);
+  constructor(_name?: string) {
+    super(_name);
     this.pods = getAllExportPods();
   }
 
@@ -33,13 +32,9 @@ export class ExportPodV2Command extends BaseCommand<
    * undefined if the user didn't select anything.
    */
   async gatherInputs(podId: string): Promise<CommandInput | undefined> {
-    const extension = this.extension!;
     // If a podId is passed in, use this instead of prompting the user
     if (podId) {
-      return PodCommandFactory.createPodCommandForStoredConfig(
-        { podId },
-        extension
-      );
+      return PodCommandFactory.createPodCommandForStoredConfig({ podId });
     }
 
     const exportChoice = await PodUIControls.promptForExportConfigOrNewExport();
@@ -52,12 +47,9 @@ export class ExportPodV2Command extends BaseCommand<
       if (!podType) {
         return;
       }
-      return PodCommandFactory.createPodCommandForPodType(podType, extension);
+      return PodCommandFactory.createPodCommandForPodType(podType);
     } else {
-      return PodCommandFactory.createPodCommandForStoredConfig(
-        exportChoice,
-        extension
-      );
+      return PodCommandFactory.createPodCommandForStoredConfig(exportChoice);
     }
   }
 

--- a/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
@@ -20,7 +20,6 @@ import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { clipboard } from "../../utils";
 import { launchGoogleOAuthFlow } from "../../utils/pods";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -38,8 +37,8 @@ export class GoogleDocsExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.googledocsexport";
 
-  public constructor(extension: IDendronExtension) {
-    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
+  public constructor() {
+    super(new QuickPickHierarchySelector());
   }
 
   public createPod(

--- a/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
@@ -15,7 +15,6 @@ import path from "path";
 import * as vscode from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getDWorkspace, getEngine, getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
@@ -31,8 +30,8 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
 > {
   public key = "dendron.markdownexportv2";
 
-  public constructor(extension: IDendronExtension) {
-    super({ hierarchySelector: new QuickPickHierarchySelector(), extension });
+  public constructor() {
+    super(new QuickPickHierarchySelector());
   }
 
   public async gatherInputs(

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -9,7 +9,6 @@ import { CodeCommandInstance } from "../../commands/base";
 import { AirtableExportPodCommand } from "../../commands/pods/AirtableExportPodCommand";
 import { GoogleDocsExportPodCommand } from "../../commands/pods/GoogleDocsExportPodCommand";
 import { MarkdownExportPodCommand } from "../../commands/pods/MarkdownExportPodCommand";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 import { getExtension } from "../../workspace";
 
 export class PodCommandFactory {
@@ -20,8 +19,7 @@ export class PodCommandFactory {
    * @returns A pod command configured with the found configuration
    */
   public static createPodCommandForStoredConfig(
-    configId: Pick<ExportPodConfigurationV2, "podId">,
-    extension: IDendronExtension
+    configId: Pick<ExportPodConfigurationV2, "podId">
   ): CodeCommandInstance {
     const storedConfig = PodV2ConfigManager.getPodConfigById({
       podsDir: path.join(getExtension().podsDir, "custom"),
@@ -38,7 +36,7 @@ export class PodCommandFactory {
 
     switch (storedConfig.podType) {
       case PodV2Types.AirtableExportV2: {
-        const airtableCmd = new AirtableExportPodCommand(extension);
+        const airtableCmd = new AirtableExportPodCommand();
         cmdWithArgs = {
           key: airtableCmd.key,
           run(): Promise<void> {
@@ -48,7 +46,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand(extension);
+        const cmd = new MarkdownExportPodCommand();
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -58,7 +56,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand(extension);
+        const cmd = new GoogleDocsExportPodCommand();
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -83,12 +81,11 @@ export class PodCommandFactory {
    * @returns
    */
   public static createPodCommandForPodType(
-    podType: PodV2Types,
-    extension: IDendronExtension
+    podType: PodV2Types
   ): CodeCommandInstance {
     switch (podType) {
       case PodV2Types.AirtableExportV2: {
-        const cmd = new AirtableExportPodCommand(extension);
+        const cmd = new AirtableExportPodCommand();
 
         return {
           key: cmd.key,
@@ -99,7 +96,7 @@ export class PodCommandFactory {
       }
 
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand(extension);
+        const cmd = new MarkdownExportPodCommand();
 
         return {
           key: cmd.key,
@@ -109,7 +106,7 @@ export class PodCommandFactory {
         };
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand(extension);
+        const cmd = new GoogleDocsExportPodCommand();
         return {
           key: cmd.key,
           run(): Promise<void> {

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -17,7 +17,6 @@ import { launchGoogleOAuthFlow } from "../../utils/pods";
 import { getExtension } from "../../workspace";
 import { PodCommandFactory } from "./PodCommandFactory";
 import { assertUnreachable } from "@dendronhq/common-all";
-import { IDendronExtension } from "../../dendronExtensionInterface";
 
 /**
  * Contains VSCode UI controls for common Pod UI operations
@@ -155,16 +154,16 @@ export class PodUIControls {
    * Prompt user to pick a pod (v2) type
    * @returns a runnable code command for the selected pod
    */
-  public static async promptForPodTypeForCommand(
-    extension: IDendronExtension
-  ): Promise<CodeCommandInstance | undefined> {
+  public static async promptForPodTypeForCommand(): Promise<
+    CodeCommandInstance | undefined
+  > {
     const picked = await PodUIControls.promptForPodType();
 
     if (!picked) {
       return;
     }
 
-    return PodCommandFactory.createPodCommandForPodType(picked, extension);
+    return PodCommandFactory.createPodCommandForPodType(picked);
   }
 
   /**

--- a/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
@@ -7,20 +7,20 @@ import {
 } from "@dendronhq/pods-core";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
+// // You can import and use all API from the 'vscode' module
+// // as well as import your extension to test it
+import * as vscode from "vscode";
 import { ConfigurePodCommand } from "../../commands/ConfigurePodCommand";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
-import {
-  getFakeExtensionForTest,
-  runLegacyMultiWorkspaceTest,
-  setupBeforeAfter,
-} from "../testUtilsV3";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("ConfigurePod", function () {
   let root: DirResult;
+  let ctx: vscode.ExtensionContext;
   let podsDir: string;
 
-  const ctx = setupBeforeAfter(this, {
+  ctx = setupBeforeAfter(this, {
     beforeHook: () => {
       root = tmpDir();
       podsDir = path.join(root.name, "pods");
@@ -31,8 +31,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async () => {
-        const cmd = new ConfigurePodCommand(getFakeExtensionForTest());
+      onInit: async ({}) => {
+        const cmd = new ConfigurePodCommand();
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         cmd.gatherInputs = async () => {
           return { podClass: podChoice.podClass };
@@ -52,8 +52,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async () => {
-        const cmd = new ConfigurePodCommand(getFakeExtensionForTest());
+      onInit: async ({}) => {
+        const cmd = new ConfigurePodCommand();
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         const podClass = podChoice.podClass;
         cmd.gatherInputs = async () => {

--- a/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
@@ -8,16 +8,16 @@ import {
 } from "@dendronhq/pods-core";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
+// // You can import and use all API from the 'vscode' module
+// // as well as import your extension to test it
+import * as vscode from "vscode";
 import { ImportPodCommand } from "../../commands/ImportPod";
 import { getDWorkspace } from "../../workspace";
-import {
-  getFakeExtensionForTest,
-  runLegacyMultiWorkspaceTest,
-  setupBeforeAfter,
-} from "../testUtilsV3";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("ImportPod", function () {
-  const ctx = setupBeforeAfter(this, {
+  let ctx: vscode.ExtensionContext;
+  ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
@@ -39,7 +39,7 @@ suite("ImportPod", function () {
               ensureDirSync(path.dirname(configPath));
               writeYAML(configPath, config);
 
-              const cmd = new ImportPodCommand(getFakeExtensionForTest());
+              const cmd = new ImportPodCommand();
               const podChoice = podClassEntryToPodItemV4(JSONImportPod);
               // @ts-ignore
               cmd.gatherInputs = async () => {

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -65,7 +65,6 @@ import { WSUtils } from "../../WSUtils";
 import { createMockQuickPick, getActiveEditorBasename } from "../testUtils";
 import { expect, resetCodeWorkspace } from "../testUtilsv2";
 import {
-  getFakeExtensionForTest,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
   withConfig,
@@ -205,7 +204,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const opts = await cmd.gatherInputs();
           const out = cmd.enrichInputs(opts);
           expect(
@@ -235,7 +234,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -263,7 +262,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -282,7 +281,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -305,7 +304,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -331,7 +330,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -367,7 +366,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -393,7 +392,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await WSUtils.openNote(engine.notes["foo"]);
           const opts = (await cmd.run({ noConfirm: true }))!;
@@ -413,7 +412,7 @@ suite("NoteLookupCommand", function () {
           fs.removeSync(path.join(vpath, "foo.ch1.md"));
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller, provider, quickpick } = await cmd.gatherInputs({
@@ -469,7 +468,7 @@ suite("NoteLookupCommand", function () {
         await ENGINE_HOOKS.setupHierarchyForLookupTests({ wsRoot, vaults });
       },
       onInit: async () => {
-        const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+        const cmd = new NoteLookupCommand();
 
         const out: CommandOutput = (await cmd.run({
           noConfirm: true,
@@ -580,7 +579,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
             noConfirm: true,
@@ -613,7 +612,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults, engine, wsRoot }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const vault = TestEngineUtils.vault1(vaults);
           stubVaultPick(vaults);
           const opts = (await cmd.run({
@@ -637,7 +636,7 @@ suite("NoteLookupCommand", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await cmd.run({
             noConfirm: true,
@@ -661,7 +660,7 @@ suite("NoteLookupCommand", function () {
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         onInit: async ({ vaults, wsRoot }) => {
           const vault = _.find(vaults, { fsPath: "vault2" });
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           sinon.stub(PickerUtilsV2, "getVaultForOpenEditor").returns(vault!);
 
           const opts = (await cmd.run({
@@ -704,7 +703,7 @@ suite("NoteLookupCommand", function () {
 
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE_OTHER.fname;
           const vault = _.find(vaults, { fsPath: "vault2" });
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           sinon
             .stub(PickerUtilsV2, "promptVault")
             .returns(Promise.resolve(vault));
@@ -734,7 +733,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await cmd.run({
             initialValue: "bar.ch1",
@@ -758,7 +757,7 @@ suite("NoteLookupCommand", function () {
         },
 
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           await cmd.run({
             initialValue: "foo.",
@@ -783,7 +782,7 @@ suite("NoteLookupCommand", function () {
           });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({
             initialValue: "daily.journal.2021.08.10",
@@ -817,7 +816,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const spyFetchPickerResultsNoInput = sinon.spy(
             NotePickerUtils,
@@ -847,7 +846,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -862,7 +861,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -879,7 +878,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           expect(promptVaultSpy.calledOnce).toBeFalsy();
@@ -896,7 +895,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           const promptVaultSpy = stubVaultPick(vaults);
           await cmd.run({ noConfirm: true, initialValue: "gamma" });
           expect(promptVaultSpy.calledOnce).toBeTruthy();
@@ -914,7 +913,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           // with journal note modifier enabled,
           await WSUtils.openNote(engine.notes["foo"]);
@@ -952,7 +951,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -984,7 +983,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -1017,7 +1016,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
@@ -1042,7 +1041,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           // with journal note modifier enabled,
           await WSUtils.openNote(engine.notes["foo"]);
@@ -1080,7 +1079,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1118,7 +1117,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1156,7 +1155,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1196,7 +1195,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           await WSUtils.openNote(engine.notes["foo"]);
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1262,7 +1261,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({});
           const { selection2linkBtn, selectionExtractBtn } =
@@ -1281,7 +1280,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({
             selectionType: LookupSelectionTypeEnum.none,
@@ -1302,7 +1301,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const gatherOut = await cmd.gatherInputs({});
           const { selection2linkBtn, selectionExtractBtn } =
@@ -1321,7 +1320,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1361,7 +1360,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1402,7 +1401,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1444,7 +1443,7 @@ suite("NoteLookupCommand", function () {
             },
             { wsRoot }
           );
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1479,7 +1478,7 @@ suite("NoteLookupCommand", function () {
       runLegacyMultiWorkspaceTest({
         ctx,
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           // open and create a file outside of vault.
@@ -1521,7 +1520,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1560,7 +1559,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
 
@@ -1611,7 +1610,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           // close all editors before running.
@@ -1646,7 +1645,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           const { controller } = await cmd.gatherInputs({
@@ -1679,7 +1678,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults }) => {
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const out = await cmd.run({
             initialValue: "foo",
@@ -1698,7 +1697,7 @@ suite("NoteLookupCommand", function () {
 
   describe("journal + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+      const cmd = new NoteLookupCommand();
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -1844,7 +1843,7 @@ suite("NoteLookupCommand", function () {
 
   describe("scratch + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+      const cmd = new NoteLookupCommand();
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -1988,7 +1987,7 @@ suite("NoteLookupCommand", function () {
 
   describe("task + selection2link interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine }: any) => {
-      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+      const cmd = new NoteLookupCommand();
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -2120,7 +2119,7 @@ suite("NoteLookupCommand", function () {
 
   describe("note modifiers + selectionExtract interactions", () => {
     const prepareCommandFunc = async ({ vaults, engine, noteType }: any) => {
-      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+      const cmd = new NoteLookupCommand();
       stubVaultPick(vaults);
 
       const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
@@ -2202,7 +2201,7 @@ suite("NoteLookupCommand", function () {
       engine,
       opts,
     }: any) => {
-      const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+      const cmd = new NoteLookupCommand();
       const notesToSelect = ["foo.ch1", "bar", "lorem", "ipsum"].map(
         (fname) => engine.notes[fname]
       );
@@ -2344,7 +2343,6 @@ suite("stateService", function () {
   let homeDirStub: SinonStub;
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: async (ctx) => {
-      // eslint-disable-next-line no-new
       new StateService(ctx);
       await resetCodeWorkspace();
       homeDirStub = TestEngineUtils.mockHomeDir();
@@ -2362,7 +2360,7 @@ suite("stateService", function () {
         onInit: async ({ vaults }) => {
           VSCodeUtils.closeAllEditors();
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           let metaData = MetadataService.instance().getMeta();
@@ -2389,7 +2387,7 @@ suite("stateService", function () {
         onInit: async ({ vaults }) => {
           VSCodeUtils.closeAllEditors();
 
-          const cmd = new NoteLookupCommand(getFakeExtensionForTest());
+          const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
 
           await cmd.run({

--- a/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
@@ -13,7 +13,6 @@ import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import {
   describeSingleWS,
-  getFakeExtensionForTest,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
 } from "../testUtilsV3";
@@ -29,7 +28,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+          const cmd = new SchemaLookupCommand();
 
           await cmd.run({ noConfirm: true, initialValue: "foo" });
           const editor = VSCodeUtils.getActiveTextEditor();
@@ -51,7 +50,7 @@ suite("SchemaLookupCommand", function () {
       () => {
         test("THEN proper information message is shown", async () => {
           const windowSpy = sinon.spy(vscode.window, "showInformationMessage");
-          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+          const cmd = new SchemaLookupCommand();
 
           await cmd.run({ noConfirm: true, initialValue: "foo.test" });
           const infoMsg = windowSpy.getCall(0).args[0];
@@ -70,7 +69,7 @@ suite("SchemaLookupCommand", function () {
             await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           },
           onInit: async () => {
-            const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+            const cmd = new SchemaLookupCommand();
             const { quickpick } = (await cmd.run({
               noConfirm: true,
               initialValue: "*",
@@ -89,7 +88,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async () => {
-          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+          const cmd = new SchemaLookupCommand();
 
           await cmd.run({ noConfirm: true, initialValue: "baz" });
           const editor = VSCodeUtils.getActiveTextEditor();
@@ -109,7 +108,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+          const cmd = new SchemaLookupCommand();
           const fooNote = engine.notes["foo"];
           await WSUtils.openNote(fooNote);
           await cmd.run({ noConfirm: true, initialValue: "baz" });
@@ -132,7 +131,7 @@ suite("SchemaLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const cmd = new SchemaLookupCommand(getFakeExtensionForTest());
+          const cmd = new SchemaLookupCommand();
           const gatherOut = await cmd.gatherInputs({
             noConfirm: true,
           });

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -1,28 +1,25 @@
-import { NoteProps } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
-import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { PodExportScope } from "@dendronhq/pods-core";
-import { after, describe } from "mocha";
+import { describe, after } from "mocha";
 import path from "path";
-import sinon from "sinon";
 import * as vscode from "vscode";
-import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { getDWorkspace } from "../../../../workspace";
 import { expect } from "../../../testUtilsv2";
 import {
   describeMultiWS,
   describeSingleWS,
-  getFakeExtensionForTest,
   setupBeforeAfter,
 } from "../../../testUtilsV3";
+import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { TestExportPodCommand } from "./TestExportCommand";
+import { NoteProps } from "@dendronhq/common-all";
+import sinon from "sinon";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 
 suite("BaseExportPodCommand", function () {
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
-  // not using this right now for tests
-  const extension = getFakeExtensionForTest();
 
   describe("GIVEN a BaseExportPodCommand implementation", () => {
     describeSingleWS(
@@ -31,7 +28,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand(extension);
+        const cmd = new TestExportPodCommand();
 
         test("THEN clipboard contents should be in the export payload", async () => {
           vscode.env.clipboard.writeText("test");
@@ -50,7 +47,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand(extension);
+        const cmd = new TestExportPodCommand();
 
         test("THEN selection contents should be undefined if nothing is highlighted", async () => {
           const payload = await cmd.enrichInputs({
@@ -70,7 +67,7 @@ suite("BaseExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new TestExportPodCommand(extension);
+        const cmd = new TestExportPodCommand();
 
         test("THEN selection contents should be in the export payload", async () => {
           const { wsRoot, vaults } = getDWorkspace();
@@ -98,7 +95,7 @@ suite("BaseExportPodCommand", function () {
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand(extension);
+        const cmd = new TestExportPodCommand();
 
         test("THEN hierarchy note props should be in the export payload", async () => {
           const payload = await cmd.enrichInputs({
@@ -122,7 +119,7 @@ suite("BaseExportPodCommand", function () {
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand(extension);
+        const cmd = new TestExportPodCommand();
 
         test("THEN workspace note props should be in the export payload", async () => {
           const payload = await cmd.enrichInputs({

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -7,9 +7,8 @@ import {
   PodExportScope,
   RunnablePodConfigV2,
 } from "@dendronhq/pods-core";
-import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
 import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
-import { IDendronExtension } from "../../../../../src/dendronExtensionInterface";
+import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.
@@ -31,11 +30,8 @@ export class TestExportPodCommand extends BaseExportPodCommand<
     },
   };
 
-  public constructor(extension: IDendronExtension) {
-    super({
-      hierarchySelector: TestExportPodCommand.mockedSelector,
-      extension,
-    });
+  public constructor() {
+    super(TestExportPodCommand.mockedSelector);
   }
 
   /**

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -49,7 +49,6 @@ import {
   SetupWorkspaceOpts,
 } from "../commands/SetupWorkspace";
 import { VaultAddCommand } from "../commands/VaultAddCommand";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { StateService } from "../services/stateService";
 import { WorkspaceConfig } from "../settings";
@@ -516,11 +515,4 @@ export function stubCancellationToken(): CancellationToken {
       };
     },
   };
-}
-
-/**
- * TODO: used as part of refactoring commands
- */
-export function getFakeExtensionForTest() {
-  return {} as IDendronExtension;
 }

--- a/packages/plugin-core/src/utils/site.ts
+++ b/packages/plugin-core/src/utils/site.ts
@@ -18,7 +18,6 @@ import _ from "lodash";
 import path from "path";
 import { ProgressLocation, window } from "vscode";
 import { ExportPodCommand } from "../commands/ExportPod";
-import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace } from "../workspace";
 
@@ -147,11 +146,11 @@ export const getSiteRootDirPath = () => {
 };
 
 export class NextJSPublishUtils {
-  static async prepareNextJSExportPod(extension: IDendronExtension) {
-    const ws = extension.getWorkspaceImplOrThrow();
+  static async prepareNextJSExportPod() {
+    const ws = getDWorkspace();
     const wsRoot = ws.wsRoot;
     const engine = ws.engine;
-    const cmd = new ExportPodCommand(extension);
+    const cmd = new ExportPodCommand();
 
     let nextPath = NextjsExportPodUtils.getNextRoot(wsRoot);
     const podConfig: NextjsExportConfig = {

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -83,7 +83,6 @@ export class AirtableExportPodV2
 {
   private _config: RunnableAirtableV2PodConfig;
   private _airtableBase: Base;
-  // @ts-ignore
   private _engine: DEngineClient;
 
   constructor({ airtable, config, engine }: AirtableExportPodV2Constructor) {


### PR DESCRIPTION
This reverts [chore(internal): Pass Extension into Plugin Command by kevinslin · Pull Request #1982 · dendronhq/dendron](https://github.com/dendronhq/dendron/pull/1982),

Passing in the `extension` argument as the first argument for all commands has some un-intended side effects (eg. some commands expect a service as the first argument and this is not typechecked because of how commands are registered)

Waiting for a wider discussion before we move forward on this