### PR TITLE
fix(pods): display all configs on export pod v2

### DIFF
--- a/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
@@ -164,8 +164,8 @@ describe("GIVEN a PodV2ConfigManager class", () => {
     fPath: path.join(podsDir, "notion.yml"),
     configSchema: NotionExportPodV2.config(),
     setProperties: podConfig4,
-    });
-    
+  });
+
   const podConfigWithoutExportScope = {
     podId: "test-config",
     podType: PodV2Types.MarkdownExportV2,
@@ -188,7 +188,6 @@ describe("GIVEN a PodV2ConfigManager class", () => {
       expect(podConfig).toBeDefined();
       expect(podConfig?.podId).toEqual("foo");
       expect(podConfig?.podType).toEqual(PodV2Types.AirtableExportV2);
-      expect(podConfig?.exportScope).toEqual(PodExportScope.Note);
     });
   });
 
@@ -209,7 +208,7 @@ describe("GIVEN a PodV2ConfigManager class", () => {
     test("THEN expect all pod configs to be returned", () => {
       const configs = PodV2ConfigManager.getAllPodConfigs(podsDir);
 
-      expect(configs.length).toEqual(4);
+      expect(configs.length).toEqual(5);
     });
   });
 });

--- a/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
@@ -164,6 +164,17 @@ describe("GIVEN a PodV2ConfigManager class", () => {
     fPath: path.join(podsDir, "notion.yml"),
     configSchema: NotionExportPodV2.config(),
     setProperties: podConfig4,
+    });
+    
+  const podConfigWithoutExportScope = {
+    podId: "test-config",
+    podType: PodV2Types.MarkdownExportV2,
+  };
+
+  ConfigFileUtils.genConfigFileV2({
+    fPath: path.join(podsDir, "test-config.yml"),
+    configSchema: MarkdownExportPodV2.config(),
+    setProperties: podConfigWithoutExportScope,
   });
 
   describe("WHEN getting a pod config by an existing ID", () => {

--- a/packages/pods-core/src/v2/ConfigFileUtils.ts
+++ b/packages/pods-core/src/v2/ConfigFileUtils.ts
@@ -55,6 +55,14 @@ export class ConfigFileUtils {
           configPrefix = "";
         }
 
+        /**
+         * add NOTE for config options having note property. Mark the option as a comment.
+         * added for exportScope config option
+         */
+        if (podConfig[ent].note) {
+          args.push(`# NOTE: ${podConfig[ent].note}`);
+          configPrefix = "# ";
+        }
         args.push(
           `${configPrefix}${ent}: ${
             setProperties && ent in setProperties
@@ -78,7 +86,7 @@ export class ConfigFileUtils {
   static createExportConfig<T>(opts: { required: (keyof T)[]; properties: T }) {
     return {
       type: "object",
-      required: ["podId", "podType", "exportScope", ...opts.required],
+      required: ["podId", "podType", ...opts.required],
       properties: {
         podId: {
           description: "configuration ID",
@@ -90,9 +98,9 @@ export class ConfigFileUtils {
           nullable: true,
         },
         exportScope: {
-          description:
-            "export scope of the pod. NOTE: Comment out this property if you would like get a UI prompt for export scope selection everytime while running the export pod. ",
+          description: "export scope of the pod.",
           type: "string",
+          note: "When a setting is missing from this config, you will get a UI prompt to select a value for that setting while running the export pod. For this particular exportScope setting, if you would rather not be prompted and always have the same exportScope, simply uncomment the line below.",
         },
         podType: {
           description: "type of pod",

--- a/packages/pods-core/src/v2/ConfigFileUtils.ts
+++ b/packages/pods-core/src/v2/ConfigFileUtils.ts
@@ -90,7 +90,8 @@ export class ConfigFileUtils {
           nullable: true,
         },
         exportScope: {
-          description: "export scope of the pod",
+          description:
+            "export scope of the pod. NOTE: Comment out this property if you would like get a UI prompt for export scope selection everytime while running the export pod. ",
           type: "string",
         },
         podType: {

--- a/packages/pods-core/src/v2/PodConfigManager.ts
+++ b/packages/pods-core/src/v2/PodConfigManager.ts
@@ -60,10 +60,11 @@ export class PodV2ConfigManager {
       const config = ConfigFileUtils.getConfigByFPath({
         fPath,
       });
-
-      // if (isExportPodConfigurationV2(config)) {
-      //   configs.push(config);
-      // }
+      /**
+       *TODO: give some UI feedback if the user config is not Runnable. Either
+       * some visual cue within the quick pick itself or
+       * When the config is open, have some sort of code warning.
+       */
       configs.push(config);
     }
 

--- a/packages/pods-core/src/v2/PodConfigManager.ts
+++ b/packages/pods-core/src/v2/PodConfigManager.ts
@@ -5,7 +5,6 @@ import {
   ConfigFileUtils,
   ExportPodConfigurationV2,
   ExternalConnectionManager,
-  isExportPodConfigurationV2,
   PodV2Types,
 } from "..";
 
@@ -62,9 +61,10 @@ export class PodV2ConfigManager {
         fPath,
       });
 
-      if (isExportPodConfigurationV2(config)) {
-        configs.push(config);
-      }
+      // if (isExportPodConfigurationV2(config)) {
+      //   configs.push(config);
+      // }
+      configs.push(config);
     }
 
     return configs;

--- a/packages/pods-core/src/v2/podConfig/PodV2Types.ts
+++ b/packages/pods-core/src/v2/podConfig/PodV2Types.ts
@@ -12,12 +12,12 @@ export enum PodV2Types {
  * Specifies what information to export
  */
 export enum PodExportScope {
-  LinksInSelection = "LinksInSelection",
-  Lookup = "Lookup",
   Note = "Note",
+  Lookup = "Lookup",
   Hierarchy = "Hierarchy",
   Vault = "Vault",
   Workspace = "Workspace",
+  LinksInSelection = "LinksInSelection",
 }
 
 /**


### PR DESCRIPTION
```markdown
This PR allows the `export pod V2` command to display a pod config when `exportScope` is omitted from the custom config.
```

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated