### PR TITLE
chore: deprecate MDUtilsV4

### DIFF
--- a/packages/engine-server/src/markdown/decorations/decorations.ts
+++ b/packages/engine-server/src/markdown/decorations/decorations.ts
@@ -34,7 +34,7 @@ import {
 } from "./diagnostics";
 import _ from "lodash";
 import visit from "unist-util-visit";
-import { NodeUtils } from "..";
+import { MdastUtils } from "..";
 
 /** Dispatches the correct decorator based on the type of AST node. */
 function runDecorator(
@@ -100,7 +100,7 @@ export async function runAllDecorators(
     const tree = proc.parse(text);
 
     // eslint-disable-next-line no-await-in-loop
-    await NodeUtils.visitAsync(tree, [], async (nodeIn) => {
+    await MdastUtils.visitAsync(tree, [], async (nodeIn) => {
       // This was parsed, it must have a position
       const node = nodeIn as NonOptional<DendronASTNode, "position">;
 

--- a/packages/engine-server/src/markdown/decorations/decorations.ts
+++ b/packages/engine-server/src/markdown/decorations/decorations.ts
@@ -20,7 +20,6 @@ import {
   NoteRefNoteV4,
   WikiLinkNoteV4,
 } from "../types";
-import { MDUtilsV4 } from "../utils";
 import { decorateHashTag } from "./hashTags";
 import { decorateReference } from "./references";
 import { Decoration, DecoratorIn, DecoratorOut } from "./utils";
@@ -35,6 +34,7 @@ import {
 } from "./diagnostics";
 import _ from "lodash";
 import visit from "unist-util-visit";
+import { NodeUtils } from "..";
 
 /** Dispatches the correct decorator based on the type of AST node. */
 function runDecorator(
@@ -100,7 +100,7 @@ export async function runAllDecorators(
     const tree = proc.parse(text);
 
     // eslint-disable-next-line no-await-in-loop
-    await MDUtilsV4.visitAsync(tree, [], async (nodeIn) => {
+    await NodeUtils.visitAsync(tree, [], async (nodeIn) => {
       // This was parsed, it must have a position
       const node = nodeIn as NonOptional<DendronASTNode, "position">;
 

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -36,7 +36,7 @@ import { MDUtilsV4, ParentWithIndex } from "../utils";
 import { MDUtilsV5, ProcMode } from "../utilsv5";
 import { LinkUtils } from "./utils";
 import { WikiLinksOpts } from "./wikiLinks";
-import { ProcFlavor } from "..";
+import { NodeUtils, ProcFlavor } from "..";
 
 const LINK_REGEX = /^\!\[\[(.+?)\]\]/;
 
@@ -1004,11 +1004,11 @@ function findHeader({
   match: string;
   slugger: ReturnType<typeof getSlugger>;
 }): FindAnchorResult {
-  let foundIndex = MDUtilsV4.findIndex(nodes, (node: Node, idx: number) => {
+  const foundIndex = NodeUtils.findIndex(nodes, (node: Node, idx: number) => {
     if (idx === 0 && match === "*") {
       return false;
     }
-    return MDUtilsV4.matchHeading(node, match, { slugger });
+    return NodeUtils.matchHeading(node, match, { slugger });
   });
   if (foundIndex < 0) return null;
   return { type: "header", index: foundIndex, anchorType: "header" };
@@ -1030,7 +1030,7 @@ function findBlockAnchor({
   // Find the anchor in the nodes
   let foundIndex: number | undefined;
   let foundAncestors: ParentWithIndex[] = [];
-  MDUtilsV4.visitParentsIndices({
+  NodeUtils.visitParentsIndices({
     nodes,
     test: DendronASTTypes.BLOCK_ANCHOR,
     visitor: ({ node, index, ancestors }) => {

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -36,7 +36,7 @@ import { MDUtilsV4, ParentWithIndex } from "../utils";
 import { MDUtilsV5, ProcMode } from "../utilsv5";
 import { LinkUtils } from "./utils";
 import { WikiLinksOpts } from "./wikiLinks";
-import { NodeUtils, ProcFlavor } from "..";
+import { MdastUtils, ProcFlavor } from "..";
 
 const LINK_REGEX = /^\!\[\[(.+?)\]\]/;
 
@@ -1004,11 +1004,11 @@ function findHeader({
   match: string;
   slugger: ReturnType<typeof getSlugger>;
 }): FindAnchorResult {
-  const foundIndex = NodeUtils.findIndex(nodes, (node: Node, idx: number) => {
+  const foundIndex = MdastUtils.findIndex(nodes, (node: Node, idx: number) => {
     if (idx === 0 && match === "*") {
       return false;
     }
-    return NodeUtils.matchHeading(node, match, { slugger });
+    return MdastUtils.matchHeading(node, match, { slugger });
   });
   if (foundIndex < 0) return null;
   return { type: "header", index: foundIndex, anchorType: "header" };
@@ -1030,7 +1030,7 @@ function findBlockAnchor({
   // Find the anchor in the nodes
   let foundIndex: number | undefined;
   let foundAncestors: ParentWithIndex[] = [];
-  NodeUtils.visitParentsIndices({
+  MdastUtils.visitParentsIndices({
     nodes,
     test: DendronASTTypes.BLOCK_ANCHOR,
     visitor: ({ node, index, ancestors }) => {

--- a/packages/engine-server/src/markdown/remark/publishSite.ts
+++ b/packages/engine-server/src/markdown/remark/publishSite.ts
@@ -4,7 +4,8 @@ import { Node } from "unist";
 import visit from "unist-util-visit";
 import { VFile } from "vfile";
 import { DendronASTDest, WikiLinkNoteV4, DendronASTTypes } from "../types";
-import { MDUtilsV4, PublishUtils } from "../utils";
+import { PublishUtils } from "../utils";
+import { MDUtilsV5 } from "../utilsv5";
 
 type PluginOpts = {
   noteIndex: NoteProps;
@@ -16,7 +17,7 @@ type PluginOpts = {
  */
 function plugin(this: Unified.Processor, opts: PluginOpts): Transformer {
   const proc = this;
-  let { dest, config } = MDUtilsV4.getDendronData(proc);
+  const { dest, config } = MDUtilsV5.getProcData(proc);
   function transformer(tree: Node, _file: VFile) {
     if (dest !== DendronASTDest.HTML) {
       return;

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -514,7 +514,7 @@ export class MDUtilsV4 {
 }
 
 /** Contains functions that help dealing with mdast trees. */
-export class NodeUtils {
+export class MdastUtils {
   /** Find the index of the list element for which the predicate `fn` returns true.
    *
    * @returns The index where the element was found, -1 otherwise.

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -135,99 +135,8 @@ type VisitorParentsIndices = ({
   ancestors: ParentWithIndex[];
 }) => boolean | undefined | "skip";
 
+/** @deprecated Please use {@link MDUtilsV5} instead. */
 export class MDUtilsV4 {
-  /** Find the index of the list element for which the predicate `fn` returns true.
-   *
-   * @returns The index where the element was found, -1 otherwise.
-   */
-  static findIndex<T>(array: T[], fn: (node: T, index: number) => boolean) {
-    for (var i = 0; i < array.length; i++) {
-      if (fn(array[i], i)) {
-        return i;
-      }
-    }
-    return -1;
-  }
-
-  /** A simplified and adapted version of visitParents from unist-utils-visit-parents, that also keeps track of indices of the ancestors as well.
-   *
-   * The limitations are:
-   * * `test`, if used, can only be a string representing the type of the node that you want to visit
-   * * Adding or removing siblings is undefined behavior
-   * Please modify this function to add support for these if needed.
-   */
-  static visitParentsIndices({
-    nodes,
-    test,
-    visitor,
-  }: {
-    nodes: Node[];
-    test?: string;
-    visitor: VisitorParentsIndices;
-  }) {
-    function recursiveTraversal(
-      nodes: Node[],
-      ancestors: ParentWithIndex[]
-    ): boolean | undefined {
-      for (let i = 0; i < nodes.length; i++) {
-        // visit the current node
-        const node = nodes[i];
-        let action: boolean | undefined | "skip" = undefined;
-        if (_.isUndefined(test) || node.type === test) {
-          action = visitor({ node, index: i, ancestors });
-        }
-        if (action === "skip") return; // don't traverse the children of this node
-        if (action === false) return false; // stop traversing completely
-
-        // visit the children of this node, if any
-        // @ts-ignore
-        if (node.children) {
-          const parent = node as Parent;
-          const newAncestors = [...ancestors, { ancestor: parent, index: i }];
-          const action = recursiveTraversal(parent.children, newAncestors);
-          if (action === false) return; // stopping traversal
-        }
-      }
-      return true; // continue traversal if needed
-    }
-    // Start recursion with no ancestors (everything is top level)
-    recursiveTraversal(nodes, []);
-  }
-
-  /** Similar to `unist-utils-visit`, but allows async visitors.
-   *
-   * Children are visited in-order, not concurrently.
-   *
-   * @param test Use an empty list to visit all nodes, otherwise specify node types to be visited.
-   * @param visitor Similar to `unist-util-visit`, returning true or undefined continues traversal, false stops traversal, and "skip" skips the children of that node.
-   *
-   * Depth-first pre-order traversal, same as `unist-util-visits`.
-   */
-  static async visitAsync(
-    tree: Node,
-    test: string[],
-    visitor: (
-      node: Node
-    ) =>
-      | void
-      | undefined
-      | boolean
-      | "skip"
-      | Promise<void | undefined | boolean | "skip">
-  ) {
-    const visitQueue = new FIFOQueue([tree]);
-    while (visitQueue.length > 0) {
-      const node = visitQueue.dequeue()!;
-      if (test.length === 0 || test.includes(node.type)) {
-        // eslint-disable-next-line no-await-in-loop
-        const out = await visitor(node);
-        if (out === false) return;
-        if (out === "skip") continue;
-      }
-      if (RemarkUtils.isParent(node)) visitQueue.enqueueAll(node.children);
-    }
-  }
-
   static genMDMsg(msg: string): Parent {
     return root(paragraph(text(msg)));
   }
@@ -310,33 +219,6 @@ export class MDUtilsV4 {
   static setProcOpts(proc: Unified.Processor, data: Partial<ProcOptsFull>) {
     const procOpts = proc.data(DendronProcDataKeys.PROC_OPTS) as ProcOptsFull;
     return proc.data(DendronProcDataKeys.PROC_OPTS, { ...procOpts, ...data });
-  }
-
-  static matchHeading(
-    node: Node,
-    text: string,
-    opts: { depth?: number; slugger: ReturnType<typeof getSlugger> }
-  ) {
-    const { depth, slugger } = opts;
-    if (node.type !== DendronASTTypes.HEADING) {
-      return false;
-    }
-
-    // wildcard is always true
-    if (text === "*") {
-      return true;
-    }
-
-    if (text) {
-      var headingText = toString(node);
-      return text.trim().toLowerCase() === slugger.slug(headingText.trim());
-    }
-
-    if (depth) {
-      return (node as Heading).depth <= depth;
-    }
-
-    return true;
   }
 
   /**
@@ -628,6 +510,128 @@ export class MDUtilsV4 {
       noteIndex,
     });
     return proc;
+  }
+}
+
+/** Contains functions that help dealing with mdast trees. */
+export class NodeUtils {
+  /** Find the index of the list element for which the predicate `fn` returns true.
+   *
+   * @returns The index where the element was found, -1 otherwise.
+   */
+  static findIndex<T>(array: T[], fn: (node: T, index: number) => boolean) {
+    for (var i = 0; i < array.length; i++) {
+      if (fn(array[i], i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** A simplified and adapted version of visitParents from unist-utils-visit-parents, that also keeps track of indices of the ancestors as well.
+   *
+   * The limitations are:
+   * * `test`, if used, can only be a string representing the type of the node that you want to visit
+   * * Adding or removing siblings is undefined behavior
+   * Please modify this function to add support for these if needed.
+   */
+  static visitParentsIndices({
+    nodes,
+    test,
+    visitor,
+  }: {
+    nodes: Node[];
+    test?: string;
+    visitor: VisitorParentsIndices;
+  }) {
+    function recursiveTraversal(
+      nodes: Node[],
+      ancestors: ParentWithIndex[]
+    ): boolean | undefined {
+      for (let i = 0; i < nodes.length; i++) {
+        // visit the current node
+        const node = nodes[i];
+        let action: boolean | undefined | "skip";
+        if (_.isUndefined(test) || node.type === test) {
+          action = visitor({ node, index: i, ancestors });
+        }
+        if (action === "skip") return; // don't traverse the children of this node
+        if (action === false) return false; // stop traversing completely
+
+        // visit the children of this node, if any
+        // @ts-ignore
+        if (node.children) {
+          const parent = node as Parent;
+          const newAncestors = [...ancestors, { ancestor: parent, index: i }];
+          const action = recursiveTraversal(parent.children, newAncestors);
+          if (action === false) return; // stopping traversal
+        }
+      }
+      return true; // continue traversal if needed
+    }
+    // Start recursion with no ancestors (everything is top level)
+    recursiveTraversal(nodes, []);
+  }
+
+  /** Similar to `unist-utils-visit`, but allows async visitors.
+   *
+   * Children are visited in-order, not concurrently.
+   *
+   * @param test Use an empty list to visit all nodes, otherwise specify node types to be visited.
+   * @param visitor Similar to `unist-util-visit`, returning true or undefined continues traversal, false stops traversal, and "skip" skips the children of that node.
+   *
+   * Depth-first pre-order traversal, same as `unist-util-visits`.
+   */
+  static async visitAsync(
+    tree: Node,
+    test: string[],
+    visitor: (
+      node: Node
+    ) =>
+      | void
+      | undefined
+      | boolean
+      | "skip"
+      | Promise<void | undefined | boolean | "skip">
+  ) {
+    const visitQueue = new FIFOQueue([tree]);
+    while (visitQueue.length > 0) {
+      const node = visitQueue.dequeue()!;
+      if (test.length === 0 || test.includes(node.type)) {
+        // eslint-disable-next-line no-await-in-loop
+        const out = await visitor(node);
+        if (out === false) return;
+        if (out === "skip") continue;
+      }
+      if (RemarkUtils.isParent(node)) visitQueue.enqueueAll(node.children);
+    }
+  }
+
+  static matchHeading(
+    node: Node,
+    text: string,
+    opts: { depth?: number; slugger: ReturnType<typeof getSlugger> }
+  ) {
+    const { depth, slugger } = opts;
+    if (node.type !== DendronASTTypes.HEADING) {
+      return false;
+    }
+
+    // wildcard is always true
+    if (text === "*") {
+      return true;
+    }
+
+    if (text) {
+      const headingText = toString(node);
+      return text.trim().toLowerCase() === slugger.slug(headingText.trim());
+    }
+
+    if (depth) {
+      return (node as Heading).depth <= depth;
+    }
+
+    return true;
   }
 }
 

--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -513,7 +513,7 @@ export class MDUtilsV4 {
   }
 }
 
-/** Contains functions that help dealing with mdast trees. */
+/** Contains functions that help dealing with MarkDown Abstract Syntax Trees. */
 export class MdastUtils {
   /** Find the index of the list element for which the predicate `fn` returns true.
    *

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -11,7 +11,7 @@ import {
   DEngineClient,
   LinkFilter,
   LinkUtils,
-  MDUtilsV4,
+  MDUtilsV5,
   RemarkUtils,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
@@ -917,7 +917,7 @@ describe("h1ToTitle", () => {
   test("basic", async () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
-        const proc = MDUtilsV4.procFull({
+        const proc = MDUtilsV5.procRemarkFull({
           dest: DendronASTDest.MD_REGULAR,
           engine,
           fname: "foo",

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -16,7 +16,7 @@ import {
   UserTag,
   HashTag,
   linkedNoteType,
-  MDUtilsV4,
+  NodeUtils,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import vscode, {
@@ -26,8 +26,8 @@ import vscode, {
   TextEditor,
   TextEditorEdit,
 } from "vscode";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { WSUtils } from "../WSUtils";
 
 export function isAnythingSelected(): boolean {
@@ -203,7 +203,7 @@ export async function isBrokenWikilink(): Promise<boolean> {
   const { editor, selection } = VSCodeUtils.getSelection();
   if (!editor || !selection) return false;
   const note = WSUtils.getNoteFromDocument(editor.document);
-  const { engine } = getDWorkspace();
+  const { engine } = ExtensionProvider.getDWorkspace();
   if (!note) return false;
   const line = editor.document.lineAt(selection.start.line).text;
   const proc = MDUtilsV5.procRemarkParse(
@@ -219,7 +219,7 @@ export async function isBrokenWikilink(): Promise<boolean> {
   let link: WikiLinkNoteV4 | UserTag | HashTag | undefined;
   let type: DECORATION_TYPES | undefined;
   let fname: string;
-  await MDUtilsV4.visitAsync(
+  await NodeUtils.visitAsync(
     parsedLine,
     [
       DendronASTTypes.WIKI_LINK,

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -16,7 +16,7 @@ import {
   UserTag,
   HashTag,
   linkedNoteType,
-  NodeUtils,
+  MdastUtils,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import vscode, {
@@ -219,7 +219,7 @@ export async function isBrokenWikilink(): Promise<boolean> {
   let link: WikiLinkNoteV4 | UserTag | HashTag | undefined;
   let type: DECORATION_TYPES | undefined;
   let fname: string;
-  await NodeUtils.visitAsync(
+  await MdastUtils.visitAsync(
     parsedLine,
     [
       DendronASTTypes.WIKI_LINK,


### PR DESCRIPTION
# Pull Request Checklist

This PR marks `MDUtilsV4` as deprecated, moves several unrelated methods out of `MDUtilsV4`, and refactors a few low-hanging fruit to switch to MDUtilsV5.

Switching more of the code will take substantial work because changes quickly break tests, and some code relies on `MDUtilsV4` features that were not brought over to `MDUtilsV5`, like being able to pass overrides for certain options. I think it makes sense to take the time to think how those should be implemented going forward, which I'll continue working on.

This PR does not affect the number of cyclic dependencies.

Docs PR: https://github.com/dendronhq/dendron-docs/pull/13

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated