### PR TITLE
enhance(pods): import note metadata on markdown import

### DIFF
--- a/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
@@ -616,6 +616,48 @@ describe("markdown import pod", () => {
       }
     );
   });
+
+  test("import note's frontmatter", async () => {
+    await runEngineTestV5(
+      async ({ engine, vaults, wsRoot }) => {
+        const pod = new MarkdownImportPod();
+        const vaultName = VaultUtils.getName(vaults[0]);
+        const vault = vaults[0];
+        vpath = vault2Path({ wsRoot, vault });
+        await pod.execute({
+          engine,
+          vaults,
+          wsRoot,
+          config: {
+            concatenate: false,
+            src: importSrc,
+            vaultName,
+            importFrontmatter: true,
+            frontmatterMapping: {
+              id: "obsidianId",
+            },
+          },
+        });
+        const note = NoteUtils.getNoteOrThrow({
+          fname: "frontmatterTest",
+          notes: engine.notes,
+          vault,
+          wsRoot,
+        });
+        expect(note.custom.obsidianId).toContain(`testing`);
+        expect(note.custom.status).toContain(`wip`);
+        expect(note.custom.created_imported).toContain(`10 Jan`);
+      },
+      {
+        expect,
+        preSetupHook: async () => {
+          await setupImport(importSrc);
+          const content = `---\nid: testing\ncreated: 10 Jan\nstatus: wip\n---\nHello World`;
+          fs.writeFileSync(path.join(importSrc, "frontmatterTest.md"), content);
+        },
+      }
+    );
+  });
 });
 
 describe("markdown export pod", () => {

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -87,13 +87,15 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           nullable: true,
         },
         importFrontmatter: {
-          description: "Import note metadata",
+          description:
+            "Import note metadata. In case of any conflicts, the conflicting fields are prefixed with _import",
           type: "boolean",
-          default: false,
+          default: true,
           nullable: true,
         },
         frontmatterMapping: {
-          description: "metadata key mappings to use incase of conflicts",
+          description:
+            "An optional set of variable mappings, with the key being the variable name in the import source and the value being the resulting variable name in Dendron. See https://wiki.dendron.so/notes/f23a6290-2dec-45dc-b616-c218ee53db6b.html for examples.",
           type: "object",
           nullable: true,
         },
@@ -413,7 +415,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
   /**
    * Method to import frontmatter of note. Imports all FM in note.custom,
    * In case of conflict in keys of dendron and imported note, checks frontmatterMapping provided in the
-   * config. If not provided, concatinates '_imported' in imported FM keys.
+   * config. If not provided, concatenates '_imported' in imported FM keys.
    */
   handleFrontmatter(opts: {
     frontmatterMapping?: { [key: string]: any };
@@ -461,7 +463,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
       config,
     });
     const notes = this.hDict2Notes(hDict, config);
-    const { importFrontmatter, frontmatterMapping } =
+    const { importFrontmatter = true, frontmatterMapping } =
       config as MarkdownImportPodConfig;
     const notesClean = await Promise.all(
       notes

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -45,6 +45,8 @@ export type MarkdownImportPodPlantOpts = ImportPodPlantOpts;
 type MarkdownImportPodConfig = ImportPodConfig & {
   noAddUUID?: boolean;
   indexName?: string;
+  importFrontmatter?: boolean;
+  frontmatterMapping?: { [key: string]: any };
 };
 
 export type MarkdownImportPodResp = {
@@ -82,6 +84,17 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           type: "string",
           description:
             "If you have an index file per directory, merge that file with the directory note",
+          nullable: true,
+        },
+        importFrontmatter: {
+          description: "Import note metadata",
+          type: "boolean",
+          default: false,
+          nullable: true,
+        },
+        frontmatterMapping: {
+          description: "metadata key mappings to use incase of conflicts",
+          type: "object",
           nullable: true,
         },
       },
@@ -397,6 +410,39 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
     note.body = lines.join("\n");
   }
 
+  /**
+   * Method to import frontmatter of note. Imports all FM in note.custom,
+   * In case of conflict in keys of dendron and imported note, checks frontmatterMapping provided in the
+   * config. If not provided, concatinates '_imported' in imported FM keys.
+   */
+  handleFrontmatter(opts: {
+    frontmatterMapping?: { [key: string]: any };
+    note: NoteProps;
+  }) {
+    const { note, frontmatterMapping } = opts;
+
+    // map through all imported note's metadata
+    Object.keys(note.data).map((val) => {
+      if (_.has(note, val)) {
+        //check for mapping in frontmatterMapping
+        if (frontmatterMapping && _.has(frontmatterMapping, val)) {
+          note.data = {
+            ...note.data,
+            [frontmatterMapping[val]]: note.data[val],
+          };
+        } else {
+          // append _imported in imported metadata keys
+          note.data = {
+            ...note.data,
+            [`${val}_imported`]: note.data[val],
+          };
+        }
+        delete note.data[val];
+      }
+    });
+    note.custom = _.merge(note.custom, note.data);
+  }
+
   async plant(
     opts: MarkdownImportPodPlantOpts
   ): Promise<MarkdownImportPodResp> {
@@ -415,6 +461,8 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
       config,
     });
     const notes = this.hDict2Notes(hDict, config);
+    const { importFrontmatter, frontmatterMapping } =
+      config as MarkdownImportPodConfig;
     const notesClean = await Promise.all(
       notes
         .filter((note) => !note.stub)
@@ -447,6 +495,9 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           }
           if (config.fnameAsId) {
             note.id = note.fname;
+          }
+          if (importFrontmatter) {
+            this.handleFrontmatter({ note, frontmatterMapping });
           }
           return note;
         })

--- a/test-workspace/other-files/the-book-thief.md
+++ b/test-workspace/other-files/the-book-thief.md
@@ -1,0 +1,10 @@
+---
+author: Markus Zusak
+status: In progress
+id: testing
+tags:
+  - scope.reading
+  - size.medium
+---
+
+The story in the book was recounted by a male voice called Death, who proved to be caring yet morose throughout the book.

--- a/test-workspace/vault2/the-book-thief.md
+++ b/test-workspace/vault2/the-book-thief.md
@@ -1,0 +1,17 @@
+---
+id: ERSdVKMDkkwFnJGHUBGFR
+title: The Book Thief
+desc: ''
+updated: 1642498483045
+created: 1642498483045
+stub: false
+isDir: false
+author: Markus Zusak
+status: In progress
+tags:
+  - scope.reading
+  - size.medium
+obsidianId: testing
+---
+
+The story in the book was recounted by a male voice called Death, who proved to be caring yet morose throughout the book.


### PR DESCRIPTION
This PR adds config options to import note metadata on markdown import. [Docs](https://github.com/dendronhq/dendron-site/pull/366)

#2198

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated