### PR TITLE
chore: allow config client soft mapping

### DIFF
--- a/packages/common-all/src/constants/configs/compat.ts
+++ b/packages/common-all/src/constants/configs/compat.ts
@@ -1,7 +1,24 @@
-export const CONFIG_TO_MINIMUM_COMPAT_MAPPING: { [key: number]: string } = {
-  1: "0.0.0",
-  2: "0.63.0", // config consolidation (commands namespace)
-  3: "0.65.0", // config consolidation (workspace namespace)
-  4: "0.70.0", // config consolidation (preview namespace)
-  // 5: "0.83.0", // config consolidation (publishing namespace): commented this out because adding this compat mapping would prevent users from keeping the v4 config and still use the cli for publishing. re-enable once we remove backward compatibility.
+import _ from "lodash";
+
+export type ConfigMapping = {
+  clientVersion: string;
+  softMapping?: boolean; // config version is mapped to minimum client version, but it's backward's compatible for now.
 };
+
+export const CONFIG_TO_MINIMUM_COMPAT_MAPPING: {
+  [key: number]: ConfigMapping;
+} = {
+  1: { clientVersion: "0.0.0" },
+  2: { clientVersion: "0.63.0" }, // config consolidation (commands namespace)
+  3: { clientVersion: "0.65.0" }, // config consolidation (workspace namespace)
+  4: { clientVersion: "0.70.0" }, // config consolidation (preview namespace)
+  5: { clientVersion: "0.83.0", softMapping: true }, // config consolidation (publishing namespace): commented this out because adding this compat mapping would prevent users from keeping the v4 config and still use the cli for publishing. re-enable once we remove backward compatibility.
+};
+
+export class CompatUtils {
+  static isSoftMapping(opts: { configVersion: number }) {
+    const softMapping =
+      CONFIG_TO_MINIMUM_COMPAT_MAPPING[opts.configVersion].softMapping;
+    return !_.isUndefined(softMapping) && softMapping;
+  }
+}

--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -16,6 +16,7 @@ import {
 } from "@dendronhq/common-server";
 import {
   ALL_MIGRATIONS,
+  CONFIG_MIGRATIONS,
   DConfig,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
@@ -132,7 +133,9 @@ export abstract class CLICommand<
       const instruction =
         reason === "client"
           ? "Please make sure dendron-cli is up to date by running the following: \n npm install @dendronhq/dendron-cli@latest"
-          : `Please make sure dendron.yml is up to date by running the following: \n dendron dev run_migration --migrationVersion=${ALL_MIGRATIONS[0].version}`;
+          : `Please make sure dendron.yml is up to date by running the following: \n dendron dev run_migration --migrationVersion=${
+              [CONFIG_MIGRATIONS, ...ALL_MIGRATIONS][0].version
+            }`;
       const clientVersionOkay =
         reason === "client" ? DENDRON_EMOJIS.NOT_OKAY : DENDRON_EMOJIS.OKAY;
       const configVersionOkay =
@@ -155,15 +158,29 @@ export abstract class CLICommand<
         instruction,
       ].join("\n");
 
-      this.print(message);
+      if (!validationResp.isSoftMapping) {
+        // we should wait for this before exiting the process.
+        await CLIAnalyticsUtils.trackSync(CLIEvents.CLIClientConfigMismatch, {
+          ...validationResp,
+          configVersion,
+        });
 
-      // we should wait for this before exiting the process.
-      await CLIAnalyticsUtils.trackSync(CLIEvents.CLIClientConfigMismatch, {
-        ...validationResp,
-        configVersion,
-      });
+        this.print(message);
+        this.print("Exiting due to configuration / client version mismatch.");
 
-      process.exit();
+        process.exit();
+      } else {
+        CLIAnalyticsUtils.track(CLIEvents.CLIClientConfigMismatch, {
+          ...validationResp,
+          configVersion,
+        });
+
+        this.print(message);
+        // show warning but don't exit if it's a soft mapping.
+        this.print(
+          "WARN: Your configuration version is outdated and is scheduled for deprecation in the near future."
+        );
+      }
     }
   }
 

--- a/packages/engine-test-utils/src/__tests__/common-all/config.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/config.spec.ts
@@ -108,6 +108,46 @@ describe("ConfigUtils", () => {
         done();
       });
     });
+    describe("GIVEN config v4 and client version 0.83", () => {
+      test("THEN config is invalid but allowed because v5 is a soft mapping", (done) => {
+        // this tests for users who decided not to migrate on v83.
+        // because v4 outdated but still compatible, we will still display a notice but not exit the process in cli.
+        const resp = ConfigUtils.configIsValid({
+          clientVersion: "0.83.0",
+          configVersion: 4,
+        });
+        expect(resp.isValid).toBeFalsy();
+        expect(resp.reason).toEqual("config");
+        expect(resp.minCompatClientVersion).toEqual("0.70.0");
+        expect(resp.minCompatConfigVersion).toEqual("5");
+        expect(resp.isSoftMapping).toBeTruthy();
+        done();
+      });
+    });
+    describe("GIVEN config v5 and client version 0.83", () => {
+      test("THEN config is valid", (done) => {
+        const resp = ConfigUtils.configIsValid({
+          clientVersion: "0.83.0",
+          configVersion: 5,
+        });
+        expect(resp.isValid).toBeTruthy();
+        done();
+      });
+    });
+    describe("GIVEN config v5 and client version 0.82", () => {
+      test("THEN config is invalid because client is incompatible", (done) => {
+        // this tests for validation where user updated to v5, but hasn't update dendron-cli
+        const resp = ConfigUtils.configIsValid({
+          clientVersion: "0.82.0",
+          configVersion: 5,
+        });
+        expect(resp.isValid).toBeFalsy();
+        expect(resp.reason).toEqual("client");
+        expect(resp.minCompatClientVersion).toEqual("0.83.0");
+        expect(resp.minCompatConfigVersion).toEqual("4");
+        done();
+      });
+    });
   });
 
   describe("getProps", () => {


### PR DESCRIPTION
# chore: allow config client soft mapping
This PR:
- readds config-client version mapping for v5 (config v5 to client version 0.83.0)
   - In https://github.com/dendronhq/dendron/pull/2424 I removed the compat mapping for v5, which introduced a bug where users who are on v5 will hit an unexpected error because the validation logic was looking for a mapping that didn't exist. This PR fixes this regression.
- allow "soft mapping" of config-client version
  - this is used to relax the config-client compatibility validation in dendron-cli when the newly introduced config version is backwards compatible.
  - If a config is outdated (e.g. config v4 on version 0.83.0), the same mismatch notice will be printed, but will not exit the process since we still accept the outdated config.

madge reports no diffs

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)