### PR TITLE
fix(pods): md export v2 to acknowledge wikiLinkToURL for links inside noteRefs

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -321,6 +321,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         //_node.value = newValue;
         //_node.value = alias;
         _node.data = {
+          vaultName: data.vaultName,
           alias,
           permalink: href,
           exists,

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -1158,21 +1158,13 @@ export class RemarkUtils {
           DendronASTTypes.WIKI_LINK,
           root
         ) as WikiLinkNoteV4[];
-
-        /** used findLinks to get vault of wikilink */
-        const links = LinkUtils.findLinks({ note, engine }).filter(
-          (linkNode) => linkNode.type === "wiki"
-        );
         let dirty = false;
-
-        links.forEach((linkNode, i) => {
+        wikiLinks.forEach((linkNode) => {
           let vault: DVault | undefined;
-
-          // If the link specifies a vault, we should only look at that vault
-          if (linkNode.to && !_.isUndefined(linkNode.to?.vaultName)) {
+          if (!_.isUndefined(linkNode.data.vaultName)) {
             vault = VaultUtils.getVaultByName({
               vaults: engine.vaults,
-              vname: linkNode.to?.vaultName,
+              vname: linkNode.data.vaultName,
             });
           }
           const existingNote = NoteUtils.getNoteFromMultiVault({
@@ -1187,12 +1179,12 @@ export class RemarkUtils {
               ConfigUtils.getPublishingConfig(dendronConfig);
             const urlRoot = publishingConfig.siteUrl || "";
             const { vault } = existingNote;
-            wikiLinks[i]["value"] = WorkspaceUtils.getNoteUrl({
+            linkNode.value = WorkspaceUtils.getNoteUrl({
               config: dendronConfig,
               note: existingNote,
               vault,
               urlRoot,
-              anchor: linkNode.to?.anchorHeader,
+              anchor: linkNode.data.anchorHeader,
             });
             dirty = true;
           }

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
@@ -2,6 +2,7 @@ import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
 import { tmpDir } from "@dendronhq/common-server";
 import {
   FileTestUtils,
+  NoteTestUtilsV4,
   NOTE_PRESETS_V4,
   RunEngineTestFunctionOpts,
 } from "@dendronhq/common-test-utils";
@@ -21,16 +22,26 @@ import { ENGINE_HOOKS } from "../../../presets";
  */
 describe("GIVEN a Markdown Export Pod with a particular config", () => {
   describe("When the destination is clipboard", () => {
-    const setupPod = (opts: RunEngineTestFunctionOpts, fname: string) => {
+    const setupPod = (setupOpts: {
+      opts: RunEngineTestFunctionOpts;
+      fname: string;
+      podConfigOpts?: Partial<RunnableMarkdownV2PodConfig>;
+    }) => {
+      const { opts, fname, podConfigOpts } = setupOpts;
+      const config = opts.engine.config;
+      if (config.publishing) {
+        config.publishing.siteUrl = "https://foo.com";
+      }
       const podConfig: RunnableMarkdownV2PodConfig = {
         exportScope: PodExportScope.Note,
         destination: "clipboard",
+        ...podConfigOpts,
       };
 
       const pod = new MarkdownExportPodV2({
         podConfig,
         engine: opts.engine,
-        dendronConfig: opts.dendronConfig!,
+        dendronConfig: config,
       });
       const props = NoteUtils.getNoteByFnameFromEngine({
         fname,
@@ -43,7 +54,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
       test("THEN expect wikilinks to be converted", async () => {
         await runEngineTestV5(
           async (opts) => {
-            const { pod, props } = setupPod(opts, "simple-wikilink");
+            const { pod, props } = setupPod({ opts, fname: "simple-wikilink" });
             const result = await pod.exportNotes([props]);
             const data = result.data?.exportedNotes!;
             expect(_.isString(data)).toBeTruthy();
@@ -73,7 +84,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
       test("THEN expect user tags to remain unchanged", async () => {
         await runEngineTestV5(
           async (opts) => {
-            const { pod, props } = setupPod(opts, "usertag");
+            const { pod, props } = setupPod({ opts, fname: "usertag" });
             const result = await pod.exportNotes([props]);
             const data = result.data?.exportedNotes!;
             expect(_.isString(data)).toBeTruthy();
@@ -99,24 +110,11 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
       test("THEN expect title to not be present as h1 header", async () => {
         await runEngineTestV5(
           async (opts) => {
-            const podConfig: RunnableMarkdownV2PodConfig = {
-              exportScope: PodExportScope.Note,
-              destination: "clipboard",
-              addFrontmatterTitle: false,
-            };
-
-            const pod = new MarkdownExportPodV2({
-              podConfig,
-              engine: opts.engine,
-              dendronConfig: opts.dendronConfig!,
-            });
-
-            const props = NoteUtils.getNoteByFnameFromEngine({
+            const { pod, props } = setupPod({
+              opts,
               fname: "usertag",
-              vault: opts.vaults[0],
-              engine: opts.engine,
-            }) as NoteProps;
-
+              podConfigOpts: { addFrontmatterTitle: false },
+            });
             const result = await pod.exportNotes([props]);
             const data = result.data?.exportedNotes!;
             expect(_.isString(data)).toBeTruthy();
@@ -141,7 +139,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
       test("THEN expect tags to remain unparsed", async () => {
         await runEngineTestV5(
           async (opts) => {
-            const { pod, props } = setupPod(opts, "footag");
+            const { pod, props } = setupPod({ opts, fname: "footag" });
             const result = await pod.exportNotes([props]);
             const data = result.data?.exportedNotes!;
             expect(_.isString(data)).toBeTruthy();
@@ -156,6 +154,130 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
               await NOTE_PRESETS_V4.NOTE_WITH_TAG.create({
                 wsRoot,
                 vault: vaults[0],
+              });
+            },
+          }
+        );
+      });
+    });
+
+    describe(" AND WHEN wikilinkToURL is set to true", () => {
+      test("THEN expect wikilinks to update with note URL and ref links to be resolved", async () => {
+        await runEngineTestV5(
+          async (opts) => {
+            const { props, pod } = setupPod({
+              opts,
+              fname: "parent",
+              podConfigOpts: { wikiLinkToURL: true },
+            });
+            const result = await pod.exportNotes([props]);
+            const data = result.data?.exportedNotes!;
+            expect(_.isString(data)).toBeTruthy();
+            if (_.isString(data)) {
+              expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
+              expect(data).toContain("foo body");
+              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
+              expect(data.indexOf("![[foo]]")).toEqual(-1);
+            }
+          },
+          {
+            expect,
+            preSetupHook: async ({ wsRoot, vaults }) => {
+              await NOTE_PRESETS_V4.NOTE_SIMPLE.create({
+                wsRoot,
+                vault: vaults[0],
+              });
+              await NoteTestUtilsV4.createNote({
+                wsRoot,
+                vault: vaults[0],
+                fname: "parent",
+                body: ["![[foo]]", "[[foo]]"].join("\n"),
+              });
+            },
+          }
+        );
+      });
+      test("THEN expect wikilinks inside ref links to be converted to Note URL", async () => {
+        await runEngineTestV5(
+          async (opts) => {
+            const { props, pod } = setupPod({
+              opts,
+              fname: "beta",
+              podConfigOpts: { wikiLinkToURL: true },
+            });
+            const result = await pod.exportNotes([props]);
+            const data = result.data?.exportedNotes!;
+            expect(_.isString(data)).toBeTruthy();
+            if (_.isString(data)) {
+              expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
+              expect(data.indexOf("![[alpha]]")).toEqual(-1);
+              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
+            }
+          },
+          {
+            expect,
+            preSetupHook: async ({ wsRoot, vaults }) => {
+              //fname foo, body: foo body
+              await NOTE_PRESETS_V4.NOTE_SIMPLE.create({
+                wsRoot,
+                vault: vaults[0],
+              });
+              // fname: "beta", body: "![[alpha]]",
+              await NOTE_PRESETS_V4.NOTE_WITH_NOTE_REF_LINK.create({
+                wsRoot,
+                vault: vaults[0],
+              });
+              await NoteTestUtilsV4.createNote({
+                wsRoot,
+                vault: vaults[0],
+                fname: "alpha",
+                body: "[[foo]]",
+              });
+            },
+          }
+        );
+      });
+      test("THEN expect cross vault wikilinks inside ref links to be converted to Note URL", async () => {
+        await runEngineTestV5(
+          async (opts) => {
+            const { props, pod } = setupPod({
+              opts,
+              fname: "beta",
+              podConfigOpts: { wikiLinkToURL: true },
+            });
+            const result = await pod.exportNotes([props]);
+            const data = result.data?.exportedNotes!;
+            expect(_.isString(data)).toBeTruthy();
+            if (_.isString(data)) {
+              expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
+              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
+              expect(data.indexOf("![[alpha]]")).toEqual(-1);
+            }
+          },
+          {
+            expect,
+            preSetupHook: async ({ wsRoot, vaults }) => {
+              //fname foo, body: foo body in vault2
+              await NOTE_PRESETS_V4.NOTE_SIMPLE.create({
+                wsRoot,
+                vault: vaults[1],
+              });
+              //fname foo, body: foo body in vault1
+              await NOTE_PRESETS_V4.NOTE_SIMPLE.create({
+                wsRoot,
+                vault: vaults[0],
+                genRandomId: true,
+              });
+              // fname: "beta", body: "![[alpha]]",
+              await NOTE_PRESETS_V4.NOTE_WITH_NOTE_REF_LINK.create({
+                wsRoot,
+                vault: vaults[0],
+              });
+              await NoteTestUtilsV4.createNote({
+                wsRoot,
+                vault: vaults[0],
+                fname: "alpha",
+                body: "[[dendron://vault2/foo]]",
               });
             },
           }

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
@@ -119,7 +119,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
             const data = result.data?.exportedNotes!;
             expect(_.isString(data)).toBeTruthy();
             if (_.isString(data)) {
-              expect(data.indexOf("Usertag")).toEqual(-1);
+              expect(data).not.toContain("Usertag");
             }
           },
           {
@@ -161,7 +161,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
       });
     });
 
-    describe(" AND WHEN wikilinkToURL is set to true", () => {
+    describe("AND WHEN wikilinkToURL is set to true", () => {
       test("THEN expect wikilinks to update with note URL and ref links to be resolved", async () => {
         await runEngineTestV5(
           async (opts) => {
@@ -176,8 +176,8 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
             if (_.isString(data)) {
               expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
               expect(data).toContain("foo body");
-              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
-              expect(data.indexOf("![[foo]]")).toEqual(-1);
+              expect(data).not.toContain("[foo](/notes/foo)");
+              expect(data).not.toContain("![[foo]]");
             }
           },
           {
@@ -210,8 +210,8 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
             expect(_.isString(data)).toBeTruthy();
             if (_.isString(data)) {
               expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
-              expect(data.indexOf("![[alpha]]")).toEqual(-1);
-              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
+              expect(data).not.toContain("![[alpha]]");
+              expect(data).not.toContain("[foo](/notes/foo)");
             }
           },
           {
@@ -250,8 +250,8 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
             expect(_.isString(data)).toBeTruthy();
             if (_.isString(data)) {
               expect(data).toContain("[Foo](https://foo.com/notes/foo.html)");
-              expect(data.indexOf("[foo](/notes/foo)")).toEqual(-1);
-              expect(data.indexOf("![[alpha]]")).toEqual(-1);
+              expect(data).not.toContain("[foo](/notes/foo)");
+              expect(data).not.toContain("![[alpha]]");
             }
           },
           {

--- a/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
@@ -13,7 +13,7 @@ import {
 } from "@dendronhq/common-all";
 import {
   DendronASTDest,
-  MDUtilsV4,
+  MDUtilsV5,
   RemarkUtils,
 } from "@dendronhq/engine-server";
 import { JSONSchemaType } from "ajv";
@@ -109,6 +109,7 @@ export class MarkdownExportPodV2
         vaultsArray.push(...this._engine.vaults);
         break;
       }
+      // no default
     }
     await Promise.all(
       vaultsArray.map(async (vault) => {
@@ -168,7 +169,7 @@ export class MarkdownExportPodV2
       previewConfig.enableFMTitle = addFrontmatterTitle;
     }
 
-    let remark = MDUtilsV4.procFull({
+    let remark = MDUtilsV5.procRemarkFull({
       dest: DendronASTDest.MD_REGULAR,
       config: {
         ...overrideConfig,
@@ -177,8 +178,6 @@ export class MarkdownExportPodV2
       engine,
       fname: input.fname,
       vault: input.vault,
-      shouldApplyPublishRules: false,
-      blockAnchorsOpts: { hideBlockAnchors: true },
     });
     if (this._config.wikiLinkToURL && !_.isUndefined(this._dendronConfig)) {
       remark = remark.use(


### PR DESCRIPTION
```md
fix(pods): markdown export pod v2 to acknowledge `wikiLinkToURL` for links inside note references 
```
- related to [issue 2444](https://github.com/dendronhq/dendron/issues/2444)
- updates MarkdownExportV2 to use `MDUtilsV5`
- fixes a regression where wikiLinkToURL: true breaks noteRefs
***
madge report
No new circular dependencies added(18)
***


## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)