### PR TITLE
chore: update github label policy

### DIFF
--- a/.github/workflows/issue-labler.yml
+++ b/.github/workflows/issue-labler.yml
@@ -1,7 +1,7 @@
 name: "Issue Labeler"
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   triage:
@@ -11,6 +11,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/config/issue-labler/labler.yml
-          not-before: '2020-02-21T00:00:00Z'
+          not-before: "2020-02-21T00:00:00Z"
           enable-versioned-regex: 1
           versioned-regex: 'issue_labeler_regex_version=(\d+)'


### PR DESCRIPTION
issue labeler should only update labels on first open instead of
everytime someone edits
