### PR TITLE
fix: properly render mermaid and katex when published

### DIFF
--- a/packages/common-frontend/src/components/DendronNote.tsx
+++ b/packages/common-frontend/src/components/DendronNote.tsx
@@ -17,7 +17,7 @@ export const useMermaid = ({
 }) => {
   React.useEffect(() => {
     const logger = createLogger("useMermaid");
-    if (config && ConfigUtils.getProp(config, "mermaid")) {
+    if (config && ConfigUtils.getEnableMermaid(config, true)) {
       // @ts-ignore
       const mermaid = (window as any)._mermaid;
       logger.info("mermaid created");

--- a/packages/dendron-cli/src/utils/build.ts
+++ b/packages/dendron-cli/src/utils/build.ts
@@ -360,6 +360,8 @@ export class BuildUtils {
       "common-assets"
     );
 
+    const commonAssetsBuildRoot = path.join(commonAssetsRoot, "build");
+
     // destination for assets
     const pluginAssetPath = path.join(this.getPluginRootPath(), "assets");
     const pluginStaticPath = path.join(pluginAssetPath, "static");
@@ -375,6 +377,18 @@ export class BuildUtils {
 
     // copy over common assets
     fs.copySync(path.join(commonAssetsRoot, "assets", "css"), pluginStaticPath);
+
+    // copy over katex fonts
+    const katexFontsPath = path.join(
+      commonAssetsBuildRoot,
+      "assets",
+      "css",
+      "fonts"
+    );
+    fs.copySync(
+      katexFontsPath,
+      path.join(pluginStaticPath, "css", "themes", "fonts")
+    );
 
     // copy assets from next server
     // DEPRECATED

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -365,7 +365,6 @@ export class MDUtilsV5 {
           if (ConfigUtils.getEnableKatex(config, shouldApplyPublishRules)) {
             proc = proc.use(math);
           }
-
           if (ConfigUtils.getEnableMermaid(config, shouldApplyPublishRules)) {
             proc = proc.use(mermaid, { simple: true });
           }
@@ -441,15 +440,13 @@ export class MDUtilsV5 {
 
     // apply plugins enabled by config
     const config = data?.config as IntermediateDendronConfig;
-    const enableKatex = MDUtilsV5.shouldApplyPublishingRules(pRehype)
-      ? ConfigUtils.getProp(config, "useKatex")
-      : ConfigUtils.getPreview(config).enableKatex;
-
-    if (enableKatex) {
+    const shouldApplyPublishRules =
+      MDUtilsV5.shouldApplyPublishingRules(pRehype);
+    if (ConfigUtils.getEnableKatex(config, shouldApplyPublishRules)) {
       pRehype = pRehype.use(katex);
     }
     // apply publishing specific things
-    if (this.shouldApplyPublishingRules(pRehype)) {
+    if (shouldApplyPublishRules) {
       pRehype = pRehype.use(link, {
         properties: {
           "aria-hidden": "true",

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -439,7 +439,7 @@ export class MDUtilsV5 {
       .use(slug);
 
     // apply plugins enabled by config
-    const config = data?.config as IntermediateDendronConfig;
+    const config = data?.engine?.config as IntermediateDendronConfig;
     const shouldApplyPublishRules =
       MDUtilsV5.shouldApplyPublishingRules(pRehype);
     if (ConfigUtils.getEnableKatex(config, shouldApplyPublishRules)) {

--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -77,7 +77,7 @@ export default function DendronLayout(
 
   const engine = useEngineAppSelector((state) => state.engine);
   const config = engine.config as IntermediateDendronConfig;
-  const enableMermaid = ConfigUtils.getProp(config, "mermaid");
+  const enableMermaid = ConfigUtils.getEnableMermaid(config, true);
 
   return (
     <Layout

--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -76,8 +76,8 @@ export default function DendronLayout(
   );
 
   const engine = useEngineAppSelector((state) => state.engine);
-  const config = engine.config as IntermediateDendronConfig;
-  const enableMermaid = ConfigUtils.getEnableMermaid(config, true);
+  const config = engine.config;
+  const enableMermaid = config && ConfigUtils.getEnableMermaid(config, true);
 
   return (
     <Layout


### PR DESCRIPTION
# fix: properly render mermaid and katex when published
This PR:
- Properly handles v5 configs for mermaid and katex (`publishing.enableMermaid` and `publishing.enableKatex`) when publishing, and fixes an issue that cause mermaid diagrams and katex expressions not rendering when the note is published.
- Properly sync katex fonts to plugin during build in `dendron dev sync_assets`

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)