### PR TITLE
chore: remove unused import

### DIFF
--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -25,7 +25,6 @@ import {
   GoToNoteCommandOutput,
   TargetKind,
 } from "./GoToNoteInterface";
-import { AnchorUtils } from "@dendronhq/engine-server";
 import { ExtensionProvider } from "../ExtensionProvider";
 
 export const findAnchorPos = (opts: {


### PR DESCRIPTION
# chore: remove unused import

This PR
- Removes an unused import in `GoToNote.ts` that was introduced in https://github.com/dendronhq/dendron/commit/8d359d39c54672fdebbd647cd8bff1867b6000d2
  - Looks like the use of `AnchorUtils` was removed from `GoToNote.ts` in #2455, then only the import statement was added back during a merge with the master branch.