### PR TITLE
fix: show preview doesn't display targeted files when using file explorer

### DIFF
--- a/packages/plugin-core/src/commands/ShowPreview.ts
+++ b/packages/plugin-core/src/commands/ShowPreview.ts
@@ -59,6 +59,7 @@ export class ShowPreviewCommand extends InputArgCommand<
     this._panel.show();
 
     if (note) {
+      this._panel.show(note);
       return { note };
     } else if (opts?.fsPath) {
       const fsPath = opts.fsPath;


### PR DESCRIPTION
This was meant to be a part of #2326 but was missed.