### PR TITLE
fix: fix schema template match when there is same grandchild from two different schema parents

### DIFF
--- a/packages/common-server/src/parser.ts
+++ b/packages/common-server/src/parser.ts
@@ -327,10 +327,7 @@ export class SchemaParserV2 extends ParserBaseV2 {
               childClone.data === undefined ||
               childClone.data.pattern === undefined
             ) {
-              if (childClone.data === undefined) {
-                childClone.data = {};
-              }
-              childClone.data.pattern = childId;
+              _.set(childClone, "data.pattern", childId);
             }
 
             // Parent likely already has a reference to the original child identifier

--- a/packages/common-server/src/parser.ts
+++ b/packages/common-server/src/parser.ts
@@ -24,6 +24,7 @@ import AjvErrors from "ajv-errors";
 
 class AJVProvider {
   static ajv: Ajv;
+
   static getAjv() {
     if (this.ajv === undefined) {
       this.ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
@@ -50,6 +51,7 @@ export class ParserBaseV2 {
     return this.opts.logger;
   }
 }
+
 const DEFAULT_LOG_CTX = "parsingSchemas";
 
 async function getSchemasFromImport(
@@ -301,16 +303,51 @@ export class SchemaParserV2 extends ParserBaseV2 {
     });
 
     const addConnections = (parent: SchemaProps) => {
-      _.forEach(parent.children, (ch) => {
-        const child = schemasDict[ch];
-        if (child) {
-          DNodeUtils.addChild(parent, child);
+      _.forEach(parent.children, (childId) => {
+        const child = schemasDict[childId];
 
-          addConnections(child);
+        if (child) {
+          if (child.parent === null) {
+            // Child does not have a parent pointers hence we can linkup the parent child as is.
+            DNodeUtils.addChild(parent, child);
+            addConnections(child);
+          } else {
+            // Child already contains a parent pointer hence we need to create a schema clone
+            // otherwise we would end up writing over the already existing parent pointer.
+            const childClone = _.cloneDeep(child);
+            // We use a dictionary hence we need to generate a brand new identifier for our clone.
+            childClone.id = `${childId}_${genUUID()}`;
+            schemasDict[childClone.id] = childClone;
+
+            // When it comes to schemas we often use the id as a matching pattern
+            // unless there is a pattern explicitly specified. Since we created a randomized
+            // identifier the id of our clone no longer can be used for pattern matching.
+            // Hence if there isn't a pattern we will set the pattern to match original id.
+            if (
+              childClone.data === undefined ||
+              childClone.data.pattern === undefined
+            ) {
+              if (childClone.data === undefined) {
+                childClone.data = {};
+              }
+              childClone.data.pattern = childId;
+            }
+
+            // Parent likely already has a reference to the original child identifier
+            // so for us to be able to add new generated child id without creating duplicates
+            // in the parent we will need to take out the original child id.
+            if (parent.children.includes(childId)) {
+              parent.children = parent.children.filter((ch) => ch !== childId);
+            }
+
+            // Finally we can create the connection between parent and the child clone.
+            DNodeUtils.addChild(parent, childClone);
+            addConnections(childClone);
+          }
         } else {
           throw new DendronError({
             status: ERROR_STATUS.MISSING_SCHEMA,
-            message: JSON.stringify({ parent, missingChild: ch }),
+            message: JSON.stringify({ parent, missingChild: childId }),
           });
         }
       });

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -326,6 +326,55 @@ export const setupSchemaPreseet: PreSetupHookFunction = async (opts) => {
 };
 
 /**
+ * Diamond schema is laid out such that:
+ *    bar
+ *   /   \
+ * ch1   ch2 (namespace: true)
+ *   \   /
+ *    gch
+ * */
+export const setupSchemaWithDiamondAndParentNamespace: PreSetupHookFunction =
+  async (opts) => {
+    await setupBasic(opts);
+    const { wsRoot, vaults } = opts;
+    const vault1 = vaults[0];
+
+    const withDiamond = path.join(
+      resolvePath(vault1.fsPath, wsRoot),
+      "withDiamond.schema.yml"
+    );
+    fs.writeFileSync(
+      withDiamond,
+      `
+version: 1
+schemas:
+  - id: withDiamond
+    children:
+      - ch1
+      - ch2
+    title: withDiamond
+    parent: root
+  - id: ch1
+    children:
+      - gch
+  - id: ch2
+    namespace: true
+    children:
+      - gch
+  - id: gch
+    template: template.test
+`
+    );
+
+    await NoteTestUtilsV4.createNote({
+      wsRoot,
+      body: "Template text",
+      fname: "template.test",
+      vault: vault1,
+    });
+  };
+
+/**
  * Sets up schema which includes a schema that has Diamond grandchildren
  *
  * */
@@ -767,6 +816,7 @@ export const ENGINE_HOOKS = {
   setupSchemaPreseet,
   setupSchemaWithDiamondGrandchildren,
   setupSchemaWithIncludeOfDiamond,
+  setupSchemaWithDiamondAndParentNamespace,
   setupSchemaPresetWithNamespaceTemplate,
   setupInlineSchema,
   setupSchemaWithExpansion,


### PR DESCRIPTION
# Pull Request Checklist

If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 

This template contains the short checklist which is used by the Dendron core team. 

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [x] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)tml)

## Manual testing
Created testSchema:
```
version: 1
schemas:
  - id: testSchema
    children:
      - child1
      - child2
    title: testSchema
    parent: root
  - id: child1
    children:
      - sharedGrandchild
  - id: child2
    children:
      - sharedGrandchild
  - id: sharedGrandchild
    template: template.test
```

Created new notes 
* testSchema.child1.sharedGrandchild
* testSchema.child2.sharedGrandchild

Prior to this change only child2 used to have the template applied after this change both of the newly created files got the template applied to them. 