### PR TITLE
fix: cursor is moved when opening file through search interface

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -865,3 +865,19 @@ export function cleanName(name: string): string {
 export function normalizeUnixPath(fsPath: string): string {
   return path.posix.format(path.parse(fsPath));
 }
+
+/** Wrapper(s) for easier testing, to wrap functions where we don't want to mock the global function. */
+export class Wrap {
+  /** A useless wrapper around `setTimeout`. Useful for testing.
+   *
+   * If you are testing code that uses `setTimeout`, you can switch that code over to this wrapper instead,
+   * and then mock the wrapper. We can't entirely mock `setTimeout` because that seems to break VSCode.
+   */
+  static setTimeout(
+    callback: (...args: any[]) => void,
+    ms: number,
+    ...args: any[]
+  ) {
+    return setTimeout(callback, ms, ...args);
+  }
+}

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -7,6 +7,7 @@ import {
   SchemaUtils,
   Time,
   VaultUtils,
+  Wrap,
 } from "@dendronhq/common-all";
 import { file2Note, vault2Path } from "@dendronhq/common-server";
 import { RemarkUtils } from "@dendronhq/engine-server";
@@ -414,7 +415,7 @@ export class WorkspaceWatcher {
       msg: "enter",
       fname: NoteUtils.uri2Fname(editor.document.uri),
     });
-    this.moveCursorPastFrontmatter(editor);
+    WorkspaceWatcher.moveCursorPastFrontmatter(editor);
     const config = getExtension().getDWorkspace().config;
     if (ConfigUtils.getWorkspace(config).enableAutoFoldFrontmatter) {
       await this.foldFrontmatter();
@@ -426,7 +427,7 @@ export class WorkspaceWatcher {
     });
   }
 
-  private moveCursorPastFrontmatter(editor: TextEditor) {
+  static moveCursorPastFrontmatter(editor: TextEditor) {
     const ctx = "moveCursorPastFrontmatter";
     const nodePosition = RemarkUtils.getNodePositionPastFrontmatter(
       editor.document.getText()
@@ -441,7 +442,7 @@ export class WorkspaceWatcher {
       // But if we move the cursor here, then it overwrites VSCode's move.
       // Worse, when VSCode calls this function the cursor hasn't updated yet
       // so the location will still be 0, so we have to delay a bit to let it update first.
-      setTimeout(() => {
+      Wrap.setTimeout(() => {
         // Since we delayed, a new document could have opened. Make sure we're still in the document we expect
         if (
           VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath === startFsPath
@@ -451,13 +452,13 @@ export class WorkspaceWatcher {
           if (line === 0 && character === 0) {
             editor.selection = new Selection(position, position);
           } else {
-            Logger.info({
+            Logger.debug({
               ctx,
               msg: "not moving cursor because the cursor was moved before we could get to it",
             });
           }
         } else {
-          Logger.info({
+          Logger.debug({
             ctx,
             msg: "not moving cursor because the document changed before we could move it",
           });

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -172,11 +172,18 @@ export class WindowWatcher {
       const position = VSCodeUtils.point2VSCodePosition(nodePosition.end, {
         line: 1,
       });
+      // If the user opened the document with something like the search window,
+      // then VSCode is supposed to move the cursor to where the match is.
+      // But if we move the cursor here, then it overwrites VSCode's move.
+      // Worse, when VSCode calls this function the cursor hasn't updated yet
+      // so the location will still be 0, so we have to delay a bit to let it update first.
       setTimeout(() => {
+        // Since we delayed, a new document could have opened. Make sure we're still in the document we expect
         if (
           VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath === startFsPath
         ) {
           const { line, character } = editor.selection.active;
+          // Move the cursor, but only if it hasn't already been moved by VSCode, another extension, or a very quick user
           if (line === 0 && character === 0) {
             editor.selection = new Selection(position, position);
           } else {


### PR DESCRIPTION
Fixes an issue where the cursor would get moved to the start of the document if the user opened the document through something like the search window, which is supposed to move the cursor to the matching position.

#2144