### PR TITLE
fix(views): faster webviews by reducing engine sync operations

### DIFF
--- a/packages/common-frontend/src/features/engine/hooks.ts
+++ b/packages/common-frontend/src/features/engine/hooks.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { engineSliceUtils } from ".";
 import { createLogger } from "../../utils";
-import { EngineState, InitNoteOpts, initNotes } from "./slice";
+import { EngineState, InitNoteOpts, initNotes, syncConfig } from "./slice";
 import { AppDispatch, RootState } from "./store";
 
 export const useEngineAppDispatch = () => useDispatch<AppDispatch>();
@@ -48,4 +48,32 @@ export const useEngine = ({
     logger.info({ ctx: "useEffect", state: "exit", engineState });
     return;
   }, [engineState.loading, opts.port, opts.ws]);
+};
+
+/**
+ * Reloads the Dendron Config
+ * @param opts.port?: workspace pot
+ * @param opts.ws?: workspace root
+ */
+export const useConfig = ({
+  opts,
+}: {
+  opts: Partial<InitNoteOpts> & { force?: boolean };
+}) => {
+  const dispatch = useEngineAppDispatch();
+  const logger = createLogger("syncConfig");
+  useEffect(() => {
+    logger.info({ ctx: "useEffect", state: "enter" });
+
+    if (_.isUndefined(opts.port)) {
+      return;
+    }
+    if (!opts.ws) {
+      return;
+    }
+    logger.info({ ctx: "useEffect", state: "syncConfig" });
+    dispatch(syncConfig({ port: parseInt(opts.port as any, 10), ws: opts.ws }));
+    logger.info({ ctx: "useEffect", state: "exit" });
+    return;
+  }, []);
 };

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -6,6 +6,7 @@ import {
   stringifyError,
   APIUtils,
   NoteUtils,
+  ConfigGetPayload,
 } from "@dendronhq/common-all";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import _ from "lodash";
@@ -41,8 +42,36 @@ export const initNotes = createAsyncThunk(
   }
 );
 
