### PR TITLE
fix(vaults): Use exact match when getting vault by dir path

### DIFF
--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -103,7 +103,7 @@ export class VaultUtils {
       fsPath,
     });
     const vault = _.find(vaults, (ent) => {
-      return normPath.startsWith(VaultUtils.getRelPath(ent));
+      return normPath.trim() === VaultUtils.getRelPath(ent).trim();
     });
     if (!vault) {
       throw new DendronError({

--- a/packages/engine-test-utils/src/__tests__/common-all/vault.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/vault.spec.ts
@@ -1,4 +1,4 @@
-import { VaultUtils } from "@dendronhq/common-all";
+import { DendronError, DVault, VaultUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import path from "path";
 import { runEngineTestV5 } from "../../engine";
@@ -13,6 +13,21 @@ describe("VaultUtils", () => {
           expect(
             VaultUtils.getVaultByDirPath({ vaults, wsRoot, fsPath })
           ).toEqual(_.find(engine.vaults, (ent) => ent.fsPath === "vault1"));
+        },
+        {
+          expect,
+        }
+      );
+    });
+
+    test("If no vault with exact name exists, return dendron error", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot }) => {
+          const test: DVault[] = [{ fsPath: "vault" }];
+          const fsPath = path.join(wsRoot, "vault1");
+          expect(() =>
+            VaultUtils.getVaultByDirPath({ vaults: test, wsRoot, fsPath })
+          ).toThrow(DendronError);
         },
         {
           expect,


### PR DESCRIPTION
**Change**
Update `getVaultByDirPath` to return exact match.

** Bug**
If vault to search has name "vault1", the method can return vaults that equal "vault", "va", etc..

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)