### PR TITLE
fix(workspace): Dendron will try to parse non-dendron files in `onFirstOpen`

### DIFF
--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -1,19 +1,19 @@
 import {
+  ConfigUtils,
   CONSTANTS,
-  IntermediateDendronConfig,
   DendronError,
   DNodeUtils,
   DVault,
   DWorkspaceV2,
   getSlugger,
+  IntermediateDendronConfig,
   isBlockAnchor,
+  isNotUndefined,
   NoteProps,
   VaultUtils,
   WorkspaceFolderCode,
   WorkspaceOpts,
   WorkspaceType,
-  ConfigUtils,
-  isNotUndefined,
 } from "@dendronhq/common-all";
 import {
   findDownTo,
@@ -100,6 +100,28 @@ export class WorkspaceUtils {
       )
     );
     return dendronWorkspaceFolders.filter(isNotUndefined);
+  }
+
+  /**
+   * Check if a file is a dendron note (vs a regular file or something else entirely)
+   */
+  static isDendronNote({
+    wsRoot,
+    vaults,
+    fpath,
+  }: { fpath: string } & WorkspaceOpts) {
+    // check if we have markdown file
+    if (!fpath.endsWith(".md")) {
+      return false;
+    }
+    // if markdown file, check if it is in a dendron vault
+    if (!WorkspaceUtils.isPathInWorkspace({ wsRoot, vaults, fpath })) {
+      return false;
+    }
+
+    // if markdown file, does it have frontmatter?
+    // this is a rough heuristic
+    return fs.readFileSync(fpath, { encoding: "utf8" }).startsWith("---");
   }
 
   static isNativeWorkspace(workspace: DWorkspaceV2) {

--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -105,7 +105,7 @@ export class WorkspaceUtils {
   /**
    * Check if a file is a dendron note (vs a regular file or something else entirely)
    */
-  static isDendronNote({
+  static async isDendronNote({
     wsRoot,
     vaults,
     fpath,
@@ -121,7 +121,7 @@ export class WorkspaceUtils {
 
     // if markdown file, does it have frontmatter?
     // this is a rough heuristic
-    return fs.readFileSync(fpath, { encoding: "utf8" }).startsWith("---");
+    return (await fs.readFile(fpath, { encoding: "utf8" })).startsWith("---");
   }
 
   static isNativeWorkspace(workspace: DWorkspaceV2) {

--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -16,6 +16,7 @@ import {
   WorkspaceType,
 } from "@dendronhq/common-all";
 import {
+  FileUtils,
   findDownTo,
   findUpTo,
   genHash,
@@ -109,7 +110,7 @@ export class WorkspaceUtils {
     wsRoot,
     vaults,
     fpath,
-  }: { fpath: string } & WorkspaceOpts) {
+  }: { fpath: string } & WorkspaceOpts): Promise<boolean> {
     // check if we have markdown file
     if (!fpath.endsWith(".md")) {
       return false;
@@ -119,9 +120,10 @@ export class WorkspaceUtils {
       return false;
     }
 
-    // if markdown file, does it have frontmatter?
-    // this is a rough heuristic
-    return (await fs.readFile(fpath, { encoding: "utf8" })).startsWith("---");
+    // if markdown file, does it have frontmatter? check for `---` at beginning of file
+    return (
+      (await FileUtils.matchFilePrefix({ fpath, prefix: "---" })).data || false
+    );
   }
 
   static isNativeWorkspace(workspace: DWorkspaceV2) {

--- a/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
@@ -9,7 +9,9 @@ import {
   goUpTo,
   schemaModuleProps2File,
   tmpDir,
+  FileUtils,
 } from "@dendronhq/common-server";
+import { FileTestUtils } from "@dendronhq/common-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -156,5 +158,68 @@ describe("file2Schema", () => {
     );
     const schema = await file2Schema(fpath, root);
     expect(_.values(schema.schemas).length).toEqual(8);
+  });
+});
+
+describe("GIVEN matchFilePrefix", () => {
+  let fpath: string;
+  const prefix = "---";
+
+  beforeEach(() => {
+    const root = FileTestUtils.tmpDir().name;
+    fpath = path.join(root, "test-file.md");
+  });
+
+  describe("WHEN file starts with prefix", () => {
+    test("THEN return true", async () => {
+      fs.writeFileSync(fpath, "---\nfoo");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: true,
+      });
+    });
+  });
+
+  describe("WHEN file matches prefix exactly", () => {
+    test("THEN return true", async () => {
+      fs.writeFileSync(fpath, "---");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: true,
+      });
+    });
+  });
+
+  describe("WHEN file does not start with prefix", () => {
+    test("THEN return false", async () => {
+      fs.writeFileSync(fpath, "--!");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: false,
+      });
+    });
+  });
+
+  describe("WHEN file is empty", () => {
+    test("THEN return false", async () => {
+      fs.writeFileSync(fpath, "");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: false,
+      });
+    });
+  });
+
+  describe("WHEN file is shorter than prefix", () => {
+    test("THEN return false", async () => {
+      fs.writeFileSync(fpath, "--");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: false,
+      });
+    });
+  });
+  describe("WHEN file match is not at start of file", () => {
+    test("THEN return false", async () => {
+      fs.writeFileSync(fpath, " ---");
+      expect(await FileUtils.matchFilePrefix({ fpath, prefix })).toEqual({
+        data: false,
+      });
+    });
   });
 });

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -20,8 +20,9 @@ import { WorkspaceUtils } from "@dendronhq/engine-server";
 let WS_UTILS: IWSUtilsV2 | undefined;
 
 /**
- *  Non static WSUtils to allow unwinding of our circular dependencies.
- *   */
+ *
+ *  Utilities to work with workspace related functions
+ **/
 export class WSUtilsV2 implements IWSUtilsV2 {
   private extension: IDendronExtension;
 

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -429,6 +429,15 @@ export class WorkspaceWatcher {
       msg: "enter",
       fname: NoteUtils.uri2Fname(editor.document.uri),
     });
+    const { vaults, wsRoot } = this._extension.getDWorkspace();
+    const fpath = editor.document.uri.fsPath;
+
+    // don't apply actions to non-dendron notes
+    // NOTE: in the future if we add `onFirstOpen` actions to non-dendron notes, this logic will need to be updated
+    if (!WorkspaceUtils.isDendronNote({ wsRoot, vaults, fpath })) {
+      return;
+    }
+
     WorkspaceWatcher.moveCursorPastFrontmatter(editor);
     const config = this._extension.getDWorkspace().config;
     if (ConfigUtils.getWorkspace(config).enableAutoFoldFrontmatter) {

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -104,10 +104,9 @@ export class WorkspaceWatcher {
     this._windowWatcher = windowWatcher;
   }
 
-  /**
-   * Used for testing. DO NOT USE IN PRODUCTION OR YOU WILL BE FIRED
-   */
-  __exposePropsForTesting() {
+  // eslint-disable-next-line camelcase
+  __exposePropsForTesting_DO_NOT_USE_IN_PROD() {
+    // or you will be fired :)
     return {
       onFirstOpen: _.bind(this.onFirstOpen, this),
     };

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -105,8 +105,7 @@ export class WorkspaceWatcher {
   }
 
   // eslint-disable-next-line camelcase
-  __exposePropsForTesting_DO_NOT_USE_IN_PROD() {
-    // or you will be fired :)
+  __DO_NOT_USE_IN_PROD_exposePropsForTesting() {
     return {
       onFirstOpen: _.bind(this.onFirstOpen, this),
     };

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -233,6 +233,11 @@ export class WorkspaceWatcher {
     }
   }
 
+  /**
+   * If note is in workspace, execute {@link onWillSaveNote}
+   * @param event
+   * @returns
+   */
   async onWillSaveTextDocument(
     event: TextDocumentWillSaveEvent
   ): Promise<{ changes: TextEdit[] }> {
@@ -273,6 +278,13 @@ export class WorkspaceWatcher {
     }
   }
 
+  /**
+   * When saving a note, do some book keeping
+   * - update the `updated` time in frontmatter
+   * - update the note metadata in the engine
+   * @param event
+   * @returns
+   */
   private onWillSaveNote(event: TextDocumentWillSaveEvent) {
     const ctx = "WorkspaceWatcher:onWillSaveNote";
     const uri = event.document.uri;
@@ -295,6 +307,7 @@ export class WorkspaceWatcher {
     const match = NoteUtils.RE_FM_UPDATED.exec(content);
     let changes: TextEdit[] = [];
 
+    // update the `updated` time in frontmatter
     if (match && parseInt(match[1], 10) !== note.updated) {
       Logger.info({ ctx, match, msg: "update activeText editor" });
       const startPos = event.document.positionAt(match.index);
@@ -302,6 +315,8 @@ export class WorkspaceWatcher {
       changes = [
         TextEdit.replace(new Range(startPos, endPos), `updated: ${now}`),
       ];
+
+      // update the note in engine
       // eslint-disable-next-line  no-async-promise-executor
       const p = new Promise(async (resolve) => {
         note.updated = now;

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -445,6 +445,10 @@ export class WorkspaceWatcher {
     }
   }
 
+  /**
+   * Dendron will perform changes like moving the cursor when first opening a Dendron note
+   * @returns boolean : returns `true` if Dendron made changes during `onFirstOpen` and `false` otherwise
+   */
   private async onFirstOpen(editor: TextEditor) {
     Logger.info({
       ctx: context("onFirstOpen"),
@@ -456,7 +460,7 @@ export class WorkspaceWatcher {
 
     // don't apply actions to non-dendron notes
     // NOTE: in the future if we add `onFirstOpen` actions to non-dendron notes, this logic will need to be updated
-    if (!WorkspaceUtils.isDendronNote({ wsRoot, vaults, fpath })) {
+    if (!(await WorkspaceUtils.isDendronNote({ wsRoot, vaults, fpath }))) {
       return false;
     }
 

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -104,6 +104,15 @@ export class WorkspaceWatcher {
     this._windowWatcher = windowWatcher;
   }
 
+  /**
+   * Used for testing. DO NOT USE IN PRODUCTION OR YOU WILL BE FIRED
+   */
+  __exposePropsForTesting() {
+    return {
+      onFirstOpen: _.bind(this.onFirstOpen, this),
+    };
+  }
+
   activate(context: ExtensionContext) {
     this._extension.addDisposable(
       workspace.onWillSaveTextDocument(
@@ -450,7 +459,7 @@ export class WorkspaceWatcher {
     // don't apply actions to non-dendron notes
     // NOTE: in the future if we add `onFirstOpen` actions to non-dendron notes, this logic will need to be updated
     if (!WorkspaceUtils.isDendronNote({ wsRoot, vaults, fpath })) {
-      return;
+      return false;
     }
 
     WorkspaceWatcher.moveCursorPastFrontmatter(editor);
@@ -463,6 +472,7 @@ export class WorkspaceWatcher {
       msg: "exit",
       fname: NoteUtils.uri2Fname(editor.document.uri),
     });
+    return true;
   }
 
   static moveCursorPastFrontmatter(editor: TextEditor) {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -73,6 +73,7 @@ export interface IDendronExtension {
   schemaLookupProviderFactory: ISchemaLookupProviderFactory;
 
   activateWatchers(): Promise<void>;
+  deactivate(): Promise<void>;
   pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
 
   getClientAPIRootUrl(): Promise<string>;

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -73,6 +73,9 @@ export interface IDendronExtension {
   schemaLookupProviderFactory: ISchemaLookupProviderFactory;
 
   activateWatchers(): Promise<void>;
+  /**
+   * This will deactivate the entire Dendron Extension. Takes care of disposing of all resources that Dendron has created
+   */
   deactivate(): Promise<void>;
   pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
 

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -16,6 +16,7 @@ import { FileWatcher } from "./fileWatcher";
 import { IEngineAPIService } from "./services/EngineAPIServiceInterface";
 import { INoteSyncService } from "./services/NoteSyncService";
 import { ISchemaSyncService } from "./services/SchemaSyncServiceInterface";
+import { WorkspaceWatcher } from "./WorkspaceWatcher";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
 
 export type DendronWorkspaceSettings = Partial<{
@@ -57,6 +58,7 @@ export type DendronWorkspaceSettings = Partial<{
 export interface IDendronExtension {
   port?: number;
   context: vscode.ExtensionContext;
+  workspaceWatcher?: WorkspaceWatcher;
   serverWatcher?: vscode.FileSystemWatcher;
   fileWatcher?: FileWatcher;
   type: WorkspaceType;
@@ -70,6 +72,7 @@ export interface IDendronExtension {
   noteLookupProviderFactory: INoteLookupProviderFactory;
   schemaLookupProviderFactory: ISchemaLookupProviderFactory;
 
+  activateWatchers(): Promise<void>;
   pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
 
   getClientAPIRootUrl(): Promise<string>;

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -99,6 +99,14 @@ export class MockDendronExtension implements IDendronExtension {
     throw new Error("Method not implemented in MockDendronExtension.");
   }
 
+  async activateWatchers(): Promise<void> {
+    return;
+  }
+
+  async deactivate(): Promise<void> {
+    return;
+  }
+
   /**
    * Note: No-Op
    * @param _cb

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -286,7 +286,6 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
 
           const stubTimeout = sinon.stub(Wrap, "setTimeout");
           expect(await onFirstOpen(editor)).toBeTruthy();
-          // WorkspaceWatcher.moveCursorPastFrontmatter(editor);
           stubTimeout.callArg(0);
           // the selection should have been moved past the frontmatter
           const { line, character } = editor.selection.active;

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -50,7 +50,7 @@ const setupBasic = async (opts: WorkspaceOpts) => {
 
 // eslint-disable-next-line camelcase
 const UNSAFE_getWorkspaceWatcherPropsForTesting = (ext: IDendronExtension) => {
-  return ext.workspaceWatcher!.__exposePropsForTesting();
+  return ext.workspaceWatcher!.__exposePropsForTesting_DO_NOT_USE_IN_PROD();
 };
 
 const doesSchemaExist = (schemaId: string) => {
@@ -219,11 +219,11 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
 
     beforeEach(async () => {
       ext = ExtensionProvider.getExtension();
-      return ext.activateWatchers();
+      await ext.activateWatchers();
     });
-    afterEach(() => {
+    afterEach(async () => {
       // imporant since we activate workspace watchers
-      return ext.deactivate();
+      await ext.deactivate();
     });
     describeSingleWS(
       "AND WHEN user opens non dendron file for the first time",

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -214,7 +214,7 @@ suite("WorkspaceWatcher: GIVEN the dendron extension is running", function () {
     });
   });
 
-  describe.only("GIVEN the user opening a file", () => {
+  describe("GIVEN the user opening a file", () => {
     let ext: IDendronExtension;
 
     beforeEach(async () => {

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -50,7 +50,7 @@ const setupBasic = async (opts: WorkspaceOpts) => {
 
 // eslint-disable-next-line camelcase
 const UNSAFE_getWorkspaceWatcherPropsForTesting = (ext: IDendronExtension) => {
-  return ext.workspaceWatcher!.__exposePropsForTesting_DO_NOT_USE_IN_PROD();
+  return ext.workspaceWatcher!.__DO_NOT_USE_IN_PROD_exposePropsForTesting();
 };
 
 const doesSchemaExist = (schemaId: string) => {


### PR DESCRIPTION
This commit makes the following changes:
- `onFirstOpen` should only track files in the workspace
- note specific operations (eg. moving cursor past frontmatter) should only happen for dendron notes
- adds two new methods to `IDendronExtension` (`activateWatchers` and `deactivate`)

Before, opening a big json file (eg. Dendron Logs) would cause vscode to crash because Dendron would try to parse the entire log file. 

This commit also introduces two new conventions:

1. The `WorkspaceWatcher` is hard to test since methods are `private` and require a working VSCode workspace to actually trigger (which we do not have access to in tests). 
Some solutions that were explored:
- ad-hoc dependency injection: resulted in too many code changes, we're better off actually implementing DI properly using one of the frameworks: https://blog.logrocket.com/top-five-typescript-dependency-injection-containers but out of scope for this task
- making private variables public - not great since they were private for a reason
- introduce the `__DO_NOT_USE_IN_PROD_exposePropsForTesting` method/convention to expose internal workspace state for testing

We went with the last option (will update in [[Testing|dendron://dendron.docs/dev.process.qa.test]] after the PR)

2. During testing, we often do typecasts of the form `foo!.bar` or use `@ts-ignore`. This isn't great. In the future, we want to enable strict type checks and dis-allow type assertions.
To make it easier to get to this future, this PR introduces the `UNSAFE_getWorkspaceWatcherPropsForTesting` convention: everytime you need to type cast, wrap it in a function. 
This groups all unsafe assertions in one place (which we can then add to a special unsafe file which we can ignore for strict type checking)

circular dependencies:
- before: 52
- after: 52

---
# Export

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code) 
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [~] sticking to existing conventions instead of creating new ones 
  - this introduces some new testing conventions
  

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 

### Basics

- [B] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)
- pending successful code review

## 

## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)