### PR TITLE
fix: publishing pages fail

### DIFF
--- a/packages/common-all/src/env.ts
+++ b/packages/common-all/src/env.ts
@@ -2,10 +2,37 @@ import _ from "lodash";
 import { config, ConfigKey } from "./config";
 import { Stage } from "./types";
 
+let overrideStage = undefined;
+
+/** Get the env variables we are interested in.
+ *
+ * This workaround is needed because nextjs replaces these with static values at
+ * **build time**. Inside the browser, there's no `process.env`. And nextjs can
+ * only replace them if they are explicit like this, it doesn't work if we do
+ * `const {stage} = process.env;`.
+ */
+function getProcEnvs() {
+  const stage = process.env["stage"];
+  const NODE_ENV = process.env["NODE_ENV"];
+  const STAGE = process.env["STAGE"];
+  const REACT_APP_STAGE = process.env["REACT_APP_STAGE"];
+  const BUILD_STAGE = process.env["BUILD_STAGE"];
+  const GITHUB_ACTIONS = process.env["GITHUB_ACTIONS"];
+  return {
+    stage,
+    NODE_ENV,
+    STAGE,
+    REACT_APP_STAGE,
+    BUILD_STAGE,
+    GITHUB_ACTIONS,
+  };
+}
+
 export function getStage(): Stage {
   // CRA overrides NODE_ENV to be dev by default
   // build_STAGE is from 11ty
-  const { stage, NODE_ENV, STAGE, REACT_APP_STAGE, BUILD_STAGE } = process.env;
+  const { stage, NODE_ENV, STAGE, REACT_APP_STAGE, BUILD_STAGE } =
+    getProcEnvs();
   let stageOut =
     REACT_APP_STAGE ||
     BUILD_STAGE ||
@@ -41,10 +68,16 @@ export function getOrThrow<T = any>(
 }
 
 export function setStageIfUndefined(newStage: Stage) {
-  const { stage, NODE_ENV, STAGE, REACT_APP_STAGE, BUILD_STAGE } = process.env;
-  let stageOut = REACT_APP_STAGE || BUILD_STAGE || stage || STAGE || NODE_ENV;
+  const { stage, NODE_ENV, STAGE, REACT_APP_STAGE, BUILD_STAGE } =
+    getProcEnvs();
+  const stageOut = REACT_APP_STAGE || BUILD_STAGE || stage || STAGE || NODE_ENV;
   if (_.isUndefined(stageOut)) {
-    process.env.stage = newStage;
+    try {
+      process.env.stage = newStage;
+    } catch {
+      // This might fail in the browser where process.env doesn't exist
+      overrideStage = newStage;
+    }
   }
 }
 
@@ -80,7 +113,7 @@ export class RuntimeUtils {
    * Check if process is running inside a CI
    */
   static isRunningInsideCI(): boolean {
-    if (_.get(process.env, "GITHUB_ACTIONS")) {
+    if (_.get(getProcEnvs(), "GITHUB_ACTIONS")) {
       return true;
     }
     return false;

--- a/packages/common-all/src/env.ts
+++ b/packages/common-all/src/env.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { config, ConfigKey } from "./config";
 import { Stage } from "./types";
 
-let overrideStage = undefined;
+let overrideStage: string | undefined;
 
 /** Get the env variables we are interested in.
  *
@@ -39,7 +39,8 @@ export function getStage(): Stage {
     stage ||
     STAGE ||
     NODE_ENV ||
-    process.env.NODE_ENV;
+    process.env.NODE_ENV ||
+    overrideStage;
   // TODO
   if (stageOut === "development") {
     stageOut = "dev";


### PR DESCRIPTION
Some pages in publishing would fail because they tried to access `process.env`, which was used by `getStage`. `process` doesn't exist in the browser, so this causes a crash.

To fix the issue, I wrapped around `process.env` with a helper function that explicitly accesses each variable, so nextjs can replace the variables. Also added the stage variable to the nextjs export.

Unrelated to the other changes, I also made the exporting of all the JSON data and the env files concurrent. This should lead to a small speedup during exports, but I didn't try to measure the difference.

I still don't know why some pages would crash and others wouldn't in publishing, but I can confirm that this change solves the issue.