### PR TITLE
chore: clean up incorrect `assertUnreachable` usages

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -189,20 +189,34 @@ export class ErrorMessages {
  *
  * An example of how this function may be used is below:
  *
- *     type Names = "bar" | "baz";
+ * ```ts
+ * type Names = "bar" | "baz";
  *
- *     function foo(name: Names) {
- *       if (name === "bar") { ... }
- *       else if (name === "baz") { ... }
- *       else assertUnreachable(name);
- *     }
+ * function foo(name: Names) {
+ *   if (name === "bar") { ... }
+ *   else if (name === "baz") { ... }
+ *   else assertUnreachable(name);
+ * }
+ * ```
  *
  * Let's say someone changes the type Names to `type Names = "bar" | "baz" | "ham";`. Thanks to this
  * assertion, the compiler will warn them that this branch is now reachable, and something is wrong.
  *
- * @param x
+ * Here's another example:
+ *
+ * ```
+ * switch (msg.type) {
+ *   case GraphViewMessageType.onSelect:
+ *   // ...
+ *   // ... all the cases
+ *   default:
+ *     assertUnreachable(msg.type);
+ * }
+ * ```
+ *
+ * Warning! Never use this function without a parameter. It won't actually do any type checks then.
  */
-export function assertUnreachable(_never?: never): never {
+export function assertUnreachable(_never: never): never {
   throw new DendronError({
     message: ErrorMessages.formatShouldNeverOccurMsg(),
   });

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -297,7 +297,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           return { error: null };
         }
         default:
-          return assertUnreachable();
+          return assertUnreachable(cmd);
       }
     } catch (err: any) {
       this.L.error(err);

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -117,6 +117,15 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
                 },
               });
               break;
+            case undefined:
+              throw new DendronError({
+                message: "Unknown output format requested",
+                payload: {
+                  ctx: "NoteCLICommand.execute",
+                  cmd,
+                  output,
+                },
+              });
             default:
               assertUnreachable(output);
           }

--- a/packages/dendron-cli/src/commands/publishCLICommand.ts
+++ b/packages/dendron-cli/src/commands/publishCLICommand.ts
@@ -210,7 +210,7 @@ export class PublishCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           return { error: null };
         }
         default:
-          assertUnreachable();
+          assertUnreachable(cmd);
       }
     } catch (err: any) {
       this.L.error(err);
@@ -305,7 +305,7 @@ export class PublishCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         return;
       }
       default:
-        assertUnreachable();
+        assertUnreachable(target);
     }
   }
 

--- a/packages/dendron-cli/src/commands/seedCLICommand.ts
+++ b/packages/dendron-cli/src/commands/seedCLICommand.ts
@@ -141,7 +141,7 @@ export class SeedCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           return { data };
         }
         default:
-          return assertUnreachable();
+          return assertUnreachable(cmd);
       }
     } catch (err: any) {
       this.L.error(err);

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -624,7 +624,7 @@ export class LinkUtils {
   }: {
     link: DNoteLink;
     dest: DendronASTDest;
-  }): string | never {
+  }): string {
     switch (dest) {
       case DendronASTDest.MD_DENDRON: {
         if (this.isHashtagLink(link.from)) {
@@ -654,7 +654,14 @@ export class LinkUtils {
         return [ref, `[[`, alias, vaultPrefix, value, anchor, `]]`].join("");
       }
       default:
-        return assertUnreachable();
+        throw new DendronError({
+          message: "Tried to render a link to an unexpected format",
+          payload: {
+            ctx: "renderNoteLink",
+            dest,
+            link,
+          },
+        });
     }
   }
 

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -422,7 +422,7 @@ export class MDUtilsV5 {
       case ProcMode.NO_DATA:
         break;
       default:
-        assertUnreachable();
+        assertUnreachable(opts.mode);
     }
     return proc;
   }

--- a/packages/engine-server/src/seed/service.ts
+++ b/packages/engine-server/src/seed/service.ts
@@ -205,7 +205,7 @@ export class SeedService {
         break;
       }
       default:
-        assertUnreachable();
+        assertUnreachable(mode);
     }
     return {
       data: {

--- a/packages/plugin-core/src/commands/ConvertLink.ts
+++ b/packages/plugin-core/src/commands/ConvertLink.ts
@@ -223,7 +223,13 @@ export class ConvertLinkCommand extends BasicCommand<
         break;
       }
       default: {
-        assertUnreachable();
+        throw new DendronError({
+          message: "Unexpected option selected",
+          payload: {
+            ctx: "prepareBrokenLinkOperation",
+            label: option.label,
+          },
+        });
       }
     }
     return text;
@@ -282,12 +288,13 @@ export class ConvertLinkCommand extends BasicCommand<
         }
         break;
       }
+      case undefined:
       case "fmtag":
       case "refv2": {
         throw ConvertLinkCommand.noAvailableOperationError();
       }
       default: {
-        assertUnreachable();
+        assertUnreachable(refType);
       }
     }
     throw new DendronError({

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -162,7 +162,7 @@ export abstract class BaseExportPodCommand<
         break;
       }
       default:
-        assertUnreachable();
+        assertUnreachable(inputs.exportScope);
     }
 
     return {
@@ -231,7 +231,7 @@ export abstract class BaseExportPodCommand<
           }
 
           default:
-            assertUnreachable();
+            assertUnreachable(opts.config.exportScope);
         }
       }
     );

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -69,7 +69,7 @@ export class PodCommandFactory {
       }
       case PodV2Types.NotionExportV2: {
         const cmd = new NotionExportPodCommand();
-         cmdWithArgs = {
+        cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
             return cmd.run(storedConfig);
@@ -77,7 +77,7 @@ export class PodCommandFactory {
         };
         break;
       }
-      
+
       case PodV2Types.JSONExportV2: {
         const cmd = new JSONExportPodCommand();
         cmdWithArgs = {
@@ -146,7 +146,7 @@ export class PodCommandFactory {
           },
         };
       }
-      
+
       case PodV2Types.JSONExportV2: {
         const cmd = new JSONExportPodCommand();
         return {
@@ -157,7 +157,7 @@ export class PodCommandFactory {
         };
       }
       default:
-        assertUnreachable();
+        assertUnreachable(podType);
     }
   }
 }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -497,7 +497,7 @@ export class PodUIControls {
         return "Exports all notes in the Dendron workspace";
 
       default:
-        assertUnreachable();
+        assertUnreachable(scope);
     }
   }
 
@@ -523,7 +523,7 @@ export class PodUIControls {
         return "Formats notes to JSON and exports it to clipboard or local file system";
 
       default:
-        assertUnreachable();
+        assertUnreachable(type);
     }
   }
 }

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -1,5 +1,6 @@
 import {
   assertUnreachable,
+  DendronError,
   DMessageEnum,
   GraphViewMessage,
   GraphViewMessageType,
@@ -80,9 +81,16 @@ export class NoteGraphPanelFactory {
             }
             break;
           }
-
+          case GraphViewMessageType.onReady:
+            throw new DendronError({
+              message: "Unexpected message received from the graph view",
+              payload: {
+                ctx: "NoteGraphPanelFactory",
+                "msg.type": msg.type,
+              },
+            });
           default:
-            assertUnreachable();
+            assertUnreachable(msg.type);
         }
       });
 

--- a/packages/plugin-core/src/features/RenameProvider.ts
+++ b/packages/plugin-core/src/features/RenameProvider.ts
@@ -98,8 +98,16 @@ export default class RenameProvider implements vscode.RenameProvider {
         case "fmtag": {
           return reference.range;
         }
+        case undefined:
+          throw new DendronError({
+            message: "Unknown reference type",
+            payload: {
+              ctx: "RenameProvider.getRangeForReference",
+              refType,
+            },
+          });
         default: {
-          assertUnreachable();
+          assertUnreachable(refType);
         }
       }
     }

--- a/packages/plugin-core/src/utils/site.ts
+++ b/packages/plugin-core/src/utils/site.ts
@@ -370,7 +370,7 @@ export class NextJSPublishUtils {
         return;
       }
       default:
-        assertUnreachable();
+        assertUnreachable(target);
     }
   }
 }

--- a/packages/plugin-core/src/views/LookupView.ts
+++ b/packages/plugin-core/src/views/LookupView.ts
@@ -1,5 +1,5 @@
 import {
-  assertUnreachable,
+  DendronError,
   DendronTreeViewKey,
   DMessage,
   LookupModifierStatePayload,
@@ -105,7 +105,13 @@ export class LookupView implements vscode.WebviewViewProvider {
             break;
           }
           default: {
-            assertUnreachable();
+            throw new DendronError({
+              message: "Got unexpected button category",
+              payload: {
+                ctx: "LookupView.onDidReceiveMessageHandler",
+                category,
+              },
+            });
           }
         }
         break;

--- a/packages/pods-core/src/v2/ConfigFileUtils.ts
+++ b/packages/pods-core/src/v2/ConfigFileUtils.ts
@@ -125,7 +125,7 @@ export class ConfigFileUtils {
       case PodV2Types.JSONExportV2:
         return JSONExportPodV2.config();
       default:
-        assertUnreachable();
+        assertUnreachable(podType);
     }
   }
 }

--- a/packages/pods-core/src/v2/external-services/ExternalConnectionManager.ts
+++ b/packages/pods-core/src/v2/external-services/ExternalConnectionManager.ts
@@ -100,7 +100,7 @@ export class ExternalConnectionManager {
         return file;
       }
       default:
-        assertUnreachable();
+        assertUnreachable(serviceType);
     }
   }
 


### PR DESCRIPTION
At several points in the codebase, `assertUnreachable` was used incorrectly with no parameter. When used this way, the function does no type checking and the code path may be actually reachable.

This PR fixes this by:
- Requiring a parameter for `assertUnreachable`
- Adding an additional example for the function, and a warning to not use it without parameters
- Where possible, updating the usage to pass a parameter
- Where not possible, adding an actual exception that will give information about the failure, rather than the "this code path should be unreachable!" error message you'd get when `assertUnreachable` is used incorrectly.