### PR TITLE
chore: switch back to vercel's title package

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -37,7 +37,7 @@
     "test:watch": "echo 0"
   },
   "dependencies": {
-    "@dendronhq/title": "^3.4.3",
+    "title": "^3.4.4",
     "@types/github-slugger": "^1.3.0",
     "@types/lodash": "^4.14.152",
     "@types/luxon": "^1.25.0",

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-throw-literal */
 // @ts-ignore
-import title from "@dendronhq/title";
+import title from "title";
 import matter from "gray-matter";
 import YAML, { JSON_SCHEMA } from "js-yaml";
 import _ from "lodash";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3705,16 +3705,6 @@
     unist-util-visit "^1.1.3"
     which "^1.3.0"
 
-"@dendronhq/title@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@dendronhq/title/-/title-3.4.3.tgz#6b800942df4e74519f675fd8a81d8bbbd9e6a97c"
-  integrity sha512-DgaHbLkpYToSZsAHKCujG3BytGYP289UBqH5oI3C8vHU19rRaCL9eHb+hrNPbW5k51mwyj6CTevBJdS6GsxvCw==
-  dependencies:
-    arg "1.0.0"
-    chalk "2.3.0"
-    clipboardy "1.2.2"
-    titleize "1.0.0"
-
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.5"
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
@@ -25753,6 +25743,16 @@ tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+title@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.npmjs.org/title/-/title-3.4.4.tgz#5c0ab11fd69643bc05dc006bba52aaf5c1630f5e"
+  integrity sha512-ViLJMyg5TFwWQ7Aqrs3e0IPINA99++cOLzQFIuBw6rKPhn8Cz7J7sdsag0BQPCf4ip7bHY1/docykbQe2R4N6Q==
+  dependencies:
+    arg "1.0.0"
+    chalk "2.3.0"
+    clipboardy "1.2.2"
+    titleize "1.0.0"
 
 titleize@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Vercel merged our contribution that fixes the international characters bug, and released a new version. This PR switches us back to that version so we can continue to get updates from upstream.

I added a warning to our fork of the repository and archived it.