### PR TITLE
enhance(publish): show lookup without waiting for notes to fetch

### DIFF
--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -119,6 +119,13 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
     [lookup, notes, setLookupResults]
   );
 
+  // This is needed to make sure the lookup results are updated when notes are fetched
+  useEffect(() => {
+    if (results === SearchMode.LOOKUP_MODE) {
+      onLookup(searchQueryValue);
+    }
+  }, [notes, results, onLookup]);
+
   const onClickLookup = useCallback(() => {
     const qs = NoteLookupUtils.getQsForCurrentLevel(initValue);
     onLookup(qs);
@@ -167,7 +174,11 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
 
   let autocompleteChildren;
   if (!verifyNoteData({ notes })) {
-    autocompleteChildren = <DendronSpinner />;
+    autocompleteChildren = (
+      <AutoComplete.Option value="Loading...">
+        <DendronSpinner />
+      </AutoComplete.Option>
+    );
   } else if (results === SearchMode.SEARCH_MODE) {
     autocompleteChildren = searchResults?.map(({ item: note, matches }) => {
       return (
@@ -244,11 +255,7 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
       }
       // @ts-ignore
       onSelect={onSelect}
-      placeholder={
-        loading
-          ? "Loading Search"
-          : "For full text search please use the '?' prefix. e.g. ? Onboarding"
-      }
+      placeholder="For full text search please use the '?' prefix. e.g. ? Onboarding"
     >
       {autocompleteChildren}
     </AutoComplete>

--- a/packages/nextjs-template/utils/fetchers.ts
+++ b/packages/nextjs-template/utils/fetchers.ts
@@ -1,6 +1,6 @@
 import {
   IntermediateDendronConfig,
-  SerializedFuseIndex
+  SerializedFuseIndex,
 } from "@dendronhq/common-all";
 import { getAssetUrl } from "./links";
 import { NoteData } from "./types";

--- a/packages/nextjs-template/utils/fuse.ts
+++ b/packages/nextjs-template/utils/fuse.ts
@@ -19,7 +19,10 @@ type FuseIndexProvider = () => Promise<FuseNoteIndex | FuseNote>;
  * just add an arrow function as the parameter. See `useGenerateFuse` for a
  * good example of what to do.
  */
-function useFuse(notes: NotePropsDict, provider: FuseIndexProvider) {
+function useFuse(
+  notes: NotePropsDict | undefined,
+  provider: FuseIndexProvider
+) {
   const [error, setError] = useState<any>();
   const [loading, setLoading] = useState<boolean>(false);
   const [fuse, setFuse] = useState<FuseNote>();
@@ -28,6 +31,10 @@ function useFuse(notes: NotePropsDict, provider: FuseIndexProvider) {
     if (_.isUndefined(fuse)) {
       setLoading(true);
       const req = async () => {
+        if (!notes) {
+          return;
+        }
+
         try {
           const value = await provider();
           if (value instanceof Fuse) {
@@ -61,7 +68,7 @@ function useFuse(notes: NotePropsDict, provider: FuseIndexProvider) {
 }
 
 /** A react hook to fetch the exported fuse index. */
-export function useFetchFuse(notes: NotePropsDict) {
+export function useFetchFuse(notes: NotePropsDict | undefined) {
   return useFuse(notes, fetchFuseIndex);
 }
 


### PR DESCRIPTION
enhance(publish): show lookup without waiting for notes to fetch

1. This PR allows the user to type in the lookup/search bar without waiting for the notes to load. 
2. I discovered that it takes a long time for the search results to render, so I'm capping the count to 30 as discussed with @kevinslin . People are unlikely to need 500 results there, so capping is a reasonable 20/80 approach.

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated