### PR TITLE
enhance(pods): configure export pod v2  to create new service and pod configs.

### DIFF
--- a/packages/plugin-core/src/commands/pods/ConfigureServiceConnection.ts
+++ b/packages/plugin-core/src/commands/pods/ConfigureServiceConnection.ts
@@ -24,13 +24,13 @@ export class ConfigureServiceConnection extends BasicCommand<
     const mngr = new ExternalConnectionManager(getExtension().podsDir);
     const allServiceConfigs = await mngr.getAllValidConfigs();
     const items = allServiceConfigs.map<QuickPickItem>((value) => {
-      return { label: value.connectionId };
+      return { label: value.connectionId, description: value.serviceType };
     });
-    const createNewServiceLabel = { label: "Create New Service Config" };
+    const createNewServiceLabel = { label: "Create New Service Connection" };
     const userChoice = await window.showQuickPick(
       items.concat(createNewServiceLabel),
       {
-        title: "Pick the service connection config",
+        title: "Pick the Service Connection Configuration or Create a New One",
         ignoreFocusOut: true,
       }
     );

--- a/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
@@ -60,16 +60,19 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
       canSelectFiles: false,
       canSelectFolders: true,
     };
-    const destination = await PodUIControls.promptUserForDestination(
-      exportScope,
-      options
-    );
+    const destination =
+      opts && opts.destination
+        ? opts.destination
+        : await PodUIControls.promptUserForDestination(exportScope, options);
     if (!destination) {
       return;
     }
 
     //use FM Title as h1 header
-    const addFrontmatterTitle = await this.promptUserForaddFMTitleSetting();
+    const addFrontmatterTitle =
+      opts && opts.addFrontmatterTitle
+        ? opts.addFrontmatterTitle
+        : await this.promptUserForaddFMTitleSetting();
     if (addFrontmatterTitle === undefined) return;
 
     const config = {

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -233,33 +233,7 @@ export class PodUIControls {
     }
 
     if (selectedServiceOption.label === createNewOptionString) {
-      switch (connectionType) {
-        case ExternalService.Airtable: {
-          await this.promptToCreateNewServiceConfig(ExternalService.Airtable);
-          vscode.window.showInformationMessage(
-            `First setup a new ${connectionType} connection and then re-run the pod command.`
-          );
-          break;
-        }
-        case ExternalService.GoogleDocs: {
-          const id = await this.promptToCreateNewServiceConfig(
-            ExternalService.GoogleDocs
-          );
-          await launchGoogleOAuthFlow(id);
-          vscode.window.showInformationMessage(
-            "Google OAuth is a beta feature. Please contact us at support@dendron.so or on Discord to first gain access. Then, try again and authenticate with Google on your browser to continue."
-          );
-          break;
-        }
-        case ExternalService.Notion: {
-          await this.promptToCreateNewServiceConfig(ExternalService.Notion);
-          vscode.window.showInformationMessage(
-            `First setup a new ${connectionType} connection and then re-run the pod command.`
-          );
-          break;
-        }
-        default:
-      }
+      await PodUIControls.createNewServiceConfig(connectionType);
       return;
     } else {
       const config = mngr.getConfigById<T>({ id: selectedServiceOption.label });
@@ -272,6 +246,37 @@ export class PodUIControls {
       }
 
       return config;
+    }
+  }
+
+  public static async createNewServiceConfig(connectionType: ExternalService) {
+    switch (connectionType) {
+      case ExternalService.Airtable: {
+        await this.promptToCreateNewServiceConfig(ExternalService.Airtable);
+        vscode.window.showInformationMessage(
+          `First setup a new ${connectionType} connection and then re-run the pod command.`
+        );
+        break;
+      }
+      case ExternalService.GoogleDocs: {
+        const id = await this.promptToCreateNewServiceConfig(
+          ExternalService.GoogleDocs
+        );
+        await launchGoogleOAuthFlow(id);
+        vscode.window.showInformationMessage(
+          "Google OAuth is a beta feature. Please contact us at support@dendron.so or on Discord to first gain access. Then, try again and authenticate with Google on your browser to continue."
+        );
+        break;
+      }
+      case ExternalService.Notion: {
+        await this.promptToCreateNewServiceConfig(ExternalService.Notion);
+        vscode.window.showInformationMessage(
+          `First setup a new ${connectionType} connection and then re-run the pod command.`
+        );
+        break;
+      }
+      default:
+        assertUnreachable();
     }
   }
 

--- a/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
@@ -29,7 +29,7 @@ suite("ConfigureServiceConnection", function () {
           const cmd = new ConfigureServiceConnection();
           sinon.stub(vscode.window, "showQuickPick").returns(
             Promise.resolve({
-              label: "Create New Service Config",
+              label: "Create New Service Connection",
             }) as Thenable<vscode.QuickPickItem>
           );
           const serviceType = ExternalService.Airtable;

--- a/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
@@ -20,17 +20,22 @@ suite("ConfigureServiceConnection", function () {
     },
   });
 
-  describe("WHEN there is no service config present for selected Service Type", () => {
-    test("THEN new service config miust be created", (done) => {
+  describe("WHEN ConfigureServiceConnection is run with Create New option", () => {
+    test("THEN new service config must be created", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async () => {
           const cmd = new ConfigureServiceConnection();
+          sinon.stub(vscode.window, "showQuickPick").returns(
+            Promise.resolve({
+              label: "Create New Service Config",
+            }) as Thenable<vscode.QuickPickItem>
+          );
           const serviceType = ExternalService.Airtable;
-          cmd.gatherInputs = async () => {
-            return { serviceType };
-          };
+          sinon
+            .stub(PodUIControls, "promptForExternalServiceType")
+            .returns(Promise.resolve(serviceType));
           sinon
             .stub(PodUIControls, "promptForGenericId")
             .returns(Promise.resolve("airtable"));
@@ -48,24 +53,18 @@ suite("ConfigureServiceConnection", function () {
     });
   });
 
-  describe("WHEN service config for selected Service Type is present", () => {
+  describe("WHEN service config are present", () => {
     test("THEN service config of selected connection Id must open ", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async () => {
           const cmd = new ConfigureServiceConnection();
-          const serviceType = ExternalService.Airtable;
-          cmd.gatherInputs = async () => {
-            return { serviceType };
-          };
-          sinon
-            .stub(vscode.window, "showQuickPick")
-            .returns(
-              Promise.resolve({
-                label: "airtable-2",
-              }) as Thenable<vscode.QuickPickItem>
-            );
+          sinon.stub(vscode.window, "showQuickPick").returns(
+            Promise.resolve({
+              label: "airtable-2",
+            }) as Thenable<vscode.QuickPickItem>
+          );
           //setup
           const configPath = path.join(
             getExtension().podsDir,

--- a/packages/pods-core/src/v2/podConfig/NotionPodConfig.ts
+++ b/packages/pods-core/src/v2/podConfig/NotionPodConfig.ts
@@ -20,9 +20,9 @@ export type PersistedNotionPodConfig = NotionV2PodConfig &
 /**
  * This is the set of parameters required for actual execution of the Pod
  */
-export type RunnableNotionV2PodConfig = Omit<
+export type RunnableNotionV2PodConfig = Pick<
   NotionV2PodConfig,
-  "podId" | "podType"
+  "parentPageId" | "exportScope"
 > &
   Pick<NotionConnection, "apiKey">;
 
@@ -32,7 +32,9 @@ export type RunnableNotionV2PodConfig = Omit<
  * @param object
  * @returns
  */
-export function isRunnableNotionV2PodConfig(object: any) {
+export function isRunnableNotionV2PodConfig(
+  object: any
+): object is RunnableNotionV2PodConfig {
   return (
     object !== undefined &&
     "apiKey" in object &&
@@ -54,10 +56,6 @@ export function createRunnableNotionV2PodConfigSchema(): JSONSchemaType<Runnable
       },
       parentPageId: {
         type: "string",
-      },
-      description: {
-        type: "string",
-        nullable: true,
       },
     },
   };


### PR DESCRIPTION
This PR adds an option to create a new service connection and export pod v2 config. Apart from this, it adds a few fixes that were found relevant while testing export pod v2 in general.

---
madge report:
- master: 65 circular dependencies
- this branch: 65 circular dependencies
---

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated