### PR TITLE
chore(treev2): Migrate from notesyncservice to engine events

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -791,6 +791,7 @@ export enum SeedBrowserMessageType {
   "onSeedStateChange" = "onSeedStateChange",
 }
 
+// TODO: split this up into a separate command, i.e. onNoteStateChanged, to capture different use cases
 export type OnDidChangeActiveTextEditorData = {
   note: NoteProps | undefined;
   /**
@@ -802,7 +803,8 @@ export type OnDidChangeActiveTextEditorData = {
    */
   syncChangedNote?: boolean;
   /**
-   * Current active note
+   * Current active note.
+   * If activeNote is defined, view will set that note as active note. Otherwise default to {@param note}
    */
   activeNote?: NoteProps;
 };

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -801,6 +801,10 @@ export type OnDidChangeActiveTextEditorData = {
    * Sync the changed note
    */
   syncChangedNote?: boolean;
+  /**
+   * Current active note
+   */
+  activeNote?: NoteProps;
 };
 
 export type NoteViewMessageType = DMessageEnum | NoteViewMessageEnum;

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -63,7 +63,9 @@ export const syncNote = createAsyncThunk(
     }
     const data = resp.data!;
     logger.info({ state: "pre:setNotes" });
-    dispatch(updateNote(data[0]));
+    if (data?.length) {
+      dispatch(updateNote(data[0]));
+    }
     logger.info({ state: "post:setNotes" });
     return resp;
   }

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -66,7 +66,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
     switch (msg.type) {
       case DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR:
         const cmsg = msg as OnDidChangeActiveTextEditorMsg;
-        const { sync, note, syncChangedNote } = cmsg.data;
+        const { sync, note, syncChangedNote, activeNote } = cmsg.data;
         if (sync) {
           // skip the initial ?
           logger.info({
@@ -87,7 +87,9 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
           await ideDispatch(engineSlice.syncNote({ ...workspace, note }));
         }
         logger.info({ ctx, msg: "setNoteActive:pre" });
-        ideDispatch(ideSlice.actions.setNoteActive(note));
+        // If activeNote is in the data payload, set that as active note. Otherwise default to changed note
+        const noteToSetActive = activeNote ? activeNote : note;
+        ideDispatch(ideSlice.actions.setNoteActive(noteToSetActive));
         logger.info({ ctx, msg: "setNoteActive:post" });
         break;
       case LookupViewMessageEnum.onUpdate:

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -64,6 +64,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
     const ctx = "useVSCodeMsg";
     logger.info({ ctx, msgType: msg.type });
     switch (msg.type) {
+      // TODO: Handle case where note is deleted. This should be implemented after we implement new message type to denote note state changes
       case DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR:
         const cmsg = msg as OnDidChangeActiveTextEditorMsg;
         const { sync, note, syncChangedNote, activeNote } = cmsg.data;

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -506,9 +506,9 @@ export class DendronEngineV2 implements DEngine {
       originalQS,
     });
 
-    //if (items.length === 0) {
-    //  return { error: null, data: [] };
-    //}
+    if (items.length === 0) {
+      return { error: null, data: [] };
+    }
 
     const item = this.notes[items[0].id];
     if (createIfNew) {

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -505,6 +505,11 @@ export class DendronEngineV2 implements DEngine {
       onlyDirectChildren,
       originalQS,
     });
+
+    //if (items.length === 0) {
+    //  return { error: null, data: [] };
+    //}
+
     const item = this.notes[items[0].id];
     if (createIfNew) {
       let noteNew: NoteProps;

--- a/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
@@ -173,20 +173,3 @@ describe("engine, config/", () => {
     });
   });
 });
-
-test("WHEN querying for a note that doesn't exist, return empty array in data", async () => {
-  await runEngineTestV5(
-    async ({ engine, vaults }) => {
-      const resp = await engine.queryNotes({
-        qs: "bar",
-        originalQS: "bar",
-        vault: vaults[0],
-      });
-      expect(resp.data.length === 0).toBeTruthy();
-    },
-    {
-      expect,
-      preSetupHook: ENGINE_HOOKS.setupEmpty,
-    }
-  );
-});

