### PR TITLE
fix: preview opens wrong path on Windows

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -49,10 +49,10 @@ export class ShowPreviewCommand extends InputArgCommand<
   async execute(opts?: ShowPreviewCommandOpts) {
     let note: NoteProps | undefined;
 
-    if (!_.isEmpty(opts)) {
+    if (opts !== undefined && !_.isEmpty(opts)) {
       // Used a context menu to open preview for a specific note
       try {
-        note = ExtensionProvider.getWSUtils().getNoteFromPath(opts!.path);
+        note = ExtensionProvider.getWSUtils().getNoteFromPath(opts.fsPath);
       } catch {
         // Sometimes VSCode gives us a weird `opts` when no note was selected, so fall back to active note
         note = ExtensionProvider.getWSUtils().getActiveNote();
@@ -64,10 +64,10 @@ export class ShowPreviewCommand extends InputArgCommand<
 
     if (note) {
       this._panel.show(note);
-    } else if (opts?.path) {
+    } else if (opts?.fsPath) {
       // We can't find the note, so this is not in the Dendron workspace.
       // Preview the file anyway if it's a markdown file.
-      await this.openFileInPreview(opts.path);
+      await this.openFileInPreview(opts.fsPath);
     } else {
       // Not file selected for preview, default to open file
       const editor = VSCodeUtils.getActiveTextEditor();

--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -51,30 +51,31 @@ export class ShowPreviewCommand extends InputArgCommand<
 
     if (opts !== undefined && !_.isEmpty(opts)) {
       // Used a context menu to open preview for a specific note
-      try {
-        note = ExtensionProvider.getWSUtils().getNoteFromPath(opts.fsPath);
-      } catch {
-        // Sometimes VSCode gives us a weird `opts` when no note was selected, so fall back to active note
-        note = ExtensionProvider.getWSUtils().getActiveNote();
-      }
+      note = ExtensionProvider.getWSUtils().getNoteFromPath(opts.fsPath);
     } else {
       // Used the command bar or keyboard shortcut to open preview for active note
-      this._panel.show();
+      note = ExtensionProvider.getWSUtils().getActiveNote();
     }
+    this._panel.show();
 
     if (note) {
-      this._panel.show(note);
+      return { note };
     } else if (opts?.fsPath) {
+      const fsPath = opts.fsPath;
       // We can't find the note, so this is not in the Dendron workspace.
       // Preview the file anyway if it's a markdown file.
-      await this.openFileInPreview(opts.fsPath);
+      await this.openFileInPreview(fsPath);
+      return { fsPath };
     } else {
       // Not file selected for preview, default to open file
       const editor = VSCodeUtils.getActiveTextEditor();
       if (editor) {
-        await this.openFileInPreview(editor.document.uri.fsPath);
+        const fsPath = editor.document.uri.fsPath;
+        await this.openFileInPreview(fsPath);
+        return { fsPath };
       }
     }
+    return undefined;
   }
 
   /**

--- a/packages/plugin-core/src/commands/ShowPreviewInterface.ts
+++ b/packages/plugin-core/src/commands/ShowPreviewInterface.ts
@@ -1,4 +1,11 @@
+import { NoteProps } from "@dendronhq/common-all";
 import { Uri } from "vscode";
 
 export type ShowPreviewCommandOpts = Uri;
-export type ShowPreviewCommandOutput = any;
+/** `note` if a note that's in the engine was opened. `fsPath' if a non-note file was opened. `undefined` if nothing was found to preview.
+ *
+ */
+export type ShowPreviewCommandOutput =
+  | { note: NoteProps; fsPath?: string }
+  | { note?: NoteProps; fsPath: string }
+  | undefined;

--- a/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowPreview.test.ts
@@ -1,0 +1,169 @@
+import { NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import { test, before } from "mocha";
+import { ShowPreviewCommand } from "../../commands/ShowPreview";
+import { PreviewPanelFactory } from "../../components/views/PreviewViewFactory";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS, setupBeforeAfter } from "../testUtilsV3";
+import vscode from "vscode";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import fs from "fs-extra";
+import path from "path";
+
+suite("GIVEN ShowPreview", function () {
+  const ctx = setupBeforeAfter(this);
+
+  describeSingleWS(
+    "WHEN opening the preview from the command bar",
+    {
+      ctx,
+    },
+    () => {
+      let note: NoteProps;
+      before(async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        note = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          wsRoot,
+          vault: vaults[0],
+          fname: "preview-test",
+        });
+        // Open the note so that's the current note
+        await ExtensionProvider.getWSUtils().openNote(note);
+      });
+      test("THEN the current note is opened", async () => {
+        const cmd = new ShowPreviewCommand(
+          PreviewPanelFactory.create(ExtensionProvider.getExtension())
+        );
+        const out = await cmd.run();
+        expect(out?.note).toBeTruthy();
+        expect(out!.note!.id).toEqual(note.id);
+        expect(out!.note!.fname).toEqual(note.fname);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN opening the preview from a context menu AND a note is open",
+    {
+      ctx,
+    },
+    () => {
+      let note: NoteProps;
+      before(async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        note = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          wsRoot,
+          vault: vaults[0],
+          fname: "preview-test",
+        });
+        const wrongNote = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          wsRoot,
+          vault: vaults[0],
+          fname: "wrong-note",
+        });
+        // A different note is open this time
+        await ExtensionProvider.getWSUtils().openNote(wrongNote);
+      });
+      test("THEN the selected note is opened", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const cmd = new ShowPreviewCommand(
+          PreviewPanelFactory.create(ExtensionProvider.getExtension())
+        );
+        // When opened from a menu, the file path will be passed as an argument
+        const path = vscode.Uri.file(NoteUtils.getFullPath({ note, wsRoot }));
+        const out = await cmd.run(path);
+        expect(out?.note).toBeTruthy();
+        expect(out!.note!.id).toEqual(note.id);
+        expect(out!.note!.fname).toEqual(note.fname);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN opening the preview from a context menu AND no note is open",
+    {
+      ctx,
+    },
+    () => {
+      let note: NoteProps;
+      before(async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        note = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          wsRoot,
+          vault: vaults[0],
+          fname: "preview-test",
+        });
+        // Make sure no note is open
+        await VSCodeUtils.closeAllEditors();
+      });
+      test("THEN the selected note is opened", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const cmd = new ShowPreviewCommand(
+          PreviewPanelFactory.create(ExtensionProvider.getExtension())
+        );
+        // When opened from a menu, the file path will be passed as an argument
+        const path = vscode.Uri.file(NoteUtils.getFullPath({ note, wsRoot }));
+        const out = await cmd.run(path);
+        expect(out?.note).toBeTruthy();
+        expect(out!.note!.id).toEqual(note.id);
+        expect(out!.note!.fname).toEqual(note.fname);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN opening a non-note file from the content menu",
+    {
+      ctx,
+    },
+    () => {
+      let fsPath: string;
+      before(async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        fsPath = path.join(wsRoot, "foo-bar.md");
+        await fs.writeFile(fsPath, "foo bar");
+        // Make sure no note is open
+        await VSCodeUtils.closeAllEditors();
+      });
+      test("THEN the selected non-note file is opened", async () => {
+        const cmd = new ShowPreviewCommand(
+          PreviewPanelFactory.create(ExtensionProvider.getExtension())
+        );
+        // When opened from a menu, the file path will be passed as an argument
+        const path = vscode.Uri.file(fsPath);
+        const out = await cmd.run(path);
+        expect(out?.fsPath).toEqual(fsPath);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN opening a non-note file from the command bar",
+    {
+      ctx,
+    },
+    () => {
+      let fsPath: string;
+      let uri: vscode.Uri;
+      before(async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        fsPath = path.join(wsRoot, "foo-bar.md");
+        await fs.writeFile(fsPath, "foo bar");
+        uri = vscode.Uri.file(fsPath);
+        await VSCodeUtils.openFileInEditor(uri);
+      });
+      test("THEN the current non-note file is opened", async () => {
+        const cmd = new ShowPreviewCommand(
+          PreviewPanelFactory.create(ExtensionProvider.getExtension())
+        );
+        const out = await cmd.run();
+        expect(out?.fsPath).toEqual(fsPath);
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -274,6 +274,10 @@ export class VSCodeUtils {
     vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(link));
   }
 
+  closeAllEditors() {
+    return vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  }
+
   static async openWS(wsFile: string) {
     return vscode.commands.executeCommand(
       "vscode.openFolder",


### PR DESCRIPTION
Fixes a couple issues:
- Preview would open the wrong path on Windows (`Uri.path` instead of `Uri.fsPath`)
- When opened from the command bar, preview would open existing notes as non-note files

Also added automated tests for the preview to hopefully catch these issues in the future.