### PR TITLE
fix(schema): Apply schema template for goto-note-command if template is in different vault

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -444,12 +444,23 @@ export class NoteUtils {
       const maybeTemplate = schema.data.template;
       if (maybeTemplate) {
         // TODO: Support xvault with user prompting for this flow
-        // Get first valid template note. If there are multiple template matches, apply first one.
-        // This is temp until we get xvault support
-        const tempNote = NoteUtils.getNotesByFnameFromEngine({
+        /*
+         * Get first valid template note.
+         * First look for template in same vault as note. Otherwise, look across all vaults.
+         * If there are multiple template matches, apply first one.
+         * This is temp until we get xvault support
+         */
+        const tempInSameVault = NoteUtils.getNoteByFnameFromEngine({
           fname: maybeTemplate.id,
+          vault: note.vault,
           engine,
-        })[0];
+        });
+        const tempNote =
+          tempInSameVault ||
+          NoteUtils.getNotesByFnameFromEngine({
+            fname: maybeTemplate.id,
+            engine,
+          })[0];
 
         if (tempNote) {
           SchemaUtils.applyTemplate({

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -444,11 +444,12 @@ export class NoteUtils {
       const maybeTemplate = schema.data.template;
       if (maybeTemplate) {
         // TODO: Support xvault with user prompting for this flow
-        const tempNote = NoteUtils.getNoteByFnameFromEngine({
+        // Get first valid template note. If there are multiple template matches, apply first one.
+        // This is temp until we get xvault support
+        const tempNote = NoteUtils.getNotesByFnameFromEngine({
           fname: maybeTemplate.id,
-          vault: note.vault,
           engine,
-        });
+        })[0];
 
         if (tempNote) {
           SchemaUtils.applyTemplate({

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -131,6 +131,29 @@ suite("GotoNote", function () {
       });
     });
 
+    test("go to new note with template in a different vault", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
+        postSetupHook: async ({ wsRoot, vaults }) => {
+          await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
+        },
+        onInit: async ({ vaults }) => {
+          // Note is in different vault from template
+          const vault = vaults[1];
+          await createGoToNoteCmd().run({
+            qs: "bar.ch1",
+            vault,
+          });
+          expect(getActiveEditorBasename()).toEqual("bar.ch1.md");
+          const content =
+            VSCodeUtils.getActiveTextEditor()?.document.getText() as string;
+          expect(content.indexOf("ch1 template") >= 0).toBeTruthy();
+          done();
+        },
+      });
+    });
+
     test("go to note with anchor", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,


### PR DESCRIPTION
**Background**
Previously, when we run Goto note command, we would only apply a template if it was in same vault as the note. Now we will apply the first template match. If there are multiple template matches across multiple vaults, pick first one to apply. This is temporary until we support xvault support for this command.

**Testing**
Verified manually and added new test case

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)