### PR TITLE
chore(analytics): fix session id logic

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 export enum VSCodeEvents {
   ServerCrashed = "ServerCrashed",
   InitializeWorkspace = "InitializeWorkspace",

--- a/packages/dendron-cli/src/utils/analytics.ts
+++ b/packages/dendron-cli/src/utils/analytics.ts
@@ -5,12 +5,20 @@ import { CLIUtils } from "./cli";
 export class CLIAnalyticsUtils {
   static track(event: string, props?: any) {
     const cliVersion = CLIUtils.getClientVersion();
-    SegmentUtils.track(event, { type: "cli", cliVersion }, props);
+    SegmentUtils.track({
+      event,
+      platformProps: { type: "cli", cliVersion },
+      properties: props,
+    });
   }
 
   static async trackSync(event: string, props?: any) {
     const cliVersion = CLIUtils.getClientVersion();
-    await SegmentUtils.trackSync(event, { type: "cli", cliVersion }, props);
+    await SegmentUtils.trackSync({
+      event,
+      platformProps: { type: "cli", cliVersion },
+      properties: props,
+    });
   }
 
   static identify() {
@@ -36,6 +44,7 @@ export class CLIAnalyticsUtils {
     ].join("\n");
     const header = `\n===================\nTelemetry notice 🌱\n===================\n`;
     const container = `${header}${message}`;
+    // eslint-disable-next-line no-console
     console.log(container);
   }
 }

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -181,16 +181,13 @@ describe("GIVEN a SegmentClient", () => {
   const invalidPayload = "this is invalid JSON";
 
   function mockedTrackInternal(
-    event: string,
-    _payload: { [key: string]: any },
-    _context: any,
-    _timestamp?: Date
+    opts: SegmentEventProps
   ): Promise<RespV2<SegmentEventProps>> {
     return new Promise<RespV2<SegmentEventProps>>((resolve) => {
-      if (event === "mockFailToSend") {
+      if (opts.event === "mockFailToSend") {
         resolve({
           error: new DendronError({
-            message: "Mock - Failed to send event " + event,
+            message: "Mock - Failed to send event " + opts.event,
           }),
         });
       } else {
@@ -209,8 +206,11 @@ describe("GIVEN a SegmentClient", () => {
 
   describe("WHEN we track an event and we can connect to Segment backend", () => {
     beforeEach(async () => {
-      await instance.track("mockWillSend", {
-        hello: "world",
+      await instance.track({
+        event: "mockWillSend",
+        properties: {
+          hello: "world",
+        },
       });
     });
 
@@ -228,8 +228,11 @@ describe("GIVEN a SegmentClient", () => {
 
   describe("WHEN we track an event but we cannot connect to Segment backend", () => {
     beforeEach(async () => {
-      await instance.track("mockFailToSend", {
-        hello: "world",
+      await instance.track({
+        event: "mockFailToSend",
+        properties: {
+          hello: "world",
+        },
       });
     });
 

--- a/packages/plugin-core/src/scripts/uninstallHook.ts
+++ b/packages/plugin-core/src/scripts/uninstallHook.ts
@@ -9,7 +9,7 @@ import { SegmentClient } from "@dendronhq/common-server";
  * hook.
  */
 async function main() {
-  SegmentClient.instance().track(VSCodeEvents.Uninstall);
+  SegmentClient.instance().track({ event: VSCodeEvents.Uninstall });
 
   // Force an upload flush():
   SegmentClient.instance().identify();

--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -43,18 +43,16 @@ export class AnalyticsUtils {
 
   static getCommonTrackProps() {
     const firstWeekSinceInstall = AnalyticsUtils.isFirstWeek();
-    const sessionId = AnalyticsUtils.getSessionId();
     const vscodeSessionId = vscode.env.sessionId;
     return {
       firstWeekSinceInstall,
       vscodeSessionId,
-      integrations: { Amplitude: { session_id: sessionId } },
     };
   }
 
   static getSessionId(): number {
     if (AnalyticsUtils.sessionStart < 0) {
-      AnalyticsUtils.sessionStart = Time.now().toSeconds();
+      AnalyticsUtils.sessionStart = Math.round(Time.now().toSeconds());
     }
     return AnalyticsUtils.sessionStart;
   }
@@ -78,11 +76,18 @@ export class AnalyticsUtils {
 
   static track(event: string, props?: any) {
     const { ideVersion, ideFlavor } = AnalyticsUtils.getVSCodeIdentifyProps();
-    SegmentUtils.track(
+    const properties = { ...props, ...AnalyticsUtils.getCommonTrackProps() };
+    const sessionId = AnalyticsUtils.getSessionId();
+    SegmentUtils.track({
       event,
-      { type: "vscode", ideVersion, ideFlavor },
-      { ...props, ...AnalyticsUtils.getCommonTrackProps() }
-    );
+      platformProps: {
+        type: "vscode",
+        ideVersion,
+        ideFlavor,
+      },
+      properties,
+      integrations: { Amplitude: { session_id: sessionId } },
+    });
   }
 
   static identify() {


### PR DESCRIPTION
chore(analytics): fix session id logic

To track session id, segment expects the field to be passed in as `track({integrations: ...})`. We currently pass in all metadata as `properties`.
This change exposes all of segment's track properties to our analytic wrappers and also changes the input parameters to be object based (vs positional)

***
no change to circular dep

***


# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

NA

## 



## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)