### PR TITLE
fix: add selection2link button for CreateScratchNoteCommand

### DIFF
--- a/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
@@ -7,6 +7,7 @@ import {
   CopyNoteLinkBtn,
   HorizontalSplitBtn,
   ScratchBtn,
+  Selection2LinkBtn,
 } from "../components/lookup/buttons";
 import { CommandRunOpts as NoteLookupRunOpts } from "./NoteLookupCommand";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
@@ -44,6 +45,7 @@ export class CreateScratchNoteCommand extends BasicCommand<
       vaultButtonPressed,
       extraButtons: [
         ScratchBtn.create({ pressed: true, canToggle: false }),
+        Selection2LinkBtn.create(true),
         CopyNoteLinkBtn.create(false),
         HorizontalSplitBtn.create(false),
       ],

--- a/packages/plugin-core/src/test/suite-integ/CreateScratchNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateScratchNoteCommand.test.ts
@@ -32,6 +32,24 @@ suite("CreateScratchNoteCommand", function () {
 
         expect(activeNote.fname.startsWith("scratch.")).toBeTruthy();
       });
+      test("THEN selection2link is applied.", async () => {
+        const ext = ExtensionProvider.getExtension();
+        const wsUtils = ext.wsUtils;
+        const cmd = new CreateScratchNoteCommand(ext);
+        const { vaults, engine } = ext.getDWorkspace();
+        const note = NoteUtils.getNoteByFnameFromEngine({
+          fname: "foo",
+          vault: vaults[0],
+          engine,
+        }) as NoteProps;
+        const fooNoteEditor = await wsUtils.openNote(note);
+        fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
+        await cmd.run({ noConfirm: true });
+        const activeNote = getNoteFromTextEditor();
+        expect(activeNote.fname.endsWith(".foo-body")).toBeTruthy();
+        const changedFooNoteText = fooNoteEditor.document.getText();
+        expect(changedFooNoteText.endsWith(".foo-body]]\n"));
+      });
     }
   );
 });


### PR DESCRIPTION
# fix: add selection2link button for CreateScratchNoteCommand
This PR:
- fixes a regression introduced with https://github.com/dendronhq/dendron/pull/2346 with `Create Scratch Note`
  - when limiting the number of buttons in the quickpick for `Create Scratch Note` command, `selection2link` button was omitted, which made the scratch note behavior to not work as usual.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)