### PR TITLE
chore(dev): emphasize no async fns on the describeWS Test functions

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -605,7 +605,7 @@ suite("windowDecorations", function () {
       });
     });
 
-    describeSingleWS("AND frontmatter is not visible", { ctx }, async () => {
+    describeSingleWS("AND frontmatter is not visible", { ctx }, () => {
       before(async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
         const note = await NoteTestUtilsV4.createNoteWithEngine({

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -456,7 +456,7 @@ suite("MigrationService", function () {
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
     },
-    async () => {
+    () => {
       const dummyFunc: MigrateFunction = async ({
         dendronConfig,
         wsConfig,

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -472,7 +472,8 @@ export function describeMultiWS(
       await _activate(opts.ctx);
     });
 
-    fn();
+    const result = fn();
+    assertTestFnNotAsync(result);
 
     // Release all registered resouces such as commands and providers
     after(() => {
@@ -501,13 +502,31 @@ export function describeSingleWS(
       await _activate(opts.ctx);
     });
 
-    fn();
+    const result = fn();
+    assertTestFnNotAsync(result);
 
     // Release all registered resouces such as commands and providers
     after(() => {
       cleanupVSCodeContextSubscriptions(opts.ctx);
     });
   });
+}
+
+/**
+ * Helper function for Describe*WS to do a run-time check to make sure an async
+ * test function hasn't been passed
+ * @param testFnResult
+ */
+function assertTestFnNotAsync(testFnResult: any) {
+  if (
+    testFnResult &&
+    testFnResult.then &&
+    typeof testFnResult.then === "function"
+  ) {
+    throw new Error(
+      "test fn passed to DescribeWS cannot be async! Please re-write the test"
+    );
+  }
 }
 
 export function stubCancellationToken(): CancellationToken {

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -436,9 +436,9 @@ export function runSuiteButSkipForWindows() {
   return runTest;
 }
 
-/** Use to run tests with a multi-vault workspace. Used in the same way as regular `describe`.
- *
- * For example:
+/**
+ * Use to run tests with a multi-vault workspace. Used in the same way as
+ * regular `describe`. For example:
  * ```ts
  * describeMultiWS(
  *   "WHEN workspace type is not specified",
@@ -455,11 +455,16 @@ export function runSuiteButSkipForWindows() {
  *   }
  * );
  * ```
+ * @param title
+ * @param opts
+ * @param fn - the test() functions to execute. NOTE: This function CANNOT be
+ * async, or else the test may not fail reliably when your expect or assert
+ * conditions are not met.
  */
 export function describeMultiWS(
   title: string,
   opts: SetupLegacyWorkspaceMultiOpts,
-  fn: () => any
+  fn: () => void
 ) {
   describe(title, () => {
     before(async () => {
@@ -476,10 +481,19 @@ export function describeMultiWS(
   });
 }
 
+/**
+ * Use to run tests with a single-vault workspace. Used in the same way as
+ * regular `describe`.
+ * @param title
+ * @param opts
+ * @param fn - the test() functions to execute. NOTE: This function CANNOT be
+ * async, or else the test may not fail reliably when your expect or assert
+ * conditions are not met.
+ */
 export function describeSingleWS(
   title: string,
   opts: SetupLegacyWorkspaceOpts,
-  fn: () => any
+  fn: () => void
 ) {
   describe(title, () => {
     before(async () => {


### PR DESCRIPTION
## chore(dev): emphasize no async fns on the describeWS Test functions

- Adds function headers to describeSingleWS and describeMultiWS
- removes two existing instances of fn's marked async 

--- 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)