### PR TITLE
chore(dev): append -nightly to the nightly build version for sentry

### DIFF
--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`" >> $GITHUB_ENV
+          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`-nightly" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV


### PR DESCRIPTION
chore(dev): append -nightly to the nightly build version for sentry

Tested:
1. Manually by running the command in my shell.
2. Manually by making a build with a random string and seeing a version with it in sentry.

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated