### PR TITLE
chore: add option for url encoded images

### DIFF
--- a/packages/common-all/src/constants/configs/dev.ts
+++ b/packages/common-all/src/constants/configs/dev.ts
@@ -26,4 +26,8 @@ export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
     label: "Enable Preview V2",
     desc: "Use preview V2 as the default preview.",
   },
+  enablePreviewDirectImage: {
+    label: "Enable Preview Direct Image",
+    desc: "Enable the engine to directly encode and send images with the preview instead of proxying them separately. Enabling this may slow down the preview. Defaults to false (images are proxied).",
+  },
 };

--- a/packages/common-all/src/types/configs/dev/dev.ts
+++ b/packages/common-all/src/types/configs/dev/dev.ts
@@ -30,6 +30,8 @@ export type DendronDevConfig = {
    * Enable new preview as default
    */
   enablePreviewV2?: boolean;
+  /** When enabled, engine will include images when rendering the preview instead of separately proxying them to the preview. Disabled by default. */
+  enablePreviewDirectImage?: boolean;
 };
 
 /**

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -414,6 +414,8 @@ export type DendronDevConfig = {
    * - engine: Uses the engine watcher, watching the files directly without VSCode
    */
   forceWatcherType?: "plugin" | "engine";
+  /** When enabled, engine will include images when rendering the preview instead of separately proxying them to the preview. Disabled by default. */
+  enablePreviewDirectImage?: boolean;
 };
 
 export type DendronSiteConfig = {

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -10,6 +10,7 @@ import { COLORS_LIST } from "./colors";
 import { CONFIG_TO_MINIMUM_COMPAT_MAPPING } from "./constants/configs/compat";
 import {
   DendronSiteConfig,
+  DendronDevConfig,
   DHookDict,
   DVault,
   NoteProps,
@@ -601,6 +602,10 @@ export class ConfigUtils {
     return ConfigUtils.getProp(config, "site");
   }
 
+  static getDev(config: IntermediateDendronConfig): DendronDevConfig {
+    return ConfigUtils.getProp(config, "dev") || {};
+  }
+
   static getVaults(config: IntermediateDendronConfig): DVault[] {
     return ConfigUtils.getWorkspace(config).vaults;
   }
@@ -737,6 +742,10 @@ export class ConfigUtils {
   ) {
     const path = `workspace.${key}`;
     _.set(config, path, value);
+  }
+
+  static setDev(config: IntermediateDendronConfig, dev: DendronDevConfig) {
+    this.setProp(config, "dev", dev);
   }
 
   static setVaults(config: IntermediateDendronConfig, value: DVault[]): void {

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -67,6 +67,7 @@
     "mdast-builder": "^1.1.1",
     "mdast-util-compact": "^2.0.1",
     "mdast-util-inject": "^1.1.0",
+    "mime-types": "^2.1.34",
     "qs": "^6.10.1",
     "rehype-autolink-headings": "^5.0.1",
     "rehype-katex": "5",
@@ -98,6 +99,7 @@
   "devDependencies": {
     "@types/execa": "^2.0.0",
     "@types/lru-cache": "^5.1.1",
+    "@types/mime-types": "^2.1.1",
     "coveralls": "^3.0.2",
     "cross-env": "^7.0.2",
     "rimraf": "^2.6.2",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
@@ -1,9 +1,12 @@
+import { ConfigUtils, VaultUtils } from "@dendronhq/common-all";
 import { DendronASTDest, ProcFlavor } from "@dendronhq/engine-server";
 import { TestConfigUtils } from "../../../..";
 import { ENGINE_HOOKS } from "../../../../presets";
 import { checkString } from "../../../../utils";
 import { createProcCompileTests } from "../utils";
 import { getOpts, runTestCases } from "./utils";
+import fs from "fs-extra";
+import path from "path";
 
 describe("GIVEN image link", () => {
   describe("WHEN assetPrefix set", () => {
@@ -33,6 +36,57 @@ describe("GIVEN image link", () => {
           TestConfigUtils.withConfig(
             (config) => {
               config.site.assetsPrefix = "/some-prefix";
+              return config;
+            },
+            { wsRoot: opts.wsRoot }
+          );
+        },
+      })
+    );
+  });
+
+  describe("WHEN enablePreviewDirectImage is set", () => {
+    runTestCases(
+      createProcCompileTests({
+        name: "ENABLE_PREVIEW_DIRECT_IMAGE_SET",
+        setup: async (opts) => {
+          const { proc } = getOpts(opts);
+          const txt = `![](/assets/images/test.png)`;
+          const resp = await proc.process(txt);
+          return { resp, proc };
+        },
+        verify: {
+          [DendronASTDest.HTML]: {
+            [ProcFlavor.PREVIEW]: async ({ extra }) => {
+              const { resp } = extra;
+              await checkString(resp.contents, `src="data:image/png;base64,`);
+            },
+          },
+        },
+        preSetupHook: async (opts) => {
+          await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
+          // Add an image to the workspace
+          const imagePath = path.join(
+            opts.wsRoot,
+            VaultUtils.getRelPath(opts.vaults[0]),
+            "assets",
+            "images"
+          );
+          await fs.ensureDir(imagePath);
+          // Add a small image PNG image file to test with. Direct image proc needs to read an actual image file.
+          await fs.writeFile(
+            path.join(imagePath, "test.png"),
+            Buffer.from(
+              // A 4px x 4px green square
+              "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAASSURBVBhXYwjZHgFHRHG2RwAAQPIWMeBpwLoAAAAASUVORK5CYII=",
+              "base64"
+            )
+          );
+          TestConfigUtils.withConfig(
+            (config) => {
+              const dev = ConfigUtils.getDev(config);
+              dev.enablePreviewDirectImage = true;
+              ConfigUtils.setDev(config, dev);
               return config;
             },
             { wsRoot: opts.wsRoot }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,6 +5745,11 @@
   resolved "https://registry.npmjs.org/@types/mermaid/-/mermaid-8.2.7.tgz#1f9610c241361f66ed0591d3186e0bf3ed2211c8"
   integrity sha512-fHgKYloGociOIEftp1IXWEktRZOw4qhEWWZe4a8RKd0AIuhj70its8VV3+sM1DmaWRLPW9rbVD83JR0XJzEh8g==
 
+"@types/mime-types@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.1.tgz#d9ba43490fa3a3df958759adf69396c3532cf2c1"
+  integrity sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -18013,12 +18018,24 @@ mime-db@1.50.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.33"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
   dependencies:
     mime-db "1.50.0"
+
+mime-types@^2.1.34:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
 
 mime@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Adds a `dev` config option which enables URL encoding of images for the preview. This builds the images into the generated HTML for the note, which avoids having to proxy images through the engine.

This may help with #1856 , where it looks like the engine can send the rendered note to the preview but the preview doesn't seem to be able to read these images.
