### PR TITLE
enhance(schemas): Support date subsitution via string replacement

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1372,22 +1372,34 @@ export class SchemaUtils {
         note.body = tempNote.body;
       }
 
-      // Apply date variable substitution to the body based on mustache delimiter if applicable
-      // E.g. if template has {{ CURRENT_YEAR }}, new note will contain 2021
-      // Use mustache delimiter
-      // TODO: Renable date variable substitution when new format is thought through
-      /*_.templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
-
+      // Apply date variable substitution to the body based on lodash interpolate delimiter if applicable
+      // E.g. if template has <%= CURRENT_YEAR %>, new note will contain 2021
       const currentDate = Time.now();
-      const compiledSchemaTemplate = _.template(note.body);
-      note.body = compiledSchemaTemplate({
-        CURRENT_YEAR: currentDate.toFormat("yyyy"),
-        CURRENT_MONTH: currentDate.toFormat("LL"),
-        CURRENT_DAY: currentDate.toFormat("dd"),
-        CURRENT_HOUR: currentDate.toFormat("HH"),
-        CURRENT_MINUTE: currentDate.toFormat("mm"),
-        CURRENT_SECOND: currentDate.toFormat("ss"),
-      });*/
+
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_YEAR\\s*%>", "g"),
+        currentDate.toFormat("yyyy")
+      );
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_MONTH\\s*%>", "g"),
+        currentDate.toFormat("LL")
+      );
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_DAY\\s*%>", "g"),
+        currentDate.toFormat("dd")
+      );
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_HOUR\\s*%>", "g"),
+        currentDate.toFormat("HH")
+      );
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_MINUTE\\s*%>", "g"),
+        currentDate.toFormat("mm")
+      );
+      note.body = note.body.replace(
+        new RegExp("<%=\\s*CURRENT_SECOND\\s*%>", "g"),
+        currentDate.toFormat("ss")
+      );
 
       return true;
     }

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1377,27 +1377,27 @@ export class SchemaUtils {
       const currentDate = Time.now();
 
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_YEAR\\s*%>", "g"),
+        /<%=\s*CURRENT_YEAR\s*%>/g,
         currentDate.toFormat("yyyy")
       );
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_MONTH\\s*%>", "g"),
+        /<%=\s*CURRENT_MONTH\s*%>/g,
         currentDate.toFormat("LL")
       );
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_DAY\\s*%>", "g"),
+        /<%=\s*CURRENT_DAY\s*%>/g,
         currentDate.toFormat("dd")
       );
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_HOUR\\s*%>", "g"),
+        /<%=\s*CURRENT_HOUR\s*%>/g,
         currentDate.toFormat("HH")
       );
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_MINUTE\\s*%>", "g"),
+        /<%=\s*CURRENT_MINUTE\s*%>/g,
         currentDate.toFormat("mm")
       );
       note.body = note.body.replace(
-        new RegExp("<%=\\s*CURRENT_SECOND\\s*%>", "g"),
+        /<%=\s*CURRENT_SECOND\s*%>/g,
         currentDate.toFormat("ss")
       );
 

--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -130,8 +130,8 @@ export const NOTE_PRESETS_V4 = {
   NOTE_WITH_DATE_VARIABLES: CreateNoteFactory({
     fname: "date-variables",
     body: [
-      "Today is {{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}",
-      "This link goes to [[daily.journal.{{ CURRENT_YEAR }}.{{ CURRENT_MONTH }}.{{ CURRENT_DAY }}]]",
+      "Today is <%= CURRENT_YEAR %>.<%=CURRENT_MONTH %>.<%=CURRENT_DAY%>",
+      "This link goes to [[daily.journal.<%=CURRENT_YEAR%>.<%= CURRENT_MONTH%>.<%= CURRENT_DAY %>]]",
       "{{ 1 + 1 }} should not be evalated to 2",
     ].join("\n"),
   }),

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -138,8 +138,7 @@ describe(`SchemaUtil tests:`, () => {
         );
       });
 
-      // TODO: Reenable once date variable substitution is enabled
-      it.skip("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
+      it("WHEN applying a template with date variables, THEN replace note's body with template's body and with proper date substitution", async () => {
         const dateTemplate: SchemaTemplate = {
           id: "date-variables",
           type: "note",


### PR DESCRIPTION
As followup from https://github.com/dendronhq/dendron/discussions/2207, we will use string replacement instead of lodash to support date variable substitution. Since we don't need javascript evalaution, we find this will be simpler. We will still use lodash default interpolate delimiter

**Testing**
Create template as follows:
```
Year is <%= CURRENT_YEAR %>
Month is <%=CURRENT_MONTH %>
Hour is <%=CURRENT_HOUR%>

This links goes to [[daily.journal.<%=CURRENT_YEAR%>.<%= CURRENT_MONTH%>.<%= CURRENT_DAY%>]]
```
Creating note with template leads to:
```
Year is 2022
Month is 01
Hour is 13

This links goes to [[daily.journal.2022.01.26]]
```

Updated docs for [[Template Variables|dendron://dendron.dendron-site/dendron.topic.templates#template-variables]]

**Madge**
Before: 130
After: 130
