### PR TITLE
fix: update tree order when a note changes order

### DIFF
--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -11,33 +11,39 @@ type Theme = "light" | "dark" | "unknown";
 
 type InitialState = {
   noteActive: NoteProps | undefined;
+  /** The previous value of `noteActive` */
+  notePrev: NoteProps | undefined;
   theme: Theme;
   graphStyles: string;
   views: {
-    [key in DendronTreeViewKey | DendronEditorViewKey]: {
+    [key in DendronTreeViewKey | DendronEditorViewKey]?: {
       ready: boolean;
     };
   };
   seedsInWorkspace: string[] | undefined; // Contains the seed ID's
 };
 
+const INITIAL_STATE: InitialState = {
+  noteActive: undefined,
+  notePrev: undefined,
+  graphStyles: "",
+  theme: "unknown",
+  views: {
+    "dendron.tree-view": {
+      ready: false,
+    },
+  },
+  seedsInWorkspace: undefined,
+};
+
 export { InitialState as IDEState };
 
 export const ideSlice = createSlice({
   name: "ide",
-  initialState: {
-    noteActive: undefined,
-    graphStyles: "",
-    theme: "unknown",
-    views: {
-      "dendron.tree-view": {
-        ready: false,
-      },
-    },
-    seedsInWorkspace: undefined,
-  } as InitialState,
+  initialState: INITIAL_STATE,
   reducers: {
     setNoteActive: (state, action: PayloadAction<NoteProps | undefined>) => {
+      state.notePrev = state.noteActive;
       state.noteActive = action.payload;
     },
     setTheme: (state, action: PayloadAction<Theme>) => {
@@ -51,7 +57,7 @@ export const ideSlice = createSlice({
       action: PayloadAction<{ key: DendronTreeViewKey; ready: boolean }>
     ) => {
       const { key, ready } = action.payload;
-      state.views[key].ready = ready;
+      state.views[key] = { ready };
     },
     setSeedsInWorkspace: (state, action: PayloadAction<string[]>) => {
       state.seedsInWorkspace = action.payload;

--- a/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
@@ -44,9 +44,8 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [numNotes, noteActive?.id]);
 
-  // calculate root
+  // calculate the tree data
   React.useEffect(() => {
-    // calculate roots once on startup
     logger.info({ msg: "calcRoots:pre", numNotes });
     const _roots = _.filter(_.values(engine.notes), DNodeUtils.isRoot).map(
       (ent) => {
@@ -63,7 +62,14 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
     // TODO: remove notes
     logger.info({ msg: "calcRoots:post:setRoots", numNotes });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [numNotes]);
+  }, [
+    // update if there are new notes
+    numNotes,
+    // update if something that may reorder the active note changes
+    noteActive?.title,
+    noteActive?.updated,
+    noteActive?.custom?.nav_order,
+  ]);
 
   const expandKeys = _.isEmpty(activeNoteIds) ? [] : activeNoteIds;
   const onExpand: OnExpandFunc = (expandedKeys, { node, expanded }) => {

--- a/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
@@ -18,11 +18,10 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
   const engine = props.engine;
   const { config, notes } = engine;
   const numNotes = _.size(notes);
-  const noteActive = props.ide.noteActive;
+  const { noteActive, notePrev } = props.ide;
   const [activeNoteIds, setActiveNoteIds] = useState<string[]>([]);
   const [roots, setRoots] = useState<DataNode[]>([]);
   // Used to avoid recomputing tree data unnecessarily
-  const [noteActiveId, setNoteActiveId] = useState<string>();
   const [numNotesLast, setNumNotesLast] = useState<number>(numNotes);
 
   logger.info({
@@ -49,18 +48,17 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
 
   // calculate the tree data
   React.useEffect(() => {
-    logger.info({ msg: "calcRoots:pre", numNotes, noteActiveId });
+    logger.info({ msg: "calcRoots:pre", numNotes, notePrevId: notePrev?.id });
     // Avoid recomputing if it's just that the active note changed
     if (
       roots.length !== 0 &&
-      noteActiveId !== noteActive?.id &&
+      notePrev?.id !== noteActive?.id &&
       numNotesLast === numNotes
     ) {
       logger.info({
         msg: "calcRoots:noteChange",
         noteActiveId: noteActive?.id,
       });
-      setNoteActiveId(noteActive?.id);
       return;
     }
     setNumNotesLast(numNotes);

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -161,6 +161,8 @@ export class NoteSyncService {
     PreviewPanelFactory.getProxy(getExtension()).showPreviewAndUpdate(
       noteClean
     );
+    // If note was renamed or had `nav_order` adjusted, it might move in the tree
+    getExtension().dendronTreeViewV2?.refresh(note);
 
     return noteClean;
   }


### PR DESCRIPTION
The tree view wouldn't update when a note's `nav_order`, title, or `updated' changes (these all affect order in the tree). This PR fixes this issue.

#1830 