### PR TITLE
fix: analytics for show preview

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -323,7 +323,7 @@ export class ShowPreviewCommand extends BasicCommand<
     return;
   }
 
-  async addAnalyticsPayload(opts?: ShowPreviewCommandOpts) {
+  addAnalyticsPayload(opts?: ShowPreviewCommandOpts) {
     return { providedFile: opts !== undefined };
   }
 

--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -126,7 +126,7 @@ export abstract class BaseCommand<
       return;
     } finally {
       const payload = this.addAnalyticsPayload
-        ? this.addAnalyticsPayload(opts, resp)
+        ? await this.addAnalyticsPayload(opts, resp)
         : {};
 
       AnalyticsUtils.track(this.key, {


### PR DESCRIPTION
Fixes the additional analytics for the show preview command, and makes sure any promises are resolved in case `addAnalyticsPayload` is async to prevent issues in the future.