### PR TITLE
chore: keep export pods v2 commands behind enableExportPodV2 dev config option

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -1242,6 +1242,10 @@
             "engine"
           ],
           "description": "Force the use of a specific type of watcher.\n\n- plugin: Uses VSCode's builtin watcher\n- engine: Uses the engine watcher, watching the files directly without VSCode"
+        },
+        "enableExportPodV2": {
+          "type": "boolean",
+          "description": "Enable experimental Export v2 commands"
         }
       },
       "additionalProperties": false

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -80,6 +80,7 @@ export enum SurveyEvents {
 
 export enum ConfigEvents {
   ConfigNotMigrated = "Config_Not_Migrated",
+  EnabledExportPodV2 = "Enabled_Export_Pod_V2",
 }
 
 export enum MigrationEvents {

--- a/packages/common-all/src/constants/configs/dev.ts
+++ b/packages/common-all/src/constants/configs/dev.ts
@@ -26,4 +26,8 @@ export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
     label: "Enable Preview V2",
     desc: "Use preview V2 as the default preview.",
   },
+  enableExportPodV2: {
+    label: "Enable Export Pod V2",
+    desc: "Enable experimental Export V2 command",
+  },
 };

--- a/packages/common-all/src/types/configs/dev/dev.ts
+++ b/packages/common-all/src/types/configs/dev/dev.ts
@@ -30,6 +30,10 @@ export type DendronDevConfig = {
    * Enable new preview as default
    */
   enablePreviewV2?: boolean;
+  /**
+   * Enable export pod v2
+   */
+  enableExportPodV2?: boolean;
 };
 
 /**

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -414,6 +414,10 @@ export type DendronDevConfig = {
    * - engine: Uses the engine watcher, watching the files directly without VSCode
    */
   forceWatcherType?: "plugin" | "engine";
+  /**
+   * Enable export pod v2
+   */
+  enableExportPodV2?: boolean;
 };
 
 export type DendronSiteConfig = {

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -1242,6 +1242,10 @@
             "engine"
           ],
           "description": "Force the use of a specific type of watcher.\n\n- plugin: Uses VSCode's builtin watcher\n- engine: Uses the engine watcher, watching the files directly without VSCode"
+        },
+        "enableExportPodV2": {
+          "type": "boolean",
+          "description": "Enable experimental Export v2 commands"
         }
       },
       "additionalProperties": false

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -567,11 +567,11 @@
         },
         {
           "command": "dendron.configureServiceConnection",
-          "when": "dendron:pluginActive"
+          "when": "dendron:pluginActive && dendron:enableExportPodV2"
         },
         {
           "command": "dendron.configureExportPodV2",
-          "when": "dendron:pluginActive"
+          "when": "dendron:pluginActive && dendron:enableExportPodV2"
         },
         {
           "command": "dendron.importPod",
@@ -583,7 +583,7 @@
         },
         {
           "command": "dendron.exportPodv2",
-          "when": "dendron:pluginActive"
+          "when": "dendron:pluginActive && dendron:enableExportPodV2"
         },
         {
           "command": "dendron.publishPod",

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -259,11 +259,13 @@
       },
       {
         "command": "dendron.configureServiceConnection",
-        "title": "Dendron: Configure Service Connection"
+        "title": "Dendron: Configure Service Connection",
+        "enablement": "dendron:pluginActive && dendron:enableExportPodV2"
       },
       {
         "command": "dendron.configureExportPodV2",
-        "title": "Dendron: Configure Export Pod V2"
+        "title": "Dendron: Configure Export Pod V2",
+        "enablement": "dendron:pluginActive && dendron:enableExportPodV2"
       },
       {
         "command": "dendron.importPod",
@@ -275,7 +277,8 @@
       },
       {
         "command": "dendron.exportPodv2",
-        "title": "Dendron: Export Pod V2"
+        "title": "Dendron: Export Pod V2",
+        "enablement": "dendron:pluginActive && dendron:enableExportPodV2"
       },
       {
         "command": "dendron.publishPod",
@@ -566,24 +569,12 @@
           "when": "dendron:pluginActive"
         },
         {
-          "command": "dendron.configureServiceConnection",
-          "when": "dendron:pluginActive && dendron:enableExportPodV2"
-        },
-        {
-          "command": "dendron.configureExportPodV2",
-          "when": "dendron:pluginActive && dendron:enableExportPodV2"
-        },
-        {
           "command": "dendron.importPod",
           "when": "dendron:pluginActive"
         },
         {
           "command": "dendron.exportPod",
           "when": "dendron:pluginActive"
-        },
-        {
-          "command": "dendron.exportPodv2",
-          "when": "dendron:pluginActive && dendron:enableExportPodV2"
         },
         {
           "command": "dendron.publishPod",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -4,6 +4,7 @@ import {
   SubProcessExitType,
 } from "@dendronhq/api-server";
 import {
+  ConfigEvents,
   ConfigUtils,
   CONSTANTS,
   DendronError,
@@ -637,6 +638,10 @@ export async function _activate(
         DendronContext.ENABLE_EXPORT_PODV2,
         dendronConfig.dev?.enableExportPodV2 ?? false
       );
+
+      if (dendronConfig.dev?.enableExportPodV2) {
+        AnalyticsUtils.track(ConfigEvents.EnabledExportPodV2);
+      }
       // round to nearest 10th
       let numNotes = _.size(getEngine().notes);
       if (numNotes > 10) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -633,13 +633,10 @@ export async function _activate(
       );
 
       //used for enablement of export pod v2 command
-      if (!_.isUndefined(dendronConfig.dev?.enableExportPodV2)) {
-        VSCodeUtils.setContext(
-          DendronContext.ENABLEEXPORTPODV2,
-          dendronConfig.dev?.enableExportPodV2 ?? false
-        );
-      }
-
+      VSCodeUtils.setContext(
+        DendronContext.ENABLE_EXPORT_PODV2,
+        dendronConfig.dev?.enableExportPodV2 ?? false
+      );
       // round to nearest 10th
       let numNotes = _.size(getEngine().notes);
       if (numNotes > 10) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -632,6 +632,14 @@ export async function _activate(
         MarkdownUtils.hasLegacyPreview()
       );
 
+      //used for enablement of export pod v2 command
+      if (!_.isUndefined(dendronConfig.dev?.enableExportPodV2)) {
+        VSCodeUtils.setContext(
+          DendronContext.ENABLEEXPORTPODV2,
+          dendronConfig.dev?.enableExportPodV2 ?? false
+        );
+      }
+
       // round to nearest 10th
       let numNotes = _.size(getEngine().notes);
       if (numNotes > 10) {

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -39,7 +39,7 @@ export abstract class BaseExportPodCommand<
     R
   >
   extends BaseCommand<
-    { config: Config; payload: string | NoteProps[] },
+    { config: Config; payload: NoteProps[] },
     any,
     Config,
     Partial<Config>
@@ -326,5 +326,11 @@ export abstract class BaseExportPodCommand<
     return Object.values(engine.notes).filter(
       (note) => note.stub !== true && VaultUtils.isEqualV2(note.vault, vault)
     );
+  }
+
+  addAnalyticsPayload(opts: { config: Config; payload: NoteProps[] }) {
+    return {
+      exportScope: opts.config.exportScope,
+    };
   }
 }

--- a/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
+++ b/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
@@ -2,6 +2,7 @@ import { getAllExportPods, PodClassEntryV4 } from "@dendronhq/pods-core";
 import { PodCommandFactory } from "../../components/pods/PodCommandFactory";
 import { PodUIControls } from "../../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../../constants";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { BaseCommand, CodeCommandInstance } from "../base";
 
 type CommandOutput = void;
@@ -32,6 +33,12 @@ export class ExportPodV2Command extends BaseCommand<
    * undefined if the user didn't select anything.
    */
   async gatherInputs(podId: string): Promise<CommandInput | undefined> {
+    // added check to return if export pod v2 is not enabled in dev config and is run using pod keyboard shortcuts
+    const { config } = ExtensionProvider.getDWorkspace();
+    if (!config.dev?.enableExportPodV2) {
+      return;
+    }
+
     // If a podId is passed in, use this instead of prompting the user
     if (podId) {
       return PodCommandFactory.createPodCommandForStoredConfig({ podId });

--- a/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
+++ b/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
@@ -70,4 +70,11 @@ export class ExportPodV2Command extends BaseCommand<
   async execute(opts: CommandOpts) {
     opts.run();
   }
+
+  addAnalyticsPayload(opts: CommandOpts) {
+    return {
+      configured: true,
+      pod: opts.key,
+    };
+  }
 }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -16,7 +16,7 @@ export enum DendronContext {
   HAS_CUSTOM_MARKDOWN_VIEW = "hasCustomMarkdownPreview",
   NOTE_LOOK_UP_ACTIVE = "dendron:noteLookupActive",
   BACKLINKS_SORT_ORDER = "dendron:backlinksSortOrder",
-  ENABLEEXPORTPODV2 = "dendron:enableExportPodV2",
+  ENABLE_EXPORT_PODV2 = "dendron:enableExportPodV2",
 }
 
 const treeViewConfig2VSCodeEntry = (id: DendronTreeViewKey) => {
@@ -542,12 +542,12 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   CONFIGURE_SERVICE_CONNECTION: {
     key: "dendron.configureServiceConnection",
     title: `${CMD_PREFIX} Configure Service Connection`,
-    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
+    enablement: `${DendronContext.PLUGIN_ACTIVE} && ${DendronContext.ENABLE_EXPORT_PODV2}`,
   },
   CONFIGURE_EXPORT_POD_V2: {
     key: "dendron.configureExportPodV2",
     title: `${CMD_PREFIX} Configure Export Pod V2`,
-    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
+    enablement: `${DendronContext.PLUGIN_ACTIVE} && ${DendronContext.ENABLE_EXPORT_PODV2}`,
   },
   IMPORT_POD: {
     key: "dendron.importPod",
@@ -562,7 +562,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   EXPORT_POD_V2: {
     key: "dendron.exportPodv2",
     title: `${CMD_PREFIX} Export Pod V2`,
-    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
+    enablement: `${DendronContext.PLUGIN_ACTIVE} && ${DendronContext.ENABLE_EXPORT_PODV2}`,
   },
   PUBLISH_POD: {
     key: "dendron.publishPod",

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -16,6 +16,7 @@ export enum DendronContext {
   HAS_CUSTOM_MARKDOWN_VIEW = "hasCustomMarkdownPreview",
   NOTE_LOOK_UP_ACTIVE = "dendron:noteLookupActive",
   BACKLINKS_SORT_ORDER = "dendron:backlinksSortOrder",
+  ENABLEEXPORTPODV2 = "dendron:enableExportPodV2",
 }
 
 const treeViewConfig2VSCodeEntry = (id: DendronTreeViewKey) => {
@@ -541,12 +542,12 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   CONFIGURE_SERVICE_CONNECTION: {
     key: "dendron.configureServiceConnection",
     title: `${CMD_PREFIX} Configure Service Connection`,
-    when: DendronContext.PLUGIN_ACTIVE,
+    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
   },
   CONFIGURE_EXPORT_POD_V2: {
     key: "dendron.configureExportPodV2",
     title: `${CMD_PREFIX} Configure Export Pod V2`,
-    when: DendronContext.PLUGIN_ACTIVE,
+    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
   },
   IMPORT_POD: {
     key: "dendron.importPod",
@@ -561,7 +562,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   EXPORT_POD_V2: {
     key: "dendron.exportPodv2",
     title: `${CMD_PREFIX} Export Pod V2`,
-    when: DendronContext.PLUGIN_ACTIVE,
+    when: DendronContext.PLUGIN_ACTIVE && DendronContext.ENABLEEXPORTPODV2,
   },
   PUBLISH_POD: {
     key: "dendron.publishPod",

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -38,7 +38,7 @@ site:
 dev:
     enableWebUI: true
     enablePreviewV2: true
-    enableExportPodV2: false
+    enableExportPodV2: true
 commands:
     lookup:
         note:

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -38,6 +38,7 @@ site:
 dev:
     enableWebUI: true
     enablePreviewV2: true
+    enableExportPodV2: false
 commands:
     lookup:
         note:


### PR DESCRIPTION
This PR adds a dev config option `enableExportPodV2` for the enablement of `Export Pod V2` commands. 
Manually tested this with:
- WHEN enableExportPodV2 is undefined or false
     - [x]  THEN `Dendron: Export Pod V2` command should not be visible in command pallet.
     - [x]  THEN `Dendron: Configure Export Pod V2` command should not be visible in command pallet.
     - [x]  THEN `Dendron: Configure Service Connection` command should not be visible in command pallet.
     - [x]  THEN export pod v2 keybinding shortcuts should not run the export v2 commands
- WHEN enableExportPodV2 is true
     - [x]  THEN `Dendron: Export Pod V2` command should be visible in command pallet.
     - [x]  THEN `Dendron: Configure Export Pod V2` command should be visible in command pallet.
     - [x]  THEN `Dendron: Configure Service Connection` command should be visible in command pallet.
     - [x]  THEN export pod v2 keybinding shortcuts should execute the export v2 commands.

