### PR TITLE
fix: highlighting breaks when there's too much text

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -124,10 +124,10 @@ router.get(
   })
 );
 
-router.get(
+router.post(
   "/decorations",
   asyncHandler(async (req: Request, res: Response<GetNoteBlocksPayload>) => {
-    const opts = req.query as any as GetDecorationsRequest;
+    const opts = req.body as any as GetDecorationsRequest;
     const { ws } = opts;
     const engine = await getWSEngine({ ws: ws || "" });
     ExpressUtils.setResponse(res, await engine.getDecorations(opts));

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -511,8 +511,8 @@ export class DendronAPI extends API {
   ): Promise<GetDecorationsPayload> {
     const resp = await this._makeRequest({
       path: "note/decorations",
-      method: "get",
-      qs: req,
+      method: "post",
+      body: req,
     });
     return resp;
   }

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -294,7 +294,7 @@ abstract class API {
       payload.error = resp.data.error;
     } catch (err: any) {
       this._log(payload.error, "error");
-      payload.error = err?.response?.data?.error;
+      payload.error = err?.response?.data?.error || err;
     }
     if (payload.error) {
       this._log(payload.error, "error");


### PR DESCRIPTION
The issue was caused by the request data being encoded in the query, which meant if there was too much text in the note the query string would be too long for the API client. (note text has to be included in the query because decorations update more frequently than notes in server).

An internal enhancement included in this PR is that the API will now propagate the error if there was an error that happened inside the API client itself, like this error here. Without this, the client simply returns an empty response with no error if that happens.

#1976