### PR TITLE
fix(workspace): Journal Note Consistency with Title and Traits

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -32,6 +32,7 @@ import {
   StrictConfigV4,
 } from "./types/intermediateConfigs";
 import { isWebUri } from "./util/regex";
+import { DateTime } from ".";
 
 /**
  * Dendron utilities
@@ -880,4 +881,29 @@ export class Wrap {
   ) {
     return setTimeout(callback, ms, ...args);
   }
+}
+
+/**
+ * Gets the appropriately formatted title for a journal note, given the full
+ * note name and the configured date format.
+ * @param noteName note name like 'daily.journal.2021.01.01'
+ * @param dateFormat - should be gotten from Journal Config's 'dateFormat'
+ * @returns formatted title, or undefined if the journal title could not be parsed.
+ */
+export function getJournalTitle(
+  noteName: string,
+  dateFormat: string
+): string | undefined {
+  let title = noteName.split(".");
+
+  while (title.length > 0) {
+    const attemptedParse = DateTime.fromFormat(title.join("."), dateFormat);
+    if (attemptedParse.isValid) {
+      return title.join("-");
+    }
+
+    title = title.length > 1 ? title.slice(1) : [];
+  }
+
+  return undefined;
 }

--- a/packages/engine-test-utils/src/__tests__/common-all/journalTitle.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/journalTitle.spec.ts
@@ -1,0 +1,48 @@
+import { getJournalTitle } from "@dendronhq/common-all";
+
+/**
+ * Tests the behavior around generating the note title for a journal note
+ */
+describe("GIVEN journal note title generation", () => {
+  describe("WHEN a journal note with the default format like journal.2021.01.01", () => {
+    test("THEN note title should be formatted properly", () => {
+      const result = getJournalTitle("journal.2021.01.01", "y.MM.dd");
+      expect(result).toEqual("2021-01-01");
+    });
+  });
+
+  describe("WHEN a journal note with a note name like double.prefix.2021.01.01", () => {
+    test("THEN note title should be formatted properly", () => {
+      const result = getJournalTitle("double.prefix.2021.01.01", "y.MM.dd");
+      expect(result).toEqual("2021-01-01");
+    });
+  });
+
+  describe("WHEN a journal note with a note name like journal.12.01 without the year", () => {
+    test("THEN note title should be formatted properly", () => {
+      const result = getJournalTitle("journal.12.01", "MM.dd");
+      expect(result).toEqual("12-01");
+    });
+  });
+
+  describe("WHEN a journal note with a configured date format of MM-dd like journal.12-01 with dashes", () => {
+    test("THEN note title should be formatted properly", () => {
+      const result = getJournalTitle("journal.12-01", "MM-dd");
+      expect(result).toEqual("12-01");
+    });
+  });
+
+  describe("WHEN a journal note does not match the configured date format ", () => {
+    test("THEN note title override should return undefined", () => {
+      const result = getJournalTitle("journal.12.01", "MM-dd");
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe("WHEN a journal note has a suffix like journal.2021.01.01.suffix", () => {
+    test("THEN note title override should return undefined", () => {
+      const result = getJournalTitle("journal.2021.01.01.suffix", "y.MM.dd");
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/packages/plugin-core/src/commands/CreateDailyJournal.ts
+++ b/packages/plugin-core/src/commands/CreateDailyJournal.ts
@@ -10,8 +10,12 @@ import {
 
 export class CreateDailyJournalCommand extends CreateNoteWithTraitCommand {
   constructor(ext: IDendronExtension) {
-    super(ext, "dendron.journal", new JournalNote());
-
+    super(
+      ext,
+      "dendron.journal",
+      new JournalNote(ext.workspaceService!.config)
+    );
+    ext.getWorkspaceConfig();
     // override the key to maintain compatibility
     this.key = DENDRON_COMMANDS.CREATE_DAILY_JOURNAL_NOTE.key;
   }

--- a/packages/plugin-core/src/commands/CreateDailyJournal.ts
+++ b/packages/plugin-core/src/commands/CreateDailyJournal.ts
@@ -1,4 +1,4 @@
-import { ConfigUtils, VaultUtils } from "@dendronhq/common-all";
+import { ConfigUtils, DendronError, VaultUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { DENDRON_COMMANDS } from "../constants";
 import { IDendronExtension } from "../dendronExtensionInterface";
@@ -10,12 +10,12 @@ import {
 
 export class CreateDailyJournalCommand extends CreateNoteWithTraitCommand {
   constructor(ext: IDendronExtension) {
-    super(
-      ext,
-      "dendron.journal",
-      new JournalNote(ext.workspaceService!.config)
-    );
-    ext.getWorkspaceConfig();
+    const workspaceService = ext.workspaceService;
+
+    if (!workspaceService) {
+      throw new DendronError({ message: "Workspace Service not initialized!" });
+    }
+    super(ext, "dendron.journal", new JournalNote(workspaceService.config));
     // override the key to maintain compatibility
     this.key = DENDRON_COMMANDS.CREATE_DAILY_JOURNAL_NOTE.key;
   }

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -1,4 +1,5 @@
 import {
+  CONSTANTS,
   DendronTreeViewKey,
   DEngineClient,
   DVault,
@@ -6,7 +7,9 @@ import {
   WorkspaceSettings,
   WorkspaceType,
 } from "@dendronhq/common-all";
+import { readJSONWithCommentsSync } from "@dendronhq/common-server";
 import { IWorkspaceService, WorkspaceService } from "@dendronhq/engine-server";
+import path from "path";
 import {
   Disposable,
   ExtensionContext,
@@ -176,7 +179,13 @@ export class MockDendronExtension implements IDendronExtension {
   }
 
   getWorkspaceConfig(): WorkspaceConfiguration {
-    throw new Error("Method not implemented in MockDendronExtension.");
+    if (!this._wsRoot) {
+      throw new Error("wsRoot not configured in MockDendronExtension.");
+    }
+    const wsConfig = readJSONWithCommentsSync(
+      path.join(this._wsRoot, CONSTANTS.DENDRON_WS_NAME)
+    );
+    return wsConfig;
   }
 
   getTreeView(_key: DendronTreeViewKey): WebviewViewProvider {

--- a/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
@@ -15,9 +15,7 @@ import { expect, getNoteFromTextEditor } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("Scratch Notes", function () {
-  let ctx: vscode.ExtensionContext;
-
-  ctx = setupBeforeAfter(this, {});
+  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {});
 
   describe("multi", () => {
     test("basic, multi", (done) => {
@@ -46,6 +44,14 @@ suite("Scratch Notes", function () {
           });
           const newNote = getNoteFromTextEditor();
           expect(newNote.fname.startsWith(`${fname}.journal`)).toBeTruthy();
+          // The note title should be in the format yyyy-MM-dd
+          expect(/\d{4}-\d{2}-\d{2}$/g.test(newNote.title)).toBeTruthy();
+
+          // @ts-ignore
+          const traits = newNote.traitIds;
+          expect(
+            traits.length === 1 && traits[0] === "journalNote"
+          ).toBeTruthy();
           done();
         },
       });

--- a/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
@@ -47,8 +47,12 @@ suite("Scratch Notes", function () {
           // The note title should be in the format yyyy-MM-dd
           expect(/\d{4}-\d{2}-\d{2}$/g.test(newNote.title)).toBeTruthy();
 
-          // @ts-ignore
-          const traits = newNote.traitIds;
+          // TODO: traits isn't exposed in newNote props here because in the test
+          //we extract noteProps via `getNoteFromTextEditor` instead of the
+          //engine. So for now, test via the raw traitIds that should have been
+          //added to the note.
+          const traits = (newNote as any).traitIds;
+
           expect(
             traits.length === 1 && traits[0] === "journalNote"
           ).toBeTruthy();


### PR DESCRIPTION
## fix(workspace): Journal Note Consistency with Title and Traits

Fixes consistency issues where sometimes the titles on Journal notes weren't properly formatted as `yyyy-MM-dd` and the journalNote traitID wasn't being applied.

This also fixes other pre-existing issues where the journal title would not get properly generated if you deviate from the default `y-MM-dd` format for the journal note config.

Related: 
- https://github.com/dendronhq/dendron/issues/2341
- https://github.com/dendronhq/dendron/issues/2211
- https://github.com/dendronhq/dendron/issues/1911

After this change, when creating a Journal note from the following scenarios below should result in consistent frontmatter
- `Dendron: Create Daily Journal Note`
- `Dendron: Create Journal Note`
- Creating a note via Lookup with the Journal button selected
- Clicking on a new date in the Calendar webview

Frontmatter should look like
```yaml
---
id: IRbGt7WJKEsHNOcfYE2lS
title: '2022-02-11'
desc: ''
updated: 1644575670992
created: 1644575670993
traitIds:
  - journalNote
---
```

NOTE: By design (for now), if you create a new note via lookup with a title like `daily.journal.2022.01.01` **without** the journal modifier button clicked - basically you typed in the note name manually - then the title and traitIds will **not** be applied.  We may look to modify this behavior as we re-examine how some of the button behavior works in Lookup, but that's out of scope in this change.

madge before and after is at 46 - I had to make some changes to `JournalNote.ts` to make it work.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [NA] check if similar function already exist in the codebase. if so, can it be re-used?
  - [NA] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [NA ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ NA] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [NA ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [NA] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [NA] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- [NA] CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [NA] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [NA] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [NA]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)