### PR TITLE
enhance: calculate backlinks and anchors in engine for improved editor responsiveness

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -5,7 +5,9 @@ import {
   EngineRenameNoteRequest,
   EngineUpdateNoteRequest,
   EngineWriteRequest,
+  GetAnchorsRequest,
   GetDecorationsRequest,
+  GetLinksRequest,
   GetNoteBlocksPayload,
   GetNoteBlocksRequest,
   NoteQueryRequest,
@@ -13,6 +15,7 @@ import {
   WriteNoteResp,
 } from "@dendronhq/common-all";
 import { ExpressUtils } from "@dendronhq/common-server";
+import { AnchorUtils } from "@dendronhq/engine-server";
 import { Request, Response, Router } from "express";
 import asyncHandler from "express-async-handler";
 import { getLogger } from "../core";
@@ -131,6 +134,28 @@ router.post(
     const { ws } = opts;
     const engine = await getWSEngine({ ws: ws || "" });
     ExpressUtils.setResponse(res, await engine.getDecorations(opts));
+  })
+);
+
+router.get(
+  "/links",
+  asyncHandler(async (req: Request, res: Response) => {
+    const opts = req.body as GetLinksRequest;
+    const { ws } = opts;
+    const engine = await getWSEngine({ ws });
+    const links = engine.getLinks(opts);
+    ExpressUtils.setResponse(res, { data: links, error: null });
+  })
+);
+
+router.get(
+  "/anchors",
+  asyncHandler(async (req: Request, res: Response) => {
+    const { note } = req.body as GetAnchorsRequest;
+    const anchors = AnchorUtils.findAnchors({
+      note,
+    });
+    ExpressUtils.setResponse(res, { data: anchors, error: null });
   })
 );
 

--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -137,18 +137,18 @@ router.post(
   })
 );
 
