### PR TITLE
enhance/schemas support cross vault links

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -869,16 +869,16 @@ export class NoteUtils {
 
   static getNoteFromMultiVault(opts: {
     fname: string;
-    notes: NotePropsDict | NoteProps[];
+    engine: DEngineClient;
     fromVault: DVault;
     wsRoot: string;
     toVault?: DVault;
   }) {
-    const { fname, notes, fromVault, toVault, wsRoot } = opts;
+    const { fname, engine, fromVault, toVault, wsRoot } = opts;
     let existingNote: NoteProps | undefined;
-    const maybeNotes = NoteUtils.getNotesByFname({
+    const maybeNotes = NoteUtils.getNotesByFnameFromEngine({
       fname,
-      notes,
+      engine,
       vault: toVault,
     });
 

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -1136,7 +1136,7 @@ export class RemarkUtils {
           }
           const existingNote = NoteUtils.getNoteFromMultiVault({
             fname: linkNode.value,
-            notes: engine.notes,
+            engine,
             fromVault: note.vault,
             toVault: vault,
             wsRoot: engine.wsRoot,

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -4,7 +4,6 @@ import {
   DVault,
   SchemaOpts,
   NoteProps,
-  SchemaTemplate,
 } from "@dendronhq/common-all";
 import sinon from "sinon";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
@@ -106,7 +105,6 @@ describe(`SchemaUtil tests:`, () => {
     const noteFactory: TestNoteFactory =
       TestNoteFactory.defaultUnitTestFactory();
     let note: NoteProps;
-    const template: SchemaTemplate = { id: "foo", type: "note" };
     const currentDate = new Date(2022, 0, 10);
     let clock: sinon.SinonFakeTimers;
 
@@ -123,8 +121,9 @@ describe(`SchemaUtil tests:`, () => {
       it("WHEN applying a template, THEN replace note's body with template's body", async () => {
         await runEngineTestV5(
           async ({ engine }) => {
+            const templateNote: NoteProps = engine.notes["foo"];
             const resp = SchemaUtils.applyTemplate({
-              template,
+              templateNote,
               note,
               engine,
             });
@@ -139,14 +138,11 @@ describe(`SchemaUtil tests:`, () => {
       });
 
       it("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
-        const dateTemplate: SchemaTemplate = {
-          id: "date-variables",
-          type: "note",
-        };
         await runEngineTestV5(
           async ({ engine }) => {
+            const dateTemplate: NoteProps = engine.notes["date-variables"];
             const resp = SchemaUtils.applyTemplate({
-              template: dateTemplate,
+              templateNote: dateTemplate,
               note,
               engine,
             });
@@ -169,14 +165,11 @@ describe(`SchemaUtil tests:`, () => {
       });
 
       it("WHEN applying a template with fm variables, THEN replace note's body with template's body without errors", async () => {
-        const dateTemplate: SchemaTemplate = {
-          id: "fm-variables",
-          type: "note",
-        };
         await runEngineTestV5(
           async ({ engine }) => {
+            const fmTemplate: NoteProps = engine.notes["fm-variables"];
             const resp = SchemaUtils.applyTemplate({
-              template: dateTemplate,
+              templateNote: fmTemplate,
               note,
               engine,
             });
@@ -204,8 +197,9 @@ describe(`SchemaUtil tests:`, () => {
       it("WHEN applying a template, THEN append note's body with a \\n + template's body", async () => {
         await runEngineTestV5(
           async ({ engine }) => {
+            const templateNote: NoteProps = engine.notes["foo"];
             const resp = SchemaUtils.applyTemplate({
-              template,
+              templateNote,
               note,
               engine,
             });
@@ -230,8 +224,10 @@ describe(`SchemaUtil tests:`, () => {
       it("WHEN applying a template, THEN do nothing and return false ", async () => {
         await runEngineTestV5(
           async ({ engine }) => {
+            const templateNote: NoteProps = engine.notes["foo"];
+            templateNote.type = "schema";
             const resp = SchemaUtils.applyTemplate({
-              template: { id: "foo", type: "snippet" },
+              templateNote,
               note,
               engine,
             });

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -99,8 +99,12 @@ export class WSUtilsV2 implements IWSUtilsV2 {
   /**
    * See {@link IWSUtilsV2.findNoteFromMultiVaultAsync}.
    */
-  async findNoteFromMultiVaultAsync(opts: { fname: string; vault?: DVault }) {
-    const { fname, vault } = opts;
+  async findNoteFromMultiVaultAsync(opts: {
+    fname: string;
+    quickpickTitle: string;
+    vault?: DVault;
+  }) {
+    const { fname, quickpickTitle, vault } = opts;
     let existingNote: NoteProps | undefined;
     const engine = ExtensionProvider.getEngine();
     const maybeNotes = NoteUtils.getNotesByFnameFromEngine({
@@ -117,7 +121,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       const vaults = maybeNotes.map((noteProps) => {
         return {
           vault: noteProps.vault,
-          label: VaultUtils.getName(noteProps.vault),
+          label: `${fname} from ${VaultUtils.getName(noteProps.vault)}`,
         };
       });
 
@@ -128,7 +132,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
           : vaultPickerItem.vault.fsPath,
       }));
       const resp = await vscode.window.showQuickPick(items, {
-        title: "Select Vault",
+        title: quickpickTitle,
       });
 
       if (!_.isUndefined(resp)) {

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -7,6 +7,7 @@ import {
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
+import _ from "lodash";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
 import { Logger } from "./logger";
 import { VSCodeUtils } from "./vsCodeUtils";
@@ -93,6 +94,48 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       wsRoot,
       notes: engine.notes,
     });
+  }
+
+  /**
+   * See {@link IWSUtilsV2.findNoteFromMultiVaultAsync}.
+   */
+  async findNoteFromMultiVaultAsync(opts: { fname: string; vault?: DVault }) {
+    const { fname, vault } = opts;
+    let existingNote: NoteProps | undefined;
+    const engine = ExtensionProvider.getEngine();
+    const maybeNotes = NoteUtils.getNotesByFnameFromEngine({
+      fname,
+      engine,
+      vault,
+    });
+
+    if (maybeNotes.length === 1) {
+      // Only one match so use that as note
+      existingNote = maybeNotes[0];
+    } else if (maybeNotes.length > 1) {
+      // If there are multiple notes with this fname, prompt user to select which vault
+      const vaults = maybeNotes.map((noteProps) => {
+        return {
+          vault: noteProps.vault,
+          label: VaultUtils.getName(noteProps.vault),
+        };
+      });
+
+      const items = vaults.map((vaultPickerItem) => ({
+        ...vaultPickerItem,
+        label: vaultPickerItem.label
+          ? vaultPickerItem.label
+          : vaultPickerItem.vault.fsPath,
+      }));
+      const resp = await vscode.window.showQuickPick(items, {
+        title: "Select Vault",
+      });
+
+      if (!_.isUndefined(resp)) {
+        existingNote = _.find(maybeNotes, { vault: resp.vault });
+      }
+    } // Else no match in which case we return undefined
+    return existingNote;
   }
 
   getVaultFromDocument(document: vscode.TextDocument) {

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -25,4 +25,18 @@ export interface IWSUtilsV2 {
   ): Promise<vscode.TextEditor>;
 
   openNote(note: NoteProps): Promise<vscode.TextEditor>;
+
+  /**
+   * Find note by fname across all vaults.
+   *
+   * If vault is specified, search notes by corresponding vault and fname. If no match, return undefined.
+   * If vault is not specified, search all notes by id.
+   *    - If no match, return undefined
+   *    - If one match, assume that is intended note and return.
+   *    - If multiple matches, prompt user to select vault from matches
+   */
+  findNoteFromMultiVaultAsync(opts: {
+    fname: string;
+    vault?: DVault;
+  }): Promise<NoteProps | undefined>;
 }

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -33,10 +33,15 @@ export interface IWSUtilsV2 {
    * If vault is not specified, search all notes by id.
    *    - If no match, return undefined
    *    - If one match, assume that is intended note and return.
-   *    - If multiple matches, prompt user to select vault from matches
+   *    - If multiple matches, prompt user via quickpick to select vault from matches
+   *
+   * @param fname: name of note to look for
+   * @param quickpickTitle: title of quickpick to display if multiple matches are found
+   * @param vault?: if provided, vault to search note from
    */
   findNoteFromMultiVaultAsync(opts: {
     fname: string;
+    quickpickTitle: string;
     vault?: DVault;
   }): Promise<NoteProps | undefined>;
 }

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -1,5 +1,5 @@
 import vscode, { Uri } from "vscode";
-import { DVault, NoteProps } from "@dendronhq/common-all";
+import { DVault, NoteProps, RespV3 } from "@dendronhq/common-all";
 
 export interface IWSUtilsV2 {
   getNoteFromDocument(document: vscode.TextDocument): undefined | NoteProps;
@@ -31,9 +31,9 @@ export interface IWSUtilsV2 {
    *
    * If vault is specified, search notes by corresponding vault and fname. If no match, return undefined.
    * If vault is not specified, search all notes by id.
-   *    - If no match, return undefined
+   *    - If no match, return error about missing note
    *    - If one match, assume that is intended note and return.
-   *    - If multiple matches, prompt user via quickpick to select vault from matches
+   *    - If multiple matches, prompt user via quickpick to select vault from matches. If user escapes out, return undefined
    *
    * @param fname: name of note to look for
    * @param quickpickTitle: title of quickpick to display if multiple matches are found
@@ -43,5 +43,5 @@ export interface IWSUtilsV2 {
     fname: string;
     quickpickTitle: string;
     vault?: DVault;
-  }): Promise<NoteProps | undefined>;
+  }): Promise<RespV3<NoteProps | undefined>>;
 }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -550,6 +550,7 @@ export class NoteLookupCommand
     if (ref) {
       maybeNote = await WSUtilsV2.instance().findNoteFromMultiVaultAsync({
         fname: ref,
+        quickpickTitle: "Select which template to apply",
         vault: maybeVault,
       });
     }

--- a/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
@@ -18,13 +18,12 @@ suite("JSONExportPodCommand", function () {
       },
       () => {
         const cmd = new JSONExportPodCommand();
-        test("THEN multi notes export error message must be displayed", () => {
-          expect(
-            async () =>
-              await cmd.gatherInputs({
-                exportScope: PodExportScope.Vault,
-                destination: "clipboard",
-              })
+        test("THEN multi notes export error message must be displayed", async () => {
+          await expect(async () =>
+            cmd.gatherInputs({
+              exportScope: PodExportScope.Vault,
+              destination: "clipboard",
+            })
           ).toThrow(
             "Multi Note Export cannot have clipboard as destination. Please configure your destination by using Dendron: Configure Export Pod V2 command"
           );


### PR DESCRIPTION
**Background**
This change will support allowing schemas to reference template notes in different vaults through 2 ways.

1. Cross vault notation (e.g dendron://vault1/foo). When this notation is used, we use the template specified in that vault and throw an error otherwise (even if it is found in a different vault)
2. Lookup + prompt. We will search the engine for all notes that match the template. If one is found, use that. If multiple is found, prompt user to select vault. If none, throw an error

See [[Support Templates in Multivault|dendron://private/task.schema.2022.01.05.support-templates-in-multivault]] for more info

**Other changes:**
* Modified SchemaUtils to take in template note instead of SchemaTemplate. This means that applyTemplate works only on valid template notes

**Testing:**
* Using test workspace, create schema to reference egg which lies in vault, vault2, and vaultThree. Verified prompt
* Other edge cases also manually created and through integ test cases

Updated docs for [[template|dendron://dendron.dendron-site/dendron.topic.schema#template]]

**Madge:**
Before: 130
After: 130