### PR TITLE
fix(schema): Ensure month/day/time has two digits when doing data variable substitution

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1380,12 +1380,12 @@ export class SchemaUtils {
       const currentDate = Time.now();
       const compiledSchemaTemplate = _.template(note.body);
       note.body = compiledSchemaTemplate({
-        CURRENT_YEAR: currentDate.year,
-        CURRENT_MONTH: this.addPadding(currentDate.month),
-        CURRENT_DAY: this.addPadding(currentDate.day),
-        CURRENT_HOUR: this.addPadding(currentDate.hour),
-        CURRENT_MINUTE: this.addPadding(currentDate.minute),
-        CURRENT_SECOND: this.addPadding(currentDate.second),
+        CURRENT_YEAR: currentDate.toFormat("yyyy"),
+        CURRENT_MONTH: currentDate.toFormat("LL"),
+        CURRENT_DAY: currentDate.toFormat("dd"),
+        CURRENT_HOUR: currentDate.toFormat("HH"),
+        CURRENT_MINUTE: currentDate.toFormat("mm"),
+        CURRENT_SECOND: currentDate.toFormat("ss"),
       });
 
       return true;
@@ -1943,16 +1943,6 @@ export class SchemaUtils {
 
   static isSchemaUri(uri: URI) {
     return uri.fsPath.endsWith(".schema.yml");
-  }
-
-  /**
-   * Adds leading zero if number is a single digit.
-   *
-   * Example: addPadding(3) -> "03"
-   *          addPadding(23) -> "23"
-   */
-  static addPadding(number: number) {
-    return number >= 0 && number < 10 ? "0" + number : "" + number;
   }
 
   // /**

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1381,11 +1381,11 @@ export class SchemaUtils {
       const compiledSchemaTemplate = _.template(note.body);
       note.body = compiledSchemaTemplate({
         CURRENT_YEAR: currentDate.year,
-        CURRENT_MONTH: currentDate.month,
-        CURRENT_DAY: currentDate.day,
-        CURRENT_HOUR: currentDate.hour,
-        CURRENT_MINUTE: currentDate.minute,
-        CURRENT_SECOND: currentDate.second,
+        CURRENT_MONTH: this.addPadding(currentDate.month),
+        CURRENT_DAY: this.addPadding(currentDate.day),
+        CURRENT_HOUR: this.addPadding(currentDate.hour),
+        CURRENT_MINUTE: this.addPadding(currentDate.minute),
+        CURRENT_SECOND: this.addPadding(currentDate.second),
       });
 
       return true;
@@ -1943,6 +1943,16 @@ export class SchemaUtils {
 
   static isSchemaUri(uri: URI) {
     return uri.fsPath.endsWith(".schema.yml");
+  }
+
+  /**
+   * Adds leading zero if number is a single digit.
+   *
+   * Example: addPadding(3) -> "03"
+   *          addPadding(23) -> "23"
+   */
+  static addPadding(number: number) {
+    return number >= 0 && number < 10 ? "0" + number : "" + number;
   }
 
   // /**

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -143,9 +143,11 @@ describe(`SchemaUtil tests:`, () => {
               note,
               engine,
             });
-            const year = Time.now().year;
-            const month = ("0" + Time.now().month).slice(-2);
-            const day = ("0" + Time.now().day).slice(-2);
+
+            const currentDate = Time.now();
+            const year = currentDate.toFormat("yyyy");
+            const month = currentDate.toFormat("LL");
+            const day = currentDate.toFormat("dd");
 
             expect(resp).toBeTruthy();
             expect(note.body).not.toEqual(engine.notes["date-variables"].body);

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -143,16 +143,16 @@ describe(`SchemaUtil tests:`, () => {
               note,
               engine,
             });
+            const year = Time.now().year;
+            const month = ("0" + Time.now().month).slice(-2);
+            const day = ("0" + Time.now().day).slice(-2);
+
             expect(resp).toBeTruthy();
             expect(note.body).not.toEqual(engine.notes["date-variables"].body);
             expect(note.body.trim()).toEqual(
-              `Today is ${Time.now().year}.${Time.now().month}.${
-                Time.now().day
-              }` +
+              `Today is ${year}.${month}.${day}` +
                 "\n" +
-                `This link goes to [[daily.journal.${Time.now().year}.${
-                  Time.now().month
-                }.${Time.now().day}]]`
+                `This link goes to [[daily.journal.${year}.${month}.${day}]]`
             );
           },
           {

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -5,8 +5,8 @@ import {
   SchemaOpts,
   NoteProps,
   SchemaTemplate,
-  Time,
 } from "@dendronhq/common-all";
+import sinon from "sinon";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { runEngineTestV5 } from "../../engine";
 import { ENGINE_HOOKS } from "../../presets";
@@ -107,10 +107,17 @@ describe(`SchemaUtil tests:`, () => {
       TestNoteFactory.defaultUnitTestFactory();
     let note: NoteProps;
     const template: SchemaTemplate = { id: "foo", type: "note" };
+    const currentDate = new Date(2022, 0, 10);
+    let clock: sinon.SinonFakeTimers;
 
     describe(`GIVEN current note's body is empty`, () => {
       beforeEach(async () => {
         note = await noteFactory.createForFName("new note");
+        clock = sinon.useFakeTimers(currentDate);
+      });
+      afterEach(() => {
+        sinon.restore();
+        clock.restore();
       });
 
       it("WHEN applying a template, THEN replace note's body with template's body", async () => {
@@ -144,17 +151,12 @@ describe(`SchemaUtil tests:`, () => {
               engine,
             });
 
-            const currentDate = Time.now();
-            const year = currentDate.toFormat("yyyy");
-            const month = currentDate.toFormat("LL");
-            const day = currentDate.toFormat("dd");
-
             expect(resp).toBeTruthy();
             expect(note.body).not.toEqual(engine.notes["date-variables"].body);
             expect(note.body.trim()).toEqual(
-              `Today is ${year}.${month}.${day}` +
+              `Today is 2022.01.10` +
                 "\n" +
-                `This link goes to [[daily.journal.${year}.${month}.${day}]]`
+                `This link goes to [[daily.journal.2022.01.10]]`
             );
           },
           {

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -794,9 +794,10 @@ suite("NoteLookupCommand", function () {
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
           const newNote = WSUtils.getNoteFromDocument(document!);
-          const year = Time.now().year;
-          const month = ("0" + Time.now().month).slice(-2);
-          const day = ("0" + Time.now().day).slice(-2);
+          const currentDate = Time.now();
+          const year = currentDate.toFormat("yyyy");
+          const month = currentDate.toFormat("LL");
+          const day = currentDate.toFormat("dd");
 
           expect(newNote!.body.trim()).toEqual(
             `Today is ${year}.${month}.${day}` +

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -794,14 +794,14 @@ suite("NoteLookupCommand", function () {
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
           const newNote = WSUtils.getNoteFromDocument(document!);
+          const year = Time.now().year;
+          const month = ("0" + Time.now().month).slice(-2);
+          const day = ("0" + Time.now().day).slice(-2);
+
           expect(newNote!.body.trim()).toEqual(
-            `Today is ${Time.now().year}.${Time.now().month}.${
-              Time.now().day
-            }` +
+            `Today is ${year}.${month}.${day}` +
               "\n" +
-              `This link goes to [[daily.journal.${Time.now().year}.${
-                Time.now().month
-              }.${Time.now().day}]]`
+              `This link goes to [[daily.journal.${year}.${month}.${day}]]`
           );
         });
       }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -26,7 +26,7 @@ import {
 import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
-import { describe, Done } from "mocha";
+import { afterEach, beforeEach, describe, Done } from "mocha";
 import path from "path";
 import sinon, { SinonStub } from "sinon";
 import * as vscode from "vscode";
@@ -786,6 +786,16 @@ suite("NoteLookupCommand", function () {
         ctx,
       },
       () => {
+        const currentDate = new Date(2021, 11, 2);
+        let clock: sinon.SinonFakeTimers;
+        beforeEach(async () => {
+          clock = sinon.useFakeTimers(currentDate);
+        });
+        afterEach(() => {
+          sinon.restore();
+          clock.restore();
+        });
+
         test("WHEN a new note matches the schema template, THEN new note's body contains proper date substitution", async () => {
           const cmd = new NoteLookupCommand();
           await cmd.run({
@@ -794,15 +804,11 @@ suite("NoteLookupCommand", function () {
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
           const newNote = WSUtils.getNoteFromDocument(document!);
-          const currentDate = Time.now();
-          const year = currentDate.toFormat("yyyy");
-          const month = currentDate.toFormat("LL");
-          const day = currentDate.toFormat("dd");
 
           expect(newNote!.body.trim()).toEqual(
-            `Today is ${year}.${month}.${day}` +
+            `Today is 2021.12.02` +
               "\n" +
-              `This link goes to [[daily.journal.${year}.${month}.${day}]]`
+              `This link goes to [[daily.journal.2021.12.02]]`
           );
         });
       }


### PR DESCRIPTION
Background: https://github.com/dendronhq/dendron/issues/2045

Testing:
Updated unit tests and tested manually using {{ CURRENT_DAY }}
<img width="685" alt="Screen Shot 2022-01-05 at 12 57 37" src="https://user-images.githubusercontent.com/1160589/148288428-bcceb915-537d-4c3b-9551-96523a06ab4a.png">
