### PR TITLE
chore: reduce unnecessary logs

### DIFF
--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -123,7 +123,7 @@ export class WindowWatcher {
       ) {
         return;
       }
-      Logger.info({ ctx, editor: uri.fsPath });
+      Logger.debug({ ctx, editor: uri.fsPath });
       // Decorations only render the visible portions of the screen, so they
       // need to be re-rendered when the user scrolls around
       this.triggerUpdateDecorations(editor);


### PR DESCRIPTION
Switches some logs created in `handleImage` and `onDidChangeTextEditorVisibleRanges` to debug. These were excessively filling up logs.

Also refactors the deprecated logger usage in `handleImage`.