### PR TITLE
fix(publish): logo doesn't respect assetsPrefix

### DIFF
--- a/packages/common-all/src/util/regex.ts
+++ b/packages/common-all/src/util/regex.ts
@@ -9,3 +9,9 @@ export const containsNonDendronUri = (uri: string): boolean | undefined => {
   if (groups.scheme === "dendron") return false;
   return true;
 };
+
+export function isWebUri(uri: string): boolean {
+  const scheme = uri.match(uriRegex)?.groups?.scheme;
+  if (scheme === "http" || scheme === "https") return true;
+  return false;
+}

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -671,7 +671,10 @@ export class ConfigUtils {
 
     // Otherwise, this has to be an asset. It can't be anywhere else because of backwards compatibility.
     const logoBase = path.basename(logo); // Why just discard the rest of logo? Because that's what code used to do and I'm preserving backwards compatibility
-    if (assetsPrefix) return `/${assetsPrefix}/assets/${logoBase}`;
+    if (assetsPrefix) {
+      const initialSlash = assetsPrefix.startsWith("/") ? "" : "/";
+      return `${initialSlash}${assetsPrefix}/assets/${logoBase}`;
+    }
     return `/assets/${logoBase}`;
   }
 

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -31,7 +31,7 @@ import {
   ScratchConfig,
   StrictConfigV4,
 } from "./types/intermediateConfigs";
-import { uriRegex } from "./util/regex";
+import { isWebUri } from "./util/regex";
 
 /**
  * Dendron utilities
@@ -666,8 +666,7 @@ export class ConfigUtils {
     if (logo === undefined) return undefined;
 
     // Let's allow logos that are hosted off-site/in subdomains by passing in a full URL
-    const scheme = logo.match(uriRegex)?.groups?.scheme;
-    if (scheme === "http" || scheme === "https") return logo;
+    if (isWebUri(logo)) return logo;
 
     // Otherwise, this has to be an asset. It can't be anywhere else because of backwards compatibility.
     const logoBase = path.basename(logo); // Why just discard the rest of logo? Because that's what code used to do and I'm preserving backwards compatibility

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -31,6 +31,7 @@ import {
   ScratchConfig,
   StrictConfigV4,
 } from "./types/intermediateConfigs";
+import { uriRegex } from "./util/regex";
 
 /**
  * Dendron utilities
@@ -658,6 +659,20 @@ export class ConfigUtils {
     return shouldApplyPublishRules
       ? ConfigUtils.getProp(config, "useKatex")
       : ConfigUtils.getPreview(config).enableKatex;
+  }
+
+  static getSiteLogoUrl(config: IntermediateDendronConfig): string | undefined {
+    const { assetsPrefix, logo } = ConfigUtils.getSite(config);
+    if (logo === undefined) return undefined;
+
+    // Let's allow logos that are hosted off-site/in subdomains by passing in a full URL
+    const scheme = logo.match(uriRegex)?.groups?.scheme;
+    if (scheme === "http" || scheme === "https") return logo;
+
+    // Otherwise, this has to be an asset. It can't be anywhere else because of backwards compatibility.
+    const logoBase = path.basename(logo); // Why just discard the rest of logo? Because that's what code used to do and I'm preserving backwards compatibility
+    if (assetsPrefix) return `/${assetsPrefix}/assets/${logoBase}`;
+    return `/assets/${logoBase}`;
   }
 
   static getEnablePrettyRefs(

--- a/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
@@ -1,0 +1,57 @@
+import { ConfigUtils, IntermediateDendronConfig } from "@dendronhq/common-all";
+import type { DeepPartial } from "@reduxjs/toolkit";
+
+function getConfig(
+  override?: DeepPartial<IntermediateDendronConfig>
+): IntermediateDendronConfig {
+  const config = ConfigUtils.genDefaultConfig();
+  return { ...config, ...override } as IntermediateDendronConfig;
+}
+
+describe("ConfigUtils", () => {
+  describe("GIVEN getSiteLogoUrl", () => {
+    describe("WHEN logo is not defined", () => {
+      test("THEN logo is undefined", () => {
+        const config = getConfig();
+        const siteUrl = ConfigUtils.getSiteLogoUrl(config);
+        expect(siteUrl).toBeUndefined();
+      });
+    });
+
+    describe("WHEN logo is a URL", () => {
+      test("THEN logo is returned identically.", () => {
+        const logo = "https://example.com/image.png";
+        const config = getConfig({
+          site: { logo },
+        });
+        const siteUrl = ConfigUtils.getSiteLogoUrl(config);
+        expect(siteUrl).toEqual(logo);
+      });
+    });
+
+    describe("WHEN logo is an asset", () => {
+      describe("AND assetsPrefix is undefined", () => {
+        test("THEN logo is a path to the asset", () => {
+          const config = getConfig({
+            site: { logo: "vault/assets/images/logo.png" },
+          });
+          const siteUrl = ConfigUtils.getSiteLogoUrl(config);
+          expect(siteUrl).toEqual("/assets/logo.png");
+        });
+      });
+
+      describe("AND assetsPrefix is defined", () => {
+        test("THEN logo respects the prefix", () => {
+          const config = getConfig({
+            site: {
+              logo: "vault/assets/images/logo.png",
+              assetsPrefix: "/site",
+            },
+          });
+          const siteUrl = ConfigUtils.getSiteLogoUrl(config);
+          expect(siteUrl).toEqual("/site/assets/logo.png");
+        });
+      });
+    });
+  });
+});

--- a/packages/nextjs-template/components/DendronLogoOrTitle.tsx
+++ b/packages/nextjs-template/components/DendronLogoOrTitle.tsx
@@ -1,4 +1,6 @@
+import { ConfigUtils } from "@dendronhq/common-all";
 import { verifyEngineSliceState } from "@dendronhq/common-frontend";
+import { Col } from "antd";
 import Link from "next/link";
 import path from "path";
 import React from "react";
@@ -11,7 +13,9 @@ export default function DendronLogoOrTitle() {
   if (!verifyEngineSliceState(engine)) {
     return null;
   }
-  const title = engine.config.site.title || "";
+  const { title } = ConfigUtils.getSite(engine.config);
+  const logoUrl = ConfigUtils.getSiteLogoUrl(engine.config) || "";
+
   return (
     <Link href={getRootUrl(engine.config.site)}>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid -- `href` will be provided by `Link` */}
