### PR TITLE
chore(dev): explicitly set sentry sampling rates and add comments

### DIFF
--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -32,7 +32,11 @@ export function initializeSentry(environment: Stage): void {
   Sentry.init({
     dsn,
     defaultIntegrations: false,
-    tracesSampleRate: 1.0,
+    // Error stack trace sample rate: send all errors to sentry
+    sampleRate: 1.0,
+    // Transaction sample rate. Transactions are activities like page loads and api calls
+    // The configuration property name is a bit misleading. We don't use them right now.
+    tracesSampleRate: 0.0,
     enabled: true,
     environment,
     attachStacktrace: true,


### PR DESCRIPTION
chore(dev): explicitly set sentry sampling rates and add comments

The current `traceSampleRate` setting does nothing whereas `sampleRate` is what we want. 

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated