### PR TITLE
fix(internal): write note orphans child notes

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -352,7 +352,6 @@ export class NoteUtils {
   }): NoteChangeEntry[] {
     const changed: NoteChangeEntry[] = [];
     const { childToDelete, notes } = opts;
-    // const parent = DNodeUtils.getParent(childToDelete, { nodeDict: notes });
     let parent;
     if (childToDelete.parent) {
       parent = notes[childToDelete.parent];

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -346,6 +346,35 @@ export class NoteUtils {
     });
   }
 
+  static deleteChildFromParent(opts: {
+    childToDelete: NoteProps;
+    notes: NotePropsDict;
+  }): NoteChangeEntry[] {
+    const changed: NoteChangeEntry[] = [];
+    const { childToDelete, notes } = opts;
+    // const parent = DNodeUtils.getParent(childToDelete, { nodeDict: notes });
+    let parent;
+    if (childToDelete.parent) {
+      parent = notes[childToDelete.parent];
+    } else {
+      throw new DendronError({
+        message: `No parent found for ${childToDelete.fname}`,
+      });
+    }
+
+    const prevParentState = { ...parent };
+    parent.children = _.reject<string[]>(
+      parent.children,
+      (ent: string) => ent === childToDelete.id
+    ) as string[];
+    changed.push({
+      status: "update",
+      prevNote: prevParentState,
+      note: parent,
+    });
+    return changed;
+  }
+
   /**
    * Add node to parents up the note tree, or create stubs if no direct parents exists
    * @param opts

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -1013,31 +1013,31 @@ export class FileStorage implements DStore {
     // the parent of this note needs to have the old note removed (because the id is now different)
     // the new note needs to have the old note's children
     if (existingNote) {
-      // make sure newly created note actually has a parent.
-      if (!note.parent) {
+      // make sure existing note actually has a parent.
+      if (!existingNote.parent) {
         throw new DendronError({
           message: `no parent found for ${note.fname}`,
         });
       }
 
       // save the state of the parent to later record changed entry.
-      const parent = this.notes[note.parent];
+      const parent = this.notes[existingNote.parent];
       const prevParentState = { ...parent };
 
       // delete the existing note.
       delete this.notes[existingNote.id];
       this.noteFnames.delete(existingNote);
 
-      // first, update parent note
+      // first, update existing note's parent
       // so that it doesn't hold the deleted existing note's id as children
       NoteUtils.deleteChildFromParent({
         childToDelete: existingNote,
         notes: this.notes,
       });
 
-      // then update parent note again
+      // then update parent note of existing note
       // so that the newly created note is a child
-      DNodeUtils.addChild(this.notes[note.parent], note);
+      DNodeUtils.addChild(this.notes[existingNote.parent], note);
 
       // add an entry for the updated parent if there was a change
       changed.push({

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -175,6 +175,11 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
 
                 expect(createEntries[0].note.fname).toEqual("foo");
                 expect(createEntries[0].note.id).toEqual("updatedID");
+                expect(createEntries[0].note.children).toEqual(["foo.ch1"]);
+                expect(
+                  createEntries[0].note.parent &&
+                    engine.notes[createEntries[0].note.parent].fname
+                ).toEqual("root");
                 expect(deleteEntries[0].note.fname).toEqual("foo");
                 expect(deleteEntries[0].note.id).toEqual("foo");
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -144,8 +144,8 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
 
   // TODO: This scenario doesn't seem to work - parent is updated, but children
   // appear to get orphaned.
-  describe.skip("WHEN writing over an existing note by changing its ID", () => {
-    test("THEN expect all dependent notes to be updated", async (done) => {
+  describe("WHEN writing over an existing note by changing its ID", () => {
+    test.only("THEN expect all dependent notes to be updated", async (done) => {
       await runEngineTestV5(
         async ({ engine }) => {
           const engineClient = engine as DendronEngineClient;
@@ -155,19 +155,52 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
 
           engineClient.onEngineNoteStateChanged(
             (noteChangeEntries: NoteChangeEntry[]) => {
-              try {
-                noteChangeEntries.forEach((entry) => {
-                  // TODO: Add validation once scenario works.
-                  console.log(entry);
+              const createEntries = extractNoteChangeEntriesByType(
+                noteChangeEntries,
+                "create"
+              );
+
+              const deleteEntries = extractNoteChangeEntriesByType(
+                noteChangeEntries,
+                "delete"
+              );
+
+              const updateEntries = extractNoteChangeEntriesByType(
+                noteChangeEntries,
+                "update"
+              ) as NoteChangeUpdateEntry[];
+
+              testAssertsInsideCallback(() => {
+                expect(createEntries.length).toEqual(1);
+                expect(updateEntries.length).toEqual(2);
+                expect(deleteEntries.length).toEqual(1);
+
+                expect(createEntries[0].note.fname).toEqual("foo");
+                expect(createEntries[0].note.id).toEqual("updatedID");
+                expect(deleteEntries[0].note.fname).toEqual("foo");
+                expect(deleteEntries[0].note.id).toEqual("foo");
+
+                updateEntries.forEach((entry) => {
+                  if (entry.note.fname === "root") {
+                    expect(entry.note.children).toEqual(["bar", "updatedID"]);
+                    expect(entry.status).toEqual("update");
+                  } else if (entry.note.fname === "foo.ch1") {
+                    expect(entry.note.parent).toEqual("updatedID");
+                    expect(entry.status).toEqual("update");
+                  } else {
+                    done({
+                      message: `Unexpected NoteChangeEntry. fname: ${entry.note.fname}, id: ${entry.note.id}, status: ${entry.status}`,
+                    });
+                    return;
+                  }
                 });
+
                 done();
-              } catch (err) {
-                done(err);
-              }
+              }, done);
             }
           );
 
-          await engineClient.writeNote(fooUpdated, { updateExisting: true });
+          await engineClient.writeNote(fooUpdated);
         },
         {
           expect,

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -142,10 +142,8 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
     });
   });
 
-  // TODO: This scenario doesn't seem to work - parent is updated, but children
-  // appear to get orphaned.
   describe("WHEN writing over an existing note by changing its ID", () => {
-    test.only("THEN expect all dependent notes to be updated", async (done) => {
+    test("THEN expect all dependent notes to be updated", async (done) => {
       await runEngineTestV5(
         async ({ engine }) => {
           const engineClient = engine as DendronEngineClient;

--- a/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
@@ -216,7 +216,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, issue.vault)
           );
-          issue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          issue.parent = rootNote.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -252,7 +255,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, scratchIssue.vault)
           );
-          scratchIssue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          scratchIssue.parent = rootNote.id;
           await engine.writeNote(scratchIssue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -293,7 +299,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, issue.vault)
           );
-          scratchIssue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          scratchIssue.parent = rootNote.id;
           scratchIssue.custom = {};
           await engine.writeNote(scratchIssue, { newNode: true });
           const resp = await pod.execute({
@@ -334,7 +343,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, issue.vault)
           );
-          issue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          issue.parent = rootNote.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -373,7 +385,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, issue.vault)
           );
-          issue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          issue.parent = rootNote.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -413,7 +428,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
             _.isEqual(note.vault, issue.vault)
           );
-          issue.parent = rootNote!.id;
+          if (!rootNote) {
+            throw new Error("No root note found.");
+          }
+          issue.parent = rootNote.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,

--- a/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
@@ -193,13 +193,11 @@ describe("GIVEN: Github publish pod is run for a note", () => {
     pod.createDiscussion = jest.fn();
     pod.createIssue = jest.fn();
     pod.updateIssue = jest.fn();
-    pod.getDataFromGithub = jest
-      .fn()
-      .mockReturnValue({
-        labelsHashMap: { "area.misc": "sfgdjio", "type.bug": "gsfahhj" },
-        discussionCategoriesHashMap: { Ideas: "sfgdjio", General: "gsfahhj" },
-        assigneesHashMap: { john: "dhdjdj", doe: "dhdjdk" },
-      });
+    pod.getDataFromGithub = jest.fn().mockReturnValue({
+      labelsHashMap: { "area.misc": "sfgdjio", "type.bug": "gsfahhj" },
+      discussionCategoriesHashMap: { Ideas: "sfgdjio", General: "gsfahhj" },
+      assigneesHashMap: { john: "dhdjdj", doe: "dhdjdk" },
+    });
   });
 
   const utilityMethods = {
@@ -214,6 +212,11 @@ describe("GIVEN: Github publish pod is run for a note", () => {
         async ({ engine, vaults, wsRoot }) => {
           const vaultName = VaultUtils.getName(vaults[0]);
           pod.updateIssue = jest.fn().mockReturnValue("https://github.com/foo");
+
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, issue.vault)
+          );
+          issue.parent = rootNote!.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -246,6 +249,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const vaultName = VaultUtils.getName(vaults[0]);
           const scratchIssue: NoteProps = _.omit(issue, "tags");
           scratchIssue.tags = "documentation";
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, scratchIssue.vault)
+          );
+          scratchIssue.parent = rootNote!.id;
           await engine.writeNote(scratchIssue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -283,6 +290,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const vaultName = VaultUtils.getName(vaults[0]);
           pod.createIssue = jest.fn().mockReturnValue("https://github.com/foo");
           const scratchIssue: NoteProps = _.omit(issue, "custom");
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, issue.vault)
+          );
+          scratchIssue.parent = rootNote!.id;
           scratchIssue.custom = {};
           await engine.writeNote(scratchIssue, { newNode: true });
           const resp = await pod.execute({
@@ -320,6 +331,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             .fn()
             .mockReturnValue("https://github.com/foo");
           issue.custom.category = "Ideas";
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, issue.vault)
+          );
+          issue.parent = rootNote!.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -355,6 +370,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             .fn()
             .mockReturnValue("https://github.com/foo");
           issue.custom.category = "abcd";
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, issue.vault)
+          );
+          issue.parent = rootNote!.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,
@@ -391,6 +410,10 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           const vaultName = VaultUtils.getName(vaults[0]);
           pod.updateIssue = jest.fn().mockReturnValue("https://github.com/foo");
           issue.custom.assignees = ["john", "doe"];
+          const rootNote = NoteUtils.getRoots(engine.notes).find((note) =>
+            _.isEqual(note.vault, issue.vault)
+          );
+          issue.parent = rootNote!.id;
           await engine.writeNote(issue, { newNode: true });
           const resp = await pod.execute({
             engine,

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -440,24 +440,22 @@ suite("MoveNoteCommand", function () {
       ctx,
       preSetupHook: async ({ wsRoot, vaults }) => {
         await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
-        await NoteTestUtilsV4.createNote({
-          fname: "scratch.2020.02.03.0123",
-          vault: vaults[0],
-          wsRoot,
-        });
       },
       onInit: async ({ engine, vaults, wsRoot }) => {
+        const ext = ExtensionProvider.getExtension();
         const notes = engine.notes;
         const vault1 = vaults[0];
         const vault2 = vaults[0];
         const fname = "scratch.2020.02.03.0123";
-        const fooNote = NoteUtils.getNoteByFnameV5({
+
+        const scratchNote = await NoteTestUtilsV4.createNoteWithEngine({
           fname,
-          notes,
-          vault: vault1,
+          vault: vaults[0],
           wsRoot,
-        }) as NoteProps;
-        await WSUtils.openNote(fooNote);
+          engine,
+        });
+
+        await ext.wsUtils.openNote(scratchNote);
         const cmd = new MoveNoteCommand();
         await cmd.execute({
           moves: [


### PR DESCRIPTION
# fix: write note orphans child notes

This PR:
- fixes a bug where overwriting an existing note's id will result in:
  - stale children props of the parent of the note
  - orphaned children of the written note
- generally refactors code that this edge case covers in `_writeNewNote` and add omitted relevant note change entries.
- adds the test that was skipped in `EngineEvents.spec.ts` that this bug was blocking.

No added circ dependencies.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)