### PR TITLE
enhance: allow notes to override the pretty refs setting

### DIFF
--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -68,7 +68,9 @@ export type DNodeImage = { url: string; alt: string };
  * Notes have a config property that can override a subset of {@link dendronConfig}
  */
 export type NoteLocalConfig = Partial<{
-  global: Partial<Pick<DendronGlobalConfig, "enableChildLinks">>;
+  global: Partial<
+    Pick<DendronGlobalConfig, "enableChildLinks" | "enablePrettyRefs">
+  >;
 }>;
 export type DNodeAllProps = DNodeExplicitPropsEnum & DNodeImplicitPropsEnum;
 

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -652,9 +652,15 @@ export class ConfigUtils {
 
   static getEnablePrettyRefs(
     config: IntermediateDendronConfig,
-    shouldApplyPublishRules?: boolean
+    opts?: {
+      note?: NoteProps;
+      shouldApplyPublishRules?: boolean;
+    }
   ): boolean | undefined {
-    return shouldApplyPublishRules
+    const override = opts?.note?.config?.global?.enablePrettyRefs;
+    if (override !== undefined) return override;
+
+    return opts?.shouldApplyPublishRules
       ? ConfigUtils.getSite(config).usePrettyRefs
       : ConfigUtils.getPreview(config).enablePrettyRefs;
   }

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -277,6 +277,12 @@ function convertNoteRef(opts: ConvertNoteRefOpts): {
     vault,
     engine,
   });