-router.get(
+router.post(
   "/links",
   asyncHandler(async (req: Request, res: Response) => {
     const opts = req.body as GetLinksRequest;
     const { ws } = opts;
     const engine = await getWSEngine({ ws });
-    const links = engine.getLinks(opts);
+    const links = await engine.getLinks(opts);
     ExpressUtils.setResponse(res, { data: links, error: null });
   })
 );
 
-router.get(
+router.post(
   "/anchors",
   asyncHandler(async (req: Request, res: Response) => {
     const { note } = req.body as GetAnchorsRequest;

--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -144,7 +144,7 @@ router.post(
     const { ws } = opts;
     const engine = await getWSEngine({ ws });
     const links = await engine.getLinks(opts);
-    ExpressUtils.setResponse(res, { data: links, error: null });
+    ExpressUtils.setResponse(res, links);
   })
 );
 

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -29,7 +29,9 @@ import { DendronError } from "./error";
 import {
   DEngineInitPayload,
   GetDecorationsPayload,
+  GetNoteAnchorsPayload,
   GetNoteBlocksPayload,
+  GetNoteLinksPayload,
   NoteQueryResp,
   RenderNoteOpts,
   RenderNotePayload,
@@ -163,6 +165,12 @@ export type GetDecorationsRequest = {
   }[];
   text: string;
 } & Partial<WorkspaceRequest>;
+export type GetAnchorsRequest = { note: NoteProps };
+export type GetLinksRequest = {
+  note: NoteProps;
+  /** regular is backlinks for wikilinks, hashtags, user tags etc., candidate is for backlink candidates */
+  type: "regular" | "candidate";
+} & WorkspaceRequest;
 
 export type SchemaDeleteRequest = {
   id: string;
@@ -512,6 +520,24 @@ export class DendronAPI extends API {
     const resp = await this._makeRequest({
       path: "note/decorations",
       method: "post",
+      body: req,
+    });
+    return resp;
+  }
+
+  async getLinks(req: GetLinksRequest): Promise<GetNoteLinksPayload> {
+    const resp = await this._makeRequest({
+      path: "note/links",
+      method: "get",
+      body: req,
+    });
+    return resp;
+  }
+
+  async getAnchors(req: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
+    const resp = await this._makeRequest({
+      path: "note/anchors",
+      method: "get",
       body: req,
     });
     return resp;

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -528,7 +528,7 @@ export class DendronAPI extends API {
   async getLinks(req: GetLinksRequest): Promise<GetNoteLinksPayload> {
     const resp = await this._makeRequest({
       path: "note/links",
-      method: "get",
+      method: "post",
       body: req,
     });
     return resp;
@@ -537,7 +537,7 @@ export class DendronAPI extends API {
   async getAnchors(req: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
     const resp = await this._makeRequest({
       path: "note/anchors",
-      method: "get",
+      method: "post",
       body: req,
     });
     return resp;

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -14,8 +14,9 @@ import { DVault } from "./workspace";
 import { IntermediateDendronConfig } from "./intermediateConfigs";
 import { VSRange } from "./compat";
 import { Decoration, Diagnostic } from ".";
-import type { NoteFNamesDict } from "../utils";
+import type { NoteFNamesDict, Optional } from "../utils";
 import { DendronASTDest, ProcFlavor } from "./unified";
+import { GetAnchorsRequest, GetLinksRequest } from "..";
 
 export enum ResponseCode {
   OK = 200,
@@ -511,6 +512,9 @@ export type GetDecorationsPayload = RespV2<{
   decorations?: Decoration[];
   diagnostics?: Diagnostic[];
 }>;
+export type GetNoteLinksPayload = RespV2<DLink[]>;
+export type GetAnchorsResp = { [index: string]: DNoteAnchorPositioned };
+export type GetNoteAnchorsPayload = RespV2<GetAnchorsResp>;
 
 export type GetNotePayload = {
   note: NoteProps | undefined;
@@ -588,6 +592,10 @@ export type DEngine = DCommonProps &
     getDecorations: (
       opts: GetDecorationsOpts
     ) => Promise<GetDecorationsPayload>;
+    getLinks: (
+      opts: Optional<GetLinksRequest, "ws">
+    ) => Promise<GetNoteLinksPayload>;
+    getAnchors: (opts: GetAnchorsRequest) => Promise<GetNoteAnchorsPayload>;
   };
 
 /**

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -163,7 +163,7 @@ export class FileStorage implements DStore {
       fileName = USER_MESSAGES.UNKNOWN;
     }
 
-    let fullPath = undefined;
+    let fullPath;
     try {
       if (resp.error && resp.error.payload) {
         fullPath = JSON.parse(
@@ -458,7 +458,6 @@ export class FileStorage implements DStore {
   }
 
   _addLinkCandidates(allNotes: NoteProps[]) {
-    const notesMap = NoteUtils.createFnameNoteMap(allNotes, true);
     return _.map(allNotes, (noteFrom: NoteProps) => {
       try {
         const maxNoteLength = ConfigUtils.getWorkspace(
@@ -470,7 +469,6 @@ export class FileStorage implements DStore {
         ) {
           const linkCandidates = LinkUtils.findLinkCandidates({
             note: noteFrom,
-            notesMap,
             engine: this.engine,
           });
           noteFrom.links = noteFrom.links.concat(linkCandidates);
@@ -579,7 +577,6 @@ export class FileStorage implements DStore {
           try {
             const anchors = await AnchorUtils.findAnchors({
               note: n,
-              wsRoot,
             });
             cacheUpdates[n.fname].data.anchors = anchors;
             n.anchors = anchors;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -131,6 +131,15 @@ export class FileStorage implements DStore {
         this.notes[ent.id] = ent;
         this.noteFnames.add(ent);
       });
+      // Backlink candidates have to be done after notes are initialized because it depends on the engine already having notes in it
+      if (this.engine.config.dev?.enableLinkCandidates) {
+        const ctx = "_addLinkCandidates";
+        const start = process.hrtime();
+        // this mutates existing note objects so we don't need to reset the notes
+        this._addLinkCandidates(_.values(this.notes));
+        const duration = getDurationMilliseconds(start);
+        this.logger.info({ ctx, duration });
+      }
 
       const { notes, schemas } = this;
       let error: IDendronError | null = errors[0] || null;
@@ -401,13 +410,6 @@ export class FileStorage implements DStore {
 
     this._addBacklinks({ notesWithLinks, allNotes });
 
-    if (this.engine.config.dev?.enableLinkCandidates) {
-      const ctx = "_addLinkCandidates";
-      const start = process.hrtime();
-      this._addLinkCandidates(allNotes);
-      const duration = getDurationMilliseconds(start);
-      this.logger.info({ ctx, duration });
-    }
     return { notes: allNotes, errors };
   }
 

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -22,10 +22,14 @@ import {
   Event,
   EventEmitter,
   FuseEngine,
+  GetAnchorsRequest,
   GetDecorationsOpts,
   GetDecorationsPayload,
+  GetLinksRequest,
+  GetNoteAnchorsPayload,
   GetNoteBlocksOpts,
   GetNoteBlocksPayload,
+  GetNoteLinksPayload,
   GetNoteOptsV2,
   GetNotePayload,
   IntermediateDendronConfig,
@@ -34,6 +38,7 @@ import {
   NoteProps,
   NotePropsDict,
   NoteUtils,
+  Optional,
   QueryNotesOpts,
   RefreshNotesOpts,
   RenameNoteOpts,
@@ -525,5 +530,18 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
       ws: this.ws,
     });
     return out;
+  }
+
+  getAnchors(opts: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
+    return this.api.getAnchors(opts);
+  }
+
+  getLinks(
+    opts: Optional<GetLinksRequest, "ws">
+  ): Promise<GetNoteLinksPayload> {
+    return this.api.getLinks({
+      ws: this.ws,
+      ...opts,
+    });
   }
 }

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -316,7 +316,7 @@ const getLinkCandidates = ({
         column: 1,
       };
     }
-    value.split(/\s+/).filter((word) => {
+    value.split(/\s+/).forEach((word) => {
       const maybeNote = NoteUtils.getNotesByFnameFromEngine({
         fname: word,
         engine,
@@ -334,7 +334,6 @@ const getLinkCandidates = ({
         } as DLink;
         linkCandidates.push(candidate);
       }
-      return maybeNote !== undefined;
     });
   });
   return linkCandidates;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -317,23 +317,24 @@ const getLinkCandidates = ({
       };
     }
     value.split(/\s+/).forEach((word) => {
-      const maybeNote = NoteUtils.getNotesByFnameFromEngine({
+      const possibleCandidates = NoteUtils.getNotesByFnameFromEngine({
         fname: word,
         engine,
       }).filter((note) => note.stub !== true);
-      if (!_.isEmpty(maybeNote)) {
-        const candidate = {
-          type: "linkCandidate",
-          from: NoteUtils.toNoteLoc(note),
-          value: value.trim(),
-          position: textNode.position as Position,
-          to: {
-            fname: word,
-            vaultName: VaultUtils.getName(maybeNote[0].vault),
-          },
-        } as DLink;
-        linkCandidates.push(candidate);
-      }
+      linkCandidates.push(
+        ...possibleCandidates.map((candidate): DLink => {
+          return {
+            type: "linkCandidate",
+            from: NoteUtils.toNoteLoc(note),
+            value: value.trim(),
+            position: textNode.position as Position,
+            to: {
+              fname: word,
+              vaultName: VaultUtils.getName(candidate.vault),
+            },
+          };
+        })
+      );
     });
   });
   return linkCandidates;

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -429,7 +429,7 @@ export class EngineUtils {
         });
         if (!linkCandidates.data)
           throw new DendronError({
-            message: "Failed to calculate note anchors",
+            message: "Failed to calculate link candidates",
             payload: {
               note: NoteUtils.toLogObj(note),
               anchorsError: anchors.error,

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -13,13 +13,13 @@ import {
   NotePropsDict,
   NotesCache,
   NotesCacheEntry,
+  NoteUtils,
   RespV3,
 } from "@dendronhq/common-all";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 import { DendronEngineClient } from "./engineClient";
-import { AnchorUtils, LinkUtils } from "./markdown";
 import { WSMeta } from "./types";
 
 function normalize(text: string) {
@@ -393,35 +393,51 @@ export class EngineUtils {
   static async refreshNoteLinksAndAnchors({
     note,
     engine,
-    notesMap,
   }: {
     note: NoteProps;
     engine: DEngineClient;
-    notesMap: Map<string, NoteProps>;
   }) {
     const maxNoteLength = ConfigUtils.getWorkspace(engine.config).maxNoteLength;
     if (
       note.body.length <
       (maxNoteLength || CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
     ) {
-      const links = LinkUtils.findLinks({ note, engine });
-      const anchors = await AnchorUtils.findAnchors({
+      const links = await engine.getLinks({ note, type: "regular" });
+      const anchors = await engine.getAnchors({
         note,
-        wsRoot: engine.wsRoot,
       });
+      if (!anchors.data || !links.data)
+        throw new DendronError({
+          message: "Failed to calculate note anchors",
+          payload: {
+            note: NoteUtils.toLogObj(note),
+            anchorsError: anchors.error,
+            linksError: links.error,
+          },
+        });
+
       // update links for note
-      note.links = links.concat(links);
+      note.links = links.data;
+      note.anchors = anchors.data;
+
       const devConfig = ConfigUtils.getProp(engine.config, "dev");
       const linkCandidatesEnabled = devConfig?.enableLinkCandidates;
       if (linkCandidatesEnabled) {
-        const linkCandidates = LinkUtils.findLinkCandidates({
+        const linkCandidates = await engine.getLinks({
           note,
-          notesMap,
-          engine,
+          type: "candidate",
         });
-        note.links = links.concat(linkCandidates);
+        if (!linkCandidates.data)
+          throw new DendronError({
+            message: "Failed to calculate note anchors",
+            payload: {
+              note: NoteUtils.toLogObj(note),
+              anchorsError: anchors.error,
+              linksError: links.error,
+            },
+          });
+        note.links = note.links.concat(linkCandidates.data);
       }
-      note.anchors = anchors;
       return note;
     }
     return note;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -1,9 +1,4 @@
-import {
-  DLink,
-  NoteProps,
-  NoteUtils,
-  WorkspaceOpts,
-} from "@dendronhq/common-all";
+import { DLink, NoteProps, WorkspaceOpts } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import {
   DendronASTDest,
@@ -853,11 +848,8 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const note = engine.notes["bar"];
-          const notes = _.values(engine.notes);
-          const notesMap = NoteUtils.createFnameNoteMap(notes, true);
-          const linkCandidates = await LinkUtils.findLinkCandidates({
+          const linkCandidates = LinkUtils.findLinkCandidates({
             note,
-            notesMap,
             engine,
           });
           expect(linkCandidates[0].from.fname).toEqual("bar");
@@ -875,11 +867,8 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const note = engine.notes["baz"];
-          const notes = _.values(engine.notes);
-          const notesMap = NoteUtils.createFnameNoteMap(notes, true);
           const linkCandidates = LinkUtils.findLinkCandidates({
             note,
-            notesMap,
             engine,
           });
           expect(linkCandidates.length).toEqual(8);
@@ -895,11 +884,8 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const note = engine.notes["nodes"];
-          const notes = _.values(engine.notes);
-          const notesMap = NoteUtils.createFnameNoteMap(notes, true);
           const linkCandidates = LinkUtils.findLinkCandidates({
             note,
-            notesMap,
             engine,
           });
           expect(linkCandidates.length).toEqual(8);

--- a/packages/engine-test-utils/src/presets/engine-server/getAnchors.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getAnchors.ts
@@ -1,0 +1,75 @@
+import { NoteUtils } from "@dendronhq/common-all";
+import {
+  TestPresetEntryV4,
+  NOTE_PRESETS_V4,
+} from "@dendronhq/common-test-utils";
+import _ from "lodash";
+
+const SCHEMAS = {};
+const NOTES = {
+  /**
+   * Check that we can get both roots from both vaults
+   */
+  REGULAR: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const note = NoteUtils.getNoteByFnameFromEngine({
+        fname: NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.fname,
+        engine,
+        vault: vaults[0],
+      });
+
+      const { data } = await engine.getAnchors({
+        note: note!,
+      });
+      return [
+        {
+          actual: data,
+          expected: {
+            "^8a": {
+              column: 5,
+              line: 8,
+              type: "block",
+              value: "8a",
+            },
+            h1: {
+              column: 0,
+              line: 7,
+              depth: 1,
+              text: "H1",
+              type: "header",
+              value: "h1",
+            },
+            h2: {
+              column: 0,
+              line: 8,
+              depth: 1,
+              text: "H2",
+              type: "header",
+              value: "h2",
+            },
+            h3: {
+              column: 0,
+              line: 9,
+              depth: 1,
+              text: "H3",
+              type: "header",
+              value: "h3",
+            },
+          },
+        },
+      ];
+    },
+    {
+      preSetupHook: async ({ vaults, wsRoot }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+      },
+    }
+  ),
+};
+export const ENGINE_GET_ANCHORS_PRESETS = {
+  NOTES,
+  SCHEMAS,
+};

--- a/packages/engine-test-utils/src/presets/engine-server/getLinks.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getLinks.ts
@@ -1,0 +1,105 @@
+import { NoteUtils } from "@dendronhq/common-all";
+import {
+  TestPresetEntryV4,
+  NOTE_PRESETS_V4,
+} from "@dendronhq/common-test-utils";
+import _ from "lodash";
+
+const SCHEMAS = {};
+const NOTES = {
+  /**
+   * Check that we can get both roots from both vaults
+   */
+  REGULAR: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const note = NoteUtils.getNoteByFnameFromEngine({
+        fname: NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.fname,
+        engine,
+        vault: vaults[0],
+      });
+
+      const { data } = await engine.getLinks({
+        note: note!,
+        type: "regular",
+      });
+      return [
+        {
+          actual: data?.length,
+          expected: 1,
+        },
+        {
+          actual: data![0].from.fname,
+          expected: "beta",
+        },
+        {
+          actual: data![0].to!.fname,
+          expected: "alpha",
+        },
+        {
+          actual: data![0].type,
+          expected: "wiki",
+        },
+      ];
+    },
+    {
+      preSetupHook: async ({ vaults, wsRoot }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+      },
+    }
+  ),
+  BACKLINK_CANDIDATES: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const note = NoteUtils.getNoteByFnameFromEngine({
+        fname: NOTE_PRESETS_V4.NOTE_WITH_LINK_CANDIDATE_TARGET.fname,
+        engine,
+        vault: vaults[0],
+      });
+
+      const { data } = await engine.getLinks({
+        note: note!,
+        type: "candidate",
+      });
+      return [
+        {
+          actual: data?.length,
+          expected: 1,
+        },
+        {
+          actual: data![0].from.fname,
+          expected: "gamma",
+        },
+        {
+          actual: data![0].to!.fname,
+          expected: "alpha",
+        },
+        {
+          actual: data![0].type,
+          expected: "linkCandidate",
+        },
+      ];
+    },
+    {
+      preSetupHook: async ({ vaults, wsRoot }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_LINK_CANDIDATE_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+      },
+    }
+  ),
+};
+export const ENGINE_GET_LINKS_PRESETS = {
+  NOTES,
+  SCHEMAS,
+};

--- a/packages/engine-test-utils/src/presets/engine-server/index.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/index.ts
@@ -13,6 +13,8 @@ import { ENGINE_RENDER_PRESETS } from "./render";
 import { ENGINE_WRITE_PRESETS, ENGINE_WRITE_PRESETS_MULTI } from "./write";
 import _ from "lodash";
 import { TestPresetEntryV4 } from "@dendronhq/common-test-utils";
+import { ENGINE_GET_LINKS_PRESETS } from "./getLinks";
+import { ENGINE_GET_ANCHORS_PRESETS } from "./getAnchors";
 
 export { ENGINE_HOOKS, ENGINE_HOOKS_BASE, ENGINE_HOOKS_MULTI } from "./utils";
 export { ENGINE_RENAME_PRESETS };
@@ -33,6 +35,8 @@ export const ENGINE_SERVER = {
   ENGINE_QUERY_PRESETS,
   ENGINE_BULK_ADD_NOTES_PRESETS,
   ENGINE_RENDER_PRESETS,
+  ENGINE_GET_LINKS_PRESETS,
+  ENGINE_GET_ANCHORS_PRESETS,
 };
 
 type TestPresetEntry = TestPresetEntryV4;
@@ -101,6 +105,8 @@ export const ENGINE_PRESETS = [
   { name: "rename", presets: ENGINE_SERVER.ENGINE_RENAME_PRESETS },
   { name: "update", presets: ENGINE_SERVER.ENGINE_UPDATE_PRESETS },
   { name: "write", presets: ENGINE_SERVER.ENGINE_WRITE_PRESETS },
+  { name: "getLinks", presets: ENGINE_SERVER.ENGINE_GET_LINKS_PRESETS },
+  { name: "getAnchors", presets: ENGINE_SERVER.ENGINE_GET_ANCHORS_PRESETS },
 ];
 
 export const ENGINE_PRESETS_MULTI = [

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -15,10 +15,14 @@ import {
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
   Event,
+  GetAnchorsRequest,
   GetDecorationsOpts,
   GetDecorationsPayload,
+  GetLinksRequest,
+  GetNoteAnchorsPayload,
   GetNoteBlocksOpts,
   GetNoteBlocksPayload,
+  GetNoteLinksPayload,
   GetNoteOptsV2,
   GetNotePayload,
   IntermediateDendronConfig,
@@ -26,6 +30,7 @@ import {
   NoteFNamesDict,
   NoteProps,
   NotePropsDict,
+  Optional,
   QueryNotesOpts,
   RefreshNotesOpts,
   RenameNoteOpts,
@@ -293,5 +298,14 @@ export class EngineAPIService
 
   getDecorations(opts: GetDecorationsOpts): Promise<GetDecorationsPayload> {
     return this._internalEngine.getDecorations(opts);
+  }
+
+  getLinks(
+    opts: Optional<GetLinksRequest, "ws">
+  ): Promise<GetNoteLinksPayload> {
+    return this._internalEngine.getLinks(opts);
+  }
+  getAnchors(opts: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
+    return this._internalEngine.getAnchors(opts);
   }
 }

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -11,10 +11,14 @@ import {
   EngineInfoResp,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
+  GetAnchorsRequest,
   GetDecorationsOpts,
   GetDecorationsPayload,
+  GetLinksRequest,
+  GetNoteAnchorsPayload,
   GetNoteBlocksOpts,
   GetNoteBlocksPayload,
+  GetNoteLinksPayload,
   GetNoteOptsV2,
   GetNotePayload,
   IntermediateDendronConfig,
@@ -22,6 +26,7 @@ import {
   NoteFNamesDict,
   NoteProps,
   NotePropsDict,
+  Optional,
   QueryNotesOpts,
   RefreshNotesOpts,
   RenameNoteOpts,
@@ -111,4 +116,8 @@ export interface IEngineAPIService {
   getConfig(): Promise<RespV2<IntermediateDendronConfig>>;
 
   getDecorations(opts: GetDecorationsOpts): Promise<GetDecorationsPayload>;
+  getLinks: (
+    opts: Optional<GetLinksRequest, "ws">
+  ) => Promise<GetNoteLinksPayload>;
+  getAnchors: (opts: GetAnchorsRequest) => Promise<GetNoteAnchorsPayload>;
 }

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -1,5 +1,6 @@
 import {
   ConfigUtils,
+  DendronError,
   DVault,
   NoteProps,
   NoteUtils,
@@ -9,7 +10,6 @@ import { DLogger, string2Note } from "@dendronhq/common-server";
 import {
   AnchorUtils,
   DendronASTDest,
-  LinkUtils,
   MDUtilsV5,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
@@ -152,28 +152,40 @@ export class NoteSyncService implements INoteSyncService {
     }
     // Links have to be updated even with frontmatter only changes
     // because `tags` in frontmatter adds new links
-    const links = LinkUtils.findLinks({ note, engine });
-    note.links = links;
+    const links = await engine.getLinks({ note, type: "regular" });
+    if (!links.data) {
+      throw new DendronError({
+        message: "Unable to calculate the backlinks in note",
+        payload: {
+          note: NoteUtils.toLogObj(note),
+          error: links.error,
+        },
+      });
+    }
+    note.links = links.data;
 
     // if only frontmatter changed, don't bother with heavy updates
     if (!fmChangeOnly) {
-      const notesMap = NoteUtils.createFnameNoteMap(
-        _.values(engine.notes),
-        true
-      );
       const anchors = await AnchorUtils.findAnchors({
         note,
-        wsRoot: engine.wsRoot,
       });
       note.anchors = anchors;
 
       if (this._extension.workspaceService?.config.dev?.enableLinkCandidates) {
-        const linkCandidates = LinkUtils.findLinkCandidates({
+        const linkCandidates = await engine.getLinks({
           note,
-          notesMap,
-          engine,
+          type: "candidate",
         });
-        note.links = links.concat(linkCandidates);
+        if (!linkCandidates.data) {
+          throw new DendronError({
+            message: "Unable to calculate the backlink candidates in note",
+            payload: {
+              note: NoteUtils.toLogObj(note),
+              error: linkCandidates.error,
+            },
+          });
+        }
+        note.links = note.links.concat(linkCandidates.data);
       }
     }
 

--- a/packages/plugin-core/src/services/NoteSyncService.ts
+++ b/packages/plugin-core/src/services/NoteSyncService.ts
@@ -8,7 +8,6 @@ import {
 } from "@dendronhq/common-all";
 import { DLogger, string2Note } from "@dendronhq/common-server";
 import {
-  AnchorUtils,
   DendronASTDest,
   MDUtilsV5,
   WorkspaceUtils,
@@ -166,10 +165,19 @@ export class NoteSyncService implements INoteSyncService {
 
     // if only frontmatter changed, don't bother with heavy updates
     if (!fmChangeOnly) {
-      const anchors = await AnchorUtils.findAnchors({
+      const anchors = await engine.getAnchors({
         note,
       });
-      note.anchors = anchors;
+      if (!anchors.data) {
+        throw new DendronError({
+          message: "Unable to calculate backlinks in note",
+          payload: {
+            note: NoteUtils.toLogObj(note),
+            error: anchors.error,
+          },
+        });
+      }
+      note.anchors = anchors.data;
 
       if (this._extension.workspaceService?.config.dev?.enableLinkCandidates) {
         const linkCandidates = await engine.getLinks({

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -41,6 +41,7 @@ const getRootChildrenBacklinks = async (sortOrder?: BacklinkSortOrder) => {
     for (const parent of parents) {
       parentsWithChildren.push({
         ...parent,
+        // eslint-disable-next-line no-await-in-loop
         children: await backlinksTreeDataProvider.getChildren(parent),
       });
     }
@@ -121,9 +122,7 @@ function assertAreEqual(actual: ProviderResult<Backlink>, expected: Backlink) {
 }
 
 suite("BacklinksTreeDataProvider", function () {
-  let ctx: vscode.ExtensionContext;
-
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {
       VSCodeUtils.closeAllEditors();
     },

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1641847291330
+updated: 1644608035769
 created: 1608518909864
 ---
 
@@ -157,3 +157,7 @@ And a link to line 6 in that file: [[/vault/root.schema.yml#L6]]
 We should be able to see these images in preview and when hovering over the link.
 
 ![[dendron.ref.image]]
+
+## Candidate links
+
+This dendron.ref.image will be a candidate link if the feature is enabled.


### PR DESCRIPTION
This PR moves the calculation of backlinks (including backlink candidates) and anchors to the engine during editing. This should improve editor responsiveness as these calculations can block the extension thread for significant time for long files.


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)