### PR TITLE
chore(dev): fix 'Non-Error exception captured' in Sentry

### DIFF
--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -87,7 +87,10 @@ export function eventModifier(
 
   // Add more information to the event extras payload:
   if (error && error instanceof DendronError) {
+    // This is a bit hacky because it overwrites the existing extra context
+    // TODO: figure out how to handle contexts in a uniform way
     event.extra = {
+      ...event.extra,
       name: error.name,
       message: error.message,
       payload: error.payload,


### PR DESCRIPTION
chore(dev): fix 'Non-Error exception captured' in Sentry

1. The `Non-Error exception captured` is happening because we are converting error in the payload with `error2PlainObject()`
2. I also discovered that we are overwriting context in `eventModifier` in `errorReporting.ts`: so I added `...event.extra`

## Testing
- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
### Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
### Analytics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated