### PR TITLE
fix: move header issues

### DIFF
--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -436,6 +436,7 @@ export class MoveHeaderCommand extends BasicCommand<
           fname: dest.fname,
           notes,
         });
+        const isXVault = oldLink.data.xvault || notesWithSameName.length > 1;
         const newLink = {
           ...oldLink,
           from: {
@@ -444,7 +445,7 @@ export class MoveHeaderCommand extends BasicCommand<
             vaultName: VaultUtils.getName(dest.vault),
           },
           data: {
-            xvault: notesWithSameName.length > 1,
+            xvault: isXVault,
           },
         } as DNoteLink;
         const newBody = LinkUtils.updateLink({

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -422,12 +422,13 @@ export class MoveHeaderCommand extends BasicCommand<
    * @param dest Note that was the destination of move header commnad
    * @returns
    */
-  private updateLinksInNote(
-    notes: NotePropsDict,
-    note: NoteProps,
-    linksToUpdate: DLink[],
-    dest: NoteProps
-  ) {
+  private updateLinksInNote(opts: {
+    notes: NotePropsDict;
+    note: NoteProps;
+    linksToUpdate: DLink[];
+    dest: NoteProps;
+  }) {
+    const { notes, note, linksToUpdate, dest } = opts;
     return _.reduce(
       linksToUpdate,
       (note: NoteProps, linkToUpdate: DLink) => {
@@ -436,6 +437,12 @@ export class MoveHeaderCommand extends BasicCommand<
           fname: dest.fname,
           notes,
         });
+
+        // original link had vault prefix?
+        //   keep it
+        // original link didn't have vault prefix?
+        //   add vault prefix if there are notes with same name in other vaults.
+        //   don't add otherwise.
         const isXVault = oldLink.data.xvault || notesWithSameName.length > 1;
         const newLink = {
           ...oldLink,
@@ -499,12 +506,12 @@ export class MoveHeaderCommand extends BasicCommand<
           origin,
           anchorNamesToUpdate
         );
-        const modifiedNote = this.updateLinksInNote(
-          engine.notes,
-          _note,
+        const modifiedNote = this.updateLinksInNote({
+          notes: engine.notes,
+          note: _note,
           linksToUpdate,
-          dest
-        );
+          dest,
+        });
         note!.body = modifiedNote.body;
         const writeResp = await engine.writeNote(note!, {
           updateExisting: true,


### PR DESCRIPTION
# fix: move header issues
This PR:
- fixes issue with move header where if the moved text includes block anchors, they get corrupted
  - this was caused because we appended to destination after running a proc.stringify on a fake note containing the header and text associated, but this proved to be finicky and dependent on quirks of the processor and now is changed to directly slice off text portion to be appended from origin note. 
- fixes issue with move header refactoring links to remove their vault prefixes.
  - now will preserve vault prefix (if it didn't exist, will not be added unless doing so introduces ambiguity. if it did exist, it will always be preserved)
- refactors move header and its test to use the new `getNote(s)ByFNameFromEngine` method and the `IEngineAPIService` interface with a static provider.

# Pull Request Checklist

If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 

This template contains the short checklist which is used by the Dendron core team. 

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [~] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated