### PR TITLE
enhance(notes): change dendron id format to be alphanumeric lowercase

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -60,7 +60,6 @@
     "luxon": "^1.25.0",
     "minimatch": "^3.0.4",
     "nanoid": "^3.1.23",
-    "nanoid-dictionary": "^4.3.0",
     "qs": "^6.10.1",
     "semver": "^7.3.2",
     "vscode-uri": "^2.1.2",

--- a/packages/common-all/src/uuid.ts
+++ b/packages/common-all/src/uuid.ts
@@ -7,7 +7,7 @@ import { customAlphabet as nanoidInsecure } from "nanoid/non-secure";
  */
 const SHORT_ID_LENGTH = 12;
 /** Default length for nanoids. */
-const LONG_ID_LENGTH = 32;
+const LONG_ID_LENGTH = 23;
 
 const alphanumericLowercase = "0123456789abcdefghijklmnopqrstuvwxyz";
 

--- a/packages/common-all/src/uuid.ts
+++ b/packages/common-all/src/uuid.ts
@@ -1,6 +1,5 @@
 import { customAlphabet as nanoid } from "nanoid";
 import { customAlphabet as nanoidInsecure } from "nanoid/non-secure";
-import { alphanumeric } from "nanoid-dictionary";
 
 /** Using this length, according to [nanoid collision calculator](https://zelark.github.io/nano-id-cc/),
  * generating 1000 IDs per hour, it would take around 919 years to have 1 percent chance of a single collision.
@@ -8,7 +7,9 @@ import { alphanumeric } from "nanoid-dictionary";
  */
 const SHORT_ID_LENGTH = 12;
 /** Default length for nanoids. */
-const LONG_ID_LENGTH = 21;
+const LONG_ID_LENGTH = 32;
+
+const alphanumericLowercase = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 /**
  * Generates a random identifier.
@@ -25,7 +26,7 @@ const LONG_ID_LENGTH = 21;
  *
  * @returns A url-safe, random identifier.
  */
-export const genUUID = nanoid(alphanumeric, LONG_ID_LENGTH);
+export const genUUID = nanoid(alphanumericLowercase, LONG_ID_LENGTH);
 
 /** Generates a shorter random identifier, faster but with potential cryptographic risks.
  *
@@ -36,4 +37,7 @@ export const genUUID = nanoid(alphanumeric, LONG_ID_LENGTH);
  *
  * @returns A url-safe, random identifier.
  */
-export const genUUIDInsecure = nanoidInsecure(alphanumeric, SHORT_ID_LENGTH);
+export const genUUIDInsecure = nanoidInsecure(
+  alphanumericLowercase,
+  SHORT_ID_LENGTH
+);


### PR DESCRIPTION
This brings more compatibility to the widest possible use cases when synchronizing dendron notes with other sources.

For example, when ids are used in urls, certain hosting providers like netlify will lowercase all urls which will break users that publish using case sensitive ids.

This update makes the following changes:

- update dendron ids to be alphanumeric lowercase
- removes nanoidDictionary dependency
- extend the default length of a dendron id to 32 characters (this is the same length as what other providers like notion and loom use )

Documentation available at https://github.com/dendronhq/dendron-site/pull/402
***
# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [~] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones [^eg-existing-convention]

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed [^eg-check-for-design-review]

## Instrumentation

NA

## Tests


### Basics

- [~] [Write Tests](dev.process.qa.test)  -> we don't have setup to exhaustively test uuid is lowercase
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

NA

## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
