### PR TITLE
fix: numbered lists without content stack on top of each other

### DIFF
--- a/packages/dendron-11ty/raw-assets/sass/base.scss
+++ b/packages/dendron-11ty/raw-assets/sass/base.scss
@@ -92,6 +92,8 @@ pre {
 
 li {
   margin: 0.25em 0;
+  // Otherwise empty list items stack on top of each other
+  height: 1rem;
 }
 
 img {

--- a/packages/dendron-11ty/raw-assets/sass/base.scss
+++ b/packages/dendron-11ty/raw-assets/sass/base.scss
@@ -93,7 +93,7 @@ pre {
 li {
   margin: 0.25em 0;
   // Otherwise empty list items stack on top of each other
-  height: 1rem;
+  min-height: 1rem;
 }
 
 img {

--- a/packages/dendron-next-server/styles/scss/base.scss
+++ b/packages/dendron-next-server/styles/scss/base.scss
@@ -92,6 +92,8 @@ pre {
 
 li {
   margin: 0.25em 0;
+  // Otherwise empty list items stack on top of each other
+  height: 1rem;
 }
 
 img {

--- a/packages/dendron-next-server/styles/scss/base.scss
+++ b/packages/dendron-next-server/styles/scss/base.scss
@@ -93,7 +93,7 @@ pre {
 li {
   margin: 0.25em 0;
   // Otherwise empty list items stack on top of each other
-  height: 1rem;
+  min-height: 1rem;
 }
 
 img {

--- a/packages/nextjs-template/styles/scss/base.scss
+++ b/packages/nextjs-template/styles/scss/base.scss
@@ -92,6 +92,8 @@ pre {
 
 li {
   margin: 0.25em 0;
+  // Otherwise empty list items stack on top of each other
+  height: 1rem;
 }
 
 img {

--- a/packages/nextjs-template/styles/scss/base.scss
+++ b/packages/nextjs-template/styles/scss/base.scss
@@ -93,7 +93,7 @@ pre {
 li {
   margin: 0.25em 0;
   // Otherwise empty list items stack on top of each other
-  height: 1rem;
+  min-height: 1rem;
 }
 
 img {

--- a/test-workspace/vault/dendron.ref.markdown.md
+++ b/test-workspace/vault/dendron.ref.markdown.md
@@ -2,7 +2,7 @@
 id: 9eae08fb-5e3f-4a7e-a989-3f206825d490
 title: Markdown
 desc: ""
-updated: 1627069555582
+updated: 1642663336126
 created: 1614629618966
 ---
 
@@ -53,6 +53,18 @@ graph TD;
 * foo
 * bar
 * baz
+
+#### Numbered list
+
+1. first
+2. second
+3. third
+
+And a list without contents
+
+5.
+6.
+7.
 
 ### Footnotes
 

--- a/test-workspace/vault/dendron.ref.markdown.md
+++ b/test-workspace/vault/dendron.ref.markdown.md
@@ -2,7 +2,7 @@
 id: 9eae08fb-5e3f-4a7e-a989-3f206825d490
 title: Markdown
 desc: ""
-updated: 1642663336126
+updated: 1642749469735
 created: 1614629618966
 ---
 
@@ -57,7 +57,7 @@ graph TD;
 #### Numbered list
 
 1. first
-2. second
+2. a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long item
 3. third
 
 And a list without contents


### PR DESCRIPTION
This PR fixes numbered lists stacking on top of each other in publishing/preview when they have no content.

CSS: 
-  dimensions 
    - [x] sm
    - [x] lg
    - [x] xxl
 - browsers
    - [x] firefox
    - [x] chrome

#2178 