### PR TITLE
DRAFT: Code coverage: quite fast with just TS files included le filter was taking 10+ minutes), run within engine-test-utils with 'jest --coverage'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /out/
 /logs/
 /build
+packages/coverage
 lerna-debug.log
 local
 vendor

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: "ts-jest",
   clearMocks: true,
   coverageDirectory: "coverage",
-  coverageReporters: ["text", "clover"],
+  coverageReporters: ["text", "clover", "html"],
   coverageThreshold: {
     global: {
       branches: 80,

--- a/packages/engine-test-utils/.gitignore
+++ b/packages/engine-test-utils/.gitignore
@@ -1,1 +1,2 @@
 lib
+coverage

--- a/packages/engine-test-utils/jest.config.js
+++ b/packages/engine-test-utils/jest.config.js
@@ -1,6 +1,22 @@
 const jestConfig = require("../../jest.config");
+const TEST_FILES_REGEX = '.*engine-test-utils.*spec\\.ts$';
 
 module.exports = {
   ...jestConfig,
+  rootDir: "./../",
+  testRegex: TEST_FILES_REGEX,
+  collectCoverage: true,
   testEnvironment: "jest-environment-jsdom-sixteen",
+  collectCoverageFrom: [
+    // Include typescript source files 
+    "**/src/**/*.ts",
+
+    // Exclude tests from code coverage metrics.
+    "!**/*.test.ts",
+
+    // Exclude definitions from code coverage metrics.
+    "!**/*.d.ts",
+    // Exclude snapshots from code coverage tests:
+    "!**/__snapshots__/**",
+  ],
 };


### PR DESCRIPTION
Submitting draft to see if the tests pass, Refer to https://github.com/dendronhq/dendron/pull/2221 for more info. 