### PR TITLE
fix(views): md parsing and preview perf improvements

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -818,30 +818,6 @@ export class NoteUtils {
     return latestUpdated;
   }
 
-  /** @deprecated see {@link NoteUtils.getNotesByFnameFromEngine} */
-  static getNotesByFname({
-    fname,
-    notes,
-    vault,
-  }: {
-    fname: string;
-    notes: NotePropsDict | NoteProps[];
-    vault?: DVault;
-  }): NoteProps[] {
-    if (!_.isArray(notes)) {
-      notes = _.values(notes);
-    }
-    const lowercaseFName = fname.toLowerCase();
-
-    const out = _.filter(notes, (ent) => {
-      return (
-        ent.fname.toLowerCase() === lowercaseFName &&
-        (vault ? ent.vault.fsPath === vault.fsPath : true)
-      );
-    });
-    return out;
-  }
-
   static getNotesByFnameFromEngine({
     fname,
     engine,

--- a/packages/engine-server/src/changelog/changelog.ts
+++ b/packages/engine-server/src/changelog/changelog.ts
@@ -48,15 +48,14 @@ function canShowDiff(opts: {
   filePath: string;
 }): boolean {
   const { engine, filePath } = opts;
-  const { wsRoot, vaults: vaults } = engine;
+  const { vaults } = engine;
   return vaults.some((vault) => {
     if (filePath.startsWith(vault.fsPath) && filePath.endsWith(".md")) {
       const fname = path.basename(filePath.split(vault.fsPath)[1], ".md");
-      const note = NoteUtils.getNoteByFnameV5({
+      const note = NoteUtils.getNoteByFnameFromEngine({
         fname,
-        notes: engine.notes,
+        engine,
         vault,
-        wsRoot,
       });
       if (!note) {
         return false;

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -391,11 +391,10 @@ export class DendronEngineV2 implements DEngine {
   }: GetNoteOptsV2): Promise<RespV2<GetNotePayload>> {
     const ctx = "getNoteByPath";
     this.logger.debug({ ctx, npath, createIfNew, msg: "enter" });
-    const maybeNote = NoteUtils.getNoteByFnameV5({
+    const maybeNote = NoteUtils.getNoteByFnameFromEngine({
       fname: npath,
-      notes: this.notes,
+      engine: this,
       vault,
-      wsRoot: this.wsRoot,
     });
     this.logger.debug({ ctx, maybeNote, msg: "post-query" });
     let noteNew: NoteProps | undefined = maybeNote;

--- a/packages/engine-server/src/markdown/decorations/taskNotes.ts
+++ b/packages/engine-server/src/markdown/decorations/taskNotes.ts
@@ -32,13 +32,12 @@ export function decorateTaskNote({
   const vault = vaultName
     ? VaultUtils.getVaultByName({ vname: vaultName, vaults })
     : undefined;
-  if (!vault) return;
 
-  const note = NoteUtils.getNoteByFnameFromEngine({
+  const note = NoteUtils.getNotesByFnameFromEngine({
     fname,
     vault,
     engine,
-  });
+  })[0];
   if (!note || !TaskNoteUtils.isTaskNote(note)) return;
 
   // Determines whether the task link is preceded by an empty or full checkbox

--- a/packages/engine-server/src/markdown/decorations/taskNotes.ts
+++ b/packages/engine-server/src/markdown/decorations/taskNotes.ts
@@ -1,14 +1,13 @@
 import {
   ConfigUtils,
   DEngine,
-  NoteProps,
   NoteUtils,
   TaskNoteUtils,
   VaultUtils,
   VSRange,
 } from "@dendronhq/common-all";
 import _ from "lodash";
-import { DECORATION_TYPES, Decoration } from "./utils";
+import { Decoration, DECORATION_TYPES } from "./utils";
 
 export type DecorationTaskNote = Decoration & {
   type: DECORATION_TYPES.taskNote;
@@ -28,16 +27,18 @@ export function decorateTaskNote({
   fname: string;
   vaultName?: string;
 }) {
-  const { notes, vaults, config } = engine;
+  const { vaults, config } = engine;
   const taskConfig = ConfigUtils.getTask(config);
   const vault = vaultName
     ? VaultUtils.getVaultByName({ vname: vaultName, vaults })
     : undefined;
-  const note: NoteProps | undefined = NoteUtils.getNotesByFname({
+  if (!vault) return;
+
+  const note = NoteUtils.getNoteByFnameFromEngine({
     fname,
     vault,
-    notes,
-  })[0];
+    engine,
+  });
   if (!note || !TaskNoteUtils.isTaskNote(note)) return;
 
   // Determines whether the task link is preceded by an empty or full checkbox

--- a/packages/engine-server/src/markdown/remark/backlinks.ts
+++ b/packages/engine-server/src/markdown/remark/backlinks.ts
@@ -23,11 +23,10 @@ const plugin: Plugin = function (this: Unified.Processor) {
       return;
     }
     const { engine } = MDUtilsV4.getEngineFromProc(proc);
-    const note = NoteUtils.getNoteByFnameV5({
+    const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
-      notes: engine.notes,
-      vault: vault!,
-      wsRoot: engine.wsRoot,
+      engine,
+      vault,
     });
     if (_.isUndefined(note)) {
       return;
@@ -44,13 +43,11 @@ const plugin: Plugin = function (this: Unified.Processor) {
         vaults: engine.vaults,
         vname: vaultName,
       })!;
-      const note = NoteUtils.getNoteByFnameV5({
+      const note = NoteUtils.getNoteByFnameFromEngine({
         fname: backlink.from.fname!,
-        notes: engine.notes,
+        engine,
         vault,
-        wsRoot: engine.wsRoot,
       });
-
       if (!note) {
         return false;
       }

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -155,7 +155,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
 
       // Special Logic for 403 Error Static Page:
       if (fname === "403") {
-        note = SiteUtils.addSiteOnlyNotes({ engine })[0];
+        note = SiteUtils.create403StaticNote({ engine });
       } else {
         note = NoteUtils.getNoteByFnameFromEngine({
           fname,

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -151,11 +151,19 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           )}`,
         });
       }
-      const note = NoteUtils.getNoteByFnameFromEngine({
-        fname,
-        vault,
-        engine,
-      });
+      let note;
+
+      // Special Logic for 403 Error Static Page:
+      if (fname === "403") {
+        note = SiteUtils.addSiteOnlyNotes({ engine })[0];
+      } else {
+        note = NoteUtils.getNoteByFnameFromEngine({
+          fname,
+          vault,
+          engine,
+        });
+      }
+
       if (!note) {
         throw new DendronError({ message: `no note found for ${fname}` });
       }

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -42,7 +42,6 @@ import { extendedImage2html } from "./extendedImage";
 import { convertNoteRefASTV2, NoteRefsOptsV2 } from "./noteRefsV2";
 import {
   addError,
-  getNoteOrError,
   hashTag2WikiLinkNoteV4,
   RemarkUtils,
   userTag2WikiLinkNoteV4,
@@ -152,7 +151,11 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           )}`,
         });
       }
-      const note = MDUtilsV5.getNoteByFname(proc, { fname });
+      const note = NoteUtils.getNoteByFnameFromEngine({
+        fname,
+        vault,
+        engine,
+      });
       if (!note) {
         throw new DendronError({ message: `no note found for ${fname}` });
       }
@@ -218,14 +221,15 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         let error: DendronError | undefined;
         let note: NoteProps | undefined;
         if (mode !== ProcMode.IMPORT) {
-          const notes = NoteUtils.getNotesByFname({
+          note = NoteUtils.getNoteByFnameFromEngine({
             fname: valueOrig,
-            notes: engine.notes,
             vault,
+            engine,
           });
-          const out = getNoteOrError(notes, value);
-          error = out.error;
-          note = out.note;
+
+          if (!note) {
+            error = new DendronError({ message: `no note found. ${value}` });
+          }
         }
 
         let color: string | undefined;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -496,7 +496,7 @@ export class LinkUtils {
     engine: DEngineClient;
   }) {
     const { activeNote, wikiLinks, engine } = opts;
-    const { vaults, notes, wsRoot } = engine;
+    const { vaults } = engine;
 
     let out: DNodeProps[] = [];
     wikiLinks.forEach((wikiLink) => {
@@ -510,19 +510,18 @@ export class LinkUtils {
         : undefined;
 
       if (vault) {
-        const note = NoteUtils.getNoteByFnameV5({
+        const note = NoteUtils.getNoteByFnameFromEngine({
           fname,
-          notes,
+          engine,
           vault,
-          wsRoot,
         });
         if (note) {
           out.push(note);
         }
       } else {
-        const notesWithSameFname = NoteUtils.getNotesByFname({
+        const notesWithSameFname = NoteUtils.getNotesByFnameFromEngine({
           fname,
-          notes,
+          engine,
         });
         out = out.concat(notesWithSameFname);
       }

--- a/packages/engine-server/src/markdown/remark/wikiLinks.ts
+++ b/packages/engine-server/src/markdown/remark/wikiLinks.ts
@@ -99,8 +99,8 @@ function attachCompiler(proc: Unified.Processor, opts?: CompilerOpts) {
         return `[[${calias}${vaultPrefix}${link}${anchor}]]`;
       }
 
-      const { dest } = MDUtilsV4.getDendronData(proc);
-      const vault = MDUtilsV4.getVault(proc, data.vaultName);
+      const { dest, vault } = MDUtilsV5.getProcData(proc);
+
       // if converting back to dendron md, no further processing
       if (dest === DendronASTDest.MD_DENDRON) {
         return LinkUtils.renderNoteLink({
@@ -129,10 +129,10 @@ function attachCompiler(proc: Unified.Processor, opts?: CompilerOpts) {
 
       if (copts.useId && dest === DendronASTDest.HTML) {
         // TODO: check for vault
-        const notes = NoteUtils.getNotesByFname({
+        const notes = NoteUtils.getNotesByFnameFromEngine({
           fname: value,
-          notes: engine.notes,
           vault,
+          engine,
         });
         const { error, note } = getNoteOrError(notes, value);
         if (error) {
@@ -243,12 +243,10 @@ function attachParser(proc: Unified.Processor) {
       out.alias === out.value &&
       vault
     ) {
-      const wsRoot = engine.wsRoot;
-      const note = NoteUtils.getNoteByFnameV5({
+      const note = NoteUtils.getNoteByFnameFromEngine({
         fname: out.value,
-        notes: engine.notes,
+        engine,
         vault,
-        wsRoot,
       });
       if (note) {
         out.alias = note.title;

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -171,19 +171,6 @@ export class MDUtilsV5 {
     return _data || {};
   }
 
-  static getNoteByFname(proc: Processor, { fname }: { fname: string }) {
-    const { notes, vault, wsRoot } = this.getProcData(proc);
-    // TODO: this is for backwards compatibility
-    const { engine } = MDUtilsV4.getEngineFromProc(proc);
-    const note = NoteUtils.getNoteByFnameV5({
-      fname,
-      notes: notes || engine.notes,
-      vault,
-      wsRoot,
-    });
-    return note;
-  }
-
   static getProcData(proc: Processor): ProcDataFullV5 {
     let _data = proc.data("dendronProcDatav5") as ProcDataFullV5;
 
@@ -304,12 +291,11 @@ export class MDUtilsV5 {
             data.wsRoot = data.engine!.wsRoot;
           }
 
-          const note = NoteUtils.getNoteByFnameV5({
+          const note = NoteUtils.getNoteByFnameFromEngine({
             fname: data.fname!,
-            notes: data.engine!.notes,
+            engine: data.engine!,
             vault: data.vault!,
-            wsRoot: data.wsRoot,
-          }) as NoteProps;
+          });
 
           if (!_.isUndefined(note)) {
             proc = proc.data("fm", this.getFM({ note, wsRoot: data.wsRoot }));
@@ -431,7 +417,7 @@ export class MDUtilsV5 {
     });
 
     // add additional plugin for publishing
-
+    //maybe something here is interfering
     let pRehype = pRemarkParse
       .use(remark2rehype, { allowDangerousHtml: true })
       .use(rehypePrism, { ignoreMissing: true })

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -417,7 +417,6 @@ export class MDUtilsV5 {
     });
 
     // add additional plugin for publishing
-    //maybe something here is interfering
     let pRehype = pRemarkParse
       .use(remark2rehype, { allowDangerousHtml: true })
       .use(rehypePrism, { ignoreMissing: true })

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -240,9 +240,9 @@ export class SiteUtils {
     const notesForHiearchy = _.clone(engine.notes);
 
     // get the domain note
-    const notes = NoteUtils.getNotesByFname({
+    const notes = NoteUtils.getNotesByFnameFromEngine({
       fname: domain,
-      notes: notesForHiearchy,
+      engine,
     });
     logger.info({
       ctx: "filterByHiearchy:candidates",
@@ -474,11 +474,10 @@ export class SiteUtils {
           vname,
           vaults: engine.vaults,
         });
-        const maybeNote = NoteUtils.getNoteByFnameV5({
+        const maybeNote = NoteUtils.getNoteByFnameFromEngine({
           fname,
-          notes: noteDict,
+          engine,
           vault,
-          wsRoot: engine.wsRoot,
         });
         if (maybeNote && maybeNote.stub && !allowStubs) {
           return;

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -125,10 +125,14 @@ export class SiteUtils {
     return;
   }
 
-  static addSiteOnlyNotes(opts: { engine: DEngineClient }) {
+  /**
+   * Creates a placeholder note that can be used for rendering a 403 error
+   * message.
+   */
+  static create403StaticNote(opts: { engine: DEngineClient }) {
     const { engine } = opts;
     const vaults = engine.vaults;
-    const note = NoteUtils.create({
+    return NoteUtils.create({
       vault: vaults[0],
       fname: "403",
       id: "403",
@@ -139,7 +143,12 @@ export class SiteUtils {
         "![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/not-sprouted.png)",
       ].join("\n"),
     });
-    return [note];
+  }
+
+  static createSiteOnlyNotes(opts: { engine: DEngineClient }) {
+    const { engine } = opts;
+    const note403 = this.create403StaticNote({ engine });
+    return [note403];
   }
 
   static async filterByConfig(opts: {

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -635,7 +635,7 @@ export class NoteLookupCommand
     const engine = ExtensionProvider.getEngine();
 
     const vaultsWithMatchingFile = new Set(
-      NoteUtils.getNotesByFname({ fname, notes: engine.notes }).map(
+      NoteUtils.getNotesByFnameFromEngine({ fname, engine }).map(
         (n) => n.vault.fsPath
       )
     );

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -364,12 +364,13 @@ export async function provideBlockCompletionItems(
         })
       : undefined;
     // If we couldn't find the linked note, don't do anything
-    if (_.isNull(link) || _.isUndefined(link.value)) return;
-    note = NoteUtils.getNotesByFname({
+    if (_.isNull(link) || _.isUndefined(link.value) || _.isUndefined(vault))
+      return;
+    note = NoteUtils.getNoteByFnameFromEngine({
       fname: link.value,
       vault,
-      notes: engine.notes,
-    })[0];
+      engine,
+    });
     otherFile = true;
   } else {
     // This anchor is to the same file, e.g. [[#

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -364,13 +364,12 @@ export async function provideBlockCompletionItems(
         })
       : undefined;
     // If we couldn't find the linked note, don't do anything
-    if (_.isNull(link) || _.isUndefined(link.value) || _.isUndefined(vault))
-      return;
-    note = NoteUtils.getNoteByFnameFromEngine({
+    if (_.isNull(link) || _.isUndefined(link.value)) return;
+    note = NoteUtils.getNotesByFnameFromEngine({
       fname: link.value,
       vault,
       engine,
-    });
+    })[0];
     otherFile = true;
   } else {
     // This anchor is to the same file, e.g. [[#

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -56,9 +56,9 @@ suite("completionProvider", function () {
           expect(items!.length).toEqual(7);
           for (const item of items!) {
             // All suggested items exist
-            const found = NoteUtils.getNotesByFname({
+            const found = NoteUtils.getNotesByFnameFromEngine({
               fname: item.label as string,
-              notes: engine.notes,
+              engine,
             });
             expect(found.length > 0).toBeTruthy();
           }
@@ -134,9 +134,9 @@ suite("completionProvider", function () {
           expect(items!.length).toEqual(2);
           for (const item of items!) {
             // All suggested items exist
-            const found = NoteUtils.getNotesByFname({
+            const found = NoteUtils.getNotesByFnameFromEngine({
               fname: `${TAGS_HIERARCHY}${item.label}`,
-              notes: engine.notes,
+              engine,
             });
             expect(found.length > 0).toBeTruthy();
           }
@@ -185,9 +185,9 @@ suite("completionProvider", function () {
           expect(items!.length).toEqual(2);
           for (const item of items!) {
             // All suggested items exist
-            const found = NoteUtils.getNotesByFname({
+            const found = NoteUtils.getNotesByFnameFromEngine({
               fname: `${TAGS_HIERARCHY}${item.label}`,
-              notes: engine.notes,
+              engine,
             });
             expect(found.length > 0).toBeTruthy();
           }
@@ -236,9 +236,9 @@ suite("completionProvider", function () {
           expect(items!.length).toEqual(2);
           for (const item of items!) {
             // All suggested items exist
-            const found = NoteUtils.getNotesByFname({
+            const found = NoteUtils.getNotesByFnameFromEngine({
               fname: `${USERS_HIERARCHY}${item.label}`,
-              notes: engine.notes,
+              engine,
             });
             expect(found.length > 0).toBeTruthy();
           }

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -34,7 +34,6 @@ import vscode, {
 } from "vscode";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 
 export type RefT = {
   label: string;
@@ -459,7 +458,7 @@ export const noteLinks2Locations = (note: NoteProps) => {
   const linksMatch = note.links.filter((l) => l.type !== "backlink");
   const fsPath = NoteUtils.getFullPath({
     note,
-    wsRoot: getDWorkspace().wsRoot,
+    wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
   });
   const fileContent = fs.readFileSync(fsPath).toString();
   const fmOffset = fileContent.indexOf("\n---") + 4;
@@ -495,9 +494,13 @@ export const findReferences = async (
 ): Promise<FoundRefT[]> => {
   const refs: FoundRefT[] = [];
 
-  const { engine } = getDWorkspace();
+  const engine = ExtensionProvider.getEngine();
   // clean for anchor
-  const notes = NoteUtils.getNotesByFname({ fname, notes: engine.notes });
+  const notes = NoteUtils.getNotesByFnameFromEngine({
+    fname,
+    engine,
+  });
+
   const notesWithRefs = await Promise.all(
     notes.flatMap((note) => {
       return NoteUtils.getNotesWithLinkTo({
@@ -513,7 +516,7 @@ export const findReferences = async (
     );
     const fsPath = NoteUtils.getFullPath({
       note,
-      wsRoot: getDWorkspace().wsRoot,
+      wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
     });
 
     if (excludePaths.includes(fsPath) || !fs.existsSync(fsPath)) {

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -255,7 +255,7 @@ export class AirtableUtils {
           note,
           filters: fieldMapping.filter ? [fieldMapping.filter] : [],
         });
-        const { vaults, notes } = engine;
+        const { vaults } = engine;
         const notesWithNoIds: NoteProps[] = [];
         const recordIds = links.flatMap((l) => {
           if (_.isUndefined(l.to)) {
@@ -268,7 +268,11 @@ export class AirtableUtils {
           const vault = vaultName
             ? VaultUtils.getVaultByName({ vaults, vname: vaultName })
             : undefined;
-          const _notes = NoteUtils.getNotesByFname({ fname, notes, vault });
+          const _notes = NoteUtils.getNotesByFnameFromEngine({
+            fname,
+            engine,
+            vault,
+          });
           const _recordIds = _notes
             .map((n) => {
               const id = AirtableUtils.getAirtableIdFromNote(n);

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -415,7 +415,7 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
       config: engineConfig,
       noExpandSingleDomain: true,
     });
-    const siteNotes = SiteUtils.addSiteOnlyNotes({
+    const siteNotes = SiteUtils.createSiteOnlyNotes({
       engine,
     });
     _.forEach(siteNotes, (ent) => {


### PR DESCRIPTION
## fix(views): md parsing and preview perf improvements

I was doing some perf testing on preview, and I found that for notes with a lot of links and tags, the render time was O(n), where n is the number of notes in the workspace.  This was true even if all of the notes or tags were the exact same link, just repeated hundreds of times. 

I tracked this down to some code in `dendronPub.ts` which was using the legacy `getNoteByFnameV5` instead of the new `getNoteByFnameFromEngine`.  The legacy `getNoteByFnameV5` and `getNotesByFnameV5` are O(n) for note lookup, whereas the new versions are ~O(1) due to using a dictionary/hash-map implementation. 

Given the pervasive use of the legacy calls, I started to scrub through to upgrade many existing instances to the new ones, which should result in performance improvements across many different kinds of operations, from preview, publishing, to many other commands as well, including writing notes.  In this PR, I've fully scrubbed out the plural version `getNotesByFnameV5`.  `getNoteByFnameV5` is more pervasive, so that'll be deferred to a later change.

Some results: rendering our super heavy [[Backlog|dendron://private/dendron.tasks.backlog]] note, which has about 300 links/tags, is down from 1500-2000 ms range to 50-200 ms range, which is a notable difference.

We should also add some perf test suites, but I'll defer that to a separate change.

---

## Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] -1 circular dependency. (18->17) circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)