### PR TITLE
chore: disable inactive user survey prompt

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -902,7 +902,8 @@ async function showWelcomeOrWhatsNew({
 
   // Show inactive users (users who were active on first week but have not used lookup in 2 weeks)
   // a reminder prompt to re-engage them.
-  if (await shouldDisplayInactiveUserSurvey()) {
+  // TODO: there is a bug in the current logic. disabling until we fix it
+  if (false) {
     await showInactiveUserMessage();
   }
 }


### PR DESCRIPTION
There's currently a bug where users that use Dendron every day are still
getting prompted. Disabling until we root cause and fix
