### PR TITLE
chore(lookup): remove circ deps between ILookupController and ILookupProvider

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -13,7 +13,6 @@ import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
 import { LookupView } from "../../views/LookupView";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import {
   ButtonCategory,
   getButtonCategory,
@@ -105,7 +104,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
       // wire up lookup controller to lookup view
       // TODO: swap out `getExtension` to use a static provider
       // once treeview related interface has been migrated to IDendronExtension
-      this._view = getExtension().getTreeView(
+      this._view = ExtensionProvider.getTreeView(
         DendronTreeViewKey.LOOKUP_VIEW
       ) as LookupView;
       this._view.registerController(this);
@@ -214,11 +213,18 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     });
     Logger.info({ ctx, msg: "onUpdatePickerItems:post" });
     if (!nonInteractive) {
-      provider.provide(this);
+      provider.provide({
+        quickpick,
+        token: cancelToken,
+        fuzzThreshold: this.fuzzThreshold,
+      });
       quickpick.show();
     } else {
       quickpick.selectedItems = quickpick.items;
-      await provider.onDidAccept({ quickpick, lc: this })();
+      await provider.onDidAccept({
+        quickpick,
+        cancellationToken: cancelToken,
+      })();
     }
     Logger.info({ ctx, msg: "exit" });
     return quickpick;

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -14,28 +14,28 @@ import {
 import { getDurationMilliseconds } from "@dendronhq/common-server";
 import { HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
+import stringSimilarity from "string-similarity";
 import { CancellationTokenSource, window } from "vscode";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
-import { LookupControllerV3 } from "./LookupControllerV3";
-import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
-import { DendronQuickPickerV2, DendronQuickPickState } from "./types";
-import { OldNewLocation, PickerUtilsV2 } from "./utils";
 import { NotePickerUtils } from "../lookup/NotePickerUtils";
 import { SchemaPickerUtils } from "../lookup/SchemaPickerUtils";
-import { transformQueryString } from "./queryStringTransformer";
-import stringSimilarity from "string-similarity";
 import { IDendronQuickInputButton } from "./ButtonTypes";
+import { CREATE_NEW_NOTE_DETAIL, CREATE_NEW_SCHEMA_DETAIL } from "./constants";
 import {
   ILookupProviderOptsV3,
   ILookupProviderV3,
   NoteLookupProviderSuccessResp,
   OnAcceptHook,
   OnUpdatePickerItemsOpts,
+  ProvideOpts,
   SchemaLookupProviderSuccessResp,
 } from "./LookupProviderV3Interface";
-import { IDendronExtension } from "../../dendronExtensionInterface";
-import { CREATE_NEW_NOTE_DETAIL, CREATE_NEW_SCHEMA_DETAIL } from "./constants";
+import { transformQueryString } from "./queryStringTransformer";
+import { DendronQuickPickerV2, DendronQuickPickState } from "./types";
+import { OldNewLocation, PickerUtilsV2 } from "./utils";
 
 /** This function presumes that 'CreateNew' should be shown and determines whether
  *  CreateNew should be at the top of the look up results or not. */
@@ -98,10 +98,15 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     this.opts = opts;
   }
 
-  async provide(lc: LookupControllerV3) {
+  async provide(opts: {
+    quickpick: DendronQuickPickerV2;
+    token: CancellationTokenSource;
+    fuzzThreshold: number;
+  }) {
     const ctx = "NoteLookupProvider.provide";
     Logger.info({ ctx, msg: "enter" });
-    const quickpick = lc.quickpick;
+
+    const { quickpick, token, fuzzThreshold } = opts;
     const onUpdatePickerItems = _.bind(this.onUpdatePickerItems, this);
     const onUpdateDebounced = _.debounce(
       () => {
@@ -109,8 +114,8 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         Logger.debug({ ctx, msg: "enter" });
         const out = onUpdatePickerItems({
           picker: quickpick,
-          token: lc.createCancelSource().token,
-          fuzzThreshold: lc.fuzzThreshold,
+          token: token.token,
+          fuzzThreshold,
         } as OnUpdatePickerItemsOpts);
         Logger.debug({ ctx, msg: "exit" });
         return out;
@@ -132,10 +137,10 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         await onUpdatePickerItems({
           picker: quickpick,
           token: new CancellationTokenSource().token,
-          fuzzThreshold: lc.fuzzThreshold,
+          fuzzThreshold,
         });
       }
-      this.onDidAccept({ quickpick, lc })();
+      this.onDidAccept({ quickpick, cancellationToken: token })();
     });
     Logger.info({ ctx, msg: "exit" });
     return;
@@ -148,11 +153,11 @@ export class NoteLookupProvider implements ILookupProviderV3 {
    */
   onDidAccept(opts: {
     quickpick: DendronQuickPickerV2;
-    lc: LookupControllerV3;
+    cancellationToken: CancellationTokenSource;
   }) {
     return async () => {
       const ctx = "NoteLookupProvider:onDidAccept";
-      const { quickpick: picker, lc } = opts;
+      const { quickpick: picker, cancellationToken } = opts;
 
       picker.buttons.forEach((button) => {
         AnalyticsUtils.track(LookupEvents.LookupModifiersSetOnAccept, {
@@ -197,13 +202,14 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         }
       }
       // last chance to cancel
-      lc.cancelToken.cancel();
+      cancellationToken.cancel();
+
       if (!this.opts.noHidePickerOnAccept) {
         picker.state = DendronQuickPickState.FULFILLED;
         picker.hide();
       }
       const onAcceptHookResp = await Promise.all(
-        await this._onAcceptHooks.map((hook) =>
+        this._onAcceptHooks.map((hook) =>
           hook({ quickpick: picker, selectedItems })
         )
       );
@@ -490,15 +496,16 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
     this.opts = opts;
   }
 
-  async provide(lc: LookupControllerV3) {
-    const quickpick = lc.quickpick;
+  async provide(opts: ProvideOpts) {
+    const { quickpick, token, fuzzThreshold } = opts;
+
     const onUpdatePickerItems = _.bind(this.onUpdatePickerItems, this);
     const onUpdateDebounced = _.debounce(
       () => {
         onUpdatePickerItems({
           picker: quickpick,
-          token: lc.createCancelSource().token,
-          fuzzThreshold: lc.fuzzThreshold,
+          token: token.token,
+          fuzzThreshold,
         } as OnUpdatePickerItemsOpts);
       },
       100,
@@ -518,10 +525,10 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         await onUpdatePickerItems({
           picker: quickpick,
           token: new CancellationTokenSource().token,
-          fuzzThreshold: lc.fuzzThreshold,
+          fuzzThreshold,
         });
       }
-      this.onDidAccept({ quickpick, lc })();
+      this.onDidAccept({ quickpick, cancellationToken: token })();
     });
     return;
   }
@@ -533,11 +540,11 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
    */
   onDidAccept(opts: {
     quickpick: DendronQuickPickerV2;
-    lc: LookupControllerV3;
+    cancellationToken: CancellationTokenSource;
   }) {
     return async () => {
       const ctx = "SchemaLookupProvider:onDidAccept";
-      const { quickpick: picker, lc } = opts;
+      const { quickpick: picker, cancellationToken } = opts;
       let selectedItems = NotePickerUtils.getSelection(picker);
       Logger.debug({
         ctx,
@@ -594,12 +601,12 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         return;
       }
       // last chance to cancel
-      lc.cancelToken.cancel();
+      cancellationToken.cancel();
       if (!this.opts.noHidePickerOnAccept) {
         picker.hide();
       }
       const onAcceptHookResp = await Promise.all(
-        await this._onAcceptHooks.map((hook) =>
+        this._onAcceptHooks.map((hook) =>
           hook({ quickpick: picker, selectedItems })
         )
       );

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -1,21 +1,20 @@
 import { DendronQuickPickerV2 } from "./types";
-import { CancellationToken } from "vscode";
+import { CancellationToken, CancellationTokenSource } from "vscode";
 import {
   DNodePropsQuickInputV2,
   NoteQuickInput,
   RespV2,
   SchemaQuickInput,
 } from "@dendronhq/common-all";
-import { ILookupControllerV3 } from "./LookupControllerV3Interface";
 
 export type ILookupProviderV3 = {
   id: string;
-  provide: (lc: ILookupControllerV3) => Promise<void>;
+  provide: (opts: ProvideOpts) => Promise<void>;
   onUpdatePickerItems: (opts: OnUpdatePickerItemsOpts) => Promise<void>;
   registerOnAcceptHook: (hook: OnAcceptHook) => void;
   onDidAccept(opts: {
     quickpick: DendronQuickPickerV2;
-    lc: ILookupControllerV3;
+    cancellationToken: CancellationTokenSource;
   }): any;
 };
 
@@ -26,6 +25,12 @@ export interface INoteLookupProviderFactory {
 export interface ISchemaLookupProviderFactory {
   create(id: string, opts: ILookupProviderOptsV3): ILookupProviderV3;
 }
+
+export type ProvideOpts = {
+  quickpick: DendronQuickPickerV2;
+  token: CancellationTokenSource;
+  fuzzThreshold: number;
+};
 
 export type OnUpdatePickerItemsOpts = {
   picker: DendronQuickPickerV2;

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1289,7 +1289,10 @@ suite("NoteLookupCommand", function () {
             noConfirm: true,
             initialValue: "foo",
           });
-          await provider.onDidAccept({ quickpick, lc: controller })();
+          await provider.onDidAccept({
+            quickpick,
+            cancellationToken: controller.cancelToken,
+          })();
           expect(spyFetchPickerResultsNoInput.calledOnce).toBeTruthy();
           done();
         },


### PR DESCRIPTION
## chore(lookup): remove circ deps between ILookupController and ILookupProvider

Part 1 of fixing circular dependencies in lookup code. 

- Sorts out `ILookupProviderV3` <-> `ILookupControllerV3`, which also unwinds a dep in `LookupProviderV3`

madge report:
before: 48
after: 46

---

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.