### PR TITLE
enahnce(pod): introduce filters field for airtable config that allows filtering by fname

### DIFF
--- a/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
+++ b/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
@@ -80,6 +80,19 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
         type: "string",
         nullable: true,
       },
+      filters: {
+        type: "object",
+        required: [],
+        nullable: true,
+        properties: {
+          fname: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
     },
   };
 }

--- a/packages/pods-core/src/v2/podConfig/PodV2Types.ts
+++ b/packages/pods-core/src/v2/podConfig/PodV2Types.ts
@@ -43,6 +43,18 @@ export type ExportPodConfigurationV2 = {
    * Specifies the scope of this export operation
    */
   exportScope: PodExportScope;
+
+  filters?: ExportPodConfigurationFilterV2;
+};
+
+/**
+ * Defines filters for export pod
+ */
+export type ExportPodConfigurationFilterV2 = {
+  /**
+   * Glob patterns to filter from
+   */
+  fname: string[];
 };
 
 /**


### PR DESCRIPTION
Docs: https://github.com/dendronhq/dendron-site/commit/e4387010bebb390f344fedbe573cc07638e2fbb2

Some future work:
- make this generic for all export pods
- support filtering by vault
