### PR TITLE
fix:show preview errors on Windows

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -27,7 +27,7 @@ import { WebViewUtils } from "../views/utils";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace, getEngine, getExtension } from "../workspace";
 import { WSUtils } from "../WSUtils";
-import { BasicCommand } from "./base";
+import { InputArgCommand } from "./base";
 import fs from "fs-extra";
 
 import {
@@ -301,7 +301,7 @@ export const handleLink = async ({
   }
 };
 
-export class ShowPreviewCommand extends BasicCommand<
+export class ShowPreviewCommand extends InputArgCommand<
   ShowPreviewCommandOpts,
   ShowPreviewCommandOutput
 > {
@@ -314,11 +314,8 @@ export class ShowPreviewCommand extends BasicCommand<
   }
 
   async sanityCheck(opts?: ShowPreviewCommandOpts) {
-    if (
-      _.isUndefined(VSCodeUtils.getActiveTextEditor()) &&
-      opts === undefined
-    ) {
-      return "No document currently open, and no document selected to open";
+    if (_.isUndefined(VSCodeUtils.getActiveTextEditor()) && _.isEmpty(opts)) {
+      return "No note currently open, and no note selected to open.";
     }
     return;
   }
@@ -391,7 +388,7 @@ export class ShowPreviewCommand extends BasicCommand<
     if (opts) {
       // Used a context menu to open preview for a specific note
       try {
-        note = WSUtils.getNoteFromPath(opts.path);
+        note = WSUtils.getNoteFromPath(opts.fsPath);
       } catch {
         // Sometimes VSCode gives us a weird `opts` when no note was selected, so fall back to active note
         note = WSUtils.getActiveNote();
@@ -406,7 +403,7 @@ export class ShowPreviewCommand extends BasicCommand<
     } else if (opts?.path) {
       // We can't find the note, so this is not in the Dendron workspace.
       // Preview the file anyway if it's a markdown file.
-      await ShowPreviewCommand.openFileInPreview(opts.path);
+      await ShowPreviewCommand.openFileInPreview(opts.fsPath);
     } else {
       // Not file selected for preview, default ot open file
       const editor = VSCodeUtils.getActiveTextEditor();

--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -19,6 +19,9 @@ export type AnalyticProps = {
   props?: any;
 };
 
+/** Anything other than `undefined` is an error and will stop the command. "cancel" will stop the command without displaying an error. */
+export type SanityCheckResults = undefined | string | "cancel";
+
 /**
  * Base class for all Dendron Plugin Commands.
  *
@@ -61,11 +64,8 @@ export abstract class BaseCommand<
     return;
   }
 
-  /**
-   * Basic error checking
-   * @returns
-   */
-  async sanityCheck(_opts?: TOpts): Promise<undefined | string | "cancel"> {
+  /** Check for errors and stop execution if needed, runs before `gatherInputs`. */
+  async sanityCheck(_opts?: Partial<TRunOpts>): Promise<SanityCheckResults> {
     return;
   }
 
@@ -80,14 +80,16 @@ export abstract class BaseCommand<
     let opts: TOpts | undefined;
     let resp: TOut | undefined;
 
+    let sanityCheck: SanityCheckResults;
+
     try {
-      // TODO: Add sanity check failure to analytics payload.
-      const out = await this.sanityCheck(opts);
-      if (out === "cancel") {
+      sanityCheck = await this.sanityCheck(args);
+      if (sanityCheck === "cancel") {
+        this.L.info({ ctx, msg: "sanity check cancelled" });
         return;
       }
-      if (!_.isUndefined(out) && out !== "cancel") {
-        window.showErrorMessage(out);
+      if (!_.isUndefined(sanityCheck) && sanityCheck !== "cancel") {
+        window.showErrorMessage(sanityCheck);
         return;
       }
 
@@ -132,11 +134,12 @@ export abstract class BaseCommand<
       const payload = this.addAnalyticsPayload
         ? await this.addAnalyticsPayload(opts, resp)
         : {};
-
+      const sanityCheckResults = sanityCheck ? { sanityCheck } : {};
       AnalyticsUtils.track(this.key, {
         duration: getDurationMilliseconds(start),
         error: isError,
         ...payload,
+        ...sanityCheckResults,
       });
     }
   }


### PR DESCRIPTION
There were multiple issues associated with this bug:
1. Base command tries to merge the output from gatherOpts and the direct input to the command together.
2. This destroys any class instances and converts them to regular JS objects.
3. I was confused when implementing ShowPreview as to why my `Uri` object wasn't really a Uri object and didn't have a `uri.fsPath`, but realized `uri.path` worked. Unfortunately, that only works on non-Windows systems.

This PR fixes this problem by allowing commands to override how the inputs are merged, and then adding a new base command that passes the command input to `execute`.

It also fixes a bug where `ShowPreview` would incorrectly give an error message that there's nothing to preview if the user had no note open, but had used show preview through the file context menu.

Finally, this PR also fixes a bug with `sanityCheck` where `sanityCheck` would always get `undefined` and not the input of the command, and it adds the output from `sanityCheck` into the telemetry data if it exists.

#2074 