### PR TITLE
fix: rename operations modify unnecessary files

### DIFF
--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -50,6 +50,7 @@ import {
 import {
   DLogger,
   file2Note,
+  genHash,
   getAllFiles,
   getDurationMilliseconds,
   note2File,
@@ -958,12 +959,14 @@ export class FileStorage implements DStore {
         },
         _n
       );
-      n.body = noteMod.body;
-      n.tags = noteMod.tags;
       const shouldChange = !(
         n.body === noteMod.body && n.tags === noteMod.tags
       );
-      if (shouldChange) notesToChange.push(n);
+      if (shouldChange) {
+        n.body = noteMod.body;
+        n.tags = noteMod.tags;
+        notesToChange.push(n);
+      }
     });
 
     /**

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -633,154 +633,154 @@ export class FileStorage implements DStore {
   }
 
   /** Update the links inside this note that need to be updated for the rename from `oldLoc` to `newLoc` */
-  private async processNoteChangedByRename({
-    note,
-    oldLoc,
-    newLoc,
-  }: {
-    note: NoteProps;
-    oldLoc: DNoteLoc;
-    newLoc: DNoteLoc;
-  }): Promise<NoteChangeUpdateEntry> {
-    const prevNote = { ...note };
-    const vault = note.vault;
-    const wsRoot = this.wsRoot;
-    const vaultPath = vault2Path({ vault, wsRoot });
-    // read note in case its changed
-    const _n = file2Note(path.join(vaultPath, note.fname + ".md"), vault);
-    const foundLinks = LinkUtils.findLinks({
-      note: _n,
-      engine: this.engine,
-      filter: { loc: oldLoc },
-    });
-    let allLinks = _.orderBy(
-      foundLinks,
-      (link) => {
-        return link.position?.start.offset;
-      },
-      "desc"
-    );
-    if (
-      oldLoc.fname.toLowerCase() === newLoc.fname.toLowerCase() &&
-      oldLoc.vaultName === newLoc.vaultName &&
-      oldLoc.anchorHeader &&
-      newLoc.anchorHeader
-    ) {
-      // Renaming the header, only update links that link to the old header
-      allLinks = _.filter(allLinks, (link): boolean => {
-        // This is a wikilink to this header
-        if (link.to?.anchorHeader === oldLoc.anchorHeader) return true;
-        // Or this is a range reference, and one part of the range includes this header
-        return (
-          link.type === "ref" &&
-          isNotUndefined(oldLoc.anchorHeader) &&
-          this.referenceRangeParts(link.to?.anchorHeader).includes(
-            oldLoc.anchorHeader
-          )
-        );
-      });
-    }
+  // private async processNoteChangedByRename({
+  //   note,
+  //   oldLoc,
+  //   newLoc,
+  // }: {
+  //   note: NoteProps;
+  //   oldLoc: DNoteLoc;
+  //   newLoc: DNoteLoc;
+  // }): Promise<NoteChangeUpdateEntry> {
+  //   const prevNote = { ...note };
+  //   const vault = note.vault;
+  //   const wsRoot = this.wsRoot;
+  //   const vaultPath = vault2Path({ vault, wsRoot });
+  //   // read note in case its changed
+  //   const _n = file2Note(path.join(vaultPath, note.fname + ".md"), vault);
+  //   const foundLinks = LinkUtils.findLinks({
+  //     note: _n,
+  //     engine: this.engine,
+  //     filter: { loc: oldLoc },
+  //   });
+  //   let allLinks = _.orderBy(
+  //     foundLinks,
+  //     (link) => {
+  //       return link.position?.start.offset;
+  //     },
+  //     "desc"
+  //   );
+  //   if (
+  //     oldLoc.fname.toLowerCase() === newLoc.fname.toLowerCase() &&
+  //     oldLoc.vaultName === newLoc.vaultName &&
+  //     oldLoc.anchorHeader &&
+  //     newLoc.anchorHeader
+  //   ) {
+  //     // Renaming the header, only update links that link to the old header
+  //     allLinks = _.filter(allLinks, (link): boolean => {
+  //       // This is a wikilink to this header
+  //       if (link.to?.anchorHeader === oldLoc.anchorHeader) return true;
+  //       // Or this is a range reference, and one part of the range includes this header
+  //       return (
+  //         link.type === "ref" &&
+  //         isNotUndefined(oldLoc.anchorHeader) &&
+  //         this.referenceRangeParts(link.to?.anchorHeader).includes(
+  //           oldLoc.anchorHeader
+  //         )
+  //       );
+  //     });
+  //   }
 
-    // only modify links that have same _to_ vault name
-    // explicitly same: has vault prefix
-    // implicitly same: to.vaultName is undefined, but link is in a note that's in the vault.
-    allLinks = allLinks.filter((link) => {
-      const oldLocVaultName = oldLoc.vaultName as string;
-      const explicitlySameVault = link.to?.vaultName === oldLocVaultName;
-      const oldLocVault = VaultUtils.getVaultByName({
-        vaults: this.vaults,
-        vname: oldLocVaultName,
-      });
-      const implicitlySameVault =
-        _.isUndefined(link.to?.vaultName) && _.isEqual(note.vault, oldLocVault);
-      return explicitlySameVault || implicitlySameVault;
-    });
+  //   // only modify links that have same _to_ vault name
+  //   // explicitly same: has vault prefix
+  //   // implicitly same: to.vaultName is undefined, but link is in a note that's in the vault.
+  //   allLinks = allLinks.filter((link) => {
+  //     const oldLocVaultName = oldLoc.vaultName as string;
+  //     const explicitlySameVault = link.to?.vaultName === oldLocVaultName;
+  //     const oldLocVault = VaultUtils.getVaultByName({
+  //       vaults: this.vaults,
+  //       vname: oldLocVaultName,
+  //     });
+  //     const implicitlySameVault =
+  //       _.isUndefined(link.to?.vaultName) && _.isEqual(note.vault, oldLocVault);
+  //     return explicitlySameVault || implicitlySameVault;
+  //   });
 
-    const noteMod = _.reduce(
-      allLinks,
-      (note: NoteProps, link: DLink) => {
-        const oldLink = LinkUtils.dlink2DNoteLink(link);
-        // current implementation adds alias for all notes
-        // check if old note has alias thats different from its fname
-        let alias: string | undefined;
-        if (oldLink.from.alias && oldLink.from.alias !== oldLink.from.fname) {
-          alias = oldLink.from.alias;
-          // Update the alias if it was using the default alias.
-          if (
-            oldLoc.alias?.toLocaleLowerCase() ===
-              oldLink.from.alias.toLocaleLowerCase() &&
-            newLoc.alias
-          ) {
-            alias = newLoc.alias;
-          }
-        }
-        // for hashtag links, we'll have to regenerate the alias
-        if (newLoc.fname.startsWith(TAGS_HIERARCHY)) {
-          const fnameWithoutTag = newLoc.fname.slice(TAGS_HIERARCHY.length);
-          // Frontmatter tags don't have the hashtag
-          if (link.type !== "frontmatterTag") alias = `#${fnameWithoutTag}`;
-          else alias = fnameWithoutTag;
-        } else if (oldLink.from.fname.startsWith(TAGS_HIERARCHY)) {
-          // If this used to be a hashtag but no longer is, the alias is like `#foo.bar` and no longer makes sense.
-          // And if this used to be a frontmatter tag, the alias being undefined will force it to be removed because a frontmatter tag can't point to something outside of tags hierarchy.
-          alias = undefined;
-        }
-        // for user tag links, we'll have to regenerate the alias
-        if (newLoc.fname.startsWith(USERS_HIERARCHY)) {
-          const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
-          alias = `@${fnameWithoutTag}`;
-        } else if (oldLink.from.fname.startsWith(USERS_HIERARCHY)) {
-          // If this used to be a user tag but no longer is, the alias is like `@foo.bar` and no longer makes sense.
-          alias = undefined;
-        }
-        // Correctly handle header renames in references with range based references
-        if (
-          oldLoc.anchorHeader &&
-          link.type === "ref" &&
-          isNotUndefined(oldLink.from.anchorHeader) &&
-          oldLink.from.anchorHeader.indexOf(":") > -1 &&
-          isNotUndefined(newLoc.anchorHeader) &&
-          newLoc.anchorHeader.indexOf(":") === -1
-        ) {
-          // This is a reference, old anchor had a ":" in it, a new anchor header is provided and does not have ":" in it.
-          // For example, `![[foo#start:#end]]` to `![[foo#something]]`. In this case, `something` is actually supposed to replace only one part of the range.
-          // Find the part that matches the old header, and replace just that with the new one.
-          let [start, end] = this.referenceRangeParts(
-            oldLink.from.anchorHeader
-          );
-          if (start === oldLoc.anchorHeader) start = newLoc.anchorHeader;
-          if (end === oldLoc.anchorHeader) end = newLoc.anchorHeader;
-          newLoc.anchorHeader = `${start}:#${end}`;
-        }
-        const newBody = LinkUtils.updateLink({
-          note,
-          oldLink,
-          newLink: {
-            ...oldLink,
-            from: {
-              ...newLoc,
-              anchorHeader: newLoc.anchorHeader || oldLink.from.anchorHeader,
-              alias,
-            },
-          },
-        });
-        _n.body = newBody;
-        return _n;
-      },
-      _n
-    );
-    // const resp = await MDUtilsV4.procTransform(
-    //   { engine: this.engine, fname: n.fname, vault: n.vault },
-    //   { from: oldLoc, to: newLoc }
-    // ).process(_n.body);
-    note.body = noteMod.body;
-    note.tags = noteMod.tags;
-    return {
-      note,
-      prevNote,
-      status: "update",
-    };
-  }
+  //   const noteMod = _.reduce(
+  //     allLinks,
+  //     (note: NoteProps, link: DLink) => {
+  //       const oldLink = LinkUtils.dlink2DNoteLink(link);
+  //       // current implementation adds alias for all notes
+  //       // check if old note has alias thats different from its fname
+  //       let alias: string | undefined;
+  //       if (oldLink.from.alias && oldLink.from.alias !== oldLink.from.fname) {
+  //         alias = oldLink.from.alias;
+  //         // Update the alias if it was using the default alias.
+  //         if (
+  //           oldLoc.alias?.toLocaleLowerCase() ===
+  //             oldLink.from.alias.toLocaleLowerCase() &&
+  //           newLoc.alias
+  //         ) {
+  //           alias = newLoc.alias;
+  //         }
+  //       }
+  //       // for hashtag links, we'll have to regenerate the alias
+  //       if (newLoc.fname.startsWith(TAGS_HIERARCHY)) {
+  //         const fnameWithoutTag = newLoc.fname.slice(TAGS_HIERARCHY.length);
+  //         // Frontmatter tags don't have the hashtag
+  //         if (link.type !== "frontmatterTag") alias = `#${fnameWithoutTag}`;
+  //         else alias = fnameWithoutTag;
+  //       } else if (oldLink.from.fname.startsWith(TAGS_HIERARCHY)) {
+  //         // If this used to be a hashtag but no longer is, the alias is like `#foo.bar` and no longer makes sense.
+  //         // And if this used to be a frontmatter tag, the alias being undefined will force it to be removed because a frontmatter tag can't point to something outside of tags hierarchy.
+  //         alias = undefined;
+  //       }
+  //       // for user tag links, we'll have to regenerate the alias
+  //       if (newLoc.fname.startsWith(USERS_HIERARCHY)) {
+  //         const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
+  //         alias = `@${fnameWithoutTag}`;
+  //       } else if (oldLink.from.fname.startsWith(USERS_HIERARCHY)) {
+  //         // If this used to be a user tag but no longer is, the alias is like `@foo.bar` and no longer makes sense.
+  //         alias = undefined;
+  //       }
+  //       // Correctly handle header renames in references with range based references
+  //       if (
+  //         oldLoc.anchorHeader &&
+  //         link.type === "ref" &&
+  //         isNotUndefined(oldLink.from.anchorHeader) &&
+  //         oldLink.from.anchorHeader.indexOf(":") > -1 &&
+  //         isNotUndefined(newLoc.anchorHeader) &&
+  //         newLoc.anchorHeader.indexOf(":") === -1
+  //       ) {
+  //         // This is a reference, old anchor had a ":" in it, a new anchor header is provided and does not have ":" in it.
+  //         // For example, `![[foo#start:#end]]` to `![[foo#something]]`. In this case, `something` is actually supposed to replace only one part of the range.
+  //         // Find the part that matches the old header, and replace just that with the new one.
+  //         let [start, end] = this.referenceRangeParts(
+  //           oldLink.from.anchorHeader
+  //         );
+  //         if (start === oldLoc.anchorHeader) start = newLoc.anchorHeader;
+  //         if (end === oldLoc.anchorHeader) end = newLoc.anchorHeader;
+  //         newLoc.anchorHeader = `${start}:#${end}`;
+  //       }
+  //       const newBody = LinkUtils.updateLink({
+  //         note,
+  //         oldLink,
+  //         newLink: {
+  //           ...oldLink,
+  //           from: {
+  //             ...newLoc,
+  //             anchorHeader: newLoc.anchorHeader || oldLink.from.anchorHeader,
+  //             alias,
+  //           },
+  //         },
+  //       });
+  //       _n.body = newBody;
+  //       return _n;
+  //     },
+  //     _n
+  //   );
+  //   // const resp = await MDUtilsV4.procTransform(
+  //   //   { engine: this.engine, fname: n.fname, vault: n.vault },
+  //   //   { from: oldLoc, to: newLoc }
+  //   // ).process(_n.body);
+  //   note.body = noteMod.body;
+  //   note.tags = noteMod.tags;
+  //   return {
+  //     note,
+  //     prevNote,
+  //     status: "update",
+  //   };
+  // }
 
   async renameNote(opts: RenameNoteOpts): Promise<RenameNotePayload> {
     const ctx = "Store:renameNote";
@@ -1038,7 +1038,7 @@ export class FileStorage implements DStore {
     }
     this.logger.info({ ctx, msg: "updateAllNotes:pre" });
     // update all new notes
-    await this.writeManyNotes(notesToChange);
+    notesChangedEntries = await this.writeManyNotes(notesToChange);
     // notesChangedEntries = await this.updateOldNoteReferences(
     //   notesToChange,
     //   ctx,

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -811,23 +811,159 @@ export class FileStorage implements DStore {
       newLoc.alias = newNoteTitle;
     }
 
-    const notesToChange = NoteUtils.getNotesWithLinkTo({
+    // const notesToChange = NoteUtils.getNotesWithLinkTo({
+    let notesChangedEntries: NoteChangeEntry[] = [];
+    const notesWithLinkTo = NoteUtils.getNotesWithLinkTo({
       note: oldNote,
       notes: this.notes,
     });
     this.logger.info({
       ctx,
-      msg: "notesToChange:gather",
-      notes: notesToChange.map((n) => NoteUtils.toLogObj(n)),
+      msg: "notesWithLinkTo:gather",
+      notes: notesWithLinkTo.map((n) => NoteUtils.toLogObj(n)),
     });
     // update note body of all notes that have changed
-    const notesChanged = await Promise.all(
-      notesToChange.map(async (n) =>
-        this.processNoteChangedByRename({ note: n, oldLoc, newLoc })
-      )
-    ).catch((err) => {
-      this.logger.error({ err });
-      throw new DendronError({ message: " error rename note", payload: err });
+    // const notesChanged = await Promise.all(
+    //   notesToChange.map(async (n) =>
+    //     this.processNoteChangedByRename({ note: n, oldLoc, newLoc })
+    //   )
+    // ).catch((err) => {
+    //   this.logger.error({ err });
+    //   throw new DendronError({ message: " error rename note", payload: err });
+    // find notes that have changes.
+    const notesToChange: NoteProps[] = [];
+    notesWithLinkTo.forEach(async (n) => {
+      const vault = n.vault;
+      const vaultPath = vault2Path({ vault, wsRoot });
+      // read note in case its changed
+      const _n = file2Note(path.join(vaultPath, n.fname + ".md"), vault);
+      const foundLinks = LinkUtils.findLinks({
+        note: _n,
+        engine: this.engine,
+        filter: { loc: oldLoc },
+      });
+      let allLinks = _.orderBy(
+        foundLinks,
+        (link) => {
+          return link.position?.start.offset;
+        },
+        "desc"
+      );
+      if (
+        oldLoc.fname.toLowerCase() === newLoc.fname.toLowerCase() &&
+        oldLoc.vaultName === newLoc.vaultName &&
+        oldLoc.anchorHeader &&
+        newLoc.anchorHeader
+      ) {
+        // Renaming the header, only update links that link to the old header
+        allLinks = _.filter(allLinks, (link): boolean => {
+          // This is a wikilink to this header
+          if (link.to?.anchorHeader === oldLoc.anchorHeader) return true;
+          // Or this is a range reference, and one part of the range includes this header
+          return (
+            link.type === "ref" &&
+            isNotUndefined(oldLoc.anchorHeader) &&
+            this.referenceRangeParts(link.to?.anchorHeader).includes(
+              oldLoc.anchorHeader
+            )
+          );
+        });
+      }
+
+      // only modify links that have same _to_ vault name
+      // explicitly same: has vault prefix
+      // implicitly same: to.vaultName is undefined, but link is in a note that's in the vault.
+      allLinks = allLinks.filter((link) => {
+        const oldLocVaultName = oldLoc.vaultName as string;
+        const explicitlySameVault = link.to?.vaultName === oldLocVaultName;
+        const oldLocVault = VaultUtils.getVaultByName({
+          vaults: this.vaults,
+          vname: oldLocVaultName,
+        });
+        const implicitlySameVault =
+          _.isUndefined(link.to?.vaultName) && _.isEqual(n.vault, oldLocVault);
+        return explicitlySameVault || implicitlySameVault;
+      });
+
+      const noteMod = _.reduce(
+        allLinks,
+        (note: NoteProps, link: DLink) => {
+          const oldLink = LinkUtils.dlink2DNoteLink(link);
+          // current implementation adds alias for all notes
+          // check if old note has alias thats different from its fname
+          let alias: string | undefined;
+          if (oldLink.from.alias && oldLink.from.alias !== oldLink.from.fname) {
+            alias = oldLink.from.alias;
+            // Update the alias if it was using the default alias.
+            if (
+              oldLoc.alias?.toLocaleLowerCase() ===
+                oldLink.from.alias.toLocaleLowerCase() &&
+              newLoc.alias
+            ) {
+              alias = newLoc.alias;
+            }
+          }
+          // for hashtag links, we'll have to regenerate the alias
+          if (newLoc.fname.startsWith(TAGS_HIERARCHY)) {
+            const fnameWithoutTag = newLoc.fname.slice(TAGS_HIERARCHY.length);
+            // Frontmatter tags don't have the hashtag
+            if (link.type !== "frontmatterTag") alias = `#${fnameWithoutTag}`;
+            else alias = fnameWithoutTag;
+          } else if (oldLink.from.fname.startsWith(TAGS_HIERARCHY)) {
+            // If this used to be a hashtag but no longer is, the alias is like `#foo.bar` and no longer makes sense.
+            // And if this used to be a frontmatter tag, the alias being undefined will force it to be removed because a frontmatter tag can't point to something outside of tags hierarchy.
+            alias = undefined;
+          }
+          // for user tag links, we'll have to regenerate the alias
+          if (newLoc.fname.startsWith(USERS_HIERARCHY)) {
+            const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
+            alias = `@${fnameWithoutTag}`;
+          } else if (oldLink.from.fname.startsWith(USERS_HIERARCHY)) {
+            // If this used to be a user tag but no longer is, the alias is like `@foo.bar` and no longer makes sense.
+            alias = undefined;
+          }
+          // Correctly handle header renames in references with range based references
+          if (
+            oldLoc.anchorHeader &&
+            link.type === "ref" &&
+            isNotUndefined(oldLink.from.anchorHeader) &&
+            oldLink.from.anchorHeader.indexOf(":") > -1 &&
+            isNotUndefined(newLoc.anchorHeader) &&
+            newLoc.anchorHeader.indexOf(":") === -1
+          ) {
+            // This is a reference, old anchor had a ":" in it, a new anchor header is provided and does not have ":" in it.
+            // For example, `![[foo#start:#end]]` to `![[foo#something]]`. In this case, `something` is actually supposed to replace only one part of the range.
+            // Find the part that matches the old header, and replace just that with the new one.
+            let [start, end] = this.referenceRangeParts(
+              oldLink.from.anchorHeader
+            );
+            if (start === oldLoc.anchorHeader) start = newLoc.anchorHeader;
+            if (end === oldLoc.anchorHeader) end = newLoc.anchorHeader;
+            newLoc.anchorHeader = `${start}:#${end}`;
+          }
+          const newBody = LinkUtils.updateLink({
+            note,
+            oldLink,
+            newLink: {
+              ...oldLink,
+              from: {
+                ...newLoc,
+                anchorHeader: newLoc.anchorHeader || oldLink.from.anchorHeader,
+                alias,
+              },
+            },
+          });
+          _n.body = newBody;
+          return _n;
+        },
+        _n
+      );
+      n.body = noteMod.body;
+      n.tags = noteMod.tags;
+      const shouldChange = !(
+        n.body === noteMod.body && n.tags === noteMod.tags
+      );
+      if (shouldChange) notesToChange.push(n);
     });
 
     /**
@@ -835,7 +971,13 @@ export class FileStorage implements DStore {
      * delete the original files. We just update the references on onWillRenameFiles and return.
      */
     if (!_.isUndefined(opts.isEventSourceEngine)) {
-      return this.writeManyNotes(notesChanged.map((entry) => entry.note));
+      return this.writeManyNotes(notesToChange);
+      // notesChangedEntries = await this.updateOldNoteReferences(
+      //   notesToChange,
+      //   ctx,
+      //   notesChangedEntries
+      // );
+      // return notesChangedEntries;
     }
     const newNote: NoteProps = {
       ...oldNote,
@@ -893,14 +1035,19 @@ export class FileStorage implements DStore {
     }
     this.logger.info({ ctx, msg: "updateAllNotes:pre" });
     // update all new notes
-    await this.writeManyNotes(notesChanged.map((entry) => entry.note));
+    await this.writeManyNotes(notesToChange);
+    // notesChangedEntries = await this.updateOldNoteReferences(
+    //   notesToChange,
+    //   ctx,
+    //   notesChangedEntries
+    // );
     // remove old note only when rename is success
     if (deleteOldFile) fs.removeSync(oldLocPath);
 
     // create needs to be very last element added
-    let notesChangedEntries = changedFromDelete
+    notesChangedEntries = changedFromDelete
       .concat(changeFromWrite)
-      .concat(notesChanged);
+      .concat(notesChangedEntries);
     // remove duplicate updates
     notesChangedEntries = _.uniqBy(notesChangedEntries, (ent) => {
       return [ent.status, ent.note.id, ent.note.fname].join("");

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -835,6 +835,8 @@ export class FileStorage implements DStore {
       }
     });
 
+    await Promise.all(notesChangedEntries).catch();
+
     /**
      * If the event source is not engine(ie: vscode rename context menu), we do not want to
      * delete the original files. We just update the references on onWillRenameFiles and return.

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -835,7 +835,7 @@ export class FileStorage implements DStore {
       }
     });
 
-    await Promise.all(notesChangedEntries).catch();
+    await Promise.all(notesChangedEntries);
 
     /**
      * If the event source is not engine(ie: vscode rename context menu), we do not want to

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -50,7 +50,6 @@ import {
 import {
   DLogger,
   file2Note,
-  genHash,
   getAllFiles,
   getDurationMilliseconds,
   note2File,

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -669,7 +669,6 @@ const NOTES = {
             { status: "update", fname: "root" },
             { status: "delete", fname: fnameTarget },
             { status: "create", fname: fnameNew },
-            { status: "update", fname: fnameLink },
           ],
         },
         {
@@ -915,7 +914,6 @@ const NOTES = {
             { status: "update", fname: "root" },
             { status: "delete", fname: "alpha" },
             { status: "create", fname: "gamma" },
-            { status: "update", fname: "beta" },
           ],
         },
         {

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -43,6 +43,7 @@ const runRename = async ({
   wsRoot,
   numChanges,
   cb,
+  noNameChange,
 }: {
   engine: DEngineClient;
   vaults: DVault[];
@@ -52,17 +53,25 @@ const runRename = async ({
     barChange: NoteChangeEntry;
     allChanged: NoteChangeEntry[];
   }) => TestResult[];
+  noNameChange?: boolean; // newLoc is oldLoc
 }) => {
   const vault = vaults[0];
+  const vaultName = VaultUtils.getName(vault);
+  const oldLoc = { fname: "foo", vaultName };
+  const newLoc = noNameChange ? oldLoc : { fname: "baz", vaultName };
   const changed = await engine.renameNote({
-    oldLoc: { fname: "foo", vaultName: VaultUtils.getName(vault) },
-    newLoc: { fname: "baz", vaultName: VaultUtils.getName(vault) },
+    oldLoc,
+    newLoc,
   });
+
+  const checkVaultMatch = noNameChange ? ["foo.md"] : ["baz.md"];
+  const checkVaultNoMatch = noNameChange ? ["baz.md"] : ["foo.md"];
+
   const checkVault = await FileTestUtils.assertInVault({
     wsRoot,
     vault,
-    match: ["baz.md"],
-    nomatch: ["foo.md"],
+    match: checkVaultMatch,
+    nomatch: checkVaultNoMatch,
   });
   const barChange = _.find(changed.data, (ent) => ent.note.fname === "bar")!;
   const out = cb({ barChange, allChanged: changed.data! });
@@ -96,6 +105,110 @@ const preSetupHook = async (
 };
 
 const NOTES = {
+  NO_UPDATE: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runRename({
+        wsRoot,
+        vaults,
+        engine,
+        numChanges: 1, // there should be no unnecessary updates added in resp
+        cb: ({ barChange }) => {
+          return [
+            {
+              actual: barChange,
+              expected: undefined,
+            },
+          ];
+        },
+        noNameChange: true,
+      });
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "bar",
+          wsRoot,
+          vault: vaults[0],
+          body: "[[foo]]",
+        });
+      },
+    }
+  ),
+  NO_UPDATE_NUMBER_IN_FM: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runRename({
+        wsRoot,
+        vaults,
+        engine,
+        numChanges: 1, // no unecessary updates in resp
+        cb: ({ barChange }) => {
+          return [
+            {
+              actual: barChange,
+              expected: undefined,
+            },
+          ];
+        },
+        noNameChange: true,
+      });
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "bar",
+          wsRoot,
+          vault: vaults[0],
+          body: "[[foo]]",
+          props: { title: "09" }, // testing for cases where frontmatter is read as number instead of string, which malforms the title
+        });
+      },
+    }
+  ),
+  NO_UPDATE_DOUBLE_QUOTE_IN_FM: new TestPresetEntryV4(
+    async ({ wsRoot, vaults, engine }) => {
+      return runRename({
+        wsRoot,
+        vaults,
+        engine,
+        numChanges: 1,
+        cb: ({ barChange }) => {
+          return [
+            {
+              actual: barChange,
+              expected: undefined,
+            },
+          ];
+        },
+        noNameChange: true,
+      });
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "bar",
+          wsRoot,
+          vault: vaults[0],
+          body: "[[foo]]",
+          props: { title: '"wow"' }, // testing for cases where double quotes are unnecessarily changed to single quotes
+        });
+      },
+    }
+  ),
   WITH_INLINE_CODE: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       return runRename({

--- a/packages/plugin-core/src/commands/RenameHeader.ts
+++ b/packages/plugin-core/src/commands/RenameHeader.ts
@@ -1,4 +1,10 @@
-import { DendronError, getSlugger, VaultUtils } from "@dendronhq/common-all";
+import {
+  DendronError,
+  getSlugger,
+  RenameNotePayload,
+  RespV2,
+  VaultUtils,
+} from "@dendronhq/common-all";
 import {
   AnchorUtils,
   DendronASTDest,
@@ -32,7 +38,7 @@ type CommandOpts =
       source?: string;
     }
   | undefined;
-type CommandOutput = {} | undefined;
+export type CommandOutput = RespV2<RenameNotePayload> | undefined;
 
 export class RenameHeaderCommand extends BasicCommand<
   CommandOpts,
@@ -127,7 +133,7 @@ export class RenameHeaderCommand extends BasicCommand<
     // This doesn't update the decorations for some reason, we need to update them to get any same-file decorations updated
     delayedUpdateDecorations();
 
-    await engine.renameNote({
+    const out = await engine.renameNote({
       oldLoc: {
         ...noteLoc,
         anchorHeader: slugger.slug(oldHeader.text),
@@ -139,7 +145,7 @@ export class RenameHeaderCommand extends BasicCommand<
         alias: newAnchorHeader,
       },
     });
-    return;
+    return out;
   }
 
   addAnalyticsPayload(opts?: CommandOpts) {

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -79,32 +79,39 @@ suite("MoveNoteCommand", function () {
   let ctx: vscode.ExtensionContext;
   ctx = setupBeforeAfter(this);
 
-  _.map(ENGINE_RENAME_PRESETS["NOTES"], (TestCase: TestPresetEntryV4, name) => {
-    test(name, (done) => {
-      const { testFunc, preSetupHook } = TestCase;
+  _.map(
+    _.omit(ENGINE_RENAME_PRESETS["NOTES"], [
+      "NO_UPDATE",
+      "NO_UPDATE_NUMBER_IN_FM",
+      "NO_UPDATE_DOUBLE_QUOTE_IN_FM",
+    ]),
+    (TestCase: TestPresetEntryV4, name) => {
+      test(name, (done) => {
+        const { testFunc, preSetupHook } = TestCase;
 
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        postSetupHook: async ({ wsRoot, vaults }) => {
-          await preSetupHook({
-            wsRoot,
-            vaults,
-          });
-        },
-        onInit: async ({ vaults, wsRoot }) => {
-          const engineMock = createEngine({ wsRoot, vaults });
-          const results = await testFunc({
-            engine: engineMock,
-            vaults,
-            wsRoot,
-            initResp: {} as any,
-          });
-          await runJestHarnessV2(results, expect);
-          done();
-        },
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          postSetupHook: async ({ wsRoot, vaults }) => {
+            await preSetupHook({
+              wsRoot,
+              vaults,
+            });
+          },
+          onInit: async ({ vaults, wsRoot }) => {
+            const engineMock = createEngine({ wsRoot, vaults });
+            const results = await testFunc({
+              engine: engineMock,
+              vaults,
+              wsRoot,
+              initResp: {} as any,
+            });
+            await runJestHarnessV2(results, expect);
+            done();
+          },
+        });
       });
-    });
-  });
+    }
+  );
 
   test("update body", (done) => {
     runLegacySingleWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -8,7 +8,6 @@ import {
   RenameHeaderCommand,
   CommandOutput,
 } from "../../commands/RenameHeader";
-import { ExtensionProvider } from "../../ExtensionProvider";
 import { WSUtils } from "../../WSUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
 import {

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -87,7 +87,6 @@ suite("RenameNote", function () {
         sandbox
           .stub(vscode.window, "showInputBox")
           .returns(Promise.resolve("Foo Bar"));
-        const ws = ExtensionProvider.getDWorkspace();
         const out = (await new RenameHeaderCommand().run({})) as CommandOutput;
 
         const updateResps = out!.data?.filter((resp) => {

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -1,13 +1,21 @@
 import { NoteProps, NoteUtils } from "@dendronhq/common-all";
 import { note2String } from "@dendronhq/common-server";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
-import { describe } from "mocha";
+import { beforeEach, afterEach, describe } from "mocha";
 import sinon from "sinon";
 import * as vscode from "vscode";
-import { RenameHeaderCommand } from "../../commands/RenameHeader";
+import {
+  RenameHeaderCommand,
+  CommandOutput,
+} from "../../commands/RenameHeader";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { WSUtils } from "../../WSUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  describeMultiWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
 // TODO:
 // In a reference range (start & end)
@@ -35,6 +43,60 @@ async function checkFile({
 
 suite("RenameNote", function () {
   const ctx = setupBeforeAfter(this, {});
+
+  let target: NoteProps;
+  describeMultiWS(
+    "GIVEN a note, and another note that references it",
+    {
+      ctx,
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        target = await NoteTestUtilsV4.createNote({
+          fname: "target",
+          wsRoot,
+          vault: vaults[0],
+          body: "## header\n\n## dummy",
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "note-with-link-to-target",
+          wsRoot,
+          vault: vaults[0],
+          body: "[[target]]",
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "another-note-with-link-to-target",
+          wsRoot,
+          vault: vaults[0],
+          body: "[[target#dummy]]",
+        });
+      },
+    },
+    () => {
+      let sandbox: sinon.SinonSandbox;
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      test("THEN, if the reference isn't pointing to the header being renamed, the note that is referencing isn't updated.", async () => {
+        const editor = await WSUtils.openNote(target);
+        editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
+
+        sandbox
+          .stub(vscode.window, "showInputBox")
+          .returns(Promise.resolve("Foo Bar"));
+        const ws = ExtensionProvider.getDWorkspace();
+        const out = (await new RenameHeaderCommand().run({})) as CommandOutput;
+
+        const updateResps = out!.data?.filter((resp) => {
+          return resp.status === "update";
+        });
+        expect(updateResps?.length).toEqual(0);
+      });
+    }
+  );
 
   describe("using selection", () => {
     test("wikilink to other file", (done) => {


### PR DESCRIPTION
# fix: rename operations modify unnecessary files

This PR:
- Fixes an issue with `FileStorage.renameNote` updating notes with link to a renamed note that doesn't actually have changes.
  - This bug would change notes that:
    - don't have note body changes at all, but is referencing a note that has a header rename.
      - e.g. note `foo` has a header that was changed by `Rename Header`, the note `foo`'s name hasn't actually changed, but internally `Rename Header` uses `renameNote` with the same note location to trigger reference updates. The bug here is that all notes that are not referencing the particular header but the note itself will be counted as modified, which add undesirable changes to the file (adding a `\n` at the end, changing `"` to `'`, etc.)
    - don't have note body (or frontmatter tag) changes, but used double quotes (`"`) in frontmatter, or
      - e.g. lots of linter-like changes as found in https://github.com/dendronhq/dendron-site/pull/338/files
    - don't have note body (or frontmatter tag) changes, but had "mistyped" frontmatter (type mismatched by frontmatter's standard)
      - e.g. `changelog.md` in `dendron-site` had a backlink to the note`weekly.journal.2021.11.09`, which had the frontmatter `title: 09`. A write note operation treated this as a number (probably because of the leading zero) and overwrote it with some garbage value. (if you change this to a very large number like 1000000000000000000000009, the write operation will overwrite this to a scientific notation)
- This bug affected 
  - commands `Rename Header`, `Move Note`, `Refactor Hierarchy`
  - `RenameProvider`
  - `WindowWatcher`

# Cause
- `FileStorage.renameNote` finds note with links to a renamed note in order to find and update all references to the old note if applicable.
- When it grabbed all notes with links to the note being renamed, it passed notes that don't really have meaningful changes at all to `updateOldNoteReferences`, which does a `writeNote` that updates existing notes in the file system, which updated the frontmatter.
  - This is fixed by only passing notes to `updateOldNoteReferences` that have note body change or frontmatter tag changes.

# Pull Request Checklist

You can go to [dendron pull requests](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html) to see full details for items in this checklist.

## General

### Quality Assurance
- [x] Add a [test](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#writing-tests) for the new feature
- [x] Make sure all the existing [tests](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#running-all-tests) pass
- [x] Do a spot check by running your feature with our [test workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace)
- [ ] If your tests involve running [[manual Testing|dendron://dendron.dendron-site/dendron.dev.qa.test#manual-testing]], make sure to update [[Test Workspace|dendron://dendron.dendron-site/dendron.dev.ref.test-workspace]] with any necessary notes/additions to perform manual test ^9jtWc6ov340p
- [x] After you submit your pull request, check the output of our [integration test](https://github.com/dendronhq/dendron/actions) and make sure all tests pass
  - NOTE: If you running MacOS or Linux, pay special attention to the Windows output and vice versa if you are developing on Windows

#### Special Cases
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in [test-workspace](https://wiki.dendron.so/notes/cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb.html#test-workspace). We use this to manually inspect new changes and for auto regression testing 

### Docs
- [x] Make sure that the PR title follows our [commit style](https://wiki.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] Please summarize the feature or impact in 1-2 lines in the PR description
- [ ] If your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## Special Cases

### Git
- [x] Make sure your branch names adhere to our commit style [[#^6zdCscSXs1MM]]
    - All PRs should start with `[feat|fix|enhance|]/[{description-of-pr-in-kebab-case}]`
        - `eg. feat/add-thisthing`

### Analytics
- [ ] If you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Github Issue
- [ ] If this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
- [ ] If the resolution comes with a document update, link the docs PR to the issue as well.