### PR TITLE
fix: don't call reload index if action is findIncompatibleExtension

### DIFF
--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -288,7 +288,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return { installStatus, contents };
   }
 
-  async reload(opts: CommandOpts) {
+  private async reload(opts: CommandOpts) {
     const engine =
       opts.action !== PluginDoctorActionsEnum.FIND_INCOMPATIBLE_EXTENSIONS
         ? ((await new ReloadIndexCommand().execute()) as DEngineClient)

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -654,7 +654,7 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
       ctx,
     },
     () => {
-      test("THEN reload resolved to undefined", async () => {
+      test("THEN reload is not called", async () => {
         const extension = ExtensionProvider.getExtension();
         const cmd = new DoctorCommand(extension);
         const reloadSpy = sinon.spy(cmd, "reload" as keyof DoctorCommand);
@@ -663,7 +663,7 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
           scope: "workspace",
         });
 
-        expect(await reloadSpy.getCall(0).returnValue).toEqual(undefined);
+        expect(reloadSpy.called).toBeFalsy();
       });
 
       test("THEN List all as not installed if found none", async () => {

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -654,6 +654,18 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
       ctx,
     },
     () => {
+      test("THEN reload resolved to undefined", async () => {
+        const extension = ExtensionProvider.getExtension();
+        const cmd = new DoctorCommand(extension);
+        const reloadSpy = sinon.spy(cmd, "reload");
+        await cmd.execute({
+          action: PluginDoctorActionsEnum.FIND_INCOMPATIBLE_EXTENSIONS,
+          scope: "workspace",
+        });
+
+        expect(await reloadSpy.getCall(0).returnValue).toEqual(undefined);
+      });
+
       test("THEN List all as not installed if found none", async () => {
         const extension = ExtensionProvider.getExtension();
         const cmd = new DoctorCommand(extension);

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -657,7 +657,7 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
       test("THEN reload resolved to undefined", async () => {
         const extension = ExtensionProvider.getExtension();
         const cmd = new DoctorCommand(extension);
-        const reloadSpy = sinon.spy(cmd, "reload");
+        const reloadSpy = sinon.spy(cmd, "reload" as keyof DoctorCommand);
         await cmd.execute({
           action: PluginDoctorActionsEnum.FIND_INCOMPATIBLE_EXTENSIONS,
           scope: "workspace",


### PR DESCRIPTION
# fix: don't call reload index if action is findIncompatibleExtension
This PR:
- fixes Doctor command so that `Reload Index` is not called before and after if the selected doctor action is `findIncompatibleExtensions`. (not needed, and significantly slows down operation in large workspaces.)

madge reports no diffs.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)