### PR TITLE
enhance(workspace): Use file picker when changing workspace

### DIFF
--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -50,7 +50,9 @@ export class WorkspaceUtils {
     return WorkspaceType.NONE;
   }
 
-  /** Finds the workspace type by analyzing the given directory. Use if plugin is not available. */
+  /** Finds the workspace type by analyzing the given directory. Use if plugin is not available.
+   * @returns WorkspaceType
+   */
   static async getWorkspaceTypeFromDir(dir: string) {
     if (fs.pathExistsSync(path.join(dir, CONSTANTS.DENDRON_WS_NAME))) {
       return WorkspaceType.CODE;
@@ -60,7 +62,7 @@ export class WorkspaceUtils {
       fname: CONSTANTS.DENDRON_CONFIG_FILE,
       returnDirPath: true,
     });
-    if (!wsRoot) return;
+    if (!wsRoot) return WorkspaceType.NONE;
     if (fs.pathExistsSync(path.join(wsRoot, CONSTANTS.DENDRON_CONFIG_FILE))) {
       return WorkspaceType.NATIVE;
     }

--- a/packages/plugin-core/src/commands/ChangeWorkspace.ts
+++ b/packages/plugin-core/src/commands/ChangeWorkspace.ts
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
-import { window } from "vscode";
+import { OpenDialogOptions, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
@@ -25,11 +25,20 @@ export class ChangeWorkspaceCommand extends BasicCommand<
 > {
   key = DENDRON_COMMANDS.CHANGE_WS.key;
   async gatherInputs(): Promise<CommandInput | undefined> {
-    const rootDirRaw = await VSCodeUtils.gatherFolderPath();
-    if (_.isUndefined(rootDirRaw)) {
-      return;
+    // Show a file picker dialog to select existing workspace directory
+    const options: OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: "Change Workspace",
+      canSelectFiles: false,
+      canSelectFolders: true,
+    };
+
+    const fileUri = await window.showOpenDialog(options);
+
+    if (fileUri && fileUri[0]) {
+      return { rootDirRaw: fileUri[0].fsPath };
     }
-    return { rootDirRaw };
+    return;
   }
 
   async execute(opts: ChangeWorkspaceCommandOpts) {

--- a/packages/plugin-core/src/test/suite-integ/ChangeWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ChangeWorkspace.test.ts
@@ -3,9 +3,10 @@ import {
   setupBeforeAfter,
   setupLegacyWorkspaceMulti,
 } from "../testUtilsV3";
-import { describe, before, after } from "mocha";
+import { describe, before, beforeEach, after, afterEach } from "mocha";
 import { ChangeWorkspaceCommand } from "../../commands/ChangeWorkspace";
 import sinon from "sinon";
+import { window } from "vscode";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WorkspaceType } from "@dendronhq/common-all";
 import { expect } from "../testUtilsv2";
@@ -14,6 +15,30 @@ import { getDWorkspace } from "../../workspace";
 // eslint-disable-next-line prefer-arrow-callback
 suite("GIVEN ChangeWorkspace command", function () {
   const ctx = setupBeforeAfter(this, {});
+
+  describeMultiWS(
+    "WHEN command is gathering inputs",
+    {
+      ctx,
+    },
+    () => {
+      let showOpenDialog: sinon.SinonStub;
+
+      beforeEach(async () => {
+        const cmd = new ChangeWorkspaceCommand();
+        showOpenDialog = sinon.stub(window, "showOpenDialog");
+        await cmd.gatherInputs();
+      });
+      afterEach(() => {
+        showOpenDialog.restore();
+      });
+
+      test("THEN file picker is opened", (done) => {
+        expect(showOpenDialog.calledOnce).toBeTruthy();
+        done();
+      });
+    }
+  );
 
   describeMultiWS(
     "WHEN command is run",


### PR DESCRIPTION
- Use file picker instead of typing out file path
- See [[Use File Picker When Changing Workspace|dendron://private/task.workspace.2022.01.04.use-file-picker-when-changing-workspace]]

Test:
- Run test workspace and run Change Workspace command
