### PR TITLE
fix(schemas): Do not include stubs as part of template suggestions when applying a template

### DIFF
--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -37,11 +37,13 @@ export interface IWSUtilsV2 {
    *
    * @param fname: name of note to look for
    * @param quickpickTitle: title of quickpick to display if multiple matches are found
+   * @param nonStubOnly?: if provided, boolean to determine whether to return non-stub notes only. Default behavior is to return all
    * @param vault?: if provided, vault to search note from
    */
   findNoteFromMultiVaultAsync(opts: {
     fname: string;
     quickpickTitle: string;
+    nonStubOnly?: boolean;
     vault?: DVault;
   }): Promise<RespV3<NoteProps | undefined>>;
 }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -552,6 +552,7 @@ export class NoteLookupCommand
         fname: ref,
         quickpickTitle:
           "Select which template to apply or press [ESC] to not apply a template",
+        nonStubOnly: true,
         vault: maybeVault,
       });
     } else {


### PR DESCRIPTION
**Bug**
1. `foo` exists in vault 1
2. `foo.two` exists in vault 2
3. Schema references template called `foo`
4. When creating a new note that matches the schema, body from `foo` in vault 1 should be applied. However, `foo` from vault 2 gets suggested b/c it is an stub note type

**Fix**
Filter out stub notes when suggesting template notes