### PR TITLE
fix(schema): Use string replace instead of lodash for date variable substitution

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1372,21 +1372,33 @@ export class SchemaUtils {
         note.body = tempNote.body;
       }
 
-      // Apply date variable substitution to the body if applicable
+      // Apply date variable substitution to the body based on mustache delimiter if applicable
       // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
-      // Use mustache delimiter
-      _.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
-
       const currentDate = Time.now();
-      const compiledSchemaTemplate = _.template(note.body);
-      note.body = compiledSchemaTemplate({
-        CURRENT_YEAR: currentDate.toFormat("yyyy"),
-        CURRENT_MONTH: currentDate.toFormat("LL"),
-        CURRENT_DAY: currentDate.toFormat("dd"),
-        CURRENT_HOUR: currentDate.toFormat("HH"),
-        CURRENT_MINUTE: currentDate.toFormat("mm"),
-        CURRENT_SECOND: currentDate.toFormat("ss"),
-      });
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_YEAR\\s*}}", "g"),
+        currentDate.toFormat("yyyy")
+      );
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_MONTH\\s*}}", "g"),
+        currentDate.toFormat("LL")
+      );
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_DAY\\s*}}", "g"),
+        currentDate.toFormat("dd")
+      );
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_HOUR\\s*}}", "g"),
+        currentDate.toFormat("HH")
+      );
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_MINUTE\\s*}}", "g"),
+        currentDate.toFormat("mm")
+      );
+      note.body = note.body.replace(
+        new RegExp("{{\\s*CURRENT_SECOND\\s*}}", "g"),
+        currentDate.toFormat("ss")
+      );
 
       return true;
     }

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -132,6 +132,7 @@ export const NOTE_PRESETS_V4 = {
     body: [
       "Today is {{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}",
       "This link goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]",
+      "{{ 1 + 1 }} should not be evalated to 2",
     ].join("\n"),
   }),
   NOTE_WITH_NOTE_REF_SIMPLE: CreateNoteFactory({

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -156,7 +156,9 @@ describe(`SchemaUtil tests:`, () => {
             expect(note.body.trim()).toEqual(
               `Today is 2022.01.10` +
                 "\n" +
-                `This link goes to [[daily.journal.2022.01.10]]`
+                `This link goes to [[daily.journal.2022.01.10]]` +
+                "\n" +
+                `{{ 1 + 1 }} should not be evalated to 2`
             );
           },
           {


### PR DESCRIPTION
- Remove lodash template method as it evaluates javascript code leading to vulnerabilities
- Use string replace as we only care about variable subsitution

Testing:
Create template with 
```
{{ 1 + 1 }}

Year is {{ CURRENT_YEAR }}
Month is {{CURRENT_MONTH}}
Id of this note is _{{ fm.id }}_


This links goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]
```
Results in:
```
{{ 1 + 1 }}

Year is 2022
Month is 01
Id of this note is _{{ fm.id }}_


This links goes to [[daily.journal.2022.01.18]]
```