### PR TITLE
chore: separate tag configs

### DIFF
--- a/packages/common-all/src/constants/configs/global.ts
+++ b/packages/common-all/src/constants/configs/global.ts
@@ -50,6 +50,24 @@ export const ENABLE_NOTE_TITLE_FOR_LINK = (
   };
 };
 
+export const ENABLE_FRONTMATTER_TAGS = (
+  namespace: TopLevelDendronConfig
+): DendronConfigEntry => {
+  return {
+    label: `Enable Frontmatter Tags (${namespace})`,
+    desc: `Show Frontmatter tags in published site. (${namespace})`,
+  };
+};
+
+export const ENABLE_HASHES_FOR_FM_TAGS = (
+  namespace: TopLevelDendronConfig
+): DendronConfigEntry => {
+  return {
+    label: `Enable Hashes for Frontmatter Tags (${namespace})`,
+    desc: `Display a '#' symbol in front of frontmatter tags in the tags listing. (${namespace})`,
+  };
+};
+
 export const ENABLE_CHILD_LINKS = (
   namespace: TopLevelDendronConfig
 ): DendronConfigEntry => {

--- a/packages/common-all/src/constants/configs/preview.ts
+++ b/packages/common-all/src/constants/configs/preview.ts
@@ -6,11 +6,15 @@ import {
   ENABLE_MERMAID,
   ENABLE_KATEX,
   ENABLE_PRETTY_REFS,
+  ENABLE_FRONTMATTER_TAGS,
+  ENABLE_HASHES_FOR_FM_TAGS,
 } from "./global";
 
 export const PREVIEW: DendronConfigEntryCollection<DendronPreviewConfig> = {
   enableFMTitle: ENABLE_FM_TITLE("preview"), // TODO: split
   enableNoteTitleForLink: ENABLE_NOTE_TITLE_FOR_LINK("preview"), // TODO: split
+  enableFrontmatterTags: ENABLE_FRONTMATTER_TAGS("preview"),
+  enableHashesForFMTags: ENABLE_HASHES_FOR_FM_TAGS("preview"),
   enableMermaid: ENABLE_MERMAID("preview"),
   enablePrettyRefs: ENABLE_PRETTY_REFS("preview"),
   enableKatex: ENABLE_KATEX("preview"),

--- a/packages/common-all/src/constants/configs/publishing.ts
+++ b/packages/common-all/src/constants/configs/publishing.ts
@@ -17,6 +17,8 @@ import {
   ENABLE_MERMAID,
   ENABLE_KATEX,
   ENABLE_PRETTY_REFS,
+  ENABLE_FRONTMATTER_TAGS,
+  ENABLE_HASHES_FOR_FM_TAGS,
 } from "./global";
 
 const GITHUB_EDIT_VIEW_MODE: Record<
@@ -157,14 +159,8 @@ export const PUBLISHING: DendronConfigEntryCollection<DendronPublishingConfig> =
       label: "Site URL",
       desc: "URL of the site without trailing slash.",
     },
-    enableFrontmatterTags: {
-      label: "Enable Frontmatter Tags",
-      desc: "Show Frontmatter tags in published site.",
-    },
-    enableHashesForFMTags: {
-      label: "Enable Hashes for Frontmatter Tags",
-      desc: "Display a `#` symbol in front of frontmatter tags in the tags listing.",
-    },
+    enableFrontmatterTags: ENABLE_FRONTMATTER_TAGS("publishing"),
+    enableHashesForFMTags: ENABLE_HASHES_FOR_FM_TAGS("publishing"),
     enableRandomlyColoredTags: {
       label: "Enable Randomly Colored Tags",
       desc: "Display randomly generated colors for tags.",

--- a/packages/common-all/src/types/configs/preview/preview.ts
+++ b/packages/common-all/src/types/configs/preview/preview.ts
@@ -4,6 +4,8 @@
 export type DendronPreviewConfig = {
   enableFMTitle: boolean; // TODO: split
   enableNoteTitleForLink: boolean; // TODO: split
+  enableFrontmatterTags: boolean;
+  enableHashesForFMTags: boolean;
   enableMermaid: boolean;
   enablePrettyRefs: boolean;
   enableKatex: boolean;
@@ -18,6 +20,8 @@ export function genDefaultPreviewConfig(): DendronPreviewConfig {
   return {
     enableFMTitle: true,
     enableNoteTitleForLink: true,
+    enableFrontmatterTags: true,
+    enableHashesForFMTags: false,
     enableMermaid: true,
     enablePrettyRefs: true,
     enableKatex: true,

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -868,20 +868,34 @@ export class ConfigUtils {
       : ConfigUtils.getPublishing(config).enableRandomlyColoredTags;
   }
 
-  static getEnableFrontmatterTags(
-    config: IntermediateDendronConfig
-  ): boolean | undefined {
-    return configIsV4(config)
+  static getEnableFrontmatterTags(opts: {
+    config: IntermediateDendronConfig;
+    shouldApplyPublishRules: boolean;
+  }): boolean | undefined {
+    const { config, shouldApplyPublishRules } = opts;
+
+    const publishRule = configIsV4(config)
       ? ConfigUtils.getSite(config)?.showFrontMatterTags
       : ConfigUtils.getPublishing(config).enableFrontmatterTags;
+
+    return shouldApplyPublishRules
+      ? publishRule
+      : ConfigUtils.getPreview(config).enableFrontmatterTags;
   }
 
-  static getEnableHashesForFMTags(
-    config: IntermediateDendronConfig
-  ): boolean | undefined {
-    return configIsV4(config)
+  static getEnableHashesForFMTags(opts: {
+    config: IntermediateDendronConfig;
+    shouldApplyPublishRules: boolean;
+  }): boolean | undefined {
+    const { config, shouldApplyPublishRules } = opts;
+
+    const publishRule = configIsV4(config)
       ? ConfigUtils.getSite(config)?.useHashesForFMTags
       : ConfigUtils.getPublishing(config).enableHashesForFMTags;
+
+    return shouldApplyPublishRules
+      ? publishRule
+      : ConfigUtils.getPreview(config).enableHashesForFMTags;
   }
 
   static getEnablePrettlyLinks(

--- a/packages/engine-server/src/markdown/remark/hierarchies.ts
+++ b/packages/engine-server/src/markdown/remark/hierarchies.ts
@@ -151,8 +151,16 @@ const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
 
     /** Add frontmatter tags, if any, ahead of time. This way wikilink compiler will pick them up and render them. */
     function addTags() {
-      const enableFrontmatterTags =
-        ConfigUtils.getEnableFrontmatterTags(config);
+      const shouldApplyPublishRules =
+        MDUtilsV5.shouldApplyPublishingRules(proc);
+      const enableFrontmatterTags = ConfigUtils.getEnableFrontmatterTags({
+        config,
+        shouldApplyPublishRules,
+      });
+      const enableHashesForFMTags = ConfigUtils.getEnableHashesForFMTags({
+        config,
+        shouldApplyPublishRules,
+      });
       if (
         enableFrontmatterTags !== false &&
         note?.tags &&
@@ -165,10 +173,7 @@ const plugin: Plugin = function (this: Unified.Processor, opts?: PluginOpts) {
           _.map(tags, (tag) =>
             listItem(
               paragraph(
-                frontmatterTag2WikiLinkNoteV4(
-                  tag,
-                  ConfigUtils.getEnableHashesForFMTags(config)
-                )
+                frontmatterTag2WikiLinkNoteV4(tag, enableHashesForFMTags)
               )
             )
           ),

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -91,6 +91,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -240,6 +242,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -371,6 +375,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -474,6 +480,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -594,6 +602,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -85,6 +85,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -234,6 +236,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -365,6 +369,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -468,6 +474,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -588,6 +596,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -716,6 +726,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
@@ -830,6 +842,8 @@ workspace:
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
     enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -189,16 +189,10 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags WHEN configured with enableHashesForFMTags option THEN tags are rendered with a # symbol 1`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: false THEN not rendered: PREVIEW 1`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
-<p>has fm tags</p>
-<hr>
-<h2 id=\\"tags\\">Tags</h2>
-<ol>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">first</a></li>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">second</a></li>
-</ol>",
+<p>has fm tags</p>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -206,16 +200,10 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are not rendered when disabled 1`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: false THEN not rendered: PUBLISHING 1`] = `
 VFile {
-  "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
-<p>has fm tags</p>
-<hr>
-<h2 id=\\"tags\\">Tags</h2>
-<ol>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">first</a></li>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">second</a></li>
-</ol>",
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -223,7 +211,7 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are not rendered when missing 1`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN not rendered when missing: PREVIEW 1`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
 <p>has no fm tags</p>",
@@ -234,7 +222,18 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are rendered when available multiple tags 1`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN not rendered when missing: PUBLISHING 1`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has no fm tags</p>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: multiple tags, PREVIEW 1`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
 <p>has fm tags</p>
@@ -251,7 +250,7 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are rendered when available multiple tags 2`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: multiple tags, PREVIEW 2`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
 <p>has fm tags</p>
@@ -268,7 +267,41 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are rendered when available single tag 1`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: multiple tags, PUBLISHING 1`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#tags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Tags</h2>
+<ol>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">first (Private)</a></li>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">second (Private)</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: multiple tags, PUBLISHING 2`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#tags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Tags</h2>
+<ol>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">first (Private)</a></li>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">second (Private)</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: single tag, PREVIEW 1`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
 <p>has fm tags</p>
@@ -284,7 +317,7 @@ VFile {
 }
 `;
 
-exports[`dendronPub frontmatter tags are rendered when available single tag 2`] = `
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: single tag, PREVIEW 2`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
 <p>has fm tags</p>
@@ -292,6 +325,72 @@ VFile {
 <h2 id=\\"tags\\">Tags</h2>
 <ol>
 <li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">first</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: single tag, PUBLISHING 1`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#tags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Tags</h2>
+<ol>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">first (Private)</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true THEN rendered when available: single tag, PUBLISHING 2`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#tags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Tags</h2>
+<ol>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">first (Private)</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true WHEN enableHashesForFMTags: true THEN rendered with a hashtag(#): PREVIEW 1`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\">Tags</h2>
+<ol>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">#first</a></li>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">#second</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`dendronPub frontmatter tags GIVEN enableFrontmatterTags: true WHEN enableHashesForFMTags: true THEN rendered with a hashtag(#): PUBLISHING 1`] = `
+VFile {
+  "contents": "<h1 id=\\"fmtags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#fmtags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Fmtags</h1>
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#tags\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Tags</h2>
+<ol>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">#first (Private)</a></li>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">#second (Private)</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -196,8 +196,8 @@ VFile {
 <hr>
 <h2 id=\\"tags\\">Tags</h2>
 <ol>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">#first</a></li>
-<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">#second</a></li>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">first</a></li>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">second</a></li>
 </ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
@@ -209,7 +209,13 @@ VFile {
 exports[`dendronPub frontmatter tags are not rendered when disabled 1`] = `
 VFile {
   "contents": "<h1 id=\\"fmtags\\">Fmtags</h1>
-<p>has fm tags</p>",
+<p>has fm tags</p>
+<hr>
+<h2 id=\\"tags\\">Tags</h2>
+<ol>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #9e3623;\\" href=\\"tags.first\\">first</a></li>
+<li><a class=\\"color-tag\\" style=\\"--tag-color: #b1d1fc;\\" href=\\"tags.second\\">second</a></li>
+</ol>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -260,6 +260,8 @@ describe("dendronPub", () => {
           await runEngineTestV5(
             async ({ engine, vaults }) => {
               const out = await runProcForHasFMTags({ engine, vaults, flavor });
+
+              // `Tags` section and a link to `first` with no hashtag should be present
               await checkVFile(out, "Tags", "first");
               await checkNotInVFile(out, "#first");
             },
@@ -281,6 +283,9 @@ describe("dendronPub", () => {
           await runEngineTestV5(
             async ({ engine, vaults }) => {
               const out = await runProcForHasFMTags({ engine, vaults, flavor });
+
+              // `Tags` section and links to `first` and `second`,
+              // both without hashtags should be present
               await checkVFile(out, "Tags", "first", "second");
               await checkNotInVFile(out, "#first", "#second");
             },
@@ -304,6 +309,8 @@ describe("dendronPub", () => {
           await runEngineTestV5(
             async ({ engine, vaults }) => {
               const out = await runProcForNoFMTags({ engine, vaults, flavor });
+
+              // `Tags` section should not be present
               await checkNotInVFile(out, "Tags");
             },
             {
@@ -330,6 +337,9 @@ describe("dendronPub", () => {
                   vaults,
                   flavor,
                 });
+
+                // `Tags` section with links to `first` and `second`, both with hashtags
+                // should be present
                 await checkVFile(out, "Tags", "#first", "#second");
               },
               {
@@ -374,6 +384,7 @@ describe("dendronPub", () => {
           await runEngineTestV5(
             async ({ engine, vaults }) => {
               const out = await runProcForHasFMTags({ engine, vaults, flavor });
+              // `Tags` section should not be present
               await checkNotInVFile(out, "Tags");
             },
             {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -1,4 +1,4 @@
-import { ConfigUtils, DEngineClient } from "@dendronhq/common-all";
+import { ConfigUtils, DEngineClient, DVault } from "@dendronhq/common-all";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import {
   DendronASTData,
@@ -10,6 +10,7 @@ import {
   ProcMode,
   VFile,
 } from "@dendronhq/engine-server";
+import _ from "lodash";
 import { TestConfigUtils } from "../../../config";
 import { runEngineTestV5, testWithEngine } from "../../../engine";
 import { ENGINE_HOOKS } from "../../../presets";
@@ -19,22 +20,26 @@ import { checkNotInVFile, checkVFile } from "./utils";
 function proc(
   engine: DEngineClient,
   dendron: DendronASTData,
-  opts?: DendronPubOpts
+  opts?: DendronPubOpts,
+  flavor?: ProcFlavor
 ) {
-  return MDUtilsV5.procRehypeFull({
-    engine,
-    ...dendron,
-    wikiLinksOpts: {
-      useId: false,
-      ...opts?.wikiLinkOpts,
-    },
-    publishOpts: {
-      wikiLinkOpts: {
+  return MDUtilsV5.procRehypeFull(
+    {
+      engine,
+      ...dendron,
+      wikiLinksOpts: {
         useId: false,
+        ...opts?.wikiLinkOpts,
       },
-      ...opts,
+      publishOpts: {
+        wikiLinkOpts: {
+          useId: false,
+        },
+        ...opts,
+      },
     },
-  });
+    flavor ? { flavor } : undefined
+  );
 }
 
 const verifyPrivateLink = async (vfile: VFile, value: string) => {
@@ -209,151 +214,200 @@ describe("dendronPub", () => {
   });
 
   describe("frontmatter tags", () => {
-    describe("are rendered when available", () => {
-      test("single tag", async () => {
-        await runEngineTestV5(
-          async ({ engine, vaults }) => {
-            const out = await proc(engine, {
-              fname: "has.fmtags",
-              dest: DendronASTDest.HTML,
-              vault: vaults[0],
-              config: engine.config,
-            }).process("has fm tags");
-            await checkVFile(out, "Tags", "first");
-            await checkNotInVFile(out, "#first");
-          },
-          {
-            preSetupHook: async ({ wsRoot, vaults }) => {
-              await NoteTestUtilsV4.createNote({
-                fname: "has.fmtags",
-                wsRoot,
-                vault: vaults[0],
-                props: { tags: "first" },
-              });
-            },
-            expect,
-          }
-        );
-      });
-
-      test("multiple tags", async () => {
-        await runEngineTestV5(
-          async ({ engine, vaults }) => {
-            const out = await proc(engine, {
-              fname: "has.fmtags",
-              dest: DendronASTDest.HTML,
-              vault: vaults[0],
-              config: engine.config,
-            }).process("has fm tags");
-            await checkVFile(out, "Tags", "first", "second");
-            await checkNotInVFile(out, "#first", "#second");
-          },
-          {
-            preSetupHook: async ({ wsRoot, vaults }) => {
-              await NoteTestUtilsV4.createNote({
-                fname: "has.fmtags",
-                wsRoot,
-                vault: vaults[0],
-                props: { tags: ["first", "second"] },
-              });
-            },
-            expect,
-          }
-        );
-      });
-    });
-
-    test("are not rendered when missing", async () => {
-      await runEngineTestV5(
-        async ({ engine, vaults }) => {
-          const out = await proc(engine, {
-            fname: "no.fmtags",
-            dest: DendronASTDest.HTML,
-            vault: vaults[0],
-            config: engine.config,
-          }).process("has no fm tags");
-          await checkNotInVFile(out, "Tags");
-        },
+    const runProcForHasFMTags = async (opts: {
+      engine: DEngineClient;
+      vaults: DVault[];
+      flavor: ProcFlavor;
+    }) => {
+      const { engine, vaults, flavor } = opts;
+      const out = await proc(
+        engine,
         {
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            await NoteTestUtilsV4.createNote({
-              fname: "no.fmtags",
-              wsRoot,
-              vault: vaults[0],
-            });
-          },
-          expect,
-        }
-      );
-    });
-
-    test("are not rendered when disabled", async () => {
-      await runEngineTestV5(
-        async ({ engine, vaults }) => {
-          const out = await proc(engine, {
-            fname: "has.fmtags",
-            dest: DendronASTDest.HTML,
-            vault: vaults[0],
-            config: engine.config,
-          }).process("has fm tags");
-          await checkNotInVFile(out, "Tags");
+          fname: "has.fmtags",
+          dest: DendronASTDest.HTML,
+          vault: vaults[0],
+          config: engine.config,
         },
+        undefined,
+        flavor
+      ).process("has fm tags");
+      return out;
+    };
+
+    const runProcForNoFMTags = async (opts: {
+      engine: DEngineClient;
+      vaults: DVault[];
+      flavor: ProcFlavor;
+    }) => {
+      const { engine, vaults, flavor } = opts;
+      const out = await proc(
+        engine,
         {
-          preSetupHook: async ({ wsRoot, vaults }) => {
-            TestConfigUtils.withConfig(
-              (c) => {
-                ConfigUtils.setPublishProp(c, "enableFrontmatterTags", false);
-                return c;
+          fname: "no.fmtags",
+          dest: DendronASTDest.HTML,
+          vault: vaults[0],
+          config: engine.config,
+        },
+        undefined,
+        flavor
+      ).process("has no fm tags");
+      return out;
+    };
+
+    describe("GIVEN enableFrontmatterTags: true", () => {
+      _.map([ProcFlavor.PUBLISHING, ProcFlavor.PREVIEW], (flavor) => {
+        test(`THEN rendered when available: single tag, ${flavor}`, async () => {
+          await runEngineTestV5(
+            async ({ engine, vaults }) => {
+              const out = await runProcForHasFMTags({ engine, vaults, flavor });
+              await checkVFile(out, "Tags", "first");
+              await checkNotInVFile(out, "#first");
+            },
+            {
+              preSetupHook: async ({ wsRoot, vaults }) => {
+                await NoteTestUtilsV4.createNote({
+                  fname: "has.fmtags",
+                  wsRoot,
+                  vault: vaults[0],
+                  props: { tags: "first" },
+                });
               },
-              { wsRoot }
+              expect,
+            }
+          );
+        });
+
+        test(`THEN rendered when available: multiple tags, ${flavor}`, async () => {
+          await runEngineTestV5(
+            async ({ engine, vaults }) => {
+              const out = await runProcForHasFMTags({ engine, vaults, flavor });
+              await checkVFile(out, "Tags", "first", "second");
+              await checkNotInVFile(out, "#first", "#second");
+            },
+            {
+              preSetupHook: async ({ wsRoot, vaults }) => {
+                await NoteTestUtilsV4.createNote({
+                  fname: "has.fmtags",
+                  wsRoot,
+                  vault: vaults[0],
+                  props: { tags: ["first", "second"] },
+                });
+              },
+              expect,
+            }
+          );
+        });
+      });
+
+      _.map([ProcFlavor.PUBLISHING, ProcFlavor.PREVIEW], (flavor) => {
+        test(`THEN not rendered when missing: ${flavor}`, async () => {
+          await runEngineTestV5(
+            async ({ engine, vaults }) => {
+              const out = await runProcForNoFMTags({ engine, vaults, flavor });
+              await checkNotInVFile(out, "Tags");
+            },
+            {
+              preSetupHook: async ({ wsRoot, vaults }) => {
+                await NoteTestUtilsV4.createNote({
+                  fname: "no.fmtags",
+                  wsRoot,
+                  vault: vaults[0],
+                });
+              },
+              expect,
+            }
+          );
+        });
+      });
+
+      describe("WHEN enableHashesForFMTags: true", () => {
+        _.map([ProcFlavor.PUBLISHING, ProcFlavor.PREVIEW], (flavor) => {
+          test(`THEN rendered with a hashtag(#): ${flavor}`, async () => {
+            await runEngineTestV5(
+              async ({ engine, vaults }) => {
+                const out = await runProcForHasFMTags({
+                  engine,
+                  vaults,
+                  flavor,
+                });
+                await checkVFile(out, "Tags", "#first", "#second");
+              },
+              {
+                preSetupHook: async ({ wsRoot, vaults }) => {
+                  await NoteTestUtilsV4.createNote({
+                    fname: "has.fmtags",
+                    wsRoot,
+                    vault: vaults[0],
+                    props: { tags: ["first", "second"] },
+                  });
+                  TestConfigUtils.withConfig(
+                    (config) => {
+                      if (flavor === ProcFlavor.PUBLISHING) {
+                        ConfigUtils.setPublishProp(
+                          config,
+                          "enableHashesForFMTags",
+                          true
+                        );
+                      } else {
+                        ConfigUtils.setPreviewProps(
+                          config,
+                          "enableHashesForFMTags",
+                          true
+                        );
+                      }
+                      return config;
+                    },
+                    { wsRoot }
+                  );
+                },
+                expect,
+              }
             );
-            await NoteTestUtilsV4.createNote({
-              fname: "has.fmtags",
-              wsRoot,
-              vault: vaults[0],
-              props: { tags: ["first", "second"] },
-            });
-          },
-          expect,
-        }
-      );
+          });
+        });
+      });
     });
 
-    describe("WHEN configured with enableHashesForFMTags option", () => {
-      test("THEN tags are rendered with a # symbol", async () => {
-        await runEngineTestV5(
-          async ({ engine, vaults }) => {
-            const out = await proc(engine, {
-              fname: "has.fmtags",
-              dest: DendronASTDest.HTML,
-              vault: vaults[0],
-              config: engine.config,
-            }).process("has fm tags");
-            await checkVFile(out, "Tags", "#first", "#second");
-          },
-          {
-            preSetupHook: async ({ wsRoot, vaults }) => {
-              await NoteTestUtilsV4.createNote({
-                fname: "has.fmtags",
-                wsRoot,
-                vault: vaults[0],
-                props: { tags: ["first", "second"] },
-              });
-              TestConfigUtils.withConfig(
-                (config) => {
-                  ConfigUtils.setPublishProp(
-                    config,
-                    "enableHashesForFMTags",
-                    true
-                  );
-                  return config;
-                },
-                { wsRoot }
-              );
+    describe("GIVEN enableFrontmatterTags: false", () => {
+      _.map([ProcFlavor.PUBLISHING, ProcFlavor.PREVIEW], (flavor) => {
+        test(`THEN not rendered: ${flavor}`, async () => {
+          await runEngineTestV5(
+            async ({ engine, vaults }) => {
+              const out = await runProcForHasFMTags({ engine, vaults, flavor });
+              await checkNotInVFile(out, "Tags");
             },
-            expect,
-          }
-        );
+            {
+              preSetupHook: async ({ wsRoot, vaults }) => {
+                TestConfigUtils.withConfig(
+                  (c) => {
+                    if (flavor === ProcFlavor.PUBLISHING) {
+                      ConfigUtils.setPublishProp(
+                        c,
+                        "enableFrontmatterTags",
+                        false
+                      );
+                    } else {
+                      ConfigUtils.setPreviewProps(
+                        c,
+                        "enableFrontmatterTags",
+                        false
+                      );
+                    }
+                    return c;
+                  },
+                  { wsRoot }
+                );
+                await NoteTestUtilsV4.createNote({
+                  fname: "has.fmtags",
+                  wsRoot,
+                  vault: vaults[0],
+                  props: { tags: ["first", "second"] },
+                });
+              },
+              expect,
+            }
+          );
+        });
       });
     });
   });

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -338,6 +338,8 @@ suite("Extension", function () {
           preview: {
             enableFMTitle: true,
             enableNoteTitleForLink: true,
+            enableFrontmatterTags: true,
+            enableHashesForFMTags: false,
             enableMermaid: true,
             enablePrettyRefs: true,
             enableKatex: true,

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -828,6 +828,8 @@ suite("Migration", function () {
             const expectedPreviewConfig: DendronPreviewConfig = {
               enableFMTitle: false,
               enableNoteTitleForLink: false,
+              enableFrontmatterTags: true,
+              enableHashesForFMTags: false,
               enableMermaid: false,
               enablePrettyRefs: false,
               enableKatex: false,


### PR DESCRIPTION
# chore: separate tag configs
This PR:
- Splits up `enableFrontmatterTags` and `enableHashesForFMTags` to be in `preview` and `publishing` namespace
  - originally (before publishing namespace migration), both preview and publishing behavior was set by one config under `site.{enableFrontmatterTag|enableHashesForFMTags}`

No diff in madge output

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 

### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 

## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)