### PR TITLE
enhance(dev): strip prefix from sentry stack traces and traces formatting

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/errorReporting.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/errorReporting.test.ts
@@ -1,0 +1,37 @@
+import { rewriteFilename } from "@dendronhq/common-server";
+import { expect } from "../testUtilsv2";
+
+suite("WHEN a stack trace is sent to sentry", () => {
+  test("THEN rewriteFilename() correctly strips down and rewrites the file names", () => {
+    // A selection of real stack traces from sentry
+    expect(
+      rewriteFilename(
+        "/Users/test_user/code_dendron/dendron/packages/plugin-core/out/src/_extension.js"
+      )
+    ).toEqual("app:///packages/plugin-core/out/src/_extension.js");
+
+    expect(
+      rewriteFilename(
+        "c:\\Users\\some_username\\.vscode\\extensions\\dendron.dendron-0.79.0\\dist\\server.js"
+      )
+    ).toEqual("app:///dist/server.js");
+
+    expect(
+      rewriteFilename(
+        "/Users/another_username/.vscode/extensions/dendron.dendron-0.79.0/dist/extension.js"
+      )
+    ).toEqual("app:///dist/extension.js");
+
+    expect(
+      rewriteFilename(
+        "/home/username/.vscode-insiders/extensions/dendron.dendron-0.79.0/dist/extension.js"
+      )
+    ).toEqual("app:///dist/extension.js");
+
+    expect(
+      rewriteFilename(
+        "/Users/user.test/.vscode-insiders/extensions/dendron.nightly-0.79.4/dist/extension.js"
+      )
+    ).toEqual("app:///dist/extension.js");
+  });
+});


### PR DESCRIPTION
enhance(dev): strip prefix from sentry stacktraces and traces formatting

For writing a test I looked through several dozen stack traces on actual traces.   

## Testing
- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated