### PR TITLE
enhance(pods): add vault filter for pods-v2 hierarchy export

### DIFF
--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -263,12 +263,13 @@ export abstract class BaseExportPodCommand<
         if (!selection) {
           return resolve(undefined);
         }
-
+        const { hierarchy, vault } = selection
         const notes = ExtensionProvider.getEngine().notes;
 
         resolve(
           Object.values(notes).filter(
-            (value) => value.fname.startsWith(selection) && value.stub !== true
+            (value) => value.fname.startsWith(hierarchy) && value.stub !== true &&
+             VaultUtils.isEqualV2(value.vault, vault)
           )
         );
       });

--- a/packages/plugin-core/src/components/lookup/HierarchySelector.ts
+++ b/packages/plugin-core/src/components/lookup/HierarchySelector.ts
@@ -1,4 +1,4 @@
-import { DendronError } from "@dendronhq/common-all";
+import { DendronError, DVault } from "@dendronhq/common-all";
 import { HistoryEvent } from "@dendronhq/engine-server";
 import path from "path";
 import * as vscode from "vscode";
@@ -15,9 +15,10 @@ import { NoteLookupProviderUtils } from "./NoteLookupProviderUtils";
 export interface HierarchySelector {
   /**
    * A method for getting the hierarchy in an async manner. Returning undefined
-   * should be interpreted that no hierarchy was selected.
+   * should be interpreted that no hierarchy was selected. It also returns the 
+   * vault of selected hierarchy.
    */
-  getHierarchy(): Promise<string | undefined>;
+  getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined>;
 }
 
 /**
@@ -25,8 +26,8 @@ export interface HierarchySelector {
  * controller V3.
  */
 export class QuickPickHierarchySelector implements HierarchySelector {
-  getHierarchy(): Promise<string | undefined> {
-    return new Promise<string | undefined>((resolve) => {
+  getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined> {
+    return new Promise<{hierarchy: string, vault: DVault} | undefined>((resolve) => {
       const lookupCreateOpts: LookupControllerV3CreateOpts = {
         nodeType: "note",
         disableVaultSelection: true,
@@ -63,7 +64,8 @@ export class QuickPickHierarchySelector implements HierarchySelector {
             resolve(undefined);
           } else {
             const hierarchy = data.selectedItems[0].fname;
-            resolve(hierarchy);
+            const vault = data.selectedItems[0].vault;
+            resolve({hierarchy, vault});
           }
           NoteLookupProviderUtils.cleanup({
             id: PROVIDER_ID,

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -74,7 +74,7 @@ suite("BaseExportPodCommand", function () {
       () => {
         const cmd = new TestExportPodCommand();
 
-        test("THEN hierarchy note props should be in the export payload", async () => {
+        test("THEN hierarchy note props should be in the export payload AND a note with a hierarchy match but in a different vault should not appear", async () => {
           const payload = await cmd.enrichInputs({
             exportScope: PodExportScope.Hierarchy,
           });

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -14,7 +14,7 @@ import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { TestExportPodCommand } from "./TestExportCommand";
 import { DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
 import sinon from "sinon";
-import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import { PodUIControls } from "../../../../components/pods/PodControls";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { ExtensionProvider } from "../../../../ExtensionProvider";
@@ -62,7 +62,14 @@ suite("BaseExportPodCommand", function () {
       "WHEN exporting a hierarchy scope",
       {
         ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS_MULTI.setupBasicMulti({ wsRoot, vaults });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[1],
+            fname: "foo.test",
+          });
+        }
       },
       () => {
         const cmd = new TestExportPodCommand();
@@ -72,7 +79,7 @@ suite("BaseExportPodCommand", function () {
             exportScope: PodExportScope.Hierarchy,
           });
 
-          // 'foo' note and its child:
+          // 'foo' note and its child: foo.test should not appear
           expect(payload?.payload.length).toEqual(2);
         });
 

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -1,4 +1,4 @@
-import { NoteProps } from "@dendronhq/common-all";
+import { DVault, NoteProps } from "@dendronhq/common-all";
 import {
   AirtableConnection,
   AirtableV2PodConfig,
@@ -9,6 +9,7 @@ import {
 } from "@dendronhq/pods-core";
 import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
 import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
+import { ExtensionProvider } from "../../../../ExtensionProvider";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.
@@ -20,12 +21,13 @@ export class TestExportPodCommand extends BaseExportPodCommand<
   public key = "dendron.testexport";
 
   /**
-   * Hardcoded to return the 'foo' Hierarchy from ENGINE_HOOKS.setupBasic
+   * Hardcoded to return the 'foo' Hierarchy and vault[0] from ENGINE_HOOKS.setupBasic 
    */
   static mockedSelector: HierarchySelector = {
-    getHierarchy(): Promise<string | undefined> {
-      return new Promise<string | undefined>((resolve) => {
-        resolve("foo");
+    getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined> {
+      return new Promise<{hierarchy: string, vault: DVault} | undefined>((resolve) => {
+        const { vaults } = ExtensionProvider.getDWorkspace();
+        resolve({hierarchy: "foo", vault: vaults[0] });
       });
     },
   };


### PR DESCRIPTION
This PR attempts to respect the vault boundaries while performing hierarchy export in pods-v2. 

***
madge report
no new circular dependencies(48)
***

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)