### PR TITLE
chore(dev): update pr templates for community and team contributions

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,17 +1,6 @@
 
 # Pull Request Checklist
 
-If this is your first time submitting a pull request to Dendron, copy and paste the full [Dendron Review Checklist](https://docs.dendron.so/notes/1EoNIXzgmhgagqcAo9nDn.html) into this request and check off each item as necessary. 
+If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.githubusercontent.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f/raw/cc83a1b3e3cb1fd1aefe9650c6af08b3836eebe7/dev.process.review.checklist.first-time.export.md) and add it to the body of the pull request. 
 
-This template contains the short checklist which is used by the Dendron core team. 
-
-## Testing
-- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
-- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
-- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
-- [ ] If your tests changes an existing snapshot, make sure that snapshots are [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)
-- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), make sure that it is included in the [test workspace](https://docs.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)
-### Docs
-- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
-### Analytics
-- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://docs.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated
+If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.githubusercontent.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2/raw/715c531efb020a526e40ed20b4cf922194b429b5/dev.process.review.checklist.extended.export.md)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,8 @@
 
 # Pull Request Checklist
 
-If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.githubusercontent.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f/raw/cc83a1b3e3cb1fd1aefe9650c6af08b3836eebe7/dev.process.review.checklist.first-time.export.md) and add it to the body of the pull request. 
+If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 
 
-If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.githubusercontent.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2/raw/715c531efb020a526e40ed20b4cf922194b429b5/dev.process.review.checklist.extended.export.md)
+If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).
+
+To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.


### PR DESCRIPTION
Team contributions have a few more steps compared to community
contributions - make this explicit by splitting out PR checklist into
two separate templates
