### PR TITLE
fix(publishing): Search Bar Results to not stay anchored to the search bar when scrolling up

### DIFF
--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -152,6 +152,7 @@ function DendronSearchComponent(
       allowClear
       style={{ width: "100%" }}
       value={searchQueryValue}
+      getPopupContainer={(trigger) => trigger.parentElement}
       // @ts-ignore
       onClick={results === SearchMode.SEARCH_MODE ? () => null : onClickLookup}
       onChange={


### PR DESCRIPTION
fix(publishing): Search Bar Results to not stay anchored to the search bar when scrolling up

Uses information from the antd's FAQ: https://ant.design/docs/react/faq

![image](https://user-images.githubusercontent.com/1133550/151242968-249d1f13-9069-4211-a877-5c7e5ce5aa78.png)


## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated