### PR TITLE
fix(publish): CSS sidebar is off on smaller screens like iPad

### DIFF
--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -159,7 +159,7 @@ export default function DendronLayout(
             className="site-layout-sidebar"
             style={{
               flex: "0 0 auto",
-              width: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2 + ${
+              width: `calc(max((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2, 0px) + ${
                 // eslint-disable-next-line no-nested-ternary
                 isResponsive
                   ? isCollapsed


### PR DESCRIPTION
fix(publish): CSS sidebar is off on smaller screens like iPad

Fixes #2290 by making sure we never actually subtract from the minimum `200px` width

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated