### PR TITLE
chore: remove lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,9 @@
     "hooks:pre-commit": "node ./hooks/pre-commit.js",
     "hooks:pre-push": "node ./hooks/pre-push.js",
     "gen:meta": "node ./bootstrap/scripts/genMeta.js",
-    "backend:updateDendronDeps": "node bootstrap/backend/updateDendronhqDeps.js"
+    "backend:updateDendronDeps": "node bootstrap/backend/updateDendronhqDeps.js",
+    "stash:unstaged": "git stash save -k 'pre-linting-stash' >> /dev/null",
+    "stash:pop": "git stash && git stash pop stash@{1} && git read-tree stash && git stash drop"
   },
   "packages": [
     "packages/*",
@@ -111,7 +113,7 @@
   "useWorkspaces": false,
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && yarn hooks:pre-commit",
+      "pre-commit": "yarn stash:unstaged && lint-staged && yarn hooks:pre-commit && yarn stash:pop",
       "pre-push": "yarn hooks:pre-push"
     }
   },


### PR DESCRIPTION
`lint-staged` causes the unstaged hunks inside partially-staged files to be staged as well. This may cause people (especially myself) to accidentally commit changes they did not intend to commit. This PR removes `lint-staged`.