### PR TITLE
fix: stop link candidate logic when disabled

### DIFF
--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -409,16 +409,16 @@ export class EngineUtils {
         note,
         wsRoot: engine.wsRoot,
       });
-      // const devConfig = ConfigUtils.getProp(engine.config, "dev");
-      // const linkCandidatesEnabled = devConfig?.enableLinkCandidates;
-      // if (linkCandidatesEnabled) {
-      const linkCandidates = LinkUtils.findLinkCandidates({
-        note,
-        notesMap,
-        engine,
-      });
-      note.links = links.concat(linkCandidates);
-      // }
+      const devConfig = ConfigUtils.getProp(engine.config, "dev");
+      const linkCandidatesEnabled = devConfig?.enableLinkCandidates;
+      if (linkCandidatesEnabled) {
+        const linkCandidates = LinkUtils.findLinkCandidates({
+          note,
+          notesMap,
+          engine,
+        });
+        note.links = links.concat(linkCandidates);
+      }
       note.anchors = anchors;
       return note;
     }

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -399,7 +399,6 @@ export class EngineUtils {
     engine: DEngineClient;
     notesMap: Map<string, NoteProps>;
   }) {
-    console.log("here");
     const maxNoteLength = ConfigUtils.getWorkspace(engine.config).maxNoteLength;
     if (
       note.body.length <

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -409,6 +409,8 @@ export class EngineUtils {
         note,
         wsRoot: engine.wsRoot,
       });
+      // update links for note
+      note.links = links.concat(links);
       const devConfig = ConfigUtils.getProp(engine.config, "dev");
       const linkCandidatesEnabled = devConfig?.enableLinkCandidates;
       if (linkCandidatesEnabled) {

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -399,22 +399,27 @@ export class EngineUtils {
     engine: DEngineClient;
     notesMap: Map<string, NoteProps>;
   }) {
+    console.log("here");
     const maxNoteLength = ConfigUtils.getWorkspace(engine.config).maxNoteLength;
     if (
       note.body.length <
       (maxNoteLength || CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
     ) {
       const links = LinkUtils.findLinks({ note, engine });
+      const anchors = await AnchorUtils.findAnchors({
+        note,
+        wsRoot: engine.wsRoot,
+      });
+      // const devConfig = ConfigUtils.getProp(engine.config, "dev");
+      // const linkCandidatesEnabled = devConfig?.enableLinkCandidates;
+      // if (linkCandidatesEnabled) {
       const linkCandidates = LinkUtils.findLinkCandidates({
         note,
         notesMap,
         engine,
       });
-      const anchors = await AnchorUtils.findAnchors({
-        note,
-        wsRoot: engine.wsRoot,
-      });
       note.links = links.concat(linkCandidates);
+      // }
       note.anchors = anchors;
       return note;
     }

--- a/packages/plugin-core/src/commands/RenameNoteV2a.ts
+++ b/packages/plugin-core/src/commands/RenameNoteV2a.ts
@@ -11,11 +11,11 @@ import {
   ProviderAcceptHooks,
 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { FileItem } from "../external/fileutils/FileItem";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getExtension, getDWorkspace } from "../workspace";
+import { getDWorkspace, getExtension } from "../workspace";
 import { BaseCommand } from "./base";
-import { ExtensionProvider } from "../ExtensionProvider";
 
 type CommandInput = {
   move: OldNewLocation[];
@@ -152,8 +152,10 @@ export class RenameNoteV2aCommand extends BaseCommand<
           if (ext.fileWatcher) {
             ext.fileWatcher.pause = false;
           }
-          this.L.info({ ctx, msg: "exit" });
+          this.L.info({ ctx, state: "exit:pause_filewatcher" });
         }, 3000);
+      } else {
+        this.L.info({ ctx, state: "exit" });
       }
     }
   }

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -7,9 +7,6 @@ import {
 import fs from "fs-extra";
 import { afterEach, beforeEach, describe } from "mocha";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
 import { RefactorHierarchyCommandV2 } from "../../commands/RefactorHierarchyV2";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -20,11 +20,24 @@ import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupPro
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 
 suite("RefactorHiearchy", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
+  /**
+   * Setup
+   * refactor.md
+   * ```
+   * - [[refactor.one]]
+   * - [[refactor.two]]
+   * ```
+   *
+   * refactor.one.md
+   * ```
+   * - [[refactor.two]]
+   * ```
+   *
+   */
   describe("GIVEN a workspace with some notes with simple hierarchy", () => {
     let note: DNodeProps;
     let noteOne: DNodeProps;
@@ -60,6 +73,20 @@ suite("RefactorHiearchy", function () {
     });
 
     describe("WHEN scope is undefined", () => {
+      /**
+       * After test
+       * refactor(.*) -> prefix$1
+       *
+       * refactor.md
+       * ```
+       * - [[prefix.one]]
+       * - [[prefix.two]]
+       * ```
+       *
+       * refactor.one.md
+       * ```
+       * - [[prefix.two]]
+       */
       test("THEN scope is all existing notes, all notes and links refactored.", (done) => {
         runLegacyMultiWorkspaceTest({
           ctx,


### PR DESCRIPTION
# fix: stop link candidate logic when disabled

This PR:
- fixes an issue with refresh note logic where link candidate logic was running even when it was disabled.

# Pull Request Checklist

If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 

This template contains the short checklist which is used by the Dendron core team. 

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated