### PR TITLE
fix/disable javascript in lodash templates

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1375,7 +1375,8 @@ export class SchemaUtils {
       // Apply date variable substitution to the body if applicable
       // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
       // Use mustache delimiter
-      _.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
+      // TODO: Renable date variable substitution until new format is thought through
+      /*_.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
 
       const currentDate = Time.now();
       const compiledSchemaTemplate = _.template(note.body);
@@ -1386,7 +1387,7 @@ export class SchemaUtils {
         CURRENT_HOUR: currentDate.toFormat("HH"),
         CURRENT_MINUTE: currentDate.toFormat("mm"),
         CURRENT_SECOND: currentDate.toFormat("ss"),
-      });
+      });*/
 
       return true;
     }

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1375,7 +1375,7 @@ export class SchemaUtils {
       // Apply date variable substitution to the body based on mustache delimiter if applicable
       // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
       // Use mustache delimiter
-      // TODO: Renable date variable substitution until new format is thought through
+      // TODO: Renable date variable substitution when new format is thought through
       /*_.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
 
       const currentDate = Time.now();

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -134,6 +134,10 @@ export const NOTE_PRESETS_V4 = {
       "This link goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]",
     ].join("\n"),
   }),
+  NOTE_WITH_FM_VARIABLES: CreateNoteFactory({
+    fname: "fm-variables",
+    body: "Title is {{ fm.title }}",
+  }),
   NOTE_WITH_NOTE_REF_SIMPLE: CreateNoteFactory({
     fname: "simple-note-ref",
     body: "![[simple-note-ref.one]]",

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -138,7 +138,8 @@ describe(`SchemaUtil tests:`, () => {
         );
       });
 
-      it("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
+      // TODO: Reenable once date variable substitution is enabled
+      it.skip("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
         const dateTemplate: SchemaTemplate = {
           id: "date-variables",
           type: "note",
@@ -158,6 +159,30 @@ describe(`SchemaUtil tests:`, () => {
                 "\n" +
                 `This link goes to [[daily.journal.2022.01.10]]`
             );
+          },
+          {
+            expect,
+            preSetupHook: ENGINE_HOOKS.setupRefs,
+          }
+        );
+      });
+
+      it("WHEN applying a template with fm variables, THEN replace note's body with template's body without errors", async () => {
+        const dateTemplate: SchemaTemplate = {
+          id: "fm-variables",
+          type: "note",
+        };
+        await runEngineTestV5(
+          async ({ engine }) => {
+            const resp = SchemaUtils.applyTemplate({
+              template: dateTemplate,
+              note,
+              engine,
+            });
+
+            expect(resp).toBeTruthy();
+            expect(note.body).toEqual(engine.notes["fm-variables"].body);
+            expect(note.body.trim()).toEqual(`Title is {{ fm.title }}`);
           },
           {
             expect,

--- a/packages/engine-test-utils/src/presets/engine-server/utils.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/utils.ts
@@ -620,6 +620,11 @@ export const setupRefs: PreSetupHookFunction = async ({ vaults, wsRoot }) => {
     vault,
     wsRoot,
   });
+  // create note with fm variables
+  await NOTE_PRESETS_V4.NOTE_WITH_FM_VARIABLES.create({
+    vault,
+    wsRoot,
+  });
 };
 
 export const ENGINE_HOOKS_BASE = {


### PR DESCRIPTION
- fix(schema): Disable lodash date variable substitution
- BREAKING: Since we are disabling date variable substitution, current users will not be able to use it for the time being
- Added test to ensure frontmatter variables don't break in schema

Testing:
Template
```
{{ 1 + 1 }}

Year is {{ CURRENT_YEAR }}
Month is {{CURRENT_MONTH}}
Id of this note is _{{ fm.id }}_


This links goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]
```

Resolves to
```
{{ 1 + 1 }}

Year is {{ CURRENT_YEAR }}
Month is {{CURRENT_MONTH}}
Id of this note is _{{ fm.id }}_


This links goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]
```