+  if (prettyRefs === undefined) {
+    prettyRefs = ConfigUtils.getEnablePrettyRefs(config, {
+      note: containingNote,
+      shouldApplyPublishRules,
+    });
+  }
   if (
     containingNote?.custom.usePrettyRefs !== undefined &&
     _.isBoolean(containingNote.custom.usePrettyRefs)
@@ -491,27 +497,21 @@ export function convertNoteRefASTV2(
     shouldApplyPublishRules = MDUtilsV5.shouldApplyPublishingRules(proc);
   }
 
-  let prettyRefs = ConfigUtils.getEnablePrettyRefs(
-    config,
-    shouldApplyPublishRules
-  );
-  if (
-    prettyRefs &&
-    _.includes([DendronASTDest.MD_DENDRON, DendronASTDest.MD_REGULAR], dest)
-  ) {
-    prettyRefs = false;
-  }
   // The note that contains this reference might override the pretty refs option for references inside it.
   const containingNote = NoteUtils.getNoteByFnameFromEngine({
     fname,
     vault,
     engine,
   });
+  let prettyRefs = ConfigUtils.getEnablePrettyRefs(config, {
+    shouldApplyPublishRules,
+    note: containingNote,
+  });
   if (
-    containingNote?.custom.usePrettyRefs !== undefined &&
-    _.isBoolean(containingNote.custom.usePrettyRefs)
+    prettyRefs &&
+    _.includes([DendronASTDest.MD_DENDRON, DendronASTDest.MD_REGULAR], dest)
   ) {
-    prettyRefs = containingNote.custom.usePrettyRefs;
+    prettyRefs = false;
   }
 
   const duplicateNoteConfig = siteConfig.duplicateNoteBehavior;

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -389,13 +389,13 @@ export class MDUtilsV4 {
     const { dest, vault, fname, shouldApplyPublishRules, engine } = opts;
     const config = opts.config || engine.config;
     let proc = this.proc(opts);
+    let note: NoteProps | undefined;
     if (vault && fname) {
       const engine = MDUtilsV4.getEngineFromProc(proc).engine;
-      const note = NoteUtils.getNoteByFnameV5({
+      note = NoteUtils.getNoteByFnameFromEngine({
         fname,
-        notes: engine.notes,
         vault,
-        wsRoot: engine.wsRoot,
+        engine,
       });
       const fm = {
         ...note?.custom,
@@ -406,10 +406,10 @@ export class MDUtilsV4 {
 
     let usePrettyRefs = opts.usePrettyRefs;
     if (_.isUndefined(usePrettyRefs)) {
-      usePrettyRefs = ConfigUtils.getEnablePrettyRefs(
-        config,
-        shouldApplyPublishRules
-      );
+      usePrettyRefs = ConfigUtils.getEnablePrettyRefs(config, {
+        shouldApplyPublishRules,
+        note,
+      });
     }
 
     const insertTitle = ConfigUtils.getEnableFMTitle(

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -560,6 +560,38 @@ VFile {
 }
 `;
 
+exports[`dendronPub usePrettyRefs WHEN config sets usePrettyRefs false AND note overrides to true THEN renders with pretty refs 1`] = `
+VFile {
+  "contents": "<h1 id=\\"with-override\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#with-override\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>With Override</h1>
+<p></p><p></p><div class=\\"portal-container\\">
+<div class=\\"portal-head\\">
+<div class=\\"portal-backlink\\">
+<div class=\\"portal-title\\">From <span class=\\"portal-text-title\\">Bar</span></div>
+
+</div>
+</div>
+<div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
+<div class=\\"portal-parent-fader-top\\"></div>
+<div class=\\"portal-parent-fader-bottom\\"></div><p>bar body</p>
+</div></div><p></p><p></p>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub usePrettyRefs WHEN config sets usePrettyRefs true AND note overrides to false THEN renders without pretty refs 1`] = `
+VFile {
+  "contents": "<h1 id=\\"with-override\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#with-override\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>With Override</h1>
+<p></p><p></p><p>bar body</p><p></p><p></p>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`dendronPub usePrettyRefs config.site.usePrettyRef: false 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -912,5 +912,97 @@ describe("dendronPub", () => {
       },
       { preSetupHook: ENGINE_HOOKS.setupBasic }
     );
+
+    describe("WHEN config sets usePrettyRefs true", () => {
+      describe("AND note overrides to false", () => {
+        testWithEngine(
+          "THEN renders without pretty refs",
+          async ({ engine, vaults }) => {
+            const config = ConfigUtils.genDefaultConfig();
+            ConfigUtils.setPreviewProps(config, "enablePrettyRefs", true);
+            config.site = {
+              siteHierarchies: ["with-override"],
+              siteRootDir: "with-override",
+              usePrettyRefs: true,
+            };
+            const resp = await MDUtilsV5.procRehypeFull(
+              {
+                engine,
+                fname: "with-override",
+                vault: vaults[0],
+                config,
+              },
+              { flavor: ProcFlavor.PUBLISHING }
+            ).process(`![[bar]]`);
+            expect(resp).toMatchSnapshot();
+            expect(
+              await AssertUtils.assertInString({
+                body: resp.contents as string,
+                nomatch: ["portal-container"],
+              })
+            ).toBeTruthy();
+          },
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              await NoteTestUtilsV4.createNote({
+                fname: "with-override",
+                vault: opts.vaults[0],
+                wsRoot: opts.wsRoot,
+                custom: {
+                  usePrettyRefs: false,
+                },
+              });
+            },
+          }
+        );
+      });
+    });
+
+    describe("WHEN config sets usePrettyRefs false", () => {
+      describe("AND note overrides to true", () => {
+        testWithEngine(
+          "THEN renders with pretty refs",
+          async ({ engine, vaults }) => {
+            const config = ConfigUtils.genDefaultConfig();
+            ConfigUtils.setPreviewProps(config, "enablePrettyRefs", false);
+            config.site = {
+              siteHierarchies: ["with-override"],
+              siteRootDir: "with-override",
+              usePrettyRefs: false,
+            };
+            const resp = await MDUtilsV5.procRehypeFull(
+              {
+                engine,
+                fname: "with-override",
+                vault: vaults[0],
+                config,
+              },
+              { flavor: ProcFlavor.PUBLISHING }
+            ).process(`![[bar]]`);
+            expect(resp).toMatchSnapshot();
+            expect(
+              await AssertUtils.assertInString({
+                body: resp.contents as string,
+                match: ["portal-container"],
+              })
+            ).toBeTruthy();
+          },
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              await NoteTestUtilsV4.createNote({
+                fname: "with-override",
+                vault: opts.vaults[0],
+                wsRoot: opts.wsRoot,
+                custom: {
+                  usePrettyRefs: true,
+                },
+              });
+            },
+          }
+        );
+      });
+    });
   });
 });

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -949,8 +949,12 @@ describe("dendronPub", () => {
                 fname: "with-override",
                 vault: opts.vaults[0],
                 wsRoot: opts.wsRoot,
-                custom: {
-                  usePrettyRefs: false,
+                props: {
+                  config: {
+                    global: {
+                      enablePrettyRefs: false,
+                    },
+                  },
                 },
               });
             },
@@ -995,8 +999,12 @@ describe("dendronPub", () => {
                 fname: "with-override",
                 vault: opts.vaults[0],
                 wsRoot: opts.wsRoot,
-                custom: {
-                  usePrettyRefs: true,
+                props: {
+                  config: {
+                    global: {
+                      enablePrettyRefs: true,
+                    },
+                  },
                 },
               });
             },

--- a/test-workspace/vault/dendron.ref.note-ref-override-usePrettyRefs.md
+++ b/test-workspace/vault/dendron.ref.note-ref-override-usePrettyRefs.md
@@ -1,0 +1,48 @@
+---
+id: XeVZSRSqYEr4ZHHstv2iP
+title: note-ref-override-usePrettyRefs
+desc: ''
+updated: 1641890813313
+created: 1641890783138
+usePrettyRefs: false
+---
+
+# Simple
+
+![[dendron.cat]]
+
+# Note Ref At Header
+
+![[dendron.cat#bananas]]
+
+# Note Ref At Header Range
+
+![[dendron.cat#bananas:#lions]]
+
+# Complex Note Ref
+
+![[dendron.ref.figure]]
+
+# Note Ref At Header With Offset
+
+![[dendron.cat#bananas:#*]]
+
+# Recursive Note Ref
+
+![[dendron.boy]]
+
+# Recursive Note Ref 2x
+
+![[dendron.apples]]
+
+# Note Ref with wildcard link
+
+![[dendron.blog.*]]
+
+# Note Ref with wildcard link and header offset
+
+![[dendron.blog.*#chap1]]
+
+# Note Ref that has variable substitution
+
+![[dendron.ref.variables]]

--- a/test-workspace/vault/dendron.ref.note-ref-override-usePrettyRefs.md
+++ b/test-workspace/vault/dendron.ref.note-ref-override-usePrettyRefs.md
@@ -2,9 +2,9 @@
 id: XeVZSRSqYEr4ZHHstv2iP
 title: note-ref-override-usePrettyRefs
 desc: ''
-updated: 1641890813313
+updated: 1642067062672
 created: 1641890783138
-usePrettyRefs: false
+config: { global: { enablePrettyRefs: false}}
 ---
 
 # Simple


### PR DESCRIPTION
Notes are now allowed to override the pretty refs setting for themselves. All references inside that note will be rendered following the override. The override doesn't apply to nested references, the user would need to manually override the nested notes as well if needed.

Docs: https://github.com/dendronhq/dendron-site/pull/354

This PR doesn't change the circular dependency count.