### PR TITLE
fix: warn for frontmatter issues even if the frontmatter is not visible

### DIFF
--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -161,6 +161,7 @@ export type GetDecorationsRequest = {
     range: VSRange;
     text: string;
   }[];
+  text: string;
 } & Partial<WorkspaceRequest>;
 
 export type SchemaDeleteRequest = {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -356,6 +356,8 @@ export type GetDecorationsOpts = {
     /** The document text that corresponds to this range. This is required because otherwise there's a data race between the notes in engine updating and decorations being generated. */
     text: string;
   }[];
+  /** The text of the entire document. Required because we show warnings for the whole note even if they are not a visible range. */
+  text: string;
 };
 
 // === Engine and Store Main

--- a/packages/engine-server/src/markdown/decorations/decorations.ts
+++ b/packages/engine-server/src/markdown/decorations/decorations.ts
@@ -7,6 +7,7 @@ import {
   IDendronError,
   NonOptional,
   NoteProps,
+  NoteUtils,
   offsetRange,
 } from "@dendronhq/common-all";
 import { decorateUserTag } from "./userTags";
@@ -34,6 +35,7 @@ import {
   warnMissingFrontmatter,
 } from "./diagnostics";
 import _ from "lodash";
+import visit from "unist-util-visit";
 
 /** Dispatches the correct decorator based on the type of AST node. */
 function runDecorator(
@@ -69,6 +71,19 @@ export async function runAllDecorators(
   const allDiagnostics: Diagnostic[] = [];
   const allErrors: IDendronError[] = [];
 
+  const proc = MDUtilsV5.procRemarkParse(
+    {
+      mode: ProcMode.FULL,
+      parseOnly: true,
+    },
+    {
+      dest: DendronASTDest.MD_DENDRON,
+      engine,
+      vault: note.vault,
+      fname: note.fname,
+    }
+  );
+
   for (const { range, text } of ranges) {
     if (text.length > ConfigUtils.getWorkspace(engine.config).maxNoteLength) {
       return {
@@ -84,20 +99,7 @@ export async function runAllDecorators(
         ],
       };
     }
-    const proc = MDUtilsV5.procRemarkParse(
-      {
-        mode: ProcMode.FULL,
-        parseOnly: true,
-      },
-      {
-        dest: DendronASTDest.MD_DENDRON,
-        engine,
-        vault: note.vault,
-        fname: note.fname,
-      }
-    );
     const tree = proc.parse(text);
-    let frontmatter: FrontmatterContent | undefined;
 
     // eslint-disable-next-line no-await-in-loop
     await MDUtilsV4.visitAsync(tree, [], async (nodeIn) => {
@@ -124,24 +126,25 @@ export async function runAllDecorators(
         );
         if (errors) allErrors.push(...errors);
       }
-      // Capture frontmatter if we come across it so we can check it for warnings
-      if (node.type === DendronASTTypes.FRONTMATTER)
-        frontmatter = nodeIn as FrontmatterContent;
     });
+  }
 
-    if (range.start.line === 0) {
-      // Can't check frontmatter if frontmatter is not visible
-      if (_.isUndefined(frontmatter)) {
-        allDiagnostics.push(warnMissingFrontmatter());
-      } else {
-        const { diagnostics, errors } = checkAndWarnBadFrontmatter(
-          note,
-          frontmatter
-        );
-        allDiagnostics.push(...diagnostics);
-        if (errors) allErrors.push(...errors);
-      }
-    }
+  // Check for frontmatter diagnostics. Diagnostics always run on the whole note because they need to be active even when they are not visible.
+  let frontmatter: FrontmatterContent | undefined;
+  const fullTree = proc.parse(opts.text);
+  visit(fullTree, ["yaml"], (node: FrontmatterContent) => {
+    frontmatter = node;
+    return false; // stop iterating
+  });
+  if (_.isUndefined(frontmatter)) {
+    allDiagnostics.push(warnMissingFrontmatter());
+  } else {
+    const { diagnostics, errors } = checkAndWarnBadFrontmatter(
+      note,
+      frontmatter
+    );
+    allDiagnostics.push(...diagnostics);
+    if (errors) allErrors.push(...errors);
   }
 
   return {

--- a/packages/engine-server/src/markdown/decorations/decorations.ts
+++ b/packages/engine-server/src/markdown/decorations/decorations.ts
@@ -7,7 +7,6 @@ import {
   IDendronError,
   NonOptional,
   NoteProps,
-  NoteUtils,
   offsetRange,
 } from "@dendronhq/common-all";
 import { decorateUserTag } from "./userTags";

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -162,6 +162,7 @@ export async function updateDecorations(editor: TextEditor): Promise<{
     const out = await engine.getDecorations({
       id: note.id,
       ranges,
+      text: editor.document.getText(),
     });
 
     if (

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -10,13 +10,15 @@ import {
 } from "../../features/windowDecorations";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
-import { describe } from "mocha";
+import { describe, before } from "mocha";
 import {
+  describeSingleWS,
   runLegacyMultiWorkspaceTest,
   runTestButSkipForWindows,
   setupBeforeAfter,
 } from "../testUtilsV3";
 import { WSUtils } from "../../WSUtils";
+import { ExtensionProvider } from "../../ExtensionProvider";
 
 /** Check if the ranges decorated by `decorations` contains `text` */
 function isTextDecorated(
@@ -600,6 +602,42 @@ suite("windowDecorations", function () {
           );
           done();
         },
+      });
+    });
+
+    describeSingleWS("AND frontmatter is not visible", { ctx }, async () => {
+      before(async () => {
+        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const note = await NoteTestUtilsV4.createNoteWithEngine({
+          fname: "foo",
+          vault: vaults[0],
+          wsRoot,
+          engine,
+        });
+        // Rewrite the file to have id missing in frontmatter
+        const path = NoteUtils.getFullPath({ note, wsRoot });
+        await writeFile(
+          path,
+          ["---", "updated: 234", "created: 123", "---"]
+            .join("\n")
+            .concat("\n".repeat(200))
+        );
+
+        const editor = await WSUtils.openNote(note);
+        editor.revealRange(new vscode.Range(200, 0, 200, 0));
+      });
+
+      test("THEN still warns for frontmatter issues", async () => {
+        const { allWarnings } = (await updateDecorations(
+          VSCodeUtils.getActiveTextEditorOrThrow()
+        ))!;
+        expect(allWarnings!.length).toEqual(1);
+        expect(
+          AssertUtils.assertInString({
+            body: allWarnings![0].message,
+            match: ["id", "missing"],
+          })
+        );
       });
     });
 


### PR DESCRIPTION
The optimizations for note decorations caused frontmatter warnings to be skipped if the frontmatter is not visible within the editor. This PR fixes this by always checking for frontmatter warnings, even if it's not visible. This is actually preferred because warnings should always be displayed even if not visible, because the user could use something like "go to previous issue" to navigate to them.