--- a/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
@@ -173,3 +173,20 @@ describe("engine, config/", () => {
     });
   });
 });
+
+test("WHEN querying for a note that doesn't exist, return empty array in data", async () => {
+  await runEngineTestV5(
+    async ({ engine, vaults }) => {
+      const resp = await engine.queryNotes({
+        qs: "bar",
+        originalQS: "bar",
+        vault: vaults[0],
+      });
+      expect(resp.data.length === 0).toBeTruthy();
+    },
+    {
+      expect,
+      preSetupHook: ENGINE_HOOKS.setupEmpty,
+    }
+  );
+});

--- a/packages/engine-test-utils/src/index.ts
+++ b/packages/engine-test-utils/src/index.ts
@@ -1,8 +1,3 @@
-export * from "./config";
-export * from "./engine";
-export * from "./topics";
-export { GitTestUtils, checkVaults, TestSeedUtils } from "./utils";
-export * from "./presets";
 import {
   ENGINE_HOOKS,
   ENGINE_HOOKS_MULTI,
@@ -11,6 +6,12 @@ import {
   ENGINE_WRITE_PRESETS,
   PODS_CORE,
 } from "./presets";
+
+export * from "./config";
+export * from "./engine";
+export * from "./topics";
+export { GitTestUtils, checkVaults, TestSeedUtils } from "./utils";
+export * from "./presets";
 export {
   ENGINE_HOOKS,
   ENGINE_HOOKS_MULTI,

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -5,7 +5,7 @@ import {
   NOTE_PRESETS_V4,
 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
-import { setupBasic } from "./utils";
+import { setupBasic, setupEmpty } from "./utils";
 
 const SCHEMAS = {
   // TODO: multi-vault, this gets overwritten
@@ -98,6 +98,26 @@ const NOTES = {
     },
     {
       preSetupHook: setupBasic,
+    }
+  ),
+  // Querying for non-existing note should return empty []
+  MISSING_QUERY: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const { data } = await engine.queryNotes({
+        qs: "bar",
+        originalQS: "bar",
+        vault: vaults[0],
+      });
+
+      return [
+        {
+          actual: data,
+          expected: [],
+        },
+      ];
+    },
+    {
+      preSetupHook: setupEmpty,
     }
   ),
   STAR_QUERY: new TestPresetEntryV4(

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -25,7 +25,6 @@ import {
   GoToNoteCommandOutput,
   TargetKind,
 } from "./GoToNoteInterface";
-import { AnchorUtils } from "@dendronhq/engine-server";
 import { ExtensionProvider } from "../ExtensionProvider";
 
 export const findAnchorPos = (opts: {

--- a/packages/plugin-core/src/views/DendronTreeViewV2.ts
+++ b/packages/plugin-core/src/views/DendronTreeViewV2.ts
@@ -9,16 +9,16 @@ import {
   VSCodeEvents,
 } from "@dendronhq/common-all";
 import { getDurationMilliseconds } from "@dendronhq/common-server";
-import { WorkspaceUtils } from "@dendronhq/engine-server";
+import { EngineEventEmitter, WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
 import * as vscode from "vscode";
+import { Disposable } from "vscode-languageclient";
 import { GotoNoteCommand } from "../commands/GotoNote";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { WSUtils } from "../WSUtils";
 import { WebViewUtils } from "./utils";
 
 /**
@@ -26,24 +26,40 @@ import { WebViewUtils } from "./utils";
  * TreeViewV2) - this is the side panel UI that gives the webview/react/antd
  * based tree view of the Dendron note hierarchy
  */
-export class DendronTreeViewV2 implements vscode.WebviewViewProvider {
+export class DendronTreeViewV2
+  implements vscode.WebviewViewProvider, Disposable
+{
   public static readonly viewType = DendronTreeViewKey.TREE_VIEW_V2;
 
   private _view?: vscode.WebviewView;
   private _ext: IDendronExtension;
+  private _onEngineNoteStateChangedDisposable: Disposable | undefined;
+  private _engineEvents;
 
-  constructor(ext: IDendronExtension) {
+  /**
+   *
+   * @param engineEvents - specifies when note state has been changed on the
+   * engine
+   */
+  constructor(ext: IDendronExtension, engineEvents: EngineEventEmitter) {
     this._ext = ext;
+    this._engineEvents = engineEvents;
 
     this._ext.context.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(this.onOpenTextDocument, this)
     );
 
-    this._ext.noteSyncService.onNoteChange((noteProps) => {
-      if (this._view && this._view.visible) {
-        this.refresh(noteProps);
-      }
-    });
+    this._onEngineNoteStateChangedDisposable =
+      this._engineEvents.onEngineNoteStateChanged((noteChangeEntry) => {
+        const ctx = "refreshDendronTreeViewV2EngineNoteStateChanged";
+        Logger.info({ ctx });
+        noteChangeEntry.map((changeEntry) => this.refresh(changeEntry.note));
+      });
+  }
+  dispose(): void {
+    if (this._onEngineNoteStateChangedDisposable) {
+      this._onEngineNoteStateChangedDisposable.dispose();
+    }
   }
 
   async onOpenTextDocument(editor: vscode.TextEditor | undefined) {
@@ -134,7 +150,7 @@ export class DendronTreeViewV2 implements vscode.WebviewViewProvider {
           AnalyticsUtils.track(VSCodeEvents.TreeView_Ready, {
             duration: profile,
           });
-          const note = WSUtils.getActiveNote();
+          const note = this._ext.wsUtils.getActiveNote();
           if (note) {
             this.refresh(note);
           }
@@ -146,6 +162,10 @@ export class DendronTreeViewV2 implements vscode.WebviewViewProvider {
     });
   }
 
+  /**
+   * Notify webview to sync given note and to focus on active note
+   * @param note to sync
+   */
   public refresh(note: NoteProps) {
     if (this._view) {
       this._view.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
@@ -154,6 +174,7 @@ export class DendronTreeViewV2 implements vscode.WebviewViewProvider {
         data: {
           note,
           syncChangedNote: true,
+          activeNote: this._ext.wsUtils.getActiveNote(),
         },
         source: "vscode",
       } as OnDidChangeActiveTextEditorMsg);

--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -7,20 +7,29 @@ import {
 } from "@dendronhq/common-all";
 import { EngineEventEmitter } from "@dendronhq/engine-server";
 import _ from "lodash";
-import vscode, { ProviderResult, ThemeIcon } from "vscode";
+import {
+  Disposable,
+  Event,
+  EventEmitter,
+  ProviderResult,
+  ThemeIcon,
+  TreeDataProvider,
+  TreeItem,
+  TreeItemCollapsibleState,
+  window,
+} from "vscode";
 import { ICONS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { TreeNote } from "./TreeNote";
-import { Disposable } from "vscode-languageclient";
 
 /**
  * Provides engine event data to generate the views for the native Tree View
  */
 export class EngineNoteProvider
-  implements vscode.TreeDataProvider<NoteProps>, Disposable
+  implements TreeDataProvider<NoteProps>, Disposable
 {
-  private _onDidChangeTreeDataEmitter: vscode.EventEmitter<
+  private _onDidChangeTreeDataEmitter: EventEmitter<
     NoteProps | undefined | void
   >;
   private _onEngineNoteStateChangedDisposable: Disposable;
@@ -30,7 +39,7 @@ export class EngineNoteProvider
   /**
    * Signals to vscode UI engine that the tree view needs to be refreshed.
    */
-  readonly onDidChangeTreeData: vscode.Event<NoteProps | undefined | void>;
+  readonly onDidChangeTreeData: Event<NoteProps | undefined | void>;
 
   /**
    *
@@ -38,7 +47,7 @@ export class EngineNoteProvider
    * engine
    */
   constructor(engineEvents: EngineEventEmitter) {
-    this._onDidChangeTreeDataEmitter = new vscode.EventEmitter<
+    this._onDidChangeTreeDataEmitter = new EventEmitter<
       NoteProps | undefined | void
     >();
 
@@ -56,7 +65,7 @@ export class EngineNoteProvider
     }
   }
 
-  getTreeItem(noteProps: NoteProps): vscode.TreeItem {
+  getTreeItem(noteProps: NoteProps): TreeItem {
     return this._tree[noteProps.id];
   }
 
@@ -66,7 +75,7 @@ export class EngineNoteProvider
     const { engine } = ExtensionProvider.getDWorkspace();
     const roots = _.filter(_.values(engine.notes), DNodeUtils.isRoot);
     if (!roots) {
-      vscode.window.showInformationMessage("No notes found");
+      window.showInformationMessage("No notes found");
       return Promise.resolve([]);
     }
     if (noteProps) {
@@ -114,8 +123,8 @@ export class EngineNoteProvider
 
   private createTreeNote(note: NoteProps) {
     const collapsibleState = _.isEmpty(note.children)
-      ? vscode.TreeItemCollapsibleState.None
-      : vscode.TreeItemCollapsibleState.Collapsed;
+      ? TreeItemCollapsibleState.None
+      : TreeItemCollapsibleState.Collapsed;
     const tn = new TreeNote({
       note,
       collapsibleState,

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -506,7 +506,7 @@ export class DendronExtension implements IDendronExtension {
     HistoryService.instance().subscribe("extension", async (event) => {
       if (event.action === "initialized") {
         Logger.info({ ctx, msg: "init:treeViewV2" });
-        const provider = new DendronTreeViewV2(this, this.getEngine());
+        const dendronTreeView = new DendronTreeViewV2(this, this.getEngine());
         const sampleView = new SampleView();
 
         this.treeViews[DendronTreeViewKey.SAMPLE_VIEW] = sampleView;
@@ -539,7 +539,7 @@ export class DendronExtension implements IDendronExtension {
           context.subscriptions.push(
             vscode.window.registerWebviewViewProvider(
               DendronTreeViewV2.viewType,
-              provider,
+              dendronTreeView,
               {
                 webviewOptions: {
                   retainContextWhenHidden: true,
@@ -557,6 +557,7 @@ export class DendronExtension implements IDendronExtension {
         // Removing it for now.
         // backlinkTreeView.message = "There are no links to this note."
         context.subscriptions.push(backlinkTreeView);
+        context.subscriptions.push(dendronTreeView);
       }
     });
   }

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -506,7 +506,7 @@ export class DendronExtension implements IDendronExtension {
     HistoryService.instance().subscribe("extension", async (event) => {
       if (event.action === "initialized") {
         Logger.info({ ctx, msg: "init:treeViewV2" });
-        const provider = new DendronTreeViewV2(this);
+        const provider = new DendronTreeViewV2(this, this.getEngine());
         const sampleView = new SampleView();
 
         this.treeViews[DendronTreeViewKey.SAMPLE_VIEW] = sampleView;


### PR DESCRIPTION
**Background**
As part of initiative to deprecate notesyncservice#onnotechanged, we will first migrate the dendron treeviewv2 to the engine events. See part 1 of [[Deprecate Notesyncservice Onnotechanged|dendron://private/task.2022.02.14.deprecate-notesyncservice-onnotechanged]]

**Changes**
1. Update `DendronTreeViewV2` to use engine events instead of notesyncservice
2. Added optional param `activeNote` to `OnDidChangeActiveTextEditorData`. This param lets the frontend know which note to focus on. Sometimes users can make changes to notes outside the active note but we do not want the focus to change.
3. Avoid TypeError due to indexoutofboundsexception in frontend and engine
4. If engine cannot find a note for a given query, return empty array instead of an error

*Madge*
plugin-core before: 20
plugin-core after: 19

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)