@@ -24,11 +28,9 @@ export default function DendronLogoOrTitle() {
         className="site-title"
       >
         {engine.config?.site.logo ? (
-          <Logo
-            logoUrl={"/assets/" + path.basename(engine.config?.site.logo)}
-          />
+          <Logo logoUrl={logoUrl} />
         ) : (
-          <Title data={title} />
+          <Title data={title || ""} />
         )}
       </a>
     </Link>
@@ -52,5 +54,16 @@ export function Logo({ logoUrl }: { logoUrl: string }) {
 }
 
 export function Title({ data }: { data: string }) {
-  return <div className="site-logo">{data}</div>;
+  return (
+    <div
+      className="site-title"
+      style={{
+        width: "100%",
+        height: "100%",
+        lineHeight: "1.5rem",
+      }}
+    >
+      {data}
+    </div>
+  );
 }

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -7,6 +7,7 @@ import {
   NoteUtils,
   createSerializedFuseNoteIndex,
   ConfigUtils,
+  isWebUri,
 } from "@dendronhq/common-all";
 import { simpleGit } from "@dendronhq/common-server";
 import {
@@ -278,7 +279,7 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
       }
     }
     // get logo
-    if (siteConfig.logo) {
+    if (siteConfig.logo && !isWebUri(siteConfig.logo)) {
       const logoPath = path.join(wsRoot, siteConfig.logo);
       fs.copySync(logoPath, path.join(siteAssetsDir, path.basename(logoPath)));
     }


### PR DESCRIPTION
Logo will now correctly respect the assets prefix.

Also as an enhancement, if the logo is set as a URL, we preserve that URL identically. This can be useful if the user hosts images on a different subdomain or domain.

This PR doesn't affect the number of cyclic dependencies.

#2161