### PR TITLE
fix(workspace): dendron can hang when trying to provide hover for large non-dendron file

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -834,3 +834,7 @@ export type SeedBrowserMessage = DMessage<
 >;
 
 export type LookupViewMessage = DMessage<LookupViewMessageEnum, any>;
+
+// from https://stackoverflow.com/questions/48011353/how-to-unwrap-the-type-of-a-promise
+// use to unwrap promise of return time
+export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -836,5 +836,5 @@ export type SeedBrowserMessage = DMessage<
 export type LookupViewMessage = DMessage<LookupViewMessageEnum, any>;
 
 // from https://stackoverflow.com/questions/48011353/how-to-unwrap-the-type-of-a-promise
-// use to unwrap promise of return time
+// use to unwrap promise of return type. can be removed once we upgrade to typescript 4.5 (will be included in typescript library)
 export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -35,7 +35,11 @@ import {
   USERS_HIERARCHY_BASE,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { createDisposableLogger } from "@dendronhq/common-server";
+import {
+  createDisposableLogger,
+  getFrontmatterTags,
+  parseFrontmatter,
+} from "@dendronhq/common-server";
 import _ from "lodash";
 import type {
   FootnoteDefinition,
@@ -51,6 +55,7 @@ import type {
   TableCell,
   TableRow,
   Text,
+  YAML,
 } from "mdast";
 import * as mdastBuilder from "mdast-builder";
 import { Processor } from "unified";
@@ -1416,5 +1421,27 @@ export class RemarkUtils {
     return selectAll(DendronASTTypes.FOOTNOTE_DEFINITION, root).filter(
       RemarkUtils.isFootnoteDefinition
     );
+  }
+
+  /**
+   * Extract frontmatter tags from note
+   * @param body
+   * @returns
+   */
+  static extractFMTags(body: string) {
+    let parsed: ReturnType<typeof parseFrontmatter> | undefined;
+    const noteAST = MDUtilsV5.procRemarkParse(
+      { mode: ProcMode.NO_DATA },
+      {}
+    ).parse(body);
+    visit(noteAST, [DendronASTTypes.FRONTMATTER], (frontmatter: YAML) => {
+      parsed = parseFrontmatter(frontmatter);
+      return false; // stop traversing, there is only one frontmatter
+    });
+    if (parsed) {
+      return getFrontmatterTags(parsed);
+    } else {
+      return [];
+    }
   }
 }

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -1,8 +1,7 @@
-import { IDendronExtension } from "./dendronExtensionInterface";
 import { DendronError, DendronTreeViewKey } from "@dendronhq/common-all";
 import _ from "lodash";
+import { IDendronExtension } from "./dendronExtensionInterface";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
-import { WorkspaceUtils } from "@dendronhq/engine-server";
 
 /**
  * Use this to statically get implementation of IDendronExtension without having to
@@ -42,15 +41,7 @@ export class ExtensionProvider {
   }
 
   static isActiveAndIsDendronNote(fpath: string) {
-    if (!this.isActive()) {
-      return false;
-    }
-    const { wsRoot, vaults } = this.getDWorkspace();
-    return WorkspaceUtils.isDendronNote({
-      wsRoot,
-      vaults,
-      fpath,
-    });
+    return ExtensionProvider.getExtension().isActiveAndIsDendronNote(fpath);
   }
 
   static getWorkspaceConfig() {

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -2,6 +2,7 @@ import { IDendronExtension } from "./dendronExtensionInterface";
 import { DendronError, DendronTreeViewKey } from "@dendronhq/common-all";
 import _ from "lodash";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
+import { WorkspaceUtils } from "@dendronhq/engine-server";
 
 /**
  * Use this to statically get implementation of IDendronExtension without having to
@@ -38,6 +39,18 @@ export class ExtensionProvider {
 
   static isActive() {
     return ExtensionProvider.getExtension().isActive();
+  }
+
+  static isActiveAndIsDendronNote(fpath: string) {
+    if (!this.isActive()) {
+      return false;
+    }
+    const { wsRoot, vaults } = this.getDWorkspace();
+    return WorkspaceUtils.isDendronNote({
+      wsRoot,
+      vaults,
+      fpath,
+    });
   }
 
   static getWorkspaceConfig() {

--- a/packages/plugin-core/src/commands/ConvertLink.ts
+++ b/packages/plugin-core/src/commands/ConvertLink.ts
@@ -307,8 +307,14 @@ export class ConvertLinkCommand extends BasicCommand<
     const { vaults, wsRoot, notes } = engine;
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
     const { document, selection } = editor;
-    const reference = getReferenceAtPosition(document, selection.start, {
-      allowInCodeBlocks: true,
+    const reference = await getReferenceAtPosition({
+      document,
+      position: selection.start,
+      vaults,
+      wsRoot,
+      opts: {
+        allowInCodeBlocks: true,
+      },
     });
 
     if (reference === null) {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -113,6 +113,12 @@ export interface IDendronExtension {
   isActive(): boolean;
 
   /**
+   * Checks if a Dendron workspace is currently active and that the current {@link fpath} is a valid Dendron Note
+   * @param fpath: full path to current file
+   */
+  isActiveAndIsDendronNote(fpath: string): boolean;
+
+  /**
    * Get Global Workspace configuration
    */
   getWorkspaceConfig(

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -116,7 +116,7 @@ export interface IDendronExtension {
    * Checks if a Dendron workspace is currently active and that the current {@link fpath} is a valid Dendron Note
    * @param fpath: full path to current file
    */
-  isActiveAndIsDendronNote(fpath: string): boolean;
+  isActiveAndIsDendronNote(fpath: string): Promise<boolean>;
 
   /**
    * Get Global Workspace configuration

--- a/packages/plugin-core/src/features/RenameProvider.ts
+++ b/packages/plugin-core/src/features/RenameProvider.ts
@@ -17,6 +17,7 @@ import {
 import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace } from "../workspace";
 import { WSUtils } from "../WSUtils";
+import { ExtensionProvider } from "../ExtensionProvider";
 
 export default class RenameProvider implements vscode.RenameProvider {
   private _targetNote: NoteProps | undefined;
@@ -176,7 +177,21 @@ export default class RenameProvider implements vscode.RenameProvider {
     document: vscode.TextDocument,
     position: vscode.Position
   ) {
-    const reference = getReferenceAtPosition(document, position);
+    if (
+      !(await ExtensionProvider.isActiveAndIsDendronNote(document.uri.fsPath))
+    ) {
+      throw new DendronError({
+        message: "Rename is not supported for non dendron notes",
+      });
+    }
+    const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+
+    const reference = await getReferenceAtPosition({
+      document,
+      position,
+      wsRoot,
+      vaults,
+    });
     if (reference !== null) {
       this.refAtPos = reference;
       const range = this.getRangeForReference({ reference, document });

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -183,7 +183,7 @@ export class MockDendronExtension implements IDendronExtension {
     return true;
   }
 
-  isActiveAndIsDendronNote(_fpath: string): boolean {
+  async isActiveAndIsDendronNote(_fpath: string): Promise<boolean> {
     throw new Error("not implemented");
   }
 

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -183,6 +183,10 @@ export class MockDendronExtension implements IDendronExtension {
     return true;
   }
 
+  isActiveAndIsDendronNote(_fpath: string): boolean {
+    throw new Error("not implemented");
+  }
+
   getWorkspaceConfig(): WorkspaceConfiguration {
     // TODO: the old implementation of this was wrong - it did not return WorkspaceConfiguration but a WorkspaceSettings object
     // since this doesn't seem to be used, just adding an exception here for future work

--- a/packages/plugin-core/src/test/suite-integ/ConvertLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConvertLink.test.ts
@@ -10,10 +10,7 @@ import sinon from "sinon";
 import vscode, { TextEditor } from "vscode";
 import { ConvertLinkCommand } from "../../commands/ConvertLink";
 import { ExtensionProvider } from "../../ExtensionProvider";
-import {
-  getReferenceAtPosition,
-  getReferenceAtPositionResp,
-} from "../../utils/md";
+import { getReferenceAtPosition } from "../../utils/md";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
@@ -33,7 +30,10 @@ const getReference = async ({
     wsRoot,
     vaults,
   });
-  return out as getReferenceAtPositionResp;
+  if (!out) {
+    throw new Error("ref should be truthy");
+  }
+  return out;
 };
 
 suite("ConvertLink", function () {

--- a/packages/plugin-core/src/test/suite-integ/ConvertLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConvertLink.test.ts
@@ -5,10 +5,11 @@ import {
 } from "@dendronhq/common-test-utils";
 import { LinkUtils, ParseLinkV2Resp } from "@dendronhq/engine-server";
 import _ from "lodash";
-import { beforeEach, afterEach } from "mocha";
+import { afterEach, beforeEach } from "mocha";
 import sinon from "sinon";
-import vscode from "vscode";
+import vscode, { TextEditor } from "vscode";
 import { ConvertLinkCommand } from "../../commands/ConvertLink";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import {
   getReferenceAtPosition,
   getReferenceAtPositionResp,
@@ -17,6 +18,23 @@ import { VSCodeUtils } from "../../vsCodeUtils";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+
+const getReference = async ({
+  editor,
+  position,
+}: {
+  editor: TextEditor;
+  position: vscode.Position;
+}) => {
+  const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+  const out = await getReferenceAtPosition({
+    document: editor.document,
+    position,
+    wsRoot,
+    vaults,
+  });
+  return out as getReferenceAtPositionResp;
+};
 
 suite("ConvertLink", function () {
   const ctx = setupBeforeAfter(this, {
@@ -71,10 +89,10 @@ suite("ConvertLink", function () {
       test("WHEN broken link with no alias, THEN doesn't show option to use alias text.", async () => {
         const editor = vscode.window.activeTextEditor as vscode.TextEditor;
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          noAliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: noAliasBrokenLinkPosition,
+        });
         const { options, parsedLink } =
           cmd.prepareBrokenLinkConvertOptions(reference);
         expect(parsedLink.alias).toBeFalsy();
@@ -92,10 +110,10 @@ suite("ConvertLink", function () {
           aliasBrokenLinkPosition
         );
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          aliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: aliasBrokenLinkPosition,
+        });
         sandbox.stub(cmd, "promptBrokenLinkConvertOptions").resolves({
           option: {
             label: "Alias",
@@ -116,10 +134,10 @@ suite("ConvertLink", function () {
           aliasBrokenLinkPosition
         );
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          aliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: aliasBrokenLinkPosition,
+        });
         sandbox.stub(cmd, "promptBrokenLinkConvertOptions").resolves({
           option: {
             label: "Note name",
@@ -140,10 +158,10 @@ suite("ConvertLink", function () {
           aliasBrokenLinkPosition
         );
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          aliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: aliasBrokenLinkPosition,
+        });
         sandbox.stub(cmd, "promptBrokenLinkConvertOptions").resolves({
           option: {
             label: "Hierarchy",
@@ -164,10 +182,10 @@ suite("ConvertLink", function () {
           aliasBrokenLinkPosition
         );
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          aliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: aliasBrokenLinkPosition,
+        });
         sandbox.stub(cmd, "promptBrokenLinkConvertOptions").resolves({
           option: {
             label: "Prompt",
@@ -189,10 +207,10 @@ suite("ConvertLink", function () {
           aliasBrokenLinkPosition
         );
         const cmd = new ConvertLinkCommand();
-        const reference = getReferenceAtPosition(
-          editor.document,
-          aliasBrokenLinkPosition
-        ) as getReferenceAtPositionResp;
+        const reference = await getReference({
+          editor,
+          position: aliasBrokenLinkPosition,
+        });
         sandbox.stub(cmd, "promptBrokenLinkConvertOptions").resolves({
           option: {
             label: "Change destination",

--- a/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
@@ -1,0 +1,1252 @@
+import { NoteProps, VaultUtils } from "@dendronhq/common-all";
+import {
+  AssertUtils,
+  FileTestUtils,
+  NoteTestUtilsV4,
+} from "@dendronhq/common-test-utils";
+import { ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
+import fs from "fs-extra";
+import { before, describe } from "mocha";
+import path from "path";
+import * as vscode from "vscode";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import ReferenceHoverProvider from "../../features/ReferenceHoverProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { getDWorkspace } from "../../workspace";
+import { WSUtils } from "../../WSUtils";
+import { expect, LocationTestUtils } from "../testUtilsv2";
+import {
+  describeMultiWS,
+  describeSingleWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
+
+async function provide({
+  editor,
+  pos,
+}: {
+  editor: vscode.TextEditor;
+  pos: vscode.Position;
+}) {
+  const doc = editor?.document as vscode.TextDocument;
+  const referenceProvider = new ReferenceHoverProvider();
+  return referenceProvider.provideHover(doc, pos);
+}
+
+async function provideForNote(editor: vscode.TextEditor) {
+  return provide({ editor, pos: new vscode.Position(7, 4) });
+}
+
+async function provideForNonNote(editor: vscode.TextEditor) {
+  return provide({ editor, pos: new vscode.Position(0, 2) });
+}
+
+suite("GIVEN ReferenceHoverProvider", function () {
+  const ctx = setupBeforeAfter(this);
+
+  describe("AND GIVEN non-dendron file", () => {
+    describeMultiWS(
+      "AND WHEN try to find references",
+      {
+        ctx,
+        preSetupHook: async (opts) => {
+          return FileTestUtils.createFiles(opts.wsRoot, [
+            { path: "sample.with-header", body: "## Foo" },
+            { path: "sample.empty", body: "" },
+          ]);
+        },
+      },
+      () => {
+        test("THEN empty file return null", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const notePath = path.join(wsRoot, "sample.empty");
+          const editor = await VSCodeUtils.openFileInEditor(
+            vscode.Uri.file(notePath)
+          );
+          const hover = await provideForNonNote(editor!);
+          expect(hover).toEqual(null);
+        });
+
+        test("THEN file with header returns null", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const notePath = path.join(wsRoot, "sample.with-header");
+          const editor = await VSCodeUtils.openFileInEditor(
+            vscode.Uri.file(notePath)
+          );
+          const hover = await provideForNonNote(editor!);
+          expect(hover).toEqual(null);
+        });
+      }
+    );
+  });
+
+  describe("has correct hover contents", () => {
+    describe("wikilink", () => {
+      test("basic", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "[[target]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test("missing notes are marked as such", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "[[target]]", // target doesn't exist
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                `Note target is missing`,
+                `use "Dendron: Go to Note" command`,
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test.skip("contains local image", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "![](/assets/test/image.png)",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "[[target]]",
+            });
+          },
+          onInit: async ({ wsRoot, vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            // Local images should get full path to image, because hover preview otherwise can't find the image
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                `![](${path.join(
+                  wsRoot,
+                  VaultUtils.getRelPath(vaults[0]),
+                  "assets/test/image.png"
+                )})`,
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test("contains remote image", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "![](https://example.com/image.png)",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "[[target]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            // remote images should be unmodified
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "![](https://example.com/image.png)",
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with alias", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "[[my note alias|target]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with xvault", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            // Creating a note of the same name in multiple vaults to check that it gets the right one
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[1],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: "Voluptatem possimus harum nisi.",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `[[dendron://${VaultUtils.getName(vaults[1])}/target]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi."],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with header", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `[[target#numquam-occaecati]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 12)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi."],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with block anchor", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima. ^my-anchor",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `[[target#^my-anchor]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi.", "Numquam occaecati"],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with everything", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[1],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: "Voluptatem possimus harum nisi.",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `[[My note: with an alias|dendron://${VaultUtils.getName(
+                vaults[1]
+              )}/target#numquam-occaecati]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi."],
+            });
+            done();
+          },
+        });
+      });
+
+      describe("multiple notes & xvault link", () => {
+        test("non-xvault link resolves to same vault", (done) => {
+          let note: NoteProps;
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async (opts) => {
+              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
+            },
+            onInit: async () => {
+              const editor = await WSUtils.openNote(note);
+              editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
+                line: 7,
+              });
+              const hover = await provideForNote(editor);
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["vault 1"],
+                  nomatch: ["vault 0", "the test note"],
+                })
+              ).toBeTruthy();
+              done();
+            },
+          });
+        });
+
+        test("xvault link to other vault", (done) => {
+          let note: NoteProps;
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async (opts) => {
+              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
+            },
+            onInit: async () => {
+              const editor = await WSUtils.openNote(note);
+              const provider = new ReferenceHoverProvider();
+              const hover = await provider.provideHover(
+                editor.document,
+                new vscode.Position(8, 4)
+              );
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["vault 0"],
+                  nomatch: ["vault 1", "the test note"],
+                })
+              ).toBeTruthy();
+              done();
+            },
+          });
+        });
+
+        test("xvault link to same vault", (done) => {
+          let note: NoteProps;
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async (opts) => {
+              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
+            },
+            onInit: async () => {
+              const editor = await WSUtils.openNote(note);
+              const provider = new ReferenceHoverProvider();
+              const hover = await provider.provideHover(
+                editor.document,
+                new vscode.Position(9, 4)
+              );
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["vault 1"],
+                  nomatch: ["vault 0", "the test note"],
+                })
+              ).toBeTruthy();
+              done();
+            },
+          });
+        });
+
+        test("xvault link to non-existant note", (done) => {
+          let note: NoteProps;
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async (opts) => {
+              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
+            },
+            onInit: async () => {
+              const editor = await WSUtils.openNote(note);
+              const provider = new ReferenceHoverProvider();
+              const hover = await provider.provideHover(
+                editor.document,
+                new vscode.Position(10, 4)
+              );
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["eggs", "vaultThree", "missing"],
+                  nomatch: [
+                    "vault 0",
+                    "vault 1",
+                    "vault1",
+                    "vault2",
+                    "the test note",
+                  ],
+                })
+              ).toBeTruthy();
+              done();
+            },
+          });
+        });
+
+        test("xvault link to non-existant vault", (done) => {
+          let note: NoteProps;
+          runLegacyMultiWorkspaceTest({
+            ctx,
+            preSetupHook: async (opts) => {
+              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
+            },
+            onInit: async () => {
+              const editor = await WSUtils.openNote(note);
+              const provider = new ReferenceHoverProvider();
+              const hover = await provider.provideHover(
+                editor.document,
+                new vscode.Position(11, 4)
+              );
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["vault3", "does not exist"],
+                  nomatch: [
+                    "vault 0",
+                    "vault 1",
+                    "vault1",
+                    "vault2",
+                    "the test note",
+                  ],
+                })
+              ).toBeTruthy();
+              done();
+            },
+          });
+        });
+      });
+    });
+
+    describe("reference", () => {
+      test("basic", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "![[target]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with xvault", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            // Creating a note of the same name in multiple vaults to check that it gets the right one
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[1],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: "Voluptatem possimus harum nisi.",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `![[dendron://${VaultUtils.getName(vaults[1])}/target]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi."],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with header", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `![[target#numquam-occaecati]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi."],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with block anchor", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima. ^my-anchor",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `![[target#^my-anchor]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: ["Voluptatem possimus harum nisi.", "Numquam occaecati"],
+            });
+            done();
+          },
+        });
+      });
+
+      test("with range", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "target",
+              body: [
+                "Voluptatem possimus harum nisi.",
+                "",
+                "# Numquam occaecati",
+                "",
+                "Sint quo sunt maxime.",
+                "",
+                "Nisi nam dolorem qui ut minima. ^my-anchor",
+                "",
+                "Ut quo eius laudantium.",
+              ].join("\n"),
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: `![[target#numquam-occaecati:#^my-anchor]]`,
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const hover = await provideForNote(editor);
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: [
+                "Numquam occaecati",
+                "Sint quo sunt maxime.",
+                "Nisi nam dolorem qui ut minima.",
+              ],
+              nomatch: [
+                "Voluptatem possimus harum nisi.",
+                "Ut quo eius laudantium.",
+              ],
+            });
+            done();
+          },
+        });
+      });
+    });
+
+    test("hashtag", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo.test",
+            body: "this is tag foo.test",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "#foo.test",
+          });
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await WSUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeTruthy();
+          await AssertUtils.assertInString({
+            body: hover!.contents.join(""),
+            match: ["this is tag foo.test"],
+          });
+          done();
+        },
+      });
+    });
+
+    test("hashtags are ignored when disabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo.test",
+            body: "this is tag foo.test",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "#foo.test",
+          });
+        },
+        modConfigCb: (config) => {
+          config.workspace!.enableHashTags = false;
+          return config;
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await WSUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeFalsy();
+          done();
+        },
+      });
+    });
+
+    test("user tag", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "user.test.mctestface",
+            body: "this is user test.mctestface",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "@test.mctestface",
+          });
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await WSUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeTruthy();
+          await AssertUtils.assertInString({
+            body: hover!.contents.join(""),
+            match: ["this is user test.mctestface"],
+          });
+          done();
+        },
+      });
+    });
+
+    test("user tags are ignored when disabled", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "user.test.mctestface",
+            body: "this is user test.mctestface",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: "@test.mctestface",
+          });
+        },
+        modConfigCb: (config) => {
+          config.workspace!.enableUserTags = false;
+          return config;
+        },
+        onInit: async ({ vaults }) => {
+          const editor = await WSUtils.openNoteByPath({
+            vault: vaults[0],
+            fname: "source",
+          });
+          const provider = new ReferenceHoverProvider();
+          const hover = await provider.provideHover(
+            editor.document,
+            new vscode.Position(7, 6)
+          );
+          expect(hover).toBeFalsy();
+          done();
+        },
+      });
+    });
+
+    describe("frontmatter tags", () => {
+      test("single tag", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "tags.foo.test",
+              body: "this is tag foo.test",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              props: {
+                tags: "foo.test",
+              },
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(6, 10)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: ["this is tag foo.test"],
+            });
+            done();
+          },
+        });
+      });
+
+      test("multiple tags", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "tags.foo.test",
+              body: "this is tag foo.test",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "tags.foo.bar",
+              body: "this is the wrong tag",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "tags.foo.baz",
+              body: "this is the wrong tag",
+            });
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              props: {
+                tags: ["foo.bar", "foo.test", "foo.baz"],
+              },
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(8, 4)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: ["this is tag foo.test"],
+            });
+            done();
+          },
+        });
+      });
+    });
+
+    describe("non-note", () => {
+      test("image", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await fs.ensureFile(
+              path.join(
+                wsRoot,
+                VaultUtils.getName(vaults[0]),
+                "assets",
+                "image.png"
+              )
+            );
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "![[/assets/image.png]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: ["[", "]", "(", "/assets/image.png", ")"],
+            });
+            done();
+          },
+        });
+      });
+
+      test("hyperlink", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "![[http://example.com]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: ["[", "]", "(", "http://example.com", ")"],
+            });
+            done();
+          },
+        });
+      });
+
+      test("email", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook: async ({ wsRoot, vaults }) => {
+            await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: "![[mailto:user@example.com]]",
+            });
+          },
+          onInit: async ({ vaults }) => {
+            const editor = await WSUtils.openNoteByPath({
+              vault: vaults[0],
+              fname: "source",
+            });
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            await AssertUtils.assertInString({
+              body: hover!.contents.join(""),
+              match: ["[", "]", "(", "mailto:user@example.com", ")"],
+            });
+            done();
+          },
+        });
+      });
+
+      describeSingleWS(
+        "WHEN used on a link to a non-note file",
+        { ctx },
+        () => {
+          before(async () => {
+            const { wsRoot, vaults } = getDWorkspace();
+            await fs.writeFile(
+              path.join(wsRoot, "test.txt"),
+              "Et nam velit laboriosam."
+            );
+            const note = await NoteTestUtilsV4.createNote({
+              vault: vaults[0],
+              wsRoot,
+              fname: "source",
+              body: ["[[test.txt]]", "[[test.txt#L1]]"].join("\n"),
+            });
+            await WSUtils.openNote(note);
+          });
+
+          test("THEN displays message to open it with the default app", async () => {
+            const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              new vscode.Position(7, 4)
+            );
+            expect(hover).toBeTruthy();
+            expect(
+              await AssertUtils.assertInString({
+                body: hover!.contents.join(""),
+                match: ["test.txt"],
+              })
+            ).toBeTruthy();
+          });
+
+          describe("AND the link has a line anchor", () => {
+            test("THEN displays message to open it with the default app", async () => {
+              const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+              const provider = new ReferenceHoverProvider();
+              const hover = await provider.provideHover(
+                editor.document,
+                new vscode.Position(8, 4)
+              );
+              expect(hover).toBeTruthy();
+              expect(
+                await AssertUtils.assertInString({
+                  body: hover!.contents.join(""),
+                  match: ["test.txt"],
+                  nomatch: ["L6"],
+                })
+              ).toBeTruthy();
+            });
+          });
+        }
+      );
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
@@ -45,20 +45,20 @@ async function provideForNonNote(editor: vscode.TextEditor) {
 suite("GIVEN ReferenceHoverProvider", function () {
   const ctx = setupBeforeAfter(this);
 
-  describe("AND GIVEN non-dendron file", () => {
-    describeMultiWS(
-      "AND WHEN try to find references",
-      {
-        ctx,
-        preSetupHook: async (opts) => {
-          return FileTestUtils.createFiles(opts.wsRoot, [
-            { path: "sample.with-header", body: "## Foo" },
-            { path: "sample.empty", body: "" },
-          ]);
-        },
+  describeMultiWS(
+    "AND WHEN used in non-dendron file",
+    {
+      ctx,
+      preSetupHook: async (opts) => {
+        return FileTestUtils.createFiles(opts.wsRoot, [
+          { path: "sample.with-header", body: "## Foo" },
+          { path: "sample.empty", body: "" },
+        ]);
       },
-      () => {
-        test("THEN empty file return null", async () => {
+    },
+    () => {
+      describe("AND the file is empty", () => {
+        test("THEN return null", async () => {
           const { wsRoot } = ExtensionProvider.getDWorkspace();
           const notePath = path.join(wsRoot, "sample.empty");
           const editor = await VSCodeUtils.openFileInEditor(
@@ -67,8 +67,10 @@ suite("GIVEN ReferenceHoverProvider", function () {
           const hover = await provideForNonNote(editor!);
           expect(hover).toEqual(null);
         });
+      });
 
-        test("THEN file with header returns null", async () => {
+      describe("AND file has a header", () => {
+        test("THEN return null", async () => {
           const { wsRoot } = ExtensionProvider.getDWorkspace();
           const notePath = path.join(wsRoot, "sample.with-header");
           const editor = await VSCodeUtils.openFileInEditor(
@@ -77,9 +79,9 @@ suite("GIVEN ReferenceHoverProvider", function () {
           const hover = await provideForNonNote(editor!);
           expect(hover).toEqual(null);
         });
-      }
-    );
-  });
+      });
+    }
+  );
 
   describe("has correct hover contents", () => {
     describe("wikilink", () => {

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -1,37 +1,88 @@
-import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { NoteProps, NoteUtils, WorkspaceOpts } from "@dendronhq/common-all";
 import {
-  AssertUtils,
+  FileTestUtils,
   NoteTestUtilsV4,
   NOTE_PRESETS_V4,
 } from "@dendronhq/common-test-utils";
-import { ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
-import fs from "fs-extra";
-import { describe, before } from "mocha";
+import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
-import ReferenceHoverProvider from "../../features/ReferenceHoverProvider";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import ReferenceProvider from "../../features/ReferenceProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
-import { expect, LocationTestUtils } from "../testUtilsv2";
+import { expect } from "../testUtilsv2";
 import {
-  describeSingleWS,
+  describeMultiWS,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
 } from "../testUtilsV3";
 
-async function provide(editor: vscode.TextEditor) {
+async function provide({
+  editor,
+  pos,
+}: {
+  editor: vscode.TextEditor;
+  pos: vscode.Position;
+}) {
   const doc = editor?.document as vscode.TextDocument;
   const referenceProvider = new ReferenceProvider();
-  const links = await referenceProvider.provideReferences(
-    doc,
-    new vscode.Position(7, 2)
-  );
+  const links = await referenceProvider.provideReferences(doc, pos);
   return links;
 }
 
-suite("ReferenceProvider", function () {
+async function provideForNote(editor: vscode.TextEditor) {
+  return provide({ editor, pos: new vscode.Position(7, 2) });
+}
+
+async function provideForNonNote(editor: vscode.TextEditor) {
+  return provide({ editor, pos: new vscode.Position(0, 2) });
+}
+
+const checkRefs = ({
+  links,
+  refs,
+  wsRoot,
+}: {
+  links: vscode.Location[];
+  refs: NoteProps[];
+  wsRoot: string;
+}) => {
+  expect(links?.length).toEqual(2);
+  const firstLineRange = new vscode.Range(
+    new vscode.Position(7, 0),
+    new vscode.Position(8, 0)
+  );
+  expect(links!.map((l) => l.range)).toEqual([firstLineRange, firstLineRange]);
+  expect(links!.map((l) => l.uri.fsPath)).toEqual(
+    refs.map((note) => NoteUtils.getFullPath({ note, wsRoot }))
+  );
+};
+
+const createSampleNotes = async ({ wsRoot, vaults }: WorkspaceOpts) => {
+  const activeNote = await NoteTestUtilsV4.createNote({
+    fname: "active",
+    vault: vaults[0],
+    wsRoot,
+    body: "## Foo",
+  });
+  const refNote1 = await NoteTestUtilsV4.createNote({
+    fname: "ref-one",
+    vault: vaults[0],
+    wsRoot,
+    body: "[[Foo|active#foo]]\n\n[[Foo|active#four]]",
+  });
+  const refNote2 = await NoteTestUtilsV4.createNote({
+    fname: "ref-two",
+    vault: vaults[0],
+    wsRoot,
+    body: "[[active#foo]]",
+  });
+  return { activeNote, refNote1, refNote2 };
+};
+
+suite("GIVEN ReferenceProvider", function () {
   const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
@@ -44,47 +95,56 @@ suite("ReferenceProvider", function () {
       runLegacyMultiWorkspaceTest({
         ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
-          activeNote = await NoteTestUtilsV4.createNote({
-            fname: "active",
-            vault: vaults[0],
+          ({ activeNote, refNote1, refNote2 } = await createSampleNotes({
             wsRoot,
-            body: "## Foo",
-          });
-          refNote1 = await NoteTestUtilsV4.createNote({
-            fname: "ref-one",
-            vault: vaults[0],
-            wsRoot,
-            body: "[[Foo|active#foo]]\n\n[[Foo|active#four]]",
-          });
-          refNote2 = await NoteTestUtilsV4.createNote({
-            fname: "ref-two",
-            vault: vaults[0],
-            wsRoot,
-            body: "[[active#foo]]",
-          });
+            vaults,
+          }));
         },
-        onInit: async () => {
+        onInit: async ({ wsRoot }) => {
           const editor = await WSUtils.openNote(activeNote);
-          const links = await provide(editor);
-
-          expect(links?.length).toEqual(2);
-          const firstLineRange = new vscode.Range(
-            new vscode.Position(7, 0),
-            new vscode.Position(8, 0)
-          );
-          expect(links!.map((l) => l.range)).toEqual([
-            firstLineRange,
-            firstLineRange,
-          ]);
-          expect(links!.map((l) => l.uri.fsPath)).toEqual(
-            [refNote1, refNote2].map((note) =>
-              NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
-            )
-          );
+          const links = (await provideForNote(editor)) as vscode.Location[];
+          checkRefs({ links, refs: [refNote1, refNote2], wsRoot });
           done();
         },
       });
     });
+  });
+
+  describe("AND GIVEN non-dendron file", () => {
+    describeMultiWS(
+      "AND WHEN try to find references",
+      {
+        ctx,
+        preSetupHook: async (opts) => {
+          await FileTestUtils.createFiles(opts.wsRoot, [
+            { path: "sample.with-header", body: "## Foo" },
+            { path: "sample.empty", body: "" },
+          ]);
+          return createSampleNotes(opts);
+        },
+      },
+      () => {
+        test("THEN empty file return null", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const notePath = path.join(wsRoot, "sample.empty");
+          const editor = await VSCodeUtils.openFileInEditor(
+            vscode.Uri.file(notePath)
+          );
+          const links = await provideForNonNote(editor!);
+          expect(links).toEqual(null);
+        });
+
+        test("THEN file with header returns null", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const notePath = path.join(wsRoot, "sample.with-header");
+          const editor = await VSCodeUtils.openFileInEditor(
+            vscode.Uri.file(notePath)
+          );
+          const links = (await provideForNonNote(editor!)) as vscode.Location[];
+          expect(links).toEqual(null);
+        });
+      }
+    );
   });
 
   describe("provides correct links", () => {
@@ -107,7 +167,7 @@ suite("ReferenceProvider", function () {
         },
         onInit: async () => {
           const editor = await WSUtils.openNote(noteWithTarget1);
-          const links = await provide(editor);
+          const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithTarget1, noteWithTarget2].map((note) =>
               NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
@@ -137,7 +197,7 @@ suite("ReferenceProvider", function () {
         },
         onInit: async () => {
           const editor = await WSUtils.openNote(noteWithTarget1);
-          const links = await provide(editor);
+          const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithTarget1, noteWithTarget2].map((note) =>
               NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
@@ -165,7 +225,7 @@ suite("ReferenceProvider", function () {
         },
         onInit: async () => {
           const editor = await WSUtils.openNote(noteWithLink);
-          const links = await provide(editor);
+          const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithLink].map((note) =>
               NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
@@ -194,7 +254,7 @@ suite("ReferenceProvider", function () {
         },
         onInit: async () => {
           const editor = await WSUtils.openNote(noteWithLink);
-          const links = await provide(editor);
+          const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithLink].map((note) =>
               NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
@@ -203,1223 +263,6 @@ suite("ReferenceProvider", function () {
           done();
         },
       });
-    });
-  });
-
-  describe("has correct hover contents", () => {
-    describe("wikilink", () => {
-      test("basic", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "[[target]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test("missing notes are marked as such", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "[[target]]", // target doesn't exist
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                `Note target is missing`,
-                `use "Dendron: Go to Note" command`,
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test.skip("contains local image", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "![](/assets/test/image.png)",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "[[target]]",
-            });
-          },
-          onInit: async ({ wsRoot, vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            // Local images should get full path to image, because hover preview otherwise can't find the image
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                `![](${path.join(
-                  wsRoot,
-                  VaultUtils.getRelPath(vaults[0]),
-                  "assets/test/image.png"
-                )})`,
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test("contains remote image", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "![](https://example.com/image.png)",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "[[target]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            // remote images should be unmodified
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "![](https://example.com/image.png)",
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with alias", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "[[my note alias|target]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with xvault", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            // Creating a note of the same name in multiple vaults to check that it gets the right one
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[1],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: "Voluptatem possimus harum nisi.",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `[[dendron://${VaultUtils.getName(vaults[1])}/target]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi."],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with header", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `[[target#numquam-occaecati]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 12)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi."],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with block anchor", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima. ^my-anchor",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `[[target#^my-anchor]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi.", "Numquam occaecati"],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with everything", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[1],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: "Voluptatem possimus harum nisi.",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `[[My note: with an alias|dendron://${VaultUtils.getName(
-                vaults[1]
-              )}/target#numquam-occaecati]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi."],
-            });
-            done();
-          },
-        });
-      });
-
-      describe("multiple notes & xvault link", () => {
-        test("non-xvault link resolves to same vault", (done) => {
-          let note: NoteProps;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            preSetupHook: async (opts) => {
-              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
-            },
-            onInit: async () => {
-              const editor = await WSUtils.openNote(note);
-              editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
-                line: 7,
-              });
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(7, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["vault 1"],
-                  nomatch: ["vault 0", "the test note"],
-                })
-              ).toBeTruthy();
-              done();
-            },
-          });
-        });
-
-        test("xvault link to other vault", (done) => {
-          let note: NoteProps;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            preSetupHook: async (opts) => {
-              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
-            },
-            onInit: async () => {
-              const editor = await WSUtils.openNote(note);
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(8, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["vault 0"],
-                  nomatch: ["vault 1", "the test note"],
-                })
-              ).toBeTruthy();
-              done();
-            },
-          });
-        });
-
-        test("xvault link to same vault", (done) => {
-          let note: NoteProps;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            preSetupHook: async (opts) => {
-              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
-            },
-            onInit: async () => {
-              const editor = await WSUtils.openNote(note);
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(9, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["vault 1"],
-                  nomatch: ["vault 0", "the test note"],
-                })
-              ).toBeTruthy();
-              done();
-            },
-          });
-        });
-
-        test("xvault link to non-existant note", (done) => {
-          let note: NoteProps;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            preSetupHook: async (opts) => {
-              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
-            },
-            onInit: async () => {
-              const editor = await WSUtils.openNote(note);
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(10, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["eggs", "vaultThree", "missing"],
-                  nomatch: [
-                    "vault 0",
-                    "vault 1",
-                    "vault1",
-                    "vault2",
-                    "the test note",
-                  ],
-                })
-              ).toBeTruthy();
-              done();
-            },
-          });
-        });
-
-        test("xvault link to non-existant vault", (done) => {
-          let note: NoteProps;
-          runLegacyMultiWorkspaceTest({
-            ctx,
-            preSetupHook: async (opts) => {
-              note = await ENGINE_HOOKS_MULTI.setupMultiVaultSameFname(opts);
-            },
-            onInit: async () => {
-              const editor = await WSUtils.openNote(note);
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(11, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["vault3", "does not exist"],
-                  nomatch: [
-                    "vault 0",
-                    "vault 1",
-                    "vault1",
-                    "vault2",
-                    "the test note",
-                  ],
-                })
-              ).toBeTruthy();
-              done();
-            },
-          });
-        });
-      });
-    });
-
-    describe("reference", () => {
-      test("basic", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "![[target]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with xvault", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            // Creating a note of the same name in multiple vaults to check that it gets the right one
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[1],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: "Voluptatem possimus harum nisi.",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `![[dendron://${VaultUtils.getName(vaults[1])}/target]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi."],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with header", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `![[target#numquam-occaecati]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi."],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with block anchor", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima. ^my-anchor",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `![[target#^my-anchor]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: ["Voluptatem possimus harum nisi.", "Numquam occaecati"],
-            });
-            done();
-          },
-        });
-      });
-
-      test("with range", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "target",
-              body: [
-                "Voluptatem possimus harum nisi.",
-                "",
-                "# Numquam occaecati",
-                "",
-                "Sint quo sunt maxime.",
-                "",
-                "Nisi nam dolorem qui ut minima. ^my-anchor",
-                "",
-                "Ut quo eius laudantium.",
-              ].join("\n"),
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: `![[target#numquam-occaecati:#^my-anchor]]`,
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: [
-                "Numquam occaecati",
-                "Sint quo sunt maxime.",
-                "Nisi nam dolorem qui ut minima.",
-              ],
-              nomatch: [
-                "Voluptatem possimus harum nisi.",
-                "Ut quo eius laudantium.",
-              ],
-            });
-            done();
-          },
-        });
-      });
-    });
-
-    test("hashtag", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "tags.foo.test",
-            body: "this is tag foo.test",
-          });
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "source",
-            body: "#foo.test",
-          });
-        },
-        onInit: async ({ vaults }) => {
-          const editor = await WSUtils.openNoteByPath({
-            vault: vaults[0],
-            fname: "source",
-          });
-          const provider = new ReferenceHoverProvider();
-          const hover = await provider.provideHover(
-            editor.document,
-            new vscode.Position(7, 6)
-          );
-          expect(hover).toBeTruthy();
-          await AssertUtils.assertInString({
-            body: hover!.contents.join(""),
-            match: ["this is tag foo.test"],
-          });
-          done();
-        },
-      });
-    });
-
-    test("hashtags are ignored when disabled", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "tags.foo.test",
-            body: "this is tag foo.test",
-          });
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "source",
-            body: "#foo.test",
-          });
-        },
-        modConfigCb: (config) => {
-          config.workspace!.enableHashTags = false;
-          return config;
-        },
-        onInit: async ({ vaults }) => {
-          const editor = await WSUtils.openNoteByPath({
-            vault: vaults[0],
-            fname: "source",
-          });
-          const provider = new ReferenceHoverProvider();
-          const hover = await provider.provideHover(
-            editor.document,
-            new vscode.Position(7, 6)
-          );
-          expect(hover).toBeFalsy();
-          done();
-        },
-      });
-    });
-
-    test("user tag", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "user.test.mctestface",
-            body: "this is user test.mctestface",
-          });
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "source",
-            body: "@test.mctestface",
-          });
-        },
-        onInit: async ({ vaults }) => {
-          const editor = await WSUtils.openNoteByPath({
-            vault: vaults[0],
-            fname: "source",
-          });
-          const provider = new ReferenceHoverProvider();
-          const hover = await provider.provideHover(
-            editor.document,
-            new vscode.Position(7, 6)
-          );
-          expect(hover).toBeTruthy();
-          await AssertUtils.assertInString({
-            body: hover!.contents.join(""),
-            match: ["this is user test.mctestface"],
-          });
-          done();
-        },
-      });
-    });
-
-    test("user tags are ignored when disabled", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "user.test.mctestface",
-            body: "this is user test.mctestface",
-          });
-          await NoteTestUtilsV4.createNote({
-            vault: vaults[0],
-            wsRoot,
-            fname: "source",
-            body: "@test.mctestface",
-          });
-        },
-        modConfigCb: (config) => {
-          config.workspace!.enableUserTags = false;
-          return config;
-        },
-        onInit: async ({ vaults }) => {
-          const editor = await WSUtils.openNoteByPath({
-            vault: vaults[0],
-            fname: "source",
-          });
-          const provider = new ReferenceHoverProvider();
-          const hover = await provider.provideHover(
-            editor.document,
-            new vscode.Position(7, 6)
-          );
-          expect(hover).toBeFalsy();
-          done();
-        },
-      });
-    });
-
-    describe("frontmatter tags", () => {
-      test("single tag", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "tags.foo.test",
-              body: "this is tag foo.test",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              props: {
-                tags: "foo.test",
-              },
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(6, 10)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: ["this is tag foo.test"],
-            });
-            done();
-          },
-        });
-      });
-
-      test("multiple tags", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "tags.foo.test",
-              body: "this is tag foo.test",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "tags.foo.bar",
-              body: "this is the wrong tag",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "tags.foo.baz",
-              body: "this is the wrong tag",
-            });
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              props: {
-                tags: ["foo.bar", "foo.test", "foo.baz"],
-              },
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(8, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: ["this is tag foo.test"],
-            });
-            done();
-          },
-        });
-      });
-    });
-
-    describe("non-note", () => {
-      test("image", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await fs.ensureFile(
-              path.join(
-                wsRoot,
-                VaultUtils.getName(vaults[0]),
-                "assets",
-                "image.png"
-              )
-            );
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "![[/assets/image.png]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: ["[", "]", "(", "/assets/image.png", ")"],
-            });
-            done();
-          },
-        });
-      });
-
-      test("hyperlink", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "![[http://example.com]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: ["[", "]", "(", "http://example.com", ")"],
-            });
-            done();
-          },
-        });
-      });
-
-      test("email", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: "![[mailto:user@example.com]]",
-            });
-          },
-          onInit: async ({ vaults }) => {
-            const editor = await WSUtils.openNoteByPath({
-              vault: vaults[0],
-              fname: "source",
-            });
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
-              match: ["[", "]", "(", "mailto:user@example.com", ")"],
-            });
-            done();
-          },
-        });
-      });
-
-      describeSingleWS(
-        "WHEN used on a link to a non-note file",
-        { ctx },
-        () => {
-          before(async () => {
-            const { wsRoot, vaults } = getDWorkspace();
-            await fs.writeFile(
-              path.join(wsRoot, "test.txt"),
-              "Et nam velit laboriosam."
-            );
-            const note = await NoteTestUtilsV4.createNote({
-              vault: vaults[0],
-              wsRoot,
-              fname: "source",
-              body: ["[[test.txt]]", "[[test.txt#L1]]"].join("\n"),
-            });
-            await WSUtils.openNote(note);
-          });
-
-          test("THEN displays message to open it with the default app", async () => {
-            const editor = VSCodeUtils.getActiveTextEditorOrThrow();
-            const provider = new ReferenceHoverProvider();
-            const hover = await provider.provideHover(
-              editor.document,
-              new vscode.Position(7, 4)
-            );
-            expect(hover).toBeTruthy();
-            expect(
-              await AssertUtils.assertInString({
-                body: hover!.contents.join(""),
-                match: ["test.txt"],
-              })
-            ).toBeTruthy();
-          });
-
-          describe("AND the link has a line anchor", () => {
-            test("THEN displays message to open it with the default app", async () => {
-              const editor = VSCodeUtils.getActiveTextEditorOrThrow();
-              const provider = new ReferenceHoverProvider();
-              const hover = await provider.provideHover(
-                editor.document,
-                new vscode.Position(8, 4)
-              );
-              expect(hover).toBeTruthy();
-              expect(
-                await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
-                  match: ["test.txt"],
-                  nomatch: ["L6"],
-                })
-              ).toBeTruthy();
-            });
-          });
-        }
-      );
     });
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -55,8 +55,10 @@ const checkRefs = ({
     new vscode.Position(8, 0)
   );
   expect(links!.map((l) => l.range)).toEqual([firstLineRange, firstLineRange]);
-  expect(links!.map((l) => l.uri.fsPath)).toEqual(
-    refs.map((note) => NoteUtils.getFullPath({ note, wsRoot }))
+  expect(links!.map((l) => l.uri.fsPath.toLocaleLowerCase())).toEqual(
+    refs.map((note) =>
+      NoteUtils.getFullPath({ note, wsRoot }).toLocaleLowerCase()
+    )
   );
 };
 

--- a/packages/plugin-core/src/test/suite-integ/md.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/md.test.ts
@@ -1,7 +1,7 @@
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import * as vscode from "vscode";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { getReferenceAtPosition } from "../../utils/md";
-import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
@@ -26,11 +26,16 @@ suite("WHEN getReferenceAtPosition", function () {
     () => {
       test("THEN initializes correctly", async () => {
         // You can access the workspace inside the test like this:
-        const { engine } = getDWorkspace();
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const activeNote = engine.notes[activeNoteName];
         const editor = await WSUtils.openNote(activeNote);
-        const pos = new vscode.Position(7, 0);
-        const reference = getReferenceAtPosition(editor.document, pos);
+        const position = new vscode.Position(7, 0);
+        const reference = await getReferenceAtPosition({
+          document: editor.document,
+          position,
+          wsRoot,
+          vaults,
+        });
         expect(reference).toEqual({
           anchorEnd: undefined,
           anchorStart: {

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -235,7 +235,7 @@ export type getReferenceAtPositionResp = {
   refText: string;
 };
 
-export const getReferenceAtPosition = async ({
+export async function getReferenceAtPosition({
   document,
   position,
   wsRoot,
@@ -250,7 +250,7 @@ export const getReferenceAtPosition = async ({
     partial?: boolean;
     allowInCodeBlocks: boolean;
   };
-}): Promise<getReferenceAtPositionResp | null> => {
+}): Promise<getReferenceAtPositionResp | null> {
   let refType: DLinkType | undefined;
   if (
     opts?.allowInCodeBlocks !== true &&
@@ -397,7 +397,7 @@ export const getReferenceAtPosition = async ({
     vaultName,
     refText,
   };
-};
+}
 
 export const parseRef = (rawRef: string): RefT => {
   const parsed = LinkUtils.parseNoteRef(rawRef);

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -304,8 +304,16 @@ export class DendronExtension implements IDendronExtension {
     return false;
   }
 
-  isActiveAndIsDendronNote(_fpath: string): boolean {
-    throw new Error("not implemented");
+  async isActiveAndIsDendronNote(fpath: string): Promise<boolean> {
+    if (!this.isActive()) {
+      return false;
+    }
+    const { wsRoot, vaults } = this.getDWorkspace();
+    return WorkspaceUtils.isDendronNote({
+      wsRoot,
+      vaults,
+      fpath,
+    });
   }
 
   /**

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -304,6 +304,10 @@ export class DendronExtension implements IDendronExtension {
     return false;
   }
 
+  isActiveAndIsDendronNote(_fpath: string): boolean {
+    throw new Error("not implemented");
+  }
+
   /**
    * When in dev mode, version is equivalent to `package.json` that is checked out locally
    * Otherwise, get from published extension `package.json`


### PR DESCRIPTION
fix(workspace): dendron can hang when trying to provide hover for large non-dendron file

This currently happens because `ReferenceHoverProvider` can be triggered for all files. This function calls `getReferenceAtPosition` which will attempt to parse the file using `unified` to find hover positions. This will blow up spectacularly when parsing large files (eg. Dendron logs) and cause the vscode process to hang.

This fix adds a check in `getReferenceAtPosition` to not parse the file if it is not a dendron note or in a dendron workspace. It also provides this check across most of the symbol provider methods in Dendron. List of changes below:

Changes:
- convert `getReferenceAtPosition` to async, do not run for non-dendron note
- ReferenceHoverProvider restrict to dendron note (cause of hanging when hovering over log file)
- ReferenceProvider restrict to dendron note (was causing silent exception)
- updated signatures in the following files which called `getReferenceAtPosition`
  - [[../packages/plugin-core/src/commands/ConvertLink.ts]]
  - [[../packages/plugin-core/src/commands/GotoNote.ts]]
  - [[../packages/plugin-core/src/features/DefinitionProvider.ts]]
  - [[../packages/plugin-core/src/features/RenameProvider.ts]]

New Utilities:
- `Awaited` utility, unwraps `promise` type from type signature
    - loc: packages/common-all/src/types/typesv2.ts
- `extractFMTags`
    - loc: packages/engine-server/src/markdown/remark/utils.ts
- `isActiveAndIsDendronNote`
    - loc: packages/plugin-core/src/ExtensionProvider.ts

***
- before: 47
- after: 49

This change introduces the following circular dependencies. This is caused by:
- [[../packages/plugin-core/src/dendronExtensionInterface.ts]] > [[../packages/plugin-core/src/WorkspaceWatcher.ts]]

To move forward, we should create a `WorkspaceWatcher` interface. Would move this as a next item since this is a high severity fix

```
9) src/ExtensionProvider.ts > src/dendronExtensionInterface.ts > src/WorkspaceWatcher.ts > src/fileWatcher.ts > src/workspace.ts > src/commandFactory.ts > src/commands/GotoNote.ts

23) src/ExtensionProvider.ts > src/dendronExtensionInterface.ts > src/WorkspaceWatcher.ts > src/fileWatcher.ts > src/workspace.ts > src/commandFactory.ts > src/commands/GotoNote.ts > src/utils/md.ts
```

***

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [.] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 

## Instrumentation
NA

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [.] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [.] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

add new utilities, will be added to docs once this pr is approved

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)