### PR TITLE
enhance(workspace): Use file picker for code workspace initialization

### DIFF
--- a/packages/common-server/src/files.ts
+++ b/packages/common-server/src/files.ts
@@ -123,7 +123,10 @@ export function resolveTilde(filePath: string) {
     return "";
   }
   // '~/folder/path' or '~'
-  if (filePath[0] === "~" && (filePath[1] === "/" || filePath.length === 1)) {
+  if (
+    filePath[0] === "~" &&
+    (filePath[1] === path.sep || filePath.length === 1)
+  ) {
     return filePath.replace("~", os.homedir());
   }
   return filePath;

--- a/packages/plugin-core/src/commands/ChangeWorkspace.ts
+++ b/packages/plugin-core/src/commands/ChangeWorkspace.ts
@@ -32,11 +32,10 @@ export class ChangeWorkspaceCommand extends BasicCommand<
       canSelectFiles: false,
       canSelectFolders: true,
     };
+    const filePath = await VSCodeUtils.openFilePicker(options);
 
-    const fileUri = await window.showOpenDialog(options);
-
-    if (fileUri && fileUri[0]) {
-      return { rootDirRaw: fileUri[0].fsPath };
+    if (filePath) {
+      return { rootDirRaw: filePath };
     }
     return;
   }

--- a/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
@@ -1,0 +1,35 @@
+import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+import { beforeEach, afterEach } from "mocha";
+import sinon from "sinon";
+import { window } from "vscode";
+import { expect } from "../testUtilsv2";
+import { SetupWorkspaceCommand } from "../../commands/SetupWorkspace";
+
+// eslint-disable-next-line prefer-arrow-callback
+suite("GIVEN SetupWorkspace command", function () {
+  const ctx = setupBeforeAfter(this, {});
+
+  describeMultiWS(
+    "WHEN command is gathering inputs",
+    {
+      ctx,
+    },
+    () => {
+      let showOpenDialog: sinon.SinonStub;
+
+      beforeEach(async () => {
+        const cmd = new SetupWorkspaceCommand();
+        showOpenDialog = sinon.stub(window, "showOpenDialog");
+        await cmd.gatherInputs();
+      });
+      afterEach(() => {
+        showOpenDialog.restore();
+      });
+
+      test("THEN file picker is opened", (done) => {
+        expect(showOpenDialog.calledOnce).toBeTruthy();
+        done();
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -287,6 +287,21 @@ export class VSCodeUtils {
     }
   }
 
+  /**
+   * Opens file picker which allows user to select a file or folder
+   *
+   * @param options Options to configure the behaviour of a file open dialog
+   * @returns Filesystem path
+   */
+  static async openFilePicker(options?: vscode.OpenDialogOptions) {
+    const fileUri = await vscode.window.showOpenDialog(options);
+
+    if (fileUri && fileUri[0]) {
+      return fileUri[0].fsPath;
+    }
+    return;
+  }
+
   /** Prompt the user for an absolute path to a folder. Supports `~`.
    *
    * @param opts.default The default path to suggest.


### PR DESCRIPTION
Use file picker instead of prompting user to manually type file path.
See [[Details|dendron://private/task.workspace.2022.01.04.use-file-picker-when-initializing-workspace#details]]

Manual Testing:
- Run Initialize Workspace and click on Code Workspace
- Verify workspace is created

We also do not prompt continue/delete for empty directories
