### PR TITLE
enhance(workspace): automatically update configuration for vaults that have remotes, but aren't configured as such

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -98,6 +98,10 @@ export enum ContextualUIEvents {
   ContextualUICodeAction = "ContextualUI_CodeAction",
 }
 
+export enum WorkspaceEvents {
+  AutoFix = "AutoFix",
+}
+
 export enum NativeWorkspaceEvents {
   DetectedInNonDendronWS = "Native_Workspace_Detected_In_Non_Dendron_WS", // watcher has detected a Dendron workspace getting created inside a non-Dendron workspace
 }
@@ -111,4 +115,5 @@ export const DendronEvents = {
   ConfigEvents,
   ContextualUIEvents,
   NativeWorkspaceEvents,
+  WorkspaceEvents,
 };

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -71,6 +71,8 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const ds = new DoctorService();
-    return ds.executeDoctorActions(opts);
+    const out = await ds.executeDoctorActions(opts);
+    ds.dispose();
+    return out;
   }
 }

--- a/packages/engine-server/src/topics/git.ts
+++ b/packages/engine-server/src/topics/git.ts
@@ -352,12 +352,37 @@ export class Git {
     }
   }
 
+  /** Returns the first remote that has been configured. */
   async getRemote(): Promise<string | undefined> {
+    // First see if we can determine the correct remote from the upstream of the current branch
+    const upstream = await this.getUpstream();
+    if (upstream) {
+      const upstreamMatch = /^([^/]+)[/].*/.exec(upstream);
+      if (upstreamMatch) {
+        const remote = upstreamMatch[1];
+        if (!_.isEmpty(remote)) return remote;
+      }
+    }
+    // If that fails, just default to the first remote the user has.
     try {
       const { stdout } = await this._execute("git remote");
-      const upstream = _.trim(stdout.split("\n")[0]);
-      if (!upstream) return undefined;
-      return upstream;
+      const remote = _.trim(stdout.split("\n")[0]);
+      if (_.isEmpty(remote)) return undefined;
+      return remote;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Returns the URL for  */
+  async getRemoteUrl(): Promise<string | undefined> {
+    const remote = await this.getRemote();
+    if (!remote) return undefined;
+    try {
+      const { stdout } = await this._execute(`git remote get-url ${remote}`);
+      const url = _.trim(stdout);
+      if (_.isEmpty(url)) return undefined;
+      return url;
     } catch {
       return undefined;
     }

--- a/packages/engine-server/src/topics/git.ts
+++ b/packages/engine-server/src/topics/git.ts
@@ -374,7 +374,7 @@ export class Git {
     }
   }
 
-  /** Returns the URL for  */
+  /** Returns the URL for the current remote. */
   async getRemoteUrl(): Promise<string | undefined> {
     const remote = await this.getRemote();
     if (!remote) return undefined;

--- a/packages/engine-server/src/workspace/workspaceServiceInterface.ts
+++ b/packages/engine-server/src/workspace/workspaceServiceInterface.ts
@@ -37,4 +37,9 @@ export interface IWorkspaceService {
   pullVaults(): Promise<SyncActionResult[]>;
 
   pushVaults(): Promise<SyncActionResult[]>;
+
+  markVaultAsRemoteInConfig(
+    targetVault: DVault,
+    remoteUrl: string
+  ): Promise<void>;
 }

--- a/packages/engine-test-utils/src/utils/git.ts
+++ b/packages/engine-test-utils/src/utils/git.ts
@@ -1,12 +1,28 @@
+import { VaultUtils } from "@dendronhq/common-all";
 import { Git } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import path from "path";
+import type { DVault } from "..";
 
 export class GitTestUtils {
   static async createRepoForWorkspace(wsRoot: string) {
     const git = new Git({ localUrl: wsRoot });
     await git.init();
     await git.add("dendron.yml");
+    await git.commit({ msg: "init" });
+  }
+
+  static async createRepoForVault({
+    wsRoot,
+    vault,
+  }: {
+    wsRoot: string;
+    vault: DVault;
+  }) {
+    const localUrl = path.join(wsRoot, VaultUtils.getRelPath(vault));
+    const git = new Git({ localUrl });
+    await git.init();
+    await git.add("root.md");
     await git.commit({ msg: "init" });
   }
 
@@ -44,6 +60,28 @@ export class GitTestUtils {
     await this.createRepoForWorkspace(wsRoot);
     await this.remoteCreate(remoteDir);
     await this.remoteAdd(wsRoot, remoteDir);
+  }
+
+  /** Set up a vault with a remote, intended to be used when testing pull or push functionality.
+   *
+   * @param wsRoot Directory where the vault exists.
+   * @param remoteDir Directory where the remote will be stored. The vault will pull and push to this remote.
+   */
+  static async createRepoForRemoteVault({
+    wsRoot,
+    vault,
+    remoteDir,
+  }: {
+    wsRoot: string;
+    vault: DVault;
+    remoteDir: string;
+  }) {
+    await this.createRepoForVault({ wsRoot, vault });
+    await this.remoteCreate(remoteDir);
+    await this.remoteAdd(
+      path.join(wsRoot, VaultUtils.getRelPath(vault)),
+      remoteDir
+    );
   }
 
   /**

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -382,6 +382,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         } else {
           window.showInformationMessage(`There are no missing links!`);
         }
+        ds.dispose();
         if (this.extension.fileWatcher) {
           this.extension.fileWatcher.pause = false;
         }
@@ -403,6 +404,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
           exit: false,
           quiet: true,
         });
+        ds.dispose();
         if (out.resp.length === 0) {
           window.showInformationMessage(`There are no broken links!`);
           break;
@@ -421,6 +423,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
           engine,
           exit: false,
         });
+        ds.dispose();
       }
     }
 

--- a/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
@@ -1,20 +1,28 @@
-import { vault2Path } from "@dendronhq/common-server";
-import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { tmpDir, vault2Path } from "@dendronhq/common-server";
+import {
+  ENGINE_HOOKS,
+  GitTestUtils,
+  TestConfigUtils,
+} from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
-import * as vscode from "vscode";
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
 import { expect } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import {
+  describeMultiWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
+import { test, describe } from "mocha";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { ConfigUtils, VaultUtils } from "@dendronhq/common-all";
+import sinon from "sinon";
 
 suite("ReloadIndex", function () {
-  // let root: DirResult;
-  let ctx: vscode.ExtensionContext;
-  // let vaultDir: string;
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
@@ -63,5 +71,120 @@ suite("ReloadIndex", function () {
         done();
       },
     });
+  });
+
+  describe("WHEN there is a vault in a repo", () => {
+    describe("AND that vault has a remote", () => {
+      describeMultiWS("AND the vault was not marked as remote", { ctx }, () => {
+        test("THEN it is marked as a remote vault", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const vault = vaults[0];
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteVault({
+            wsRoot,
+            vault,
+            remoteDir,
+          });
+
+          await new ReloadIndexCommand().run();
+          const configAfter = TestConfigUtils.getConfig({ wsRoot });
+          const vaultsAfter = ConfigUtils.getVaults(configAfter);
+          const vaultAfter = VaultUtils.getVaultByName({
+            vaults: vaultsAfter,
+            vname: VaultUtils.getName(vault),
+          });
+          expect(vaultAfter?.remote?.type).toEqual("git");
+          expect(vaultAfter?.remote?.url).toEqual(remoteDir);
+        });
+      });
+
+      describeMultiWS(
+        "AND if the vault was already marked as a remote vault",
+        {
+          ctx,
+          postSetupHook: async (opts) => {
+            // Have to override the config here and not in `modConfigCb` because the vaults are not in the config by then
+            TestConfigUtils.withConfig((config) => {
+              const vaults = ConfigUtils.getVaults(config);
+              vaults[0].remote = {
+                type: "git",
+                url: "https://github.com/dendronhq/example.git",
+              };
+              ConfigUtils.setVaults(config, vaults);
+              return config;
+            }, opts);
+          },
+        },
+        () => {
+          test("THEN we don't touch the configuration", async () => {
+            const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+            const vault = vaults[0];
+            const remoteDir = tmpDir().name;
+            await GitTestUtils.createRepoForRemoteVault({
+              wsRoot,
+              vault,
+              remoteDir,
+            });
+            const { workspaceService } = ExtensionProvider.getExtension();
+            expect(workspaceService).toBeTruthy();
+            const markVault = sinon.stub(
+              workspaceService!,
+              "markVaultAsRemoteInConfig"
+            );
+
+            await new ReloadIndexCommand().run();
+            expect(markVault.called).toBeFalsy();
+            markVault.restore();
+          });
+        }
+      );
+    });
+
+    describeMultiWS("AND that repo does NOT have a remote", { ctx }, () => {
+      test("THEN it is NOT marked as a remote vault", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = vaults[0];
+        await GitTestUtils.createRepoForVault({
+          wsRoot,
+          vault,
+        });
+
+        await new ReloadIndexCommand().run();
+
+        const configAfter = TestConfigUtils.getConfig({ wsRoot });
+        const vaultsAfter = ConfigUtils.getVaults(configAfter);
+        const vaultAfter = VaultUtils.getVaultByName({
+          vaults: vaultsAfter,
+          vname: VaultUtils.getName(vault),
+        });
+        expect(vaultAfter?.remote).toBeFalsy();
+      });
+    });
+
+    describeMultiWS(
+      "AND that repo contains the whole workspace and not just this vault",
+      { ctx },
+      () => {
+        test("THEN it is NOT marked as a remote vault", async () => {
+          // In this case, we don't want to mark it because the whole workspace
+          // is in the repository and not just this vault. Someone who has the
+          // workspace doesn't need to also clone the vault.
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const vault = vaults[0];
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+
+          await new ReloadIndexCommand().run();
+
+          const configAfter = TestConfigUtils.getConfig({ wsRoot });
+          const vaultsAfter = ConfigUtils.getVaults(configAfter);
+          const vaultAfter = VaultUtils.getVaultByName({
+            vaults: vaultsAfter,
+            vname: VaultUtils.getName(vault),
+          });
+          expect(vaultAfter?.remote).toBeFalsy();
+        });
+      }
+    );
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
@@ -1,9 +1,5 @@
-import { tmpDir, vault2Path } from "@dendronhq/common-server";
-import {
-  ENGINE_HOOKS,
-  GitTestUtils,
-  TestConfigUtils,
-} from "@dendronhq/engine-test-utils";
+import { vault2Path } from "@dendronhq/common-server";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -11,15 +7,8 @@ import path from "path";
 // // as well as import your extension to test it
 import { ReloadIndexCommand } from "../../commands/ReloadIndex";
 import { expect } from "../testUtilsv2";
-import {
-  describeMultiWS,
-  runLegacyMultiWorkspaceTest,
-  setupBeforeAfter,
-} from "../testUtilsV3";
-import { test, describe } from "mocha";
-import { ExtensionProvider } from "../../ExtensionProvider";
-import { ConfigUtils, VaultUtils } from "@dendronhq/common-all";
-import sinon from "sinon";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { test } from "mocha";
 
 suite("ReloadIndex", function () {
   const ctx = setupBeforeAfter(this, {
@@ -71,120 +60,5 @@ suite("ReloadIndex", function () {
         done();
       },
     });
-  });
-
-  describe("WHEN there is a vault in a repo", () => {
-    describe("AND that vault has a remote", () => {
-      describeMultiWS("AND the vault was not marked as remote", { ctx }, () => {
-        test("THEN it is marked as a remote vault", async () => {
-          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-          const vault = vaults[0];
-          const remoteDir = tmpDir().name;
-          await GitTestUtils.createRepoForRemoteVault({
-            wsRoot,
-            vault,
-            remoteDir,
-          });
-
-          await new ReloadIndexCommand().run();
-          const configAfter = TestConfigUtils.getConfig({ wsRoot });
-          const vaultsAfter = ConfigUtils.getVaults(configAfter);
-          const vaultAfter = VaultUtils.getVaultByName({
-            vaults: vaultsAfter,
-            vname: VaultUtils.getName(vault),
-          });
-          expect(vaultAfter?.remote?.type).toEqual("git");
-          expect(vaultAfter?.remote?.url).toEqual(remoteDir);
-        });
-      });
-
-      describeMultiWS(
-        "AND if the vault was already marked as a remote vault",
-        {
-          ctx,
-          postSetupHook: async (opts) => {
-            // Have to override the config here and not in `modConfigCb` because the vaults are not in the config by then
-            TestConfigUtils.withConfig((config) => {
-              const vaults = ConfigUtils.getVaults(config);
-              vaults[0].remote = {
-                type: "git",
-                url: "https://github.com/dendronhq/example.git",
-              };
-              ConfigUtils.setVaults(config, vaults);
-              return config;
-            }, opts);
-          },
-        },
-        () => {
-          test("THEN we don't touch the configuration", async () => {
-            const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-            const vault = vaults[0];
-            const remoteDir = tmpDir().name;
-            await GitTestUtils.createRepoForRemoteVault({
-              wsRoot,
-              vault,
-              remoteDir,
-            });
-            const { workspaceService } = ExtensionProvider.getExtension();
-            expect(workspaceService).toBeTruthy();
-            const markVault = sinon.stub(
-              workspaceService!,
-              "markVaultAsRemoteInConfig"
-            );
-
-            await new ReloadIndexCommand().run();
-            expect(markVault.called).toBeFalsy();
-            markVault.restore();
-          });
-        }
-      );
-    });
-
-    describeMultiWS("AND that repo does NOT have a remote", { ctx }, () => {
-      test("THEN it is NOT marked as a remote vault", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-        const vault = vaults[0];
-        await GitTestUtils.createRepoForVault({
-          wsRoot,
-          vault,
-        });
-
-        await new ReloadIndexCommand().run();
-
-        const configAfter = TestConfigUtils.getConfig({ wsRoot });
-        const vaultsAfter = ConfigUtils.getVaults(configAfter);
-        const vaultAfter = VaultUtils.getVaultByName({
-          vaults: vaultsAfter,
-          vname: VaultUtils.getName(vault),
-        });
-        expect(vaultAfter?.remote).toBeFalsy();
-      });
-    });
-
-    describeMultiWS(
-      "AND that repo contains the whole workspace and not just this vault",
-      { ctx },
-      () => {
-        test("THEN it is NOT marked as a remote vault", async () => {
-          // In this case, we don't want to mark it because the whole workspace
-          // is in the repository and not just this vault. Someone who has the
-          // workspace doesn't need to also clone the vault.
-          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-          const vault = vaults[0];
-          const remoteDir = tmpDir().name;
-          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-
-          await new ReloadIndexCommand().run();
-
-          const configAfter = TestConfigUtils.getConfig({ wsRoot });
-          const vaultsAfter = ConfigUtils.getVaults(configAfter);
-          const vaultAfter = VaultUtils.getVaultByName({
-            vaults: vaultsAfter,
-            vname: VaultUtils.getName(vault),
-          });
-          expect(vaultAfter?.remote).toBeFalsy();
-        });
-      }
-    );
   });
 });


### PR DESCRIPTION
If a vault has a remote configured, but the vault configuration did not have a remote set, then this PR automatically updates the configuration to mark the vault as a remote vault.

The PR also adds telemetry for both this feature, and also the existing features that fix missing root note and schemas.

Finally, the PR improves our git wrapper when detecting the current remote. Before we would just use the first remote available, but that might not be the remote for the current branch. The new code tries to parse the remote from the upstream of the current branch, then falls back to the first available remote if that fails.

Docs: https://github.com/dendronhq/dendron-site/pull/418

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
  - No change
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
    - Minimal, in the most common case this will only check if a single file exists during initialization
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
    - Considered edge cases, and the action only works if we're sure that the user has a repo with a remote set. Fully automatic so no confusing interface.
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated
  - linked above

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)
    - telemetry above tracks usage

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- [~] CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
  - linked above

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)