+/**
+ * Syncs the Dendron config from the engine
+ */
+export const syncConfig = createAsyncThunk(
+  "engine/syncConfig",
+  async ({ port, ws }: { port: number; ws: string }, { dispatch }) => {
+    const logger = createLogger("syncConfigThunk");
+    const endpoint = APIUtils.getLocalEndpoint(port);
+    const api = new DendronApiV2({
+      endpoint,
+      apiPath: "api",
+      logger,
+    });
+    logger.info({ state: "pre:initConfig" });
+    const resp = await api.configGet({ ws });
+    logger.info({ state: "post:initConfig" });
+    if (resp.error) {
+      dispatch(setError(stringifyError(resp.error)));
+      return resp;
+    }
+    const data = resp.data!;
+    logger.info({ state: "pre:setConfig" });
+    dispatch(setConfig(data));
+    logger.info({ state: "post:setConfig" });
+    return resp;
+  }
+);
+
 export const syncNote = createAsyncThunk(
-  "engine/init",
+  "engine/sync",
   async (
     { port, ws, note }: { port: number; ws: string; note: NoteProps },
     { dispatch }
@@ -127,6 +156,9 @@ export const engineSlice = createSlice({
       state.vaults = vaults;
       state.config = config;
     },
+    setConfig: (state, action: PayloadAction<ConfigGetPayload>) => {
+      state.config = action.payload;
+    },
     setNotes: (state, action: PayloadAction<NotePropsDict>) => {
       state.notes = action.payload;
     },
@@ -178,8 +210,7 @@ export const engineSlice = createSlice({
         state.currentRequestId = meta.requestId;
       }
     });
-    // @ts-ignore
-    builder.addCase(initNotes.fulfilled, (state, { payload, meta }) => {
+    builder.addCase(initNotes.fulfilled, (state, { meta }) => {
       const { requestId } = meta;
       logger.info({
         state: "fin:initNotes",
@@ -197,6 +228,7 @@ export const {
   setNotes,
   setError,
   setFromInit,
+  setConfig,
   setRenderNote,
   updateNote,
   tearDown,

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -25,7 +25,7 @@ import "../styles/scss/main.scss";
 import { Layout } from "antd";
 const { Content } = Layout;
 
-const { useEngineAppSelector, useEngine } = engineHooks;
+const { useEngineAppSelector } = engineHooks;
 
 function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
   const ctx = "DendronVSCodeApp";
@@ -36,8 +36,6 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
   const logger = createLogger("DendronApp");
 
   logger.info({ ctx, msg: "enter", workspace });
-  // used to initialize the engine
-  useEngine({ engineState: engine, opts: workspace });
 
   const props = {
     engine,
@@ -100,11 +98,6 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         break;
     }
   });
-
-  // don't load until active
-  if (_.isEmpty(engine.notes)) {
-    return <div>Loading...</div>;
-  }
 
   return <Component {...props} />;
 }

--- a/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
@@ -4,11 +4,20 @@ import {
   FOOTNOTE_REF_CLASS,
   NoteViewMessageEnum,
 } from "@dendronhq/common-all";
-import { createLogger, DendronNote } from "@dendronhq/common-frontend";
+import {
+  createLogger,
+  DendronNote,
+  engineHooks,
+} from "@dendronhq/common-frontend";
 import _ from "lodash";
 import mermaid from "mermaid";
 import React from "react";
-import { useCurrentTheme, useMermaid, useRenderedNoteBody } from "../hooks";
+import {
+  useCurrentTheme,
+  useMermaid,
+  useRenderedNoteBody,
+  useWorkspaceProps,
+} from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage } from "../utils/vscode";
 
@@ -80,6 +89,9 @@ const DendronNotePage: DendronComponent = (props) => {
   const logger = createLogger("DendronNotePage");
   const noteProps = props.ide.noteActive;
   const config = props.engine.config;
+  const [workspace] = useWorkspaceProps();
+  const { useConfig } = engineHooks;
+  useConfig({ opts: workspace });
 
   logger.info({
     ctx,
@@ -99,7 +111,7 @@ const DendronNotePage: DendronComponent = (props) => {
   useMermaid({ config, themeType, mermaid, noteRenderedBody });
 
   if (!noteRenderedBody || !config) {
-    return null;
+    return <div>Loading...</div>;
   }
   return <DendronNote noteContent={noteRenderedBody} config={config} />;
 };

--- a/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
@@ -4,11 +4,16 @@ import {
   TreeViewMessage,
   TreeViewMessageEnum,
 } from "@dendronhq/common-all";
-import { createLogger, TreeViewUtils } from "@dendronhq/common-frontend";
+import {
+  createLogger,
+  TreeViewUtils,
+  engineHooks,
+} from "@dendronhq/common-frontend";
 import { Spin, Tree, TreeProps } from "antd";
 import _ from "lodash";
 import { DataNode } from "rc-tree/lib/interface";
 import React, { useState } from "react";
+import { useWorkspaceProps } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage } from "../utils/vscode";
 type OnExpandFunc = TreeProps["onExpand"];
@@ -23,6 +28,7 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
   const [roots, setRoots] = useState<DataNode[]>([]);
   // Used to avoid recomputing tree data unnecessarily
   const [numNotesLast, setNumNotesLast] = useState<number>(numNotes);
+  const { useEngine } = engineHooks;
 
   logger.info({
     msg: "enter",
@@ -30,6 +36,10 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
     config,
     numNotes,
   });
+
+  // Load up the full engine state as all notes are needed for the Tree View
+  const [workspace] = useWorkspaceProps();
+  useEngine({ engineState: engine, opts: workspace });
 
   // update active notes in tree
   React.useEffect(() => {


### PR DESCRIPTION
## fix(views): faster webviews by reducing engine sync operations

This change makes loading of our webviews faster. 

1. There was what I assume is a copy-paste error in `slice.ts` where `initNotes` and `syncNote` both had the same typePrefix of "engine/init" being passed into `createAsyncThunk`.  This inadvertently caused a big problem - we have `extraReducers` hooked up to trigger off of pending+fulfilled of `initNotes`.  But under the hood in redux, it seems like these are actually keyed off of the registered typePrefix - so the resulting effect is that every time we just wanted to do `syncNote`, we ended up triggering `initNotes` _twice_ (why twice instead of once I'm not too sure, but the logs showed that this was happening).  We set the `syncNote` flag extensively - it's set during tree view state changes and every time preview is changed - including every time you type into the editor with preview open.  So we were doing maybe 4 sets of `initNotes` every time you did a note navigation and had tree view and note preview open.
2. `initNotes` is a very expensive operation - and we don't actually need it except in TreeView.  I've moved `useEngine` from out of the main `DendronApp.tsx` and pushed it into `DendronTreeExplorerPanel.tsx`.  `DendronNotePage.tsx` does  need `engine.config` state to set, so I added a new method in the engine slice to allow it to just retrieve the config from the engine instead of initializing everything.

Results: 
- Loading of Preview is much faster
- Swapping Between Notes while preview is open is very quick
- LookupView loads very fast (although there's some UI glitching/flickering as a result, which we can address later)
- TreeView looks smoother as well.

Rendering of large markdown files is still quite sluggish though.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [ N/A - no plugin-core changes] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Tests

### Basics

Not sure - we don't seem to have any coverage on plugin-views yet.
- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)