### PR TITLE
fix(publish): horizontal rule height in publishing

### DIFF
--- a/packages/dendron-next-server/styles/scss/base.scss
+++ b/packages/dendron-next-server/styles/scss/base.scss
@@ -103,6 +103,10 @@ img {
 
 hr {
   height: 1px;
+  // `border-width` is already this by default (browser default style), but Ant
+  // design's stylesheet overrides the height and hr depends on `border-width` to
+  // set its height instead. Setting explicitly so we don't depend on the default.
+  border-width: 1px;
   padding: 0;
   margin: $sp-6 0;
   background-color: $border-color;

--- a/packages/nextjs-template/styles/scss/base.scss
+++ b/packages/nextjs-template/styles/scss/base.scss
@@ -106,5 +106,4 @@ hr {
   padding: 0;
   margin: $sp-6 0;
   background-color: $border-color;
-  border: 0;
 }

--- a/packages/nextjs-template/styles/scss/main.scss
+++ b/packages/nextjs-template/styles/scss/main.scss
@@ -26,7 +26,10 @@ $text-color: #111 !default;
 }
 
 hr {
-  height: "1px";
+  // the height below is overridden by Ant design theme, we instead set
+  // `border-width` to set the height (along with `box-sizing: border-box`)
+  border-width: 1px;
+  height: 1px;
 }
 
 // Components

--- a/test-workspace/vault/dendron.ref.markdown.md
+++ b/test-workspace/vault/dendron.ref.markdown.md
@@ -30,6 +30,17 @@ $$
 f(x) = 5
 $$
 
+### Rule
+
+Horizontal rule below
+
+---
+
+Another rule below this too
+
+*** 
+
+Rules above!
 
 ### Mermaid
 


### PR DESCRIPTION
The height of the horizontal rule (line) in the preview depended on a browser default style that sets the border size for the rule. This PR makes that explicit so it's clearer in future refactors, and fixes this in publishing where that wasn't the default.

![Screenshot_20220216_184652](https://user-images.githubusercontent.com/1008124/154377406-6a70b5be-3b12-4c63-b14c-46431f02a1d5.png)


#2438

# Dendron Extended PR Checklist

- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [x] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [x] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [x] firefox
    - [x] chrome
