### PR TITLE
fix: add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score.

### DIFF
--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -78,7 +78,7 @@ export class NoteController {
       ? await getWSEngine({ ws })
       : MemoryStore.instance().getEngine();
     try {
-      const data = await engine.queryNotes(opts);
+      const data = await engine.queryNotes({ ...opts, originalQS: opts.qs });
       return data;
     } catch (err) {
       return {

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -48,6 +48,7 @@
     "@types/yamljs": "^0.2.31",
     "axios": "^0.21.4",
     "dropbox": "^4.0.30",
+    "fast-levenshtein": "^3.0.0",
     "fuse.js": "^6.4.6",
     "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.2",
@@ -65,6 +66,7 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
+    "@types/fast-levenshtein": "^0.0.2",
     "@types/js-yaml": "^3.12.5",
     "@types/nanoid-dictionary": "^4.2.0",
     "coveralls": "^3.0.2",

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -310,9 +310,6 @@ export class FuseEngine {
   }): Fuse.FuseResult<NoteIndexProps>[] {
     if (results.length === 0) return [];
 
-    console.log(`Results length: '${results.length}'`);
-    console.log(`Results: '${JSON.stringify(results)}'`);
-
     const sortOrder: SortOrderObj[] = [
       // We want match scores to be ascending since the lowest score
       // represents the best match. We first group sort by FuseJS score

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -215,6 +215,10 @@ export class FuseEngine {
         onlyDirectChildren,
       });
 
+      if (originalQS === undefined) {
+        // TODO: add log WARN (does not appear to be easily accessible logger in common-all)
+        originalQS = qs;
+      }
       results = FuseEngine.sortResults({ results, originalQS });
 
       items = _.map(results, (resp) => resp.item);

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -556,7 +556,14 @@ export type DEngine = DCommonProps &
     getSchema: (qs: string) => Promise<RespV2<SchemaModuleProps>>;
     querySchema: (qs: string) => Promise<SchemaQueryResp>;
     queryNotes: (opts: QueryNotesOpts) => Promise<NoteQueryResp>;
-    queryNotesSync({ qs }: { qs: string; vault?: DVault }): NoteQueryResp;
+    queryNotesSync({
+      qs,
+      originalQS,
+    }: {
+      qs: string;
+      originalQS: string;
+      vault?: DVault;
+    }): NoteQueryResp;
     renameNote: (opts: RenameNoteOpts) => Promise<RespV2<RenameNotePayload>>;
     renderNote: (opts: RenderNoteOpts) => Promise<RespV2<RenderNotePayload>>;
     /**

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -518,7 +518,7 @@ export type QueryNotesOpts = {
    * Original query string (which can contain minor modifications such as mapping '/'->'.')
    * This string is added for sorting the lookup results when there is exact match with
    * original query. */
-  originalQS?: string;
+  originalQS: string;
   onlyDirectChildren?: boolean;
   vault?: DVault;
   createIfNew?: boolean;

--- a/packages/common-all/src/util/stringUtil.ts
+++ b/packages/common-all/src/util/stringUtil.ts
@@ -1,0 +1,8 @@
+import levenshtein from "fast-levenshtein";
+
+/**
+ * Returns levenshtein distance between the two strings, the higher the number
+ * the further apart the strings are. 0 signals that the strings are equal. */
+export function levenshteinDistance(s1: string, s2: string): number {
+  return levenshtein.get(s1, s2);
+}

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -128,7 +128,7 @@ export class DoctorService {
     let notes: NoteProps[];
     if (_.isUndefined(candidates)) {
       notes = query
-        ? engine.queryNotesSync({ qs: query }).data
+        ? engine.queryNotesSync({ qs: query, originalQS: query }).data
         : _.values(engine.notes);
     } else {
       notes = candidates;

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -272,8 +272,16 @@ export class DendronEngineClient implements DEngineClient {
     };
   }
 
-  queryNotesSync({ qs, vault }: { qs: string; vault?: DVault }) {
-    let items = this.fuseEngine.queryNote({ qs });
+  queryNotesSync({
+    qs,
+    originalQS,
+    vault,
+  }: {
+    qs: string;
+    originalQS: string;
+    vault?: DVault;
+  }) {
+    let items = this.fuseEngine.queryNote({ qs, originalQS });
     if (vault) {
       items = items.filter((ent) => {
         return VaultUtils.isEqual(ent.vault, vault, this.wsRoot);

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -421,10 +421,12 @@ export class DendronEngineV2 implements DEngine {
 
   queryNotesSync({
     qs,
+    originalQS,
   }: {
     qs: string;
+    originalQS: string;
   }): ReturnType<DEngineClient["queryNotesSync"]> {
-    const items = this.fuseEngine.queryNote({ qs });
+    const items = this.fuseEngine.queryNote({ qs, originalQS });
     return {
       error: null,
       data: items.map((ent) => this.notes[ent.id]),

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -270,7 +270,11 @@ function convertNoteRef(opts: ConvertNoteRefOpts): {
 
   let noteRefs: DNoteLoc[] = [];
   if (link.from.fname.endsWith("*")) {
-    const resp = engine.queryNotesSync({ qs: link.from.fname, vault });
+    const resp = engine.queryNotesSync({
+      qs: link.from.fname,
+      originalQS: link.from.fname,
+      vault,
+    });
     const out = _.filter(resp.data, (ent) =>
       DUtils.minimatch(ent.fname, link.from.fname)
     );
@@ -493,7 +497,11 @@ export function convertNoteRefASTV2(
   if (link.from.fname.endsWith("*")) {
     // wildcard reference case
     const vault = dendronData.vault;
-    const resp = engine.queryNotesSync({ qs: link.from.fname, vault });
+    const resp = engine.queryNotesSync({
+      qs: link.from.fname,
+      originalQS: link.from.fname,
+      vault,
+    });
     const out = _.filter(resp.data, (ent) =>
       DUtils.minimatch(ent.fname, link.from.fname)
     );

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -77,7 +77,11 @@ const NOTES = {
     async ({ vaults, engine }) => {
       const vault = vaults[0];
       const notes = engine.notes;
-      const { data } = await engine.queryNotes({ qs: "", vault });
+      const { data } = await engine.queryNotes({
+        qs: "",
+        originalQS: "",
+        vault,
+      });
       const expectedNote = NoteUtils.getNoteByFnameV5({
         wsRoot: engine.wsRoot,
         fname: "root",
@@ -99,7 +103,11 @@ const NOTES = {
   STAR_QUERY: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const { data } = await engine.queryNotes({ qs: "*", vault });
+      const { data } = await engine.queryNotes({
+        qs: "*",
+        originalQS: "*",
+        vault,
+      });
       return [
         {
           actual: data.length,
@@ -116,7 +124,11 @@ const NOTES = {
       const vault = vaults[0];
       const notes = engine.notes;
       const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-      const { data } = await engine.queryNotes({ qs: fname, vault });
+      const { data } = await engine.queryNotes({
+        qs: fname,
+        originalQS: fname,
+        vault,
+      });
       const expectedNote = NoteUtils.getNoteByFnameV5({
         fname,
         notes,
@@ -146,7 +158,11 @@ const NOTES = {
       const vault = vaults[0];
       const notes = engine.notes;
       const fname = NOTE_PRESETS_V4.NOTE_SIMPLE_CHILD.fname;
-      const { data } = await engine.queryNotes({ qs: fname, vault });
+      const { data } = await engine.queryNotes({
+        qs: fname,
+        originalQS: fname,
+        vault,
+      });
       const expectedNote = NoteUtils.getNoteByFnameV5({
         fname,
         notes,

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -172,7 +172,11 @@ const NOTES = {
     });
     await engine.writeNote(noteNew);
 
-    const resp = await engine.queryNotes({ qs: "bar", vault });
+    const resp = await engine.queryNotes({
+      qs: "bar",
+      originalQS: "bar",
+      vault,
+    });
     const note = resp.data[0];
 
     return [
@@ -460,7 +464,11 @@ const NOTES_MULTI = {
     });
     await engine.writeNote(noteNew);
 
-    const resp = await engine.queryNotes({ qs: "bar", vault });
+    const resp = await engine.queryNotes({
+      qs: "bar",
+      originalQS: "bar",
+      vault,
+    });
     const note = resp.data[0];
 
     return [
@@ -488,7 +496,11 @@ const NOTES_MULTI = {
       });
       await engine.writeNote(noteNew);
 
-      const resp = await engine.queryNotes({ qs: "bar", vault });
+      const resp = await engine.queryNotes({
+        qs: "bar",
+        originalQS: "bar",
+        vault,
+      });
       const note = resp.data[0];
 
       return [

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -118,7 +118,7 @@ function DendronSearchComponent(
     const out =
       qs === ""
         ? NoteLookupUtils.fetchRootResults(notes)
-        : lookup?.queryNote({ qs });
+        : lookup?.queryNote({ qs, originalQS: qs });
     setLookupResults(_.isUndefined(out) ? [] : out);
   };
 

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -572,6 +572,7 @@ export class PickerUtilsV2 {
     const newQs = domain.join(".");
     const queryResponse = await engine.queryNotes({
       qs: newQs,
+      originalQS: newQs,
       createIfNew: false,
     });
 
@@ -848,6 +849,7 @@ export class NotePickerUtils {
     const engine = getDWorkspace().engine;
     const resp = await NoteLookupUtils.lookup({
       qs: picker.value,
+      originalQS: picker.value,
       engine,
       showDirectChildrenOnly: picker.showDirectChildrenOnly,
     });

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -235,12 +235,14 @@ export class EngineAPIService implements DEngineClient, IEngineAPIService {
 
   queryNotesSync({
     qs,
+    originalQS,
     vault,
   }: {
     qs: string;
+    originalQS: string;
     vault?: DVault | undefined;
   }): Required<RespV2<NoteProps[]>> {
-    return this.internalEngine.queryNotesSync({ qs, vault });
+    return this.internalEngine.queryNotesSync({ qs, originalQS, vault });
   }
 
   renameNote(opts: RenameNoteOpts): Promise<RespV2<RenameNotePayload>> {

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -92,9 +92,11 @@ export interface IEngineAPIService {
 
   queryNotesSync({
     qs,
+    originalQS,
     vault,
   }: {
     qs: string;
+    originalQS: string;
     vault?: DVault | undefined;
   }): Required<RespV2<NoteProps[]>>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5540,6 +5540,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fast-levenshtein@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/fast-levenshtein/-/fast-levenshtein-0.0.2.tgz#9f618cff4469da8df46c9ee91b1c95b9af1d8f6a"
+  integrity sha512-h9AGeNlFimLtFUlEZgk+hb3LUT4tNHu8y0jzCUeTdi1BM4e86sBQs/nQYgHk70ksNyNbuLwpymFAXkb0GAehmw==
+
 "@types/form-data@^2.5.0":
   version "2.5.0"
   resolved "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz#5025f7433016f923348434c40006d9a797c1b0e8"
@@ -12626,6 +12631,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-levenshtein@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz#37b899ae47e1090e40e3fd2318e4d5f0142ca912"
+  integrity sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==
+  dependencies:
+    fastest-levenshtein "^1.0.7"
+
 fast-redact@^3.0.0:
   version "3.0.2"
   resolved "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz#c940ba7162dde3aeeefc522926ae8c5231412904"
@@ -12648,7 +12660,7 @@ fast-xml-parser@^3.16.0:
   dependencies:
     strnum "^1.0.4"
 
-fastest-levenshtein@^1.0.12:
+fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.7:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==


### PR DESCRIPTION
Related Doc Update PR:  https://github.com/dendronhq/dendron-site/pull/353

### Note
Background/Current state prior to this task is can be found in ![[dendron://private/task.lookup.2022.01.04.lookup-sort-order-inconsistent#notes,1:#*]] 

### Levenshtein Distance
Using Levenshtein distance instead of referenced Hamming distance since its deemed to be more intuitive (and hence much more widely used), than hamming distance.

### Added dependency
Added dependency `fast-levenshtein` to common-all it has an MIT license with 20mil a week downloads, and we already have `fast-levenshtein` dependency in some of the other packages. 

### Manual testing
#### Test of distance sorting
Querying for `task.tem` in test workspace makes `task.temp` show up ahead in the results even if `task.workspace.2022.01.04.sync-missing-template-frontmatter` is modified after `task.temp`

#### Test of updated sorting with same distance
Added the following notes
```
task.temp
task.hi-world.a
task.hi-world.a.03
task.hi-world.a.02
task.hi-world.a.01
```

Query: `task.hi-world`
Results
```
task.hi-world (stub exact match)
task.hi-world.a
task.hi-world.a.03
task.hi-world.a.02
task.hi-world.a.01
```

Query `task`
Results:
```
task (stub exact match)
task.temp (closer distance shows up on top even though edit time is older than others)
task.hi-world.a
task.hi-world.a.03
task.hi-world.a.02
task.hi-world.a.01
```

Query `task.a`
Results:
```
Create New
task.hi-world.a    (closer distance shows up on top even though edit times are older)
task.hi-world.a.03 
task.hi-world.a.02
task.hi-world.a.01
```
### Benchmarking 
Took about 10 milliseconds to calculate levenshtein distance for ~500 comparisons. Should not affect user experience of lookup.

Note: We are doing it on sorting search results prior to limiting the results to the first 50. 

If performance starts to sloth around this area we can move the limiting of number of entries prior to calculation of the distance such as: First sort by score, or keep MinHeap of best 50 scores which from bigO perspective should be faster than plain sort (also make sure to check for exact match to original query string prior to any slicing). Then calculate the distance for those 50 elements only and do the sorting within the score groups for those best score 50 elements only. 

```ts
import { uuid } from "./util/misc/UUID";

const levenshtein = require('fast-levenshtein');

const length = 600;
const arr = [];
for (let i = 0; i < length; i++) {
  arr.push(uuid() + uuid());
}

const id1 = uuid() + uuid();

const millisPre = new Date().getMilliseconds();

arr.forEach(entry => levenshtein.get(id1, entry));

const millisTaken = new Date().getMilliseconds() - millisPre;

console.log(`Millis taken '${millisTaken}ms' to process '${length}' words`);
// Millis taken '11ms' to process '600' words
// Millis taken '12ms' to process '600' words

```
# Pull Request Checklist

If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 

This template contains the short checklist which is used by the Dendron core team. 

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
- [x] Doc update: https://github.com/dendronhq/dendron-site/pull/353 