### PR TITLE
fix: insert note index enablement

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -463,7 +463,7 @@
         },
         {
           "command": "dendron.insertNoteIndex",
-          "when": "editorFocus && dendron:pluginActive"
+          "when": "dendron:pluginActive"
         },
         {
           "command": "dendron.moveNote",

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -323,7 +323,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   INSERT_NOTE_INDEX: {
     key: "dendron.insertNoteIndex",
     title: `${CMD_PREFIX} Insert Note Index`,
-    when: `editorFocus && ${DendronContext.PLUGIN_ACTIVE}`,
+    when: DendronContext.PLUGIN_ACTIVE,
   },
   MOVE_NOTE: {
     key: "dendron.moveNote",


### PR DESCRIPTION
# fix: insert note index enablement
This PR:
- fixes enablement of insert note index.

# Cause
- #2081 cleans up contribution points in `package.json` and properly applies `when` clauses for Dendron commands
- Before the changes, all enablement clauses were not in effect except a few that were explicitly tested to work.
- `Insert Note Index` enablement was set to `editorFocus && dendron:pluginActive`, which will always be false in the command palette because once the command palette is in focus `editorFocus` is not set.
- The proper application of `when` clauses caused `Insert Note Index` to not be enabled.

# Pull Request Checklist

If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 

This template contains the short checklist which is used by the Dendron core team. 

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated