### PR TITLE
fix: frontmatter tags are not highlighted

### DIFF
--- a/packages/engine-server/src/markdown/decorations/frontmatter.ts
+++ b/packages/engine-server/src/markdown/decorations/frontmatter.ts
@@ -63,7 +63,7 @@ export const decorateFrontmatter: Decorator<
   const tags = getFrontmatterTags(parseFrontmatter(contents));
   const tagDecorations: DecorationHashTag[] = [];
   const errors: IDendronError[] = [];
-  Promise.all(
+  await Promise.all(
     tags.map(async (tag) => {
       const { errors, decorations } = await decorateTag({
         fname: `${TAGS_HIERARCHY}${tag.value}`,

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -82,6 +82,7 @@ suite("windowDecorations", function () {
             props: {
               created: _.toInteger(CREATED),
               updated: _.toInteger(UPDATED),
+              tags: ["foo", "bar"],
             },
             vault: vaults[0],
             wsRoot,
@@ -132,7 +133,7 @@ suite("windowDecorations", function () {
           const wikilinkDecorations = allDecorations!.get(
             EDITOR_DECORATION_TYPES.wikiLink
           );
-          expect(wikilinkDecorations!.length).toEqual(6);
+          expect(wikilinkDecorations!.length).toEqual(7);
           expect(
             isTextDecorated("[[root]]", wikilinkDecorations!, document)
           ).toBeTruthy();
@@ -167,7 +168,7 @@ suite("windowDecorations", function () {
           const brokenWikilinkDecorations = allDecorations!.get(
             EDITOR_DECORATION_TYPES.brokenWikilink
           );
-          expect(brokenWikilinkDecorations!.length).toEqual(4);
+          expect(brokenWikilinkDecorations!.length).toEqual(5);
           expect(
             isTextDecorated(
               "[[does.not.exist]]",


### PR DESCRIPTION
Fixes a bug where frontmatter tags were not being highlighted. Also updates the tests to prevent further regressions.