### PR TITLE
chore(workspace) First pass at resolving cyclic dependencies wrt windowwatcher/workspacewatcher

### DIFF
--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -44,6 +44,9 @@ export class ExtensionProvider {
     return ExtensionProvider.getExtension().getWorkspaceConfig();
   }
 
+  /**
+   * @deprecated. See {@link IDendronExtension.getTreeView}
+   */
   static getTreeView(key: DendronTreeViewKey) {
     return ExtensionProvider.getExtension().getTreeView(key);
   }

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -1,5 +1,5 @@
 import { IDendronExtension } from "./dendronExtensionInterface";
-import { DendronError } from "@dendronhq/common-all";
+import { DendronError, DendronTreeViewKey } from "@dendronhq/common-all";
 import _ from "lodash";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
 
@@ -34,6 +34,18 @@ export class ExtensionProvider {
 
   static getWSUtils(): IWSUtilsV2 {
     return ExtensionProvider.getExtension().wsUtils;
+  }
+
+  static isActive() {
+    return ExtensionProvider.getExtension().isActive();
+  }
+
+  static getWorkspaceConfig() {
+    return ExtensionProvider.getExtension().getWorkspaceConfig();
+  }
+
+  static getTreeView(key: DendronTreeViewKey) {
+    return ExtensionProvider.getExtension().getTreeView(key);
   }
 
   static register(extension: IDendronExtension) {

--- a/packages/plugin-core/src/clientUtils.ts
+++ b/packages/plugin-core/src/clientUtils.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import { LookupNoteTypeEnum } from "./components/lookup/types";
 import { PickerUtilsV2 } from "./components/lookup/utils";
 import { _noteAddBehaviorEnum } from "./constants";
-import { getDWorkspace, getExtension } from "./workspace";
+import { ExtensionProvider } from "./ExtensionProvider";
 
 type CreateFnameOverrides = {
   domain?: string;
@@ -53,7 +53,7 @@ export class DendronClientUtilsV2 {
           fname,
           notes: opts.engine.notes,
           vault,
-          wsRoot: getDWorkspace().wsRoot,
+          wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
         });
         if (domain && domain.schema) {
           const smod = opts.engine.schemas[domain.schema.moduleId];
@@ -94,7 +94,7 @@ export class DendronClientUtilsV2 {
     prefix: string;
   } {
     // gather inputs
-    const config = getDWorkspace().config;
+    const config = ExtensionProvider.getDWorkspace().config;
 
     let dateFormat: string;
     let addBehavior: NoteAddBehavior;
@@ -102,15 +102,17 @@ export class DendronClientUtilsV2 {
 
     switch (type) {
       case "SCRATCH": {
-        dateFormat = getExtension().getWorkspaceSettingOrDefault({
-          wsConfigKey: "dendron.defaultScratchDateFormat",
-          dendronConfigKey: "workspace.scratch.dateFormat",
-        });
-        addBehavior = getExtension().getWorkspaceSettingOrDefault({
-          wsConfigKey: "dendron.defaultScratchAddBehavior",
-          dendronConfigKey: "workspace.scratch.addBehavior",
-        });
-        name = getExtension().getWorkspaceSettingOrDefault({
+        dateFormat =
+          ExtensionProvider.getExtension().getWorkspaceSettingOrDefault({
+            wsConfigKey: "dendron.defaultScratchDateFormat",
+            dendronConfigKey: "workspace.scratch.dateFormat",
+          });
+        addBehavior =
+          ExtensionProvider.getExtension().getWorkspaceSettingOrDefault({
+            wsConfigKey: "dendron.defaultScratchAddBehavior",
+            dendronConfigKey: "workspace.scratch.addBehavior",
+          });
+        name = ExtensionProvider.getExtension().getWorkspaceSettingOrDefault({
           wsConfigKey: "dendron.defaultScratchName",
           dendronConfigKey: "workspace.scratch.name",
         });
@@ -148,7 +150,7 @@ export class DendronClientUtilsV2 {
       throw Error("Must be run from within a note");
     }
 
-    const engine = getDWorkspace().engine;
+    const engine = ExtensionProvider.getEngine();
     const prefix = DendronClientUtilsV2.genNotePrefix(
       currentNoteFname,
       addBehavior as AddBehavior,
@@ -179,7 +181,7 @@ export class DendronClientUtilsV2 {
   };
 
   static shouldUseVaultPrefix(engine: DEngineClient) {
-    const config = getDWorkspace().config;
+    const config = ExtensionProvider.getDWorkspace().config;
     const enableXVaultWikiLink =
       ConfigUtils.getWorkspace(config).enableXVaultWikiLink;
     const useVaultPrefix =

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -35,8 +35,6 @@ import { DENDRON_COMMANDS } from "../constants";
 import { delayedUpdateDecorations } from "../features/windowDecorations";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { findReferences, FoundRefT } from "../utils/md";
-import { getVaultFromUri } from "../workspace";
-import { WSUtils } from "../WSUtils";
 import { BasicCommand } from "./base";
 import { ExtensionProvider } from "../ExtensionProvider";
 import {
@@ -117,7 +115,9 @@ export class MoveHeaderCommand extends BasicCommand<
     if (!selection) throw this.headerNotSelectedError;
 
     const line = editor.document.lineAt(selection.start.line).text;
-    const maybeNote = WSUtils.getNoteFromDocument(editor.document);
+    const maybeNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+      editor.document
+    );
     if (!maybeNote) {
       throw this.noActiveNoteError;
     }
@@ -325,7 +325,7 @@ export class MoveHeaderCommand extends BasicCommand<
     const fsPath = location.uri.fsPath;
     const fname = NoteUtils.normalizeFname(path.basename(fsPath));
 
-    const vault = getVaultFromUri(location.uri);
+    const vault = ExtensionProvider.getWSUtils().getVaultFromUri(location.uri);
     const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
       engine,

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -14,7 +14,6 @@ import path from "path";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtilsV2 } from "../../WSUtilsV2";
 import { CREATE_NEW_NOTE_DETAIL, CREATE_NEW_LABEL } from "./constants";
 import { DendronQuickPickerV2, TransformedQueryString } from "./types";
 import { filterPickerResults, PickerUtilsV2 } from "./utils";
@@ -38,7 +37,8 @@ export class NotePickerUtils {
     // dedupe wikilinks by value
     const uniqueWikiLinks = _.uniqBy(wikiLinks, "value");
 
-    const activeNote = WSUtilsV2.instance().getActiveNote() as DNodeProps;
+    const activeNote =
+      ExtensionProvider.getWSUtils().getActiveNote() as DNodeProps;
 
     // make a list of picker items from wikilinks
     const notesFromWikiLinks = LinkUtils.getNotesFromWikiLinks({

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -14,7 +14,7 @@ import path from "path";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtils } from "../../WSUtils";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 import { CREATE_NEW_NOTE_DETAIL, CREATE_NEW_LABEL } from "./constants";
 import { DendronQuickPickerV2, TransformedQueryString } from "./types";
 import { filterPickerResults, PickerUtilsV2 } from "./utils";
@@ -38,7 +38,7 @@ export class NotePickerUtils {
     // dedupe wikilinks by value
     const uniqueWikiLinks = _.uniqBy(wikiLinks, "value");
 
-    const activeNote = WSUtils.getActiveNote() as DNodeProps;
+    const activeNote = WSUtilsV2.instance().getActiveNote() as DNodeProps;
 
     // make a list of picker items from wikilinks
     const notesFromWikiLinks = LinkUtils.getNotesFromWikiLinks({

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -14,7 +14,6 @@ import { DendronClientUtilsV2 } from "../../clientUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { clipboard } from "../../utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtilsV2 } from "../../WSUtilsV2";
 import { DendronBtn } from "./ButtonTypes";
 import { NotePickerUtils } from "./NotePickerUtils";
 import {
@@ -367,7 +366,7 @@ export class TaskBtn extends DendronBtn {
     // If the lookup value ends up being identical to the current note, this will be confusing for the user because
     // they won't be able to create a new note. This can happen with the default settings of Task notes.
     // In that case, we add a trailing dot to suggest that they need to type something more.
-    const activeName = WSUtilsV2.instance().getActiveNote()?.fname;
+    const activeName = ExtensionProvider.getWSUtils().getActiveNote()?.fname;
     if (quickPick.value === activeName) quickPick.value = `${quickPick.value}.`;
     // Add default task note props to the created note
     quickPick.onCreate = async (note) => {

--- a/packages/plugin-core/src/components/lookup/buttons.ts
+++ b/packages/plugin-core/src/components/lookup/buttons.ts
@@ -14,7 +14,7 @@ import { DendronClientUtilsV2 } from "../../clientUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { clipboard } from "../../utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtils } from "../../WSUtils";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 import { DendronBtn } from "./ButtonTypes";
 import { NotePickerUtils } from "./NotePickerUtils";
 import {
@@ -367,7 +367,7 @@ export class TaskBtn extends DendronBtn {
     // If the lookup value ends up being identical to the current note, this will be confusing for the user because
     // they won't be able to create a new note. This can happen with the default settings of Task notes.
     // In that case, we add a trailing dot to suggest that they need to type something more.
-    const activeName = WSUtils.getActiveNote()?.fname;
+    const activeName = WSUtilsV2.instance().getActiveNote()?.fname;
     if (quickPick.value === activeName) quickPick.value = `${quickPick.value}.`;
     // Add default task note props to the created note
     quickPick.onCreate = async (note) => {

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -679,7 +679,7 @@ export class PickerUtilsV2 {
     const lookupView = ExtensionProvider.getTreeView(
       DendronTreeViewKey.LOOKUP_VIEW
     ) as LookupView;
-    lookupView.refreshLookupView({ buttons: opts.quickpick.buttons });
+    lookupView.refresh({ buttons: opts.quickpick.buttons });
   }
 
   static resetPaginationOpts(picker: DendronQuickPickerV2) {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -1,4 +1,5 @@
 import {
+  DendronTreeViewKey,
   DWorkspaceV2,
   WorkspaceSettings,
   WorkspaceType,
@@ -98,4 +99,18 @@ export interface IDendronExtension {
   addDisposable(disposable: vscode.Disposable): void;
 
   getEngine(): IEngineAPIService;
+
+  /**
+   * Checks if a Dendron workspace is currently active.
+   */
+  isActive(): boolean;
+
+  /**
+   * Get Global Workspace configuration
+   */
+  getWorkspaceConfig(
+    section?: string | undefined
+  ): vscode.WorkspaceConfiguration;
+
+  getTreeView(key: DendronTreeViewKey): vscode.WebviewViewProvider;
 }

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -112,5 +112,9 @@ export interface IDendronExtension {
     section?: string | undefined
   ): vscode.WorkspaceConfiguration;
 
+  /**
+   * @deprecated Temporarily exposed to resolve circular dependencies
+   * Moving forward with the eventing pattern, we shouldn't need to expose any tree views anymore
+   */
   getTreeView(key: DendronTreeViewKey): vscode.WebviewViewProvider;
 }

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -32,7 +32,6 @@ import { Logger } from "../logger";
 import { CodeConfigKeys, DateTimeFormat } from "../types";
 import { delayedFrontmatterWarning } from "../utils/frontmatter";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { WSUtilsV2 } from "../WSUtilsV2";
 
 /** Wait this long in miliseconds before trying to update decorations when a command forces a decoration update. */
 const DECORATION_UPDATE_DELAY = 100;
@@ -132,7 +131,9 @@ export async function updateDecorations(editor: TextEditor): Promise<{
     // Only show decorations & warnings for notes
     let note: NoteProps | undefined;
     try {
-      note = WSUtilsV2.instance().getNoteFromDocument(editor.document);
+      note = ExtensionProvider.getWSUtils().getNoteFromDocument(
+        editor.document
+      );
       if (_.isUndefined(note)) return {};
     } catch (error) {
       Logger.info({

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -27,12 +27,12 @@ import {
   ThemeColor,
   window,
 } from "vscode";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { CodeConfigKeys, DateTimeFormat } from "../types";
-import { getConfigValue, getDWorkspace } from "../workspace";
 import { delayedFrontmatterWarning } from "../utils/frontmatter";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { WSUtils } from "../WSUtils";
+import { WSUtilsV2 } from "../WSUtilsV2";
 
 /** Wait this long in miliseconds before trying to update decorations when a command forces a decoration update. */
 const DECORATION_UPDATE_DELAY = 100;
@@ -121,7 +121,7 @@ export async function updateDecorations(editor: TextEditor): Promise<{
 }> {
   try {
     const ctx = "updateDecorations";
-    const { engine } = getDWorkspace();
+    const engine = ExtensionProvider.getEngine();
     if (
       ConfigUtils.getWorkspace(engine.config).enableEditorDecorations === false
     ) {
@@ -132,7 +132,7 @@ export async function updateDecorations(editor: TextEditor): Promise<{
     // Only show decorations & warnings for notes
     let note: NoteProps | undefined;
     try {
-      note = WSUtils.getNoteFromDocument(editor.document);
+      note = WSUtilsV2.instance().getNoteFromDocument(editor.document);
       if (_.isUndefined(note)) return {};
     } catch (error) {
       Logger.info({
@@ -263,7 +263,7 @@ function mapBasicDecoration(
 }
 
 function mapTimestamp(decoration: DecorationTimestamp): DecorationAndType {
-  const tsConfig = getConfigValue(
+  const tsConfig = ExtensionProvider.getWorkspaceConfig().get(
     CodeConfigKeys.DEFAULT_TIMESTAMP_DECORATION_FORMAT
   ) as DateTimeFormat;
   const formatOption = DateTime[tsConfig];

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -172,7 +172,7 @@ export class MockDendronExtension implements IDendronExtension {
   }
 
   isActive(): boolean {
-    throw new Error("Method not implemented in MockDendronExtension.");
+    return true;
   }
 
   getWorkspaceConfig(): WorkspaceConfiguration {

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -1,4 +1,5 @@
 import {
+  DendronTreeViewKey,
   DEngineClient,
   DVault,
   DWorkspaceV2,
@@ -6,7 +7,13 @@ import {
   WorkspaceType,
 } from "@dendronhq/common-all";
 import { IWorkspaceService, WorkspaceService } from "@dendronhq/engine-server";
-import { Disposable, ExtensionContext, FileSystemWatcher } from "vscode";
+import {
+  Disposable,
+  ExtensionContext,
+  FileSystemWatcher,
+  WebviewViewProvider,
+  WorkspaceConfiguration,
+} from "vscode";
 import { ICommandFactory } from "../commandFactoryInterface";
 import { ILookupControllerV3Factory } from "../components/lookup/LookupControllerV3Interface";
 import {
@@ -162,5 +169,17 @@ export class MockDendronExtension implements IDendronExtension {
       throw new Error("Engine not initialized in MockDendronExtension");
     }
     return this._engine as IEngineAPIService;
+  }
+
+  isActive(): boolean {
+    throw new Error("Method not implemented in MockDendronExtension.");
+  }
+
+  getWorkspaceConfig(): WorkspaceConfiguration {
+    throw new Error("Method not implemented in MockDendronExtension.");
+  }
+
+  getTreeView(_key: DendronTreeViewKey): WebviewViewProvider {
+    throw new Error("Method not implemented in MockDendronExtension.");
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -57,7 +57,7 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           const editor = await VSCodeUtils.openFileInEditor(uri);
-          await WindowWatcher.triggerUpdateDecorations(editor!);
+          await watcher.triggerUpdateDecorations(editor!);
           // TODO: check for decorations
           done();
         },
@@ -161,11 +161,19 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         onInit: async ({ vaults, wsRoot, engine }) => {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
+          const previewProxy = new MockPreviewProxy();
+          const extension = ExtensionProvider.getExtension();
+
+          const windowWatcher = new WindowWatcher({
+            extension,
+            previewProxy,
+          });
 
           getExtension().workspaceWatcher = new WorkspaceWatcher({
             schemaSyncService:
               ExtensionProvider.getExtension().schemaSyncService,
-            extension: ExtensionProvider.getExtension(),
+            extension,
+            windowWatcher,
           });
           getExtension().workspaceWatcher?.activate(ctx);
           watcher!.activate();
@@ -191,10 +199,19 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
         onInit: async ({ vaults, wsRoot, engine }) => {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
+
+          const previewProxy = new MockPreviewProxy();
+          const extension = ExtensionProvider.getExtension();
+
+          const windowWatcher = new WindowWatcher({
+            extension,
+            previewProxy,
+          });
           getExtension().workspaceWatcher = new WorkspaceWatcher({
             schemaSyncService:
               ExtensionProvider.getExtension().schemaSyncService,
-            extension: ExtensionProvider.getExtension(),
+            extension,
+            windowWatcher,
           });
           getExtension().workspaceWatcher?.activate(ctx);
 

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -12,6 +12,7 @@ import sinon from "sinon";
 import path from "path";
 import * as vscode from "vscode";
 import { WorkspaceWatcher } from "../../WorkspaceWatcher";
+import { WindowWatcher } from "../../windowWatcher";
 import { expect } from "../testUtilsv2";
 import {
   describeMultiWS,
@@ -27,6 +28,7 @@ import * as _ from "lodash";
 import { WSUtils } from "../../WSUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
+import { MockPreviewProxy } from "../MockPreviewProxy";
 
 const setupBasic = async (opts: WorkspaceOpts) => {
   const { wsRoot, vaults } = opts;
@@ -112,10 +114,19 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
         ctx,
         postSetupHook: setupBasic,
         onInit: async ({ vaults, wsRoot, engine }) => {
+          const previewProxy = new MockPreviewProxy();
+          const extension = ExtensionProvider.getExtension();
+
+          const windowWatcher = new WindowWatcher({
+            extension,
+            previewProxy,
+          });
+
           watcher = new WorkspaceWatcher({
             schemaSyncService:
               ExtensionProvider.getExtension().schemaSyncService,
-            extension: ExtensionProvider.getExtension(),
+            extension,
+            windowWatcher,
           });
           const oldPath = path.join(wsRoot, vaults[0].fsPath, "oldfile.md");
           const oldUri = vscode.Uri.file(oldPath);
@@ -152,10 +163,18 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
         ctx,
         postSetupHook: setupBasic,
         onInit: async ({ vaults, wsRoot, engine }) => {
+          const previewProxy = new MockPreviewProxy();
+          const extension = ExtensionProvider.getExtension();
+
+          const windowWatcher = new WindowWatcher({
+            extension,
+            previewProxy,
+          });
           watcher = new WorkspaceWatcher({
             schemaSyncService:
               ExtensionProvider.getExtension().schemaSyncService,
-            extension: ExtensionProvider.getExtension(),
+            extension,
+            windowWatcher,
           });
           const oldPath = path.join(wsRoot, vaults[0].fsPath, "oldfile.md");
           const oldUri = vscode.Uri.file(oldPath);

--- a/packages/plugin-core/src/views/LookupView.ts
+++ b/packages/plugin-core/src/views/LookupView.ts
@@ -120,7 +120,7 @@ export class LookupView implements vscode.WebviewViewProvider {
       }
       case LookupViewMessageEnum.onRequestControllerState: {
         const quickpick = this._controller?.quickpick as DendronQuickPickerV2;
-        this.refreshLookupView({ buttons: quickpick.buttons });
+        this.refresh({ buttons: quickpick.buttons });
         break;
       }
       case LookupViewMessageEnum.onUpdate:
@@ -129,7 +129,7 @@ export class LookupView implements vscode.WebviewViewProvider {
     }
   }
 
-  public refreshLookupView(opts: { buttons: DendronBtn[] }) {
+  public refresh(opts: { buttons: DendronBtn[] }) {
     const { buttons } = opts;
     const payload: LookupModifierStatePayload = buttons.map(
       (button: DendronBtn) => {
@@ -140,13 +140,6 @@ export class LookupView implements vscode.WebviewViewProvider {
       }
     );
 
-    const lookupView = this._extension.getTreeView(
-      DendronTreeViewKey.LOOKUP_VIEW
-    ) as LookupView;
-    lookupView.refresh(payload);
-  }
-
-  public refresh(payload: LookupModifierStatePayload) {
     if (this._view) {
       this._view.webview.postMessage({
         type: LookupViewMessageEnum.onUpdate,

--- a/packages/plugin-core/src/views/LookupView.ts
+++ b/packages/plugin-core/src/views/LookupView.ts
@@ -9,23 +9,27 @@ import {
 import { Logger } from "../logger";
 import * as vscode from "vscode";
 import { WebViewUtils } from "./utils";
-import { LookupControllerV3 } from "../components/lookup/LookupControllerV3";
-import { PickerUtilsV2 } from "../components/lookup/utils";
+import { ILookupControllerV3 } from "../components/lookup/LookupControllerV3Interface";
 import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { getButtonCategory } from "../components/lookup/buttons";
-import { getExtension } from "../workspace";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { DendronBtn } from "../components/lookup/ButtonTypes";
 
 export class LookupView implements vscode.WebviewViewProvider {
   public static readonly viewType = DendronTreeViewKey.LOOKUP_VIEW;
   private _view?: vscode.WebviewView;
-  private _controller?: LookupControllerV3;
+  private _controller?: ILookupControllerV3;
+  private _extension: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    this._extension = extension;
+  }
 
   public postMessage(msg: DMessage) {
     this._view?.webview.postMessage(msg);
   }
 
-  public registerController(controller: LookupControllerV3) {
+  public registerController(controller: ILookupControllerV3) {
     this._controller = controller;
   }
 
@@ -40,10 +44,8 @@ export class LookupView implements vscode.WebviewViewProvider {
   ) {
     this._view = webviewView;
 
-    // TODO: swap `getExtension()` out for `ExtensionProvider.getExtension()`
-    // once IDendronExtension gets properties for tree views.
     WebViewUtils.prepareTreeView({
-      ext: getExtension(),
+      ext: this._extension,
       key: DendronTreeViewKey.LOOKUP_VIEW,
       webviewView,
     });
@@ -118,13 +120,30 @@ export class LookupView implements vscode.WebviewViewProvider {
       }
       case LookupViewMessageEnum.onRequestControllerState: {
         const quickpick = this._controller?.quickpick as DendronQuickPickerV2;
-        PickerUtilsV2.refreshLookupView({ buttons: quickpick.buttons });
+        this.refreshLookupView({ buttons: quickpick.buttons });
         break;
       }
       case LookupViewMessageEnum.onUpdate:
       default:
         break;
     }
+  }
+
+  public refreshLookupView(opts: { buttons: DendronBtn[] }) {
+    const { buttons } = opts;
+    const payload: LookupModifierStatePayload = buttons.map(
+      (button: DendronBtn) => {
+        return {
+          type: button.type,
+          pressed: button.pressed,
+        };
+      }
+    );
+
+    const lookupView = this._extension.getTreeView(
+      DendronTreeViewKey.LOOKUP_VIEW
+    ) as LookupView;
+    lookupView.refresh(payload);
   }
 
   public refresh(payload: LookupModifierStatePayload) {

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -9,9 +9,9 @@ import { findUpTo, WebViewCommonUtils } from "@dendronhq/common-server";
 import path from "path";
 import * as vscode from "vscode";
 import { IDendronExtension } from "../dendronExtensionInterface";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
 
 export class WebViewUtils {
   /**
@@ -20,7 +20,9 @@ export class WebViewUtils {
    * @returns
    */
   static getViewRootUri() {
-    const assetUri = VSCodeUtils.getAssetUri(getExtension().context);
+    const assetUri = VSCodeUtils.getAssetUri(
+      ExtensionProvider.getExtension().context
+    );
     const pkgRoot = path.dirname(
       findUpTo({ base: __dirname, fname: "package.json", maxLvl: 5 })!
     );
@@ -72,7 +74,9 @@ export class WebViewUtils {
     wsRoot: string;
     panel: vscode.WebviewPanel | vscode.WebviewView;
   }) {
-    const root = VSCodeUtils.getAssetUri(getExtension().context);
+    const root = VSCodeUtils.getAssetUri(
+      ExtensionProvider.getExtension().context
+    );
     const themes = ["light", "dark"];
     const themeMap: any = {};
     themes.map((th) => {
@@ -135,9 +139,9 @@ export class WebViewUtils {
     title: string;
     view: DendronTreeViewKey | DendronEditorViewKey;
   }) => {
-    const { wsRoot, config } = getDWorkspace();
-    const ext = getExtension();
-    const port = getExtension().port;
+    const { wsRoot, config } = ExtensionProvider.getDWorkspace();
+    const ext = ExtensionProvider.getExtension();
+    const port = ext.port;
     const qs = DUtils.querystring.stringify({
       ws: wsRoot,
       port,

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -84,7 +84,7 @@ export class WindowWatcher {
           return;
         }
         Logger.info({ ctx, editor: uri.fsPath });
-        WindowWatcher.triggerUpdateDecorations(editor);
+        this.triggerUpdateDecorations(editor);
 
         // other components can register handlers for window watcher
         // those handlers get called here
@@ -126,14 +126,14 @@ export class WindowWatcher {
       Logger.debug({ ctx, editor: uri.fsPath });
       // Decorations only render the visible portions of the screen, so they
       // need to be re-rendered when the user scrolls around
-      WindowWatcher.triggerUpdateDecorations(editor);
+      this.triggerUpdateDecorations(editor);
     }
   );
 
   /**
    * Decorate wikilinks, user tags etc. as well as warning about some issues like missing frontmatter
    */
-  static async triggerUpdateDecorations(editor: TextEditor) {
+  async triggerUpdateDecorations(editor: TextEditor) {
     if (!editor) return;
     // This may be the active editor, but could be another editor that's open side by side without being selected.
     // Also, debouncing this based on the editor URI so that decoration updates in different editors don't affect each other but updates don't trigger too often for the same editor


### PR DESCRIPTION
Madge Before: 53
Madge After: 48

Some notables changes in this commit:
- Update extension interface and extensionprovider to expose `isActive`, `getWorkspaceConfig`, and `getTreeView`
- Remove dependency on `workspace.ts` from `WorkspaceWatcher.ts`
- Update constructor of `WorkspaceWatcher.ts` to pass in windowwatcher instance
- Move `refreshLookupView` from `PickerUtilsV2` to class method of `LookupView`
- Update constructor of `LookupView` to take in extension instance

TODO: Resolve cyclic dependencies around `fileWatcher.ts` which should resolve rest of watcher specific issues