### PR TITLE
chore: correct how preview analytics "providedFile" is calculated

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -321,7 +321,7 @@ export class ShowPreviewCommand extends InputArgCommand<
   }
 
   addAnalyticsPayload(opts?: ShowPreviewCommandOpts) {
-    return { providedFile: opts !== undefined };
+    return { providedFile: !_.isEmpty(opts) };
   }
 
   public static openNoteInPreview(note: NoteProps, opts?: PreviewProxyOpts) {


### PR DESCRIPTION
This was broken after the last fix.