### PR TITLE
DRAFT - feat(pods): Airtable export v2 to support multiple ids

### DIFF
--- a/packages/dendron-cli/src/commands/exportPodV2.ts
+++ b/packages/dendron-cli/src/commands/exportPodV2.ts
@@ -156,7 +156,11 @@ export class ExportPodV2CLICommand extends CLICommand<
     const { exportReturnValue, podType, engine, config } = opts;
     switch (podType) {
       case PodV2Types.AirtableExportV2:
-        return this.onAirtableExportComplete({ exportReturnValue, engine });
+        return this.onAirtableExportComplete({
+          exportReturnValue,
+          engine,
+          podId: config.podId,
+        });
       case PodV2Types.GoogleDocsExportV2:
         return this.onGoogleDocsExportComplete({ exportReturnValue, engine });
       case PodV2Types.NotionExportV2:
@@ -173,14 +177,16 @@ export class ExportPodV2CLICommand extends CLICommand<
   async onAirtableExportComplete(opts: {
     exportReturnValue: AirtableExportReturnType;
     engine: DEngineClient;
+    podId?: string;
   }) {
-    const { exportReturnValue, engine } = opts;
+    const { exportReturnValue, engine, podId } = opts;
     const records = exportReturnValue.data;
     if (records?.created) {
-      await AirtableUtils.updateAirtableIdForNewlySyncedNotes({
+      await AirtableUtils.updateMedataFileForNewlySyncedNotes({
         records: records.created,
         engine,
         logger: this.L,
+        podId,
       });
     }
     const createdCount = exportReturnValue.data?.created?.length ?? 0;

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -29,6 +29,7 @@ export enum DoctorActionsEnum {
   REGENERATE_NOTE_ID = "regenerateNoteId",
   FIND_BROKEN_LINKS = "findBrokenLinks",
   FIX_REMOTE_VAULTS = "fixRemoteVaults",
+  UPDATE_AIRTABLE_METADATA = "updateAirtableMetadata",
 }
 
 export type DoctorServiceOpts = {
@@ -329,6 +330,20 @@ export class DoctorService implements Disposable {
           })
         );
         return { exit: true };
+      }
+      case DoctorActionsEnum.UPDATE_AIRTABLE_METADATA: {
+        resp = [];
+        doctorAction = async (note: NoteProps) => {
+          //get airtable id from note
+          const airtableId = _.get(note.custom, "airtableId") as string;
+          // get note id
+          const dendronId = note.id;
+          resp.push({ dendronId, airtableId });
+          delete note.custom["airtableId"];
+          // update note
+          engine.writeNote(note, { updateExisting: true });
+        };
+        break;
       }
       default:
         throw new DendronError({

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -445,6 +445,10 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
             VaultUtils.isEqualV2(value.vault, vault) &&
             value.custom.airtableId
         );
+        this.L.info({
+          ctx,
+          msg: `${DoctorActionsEnum.UPDATE_AIRTABLE_METADATA} candidates: ${candidates.length}`,
+        });
         const ds = new DoctorService();
         const out = await ds.executeDoctorActions({
           action: opts.action,

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -94,6 +94,10 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
     this.extension = ext;
   }
 
+  getHierarchy() {
+    return new QuickPickHierarchySelector().getHierarchy();
+  }
+
   createQuickPick(opts: CreateQuickPickOpts) {
     const { title, placeholder, ignoreFocusOut, items } = _.defaults(opts, {
       ignoreFocusOut: true,
@@ -428,7 +432,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActionsEnum.UPDATE_AIRTABLE_METADATA: {
-        const selection = await new QuickPickHierarchySelector().getHierarchy();
+        const selection = await this.getHierarchy();
         if (!selection) break;
         const { hierarchy, vault } = selection;
         const podId = await PodUIControls.promptToSelectCustomPodId();

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -178,6 +178,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
     const records = exportReturnValue.data;
     const engine = ExtensionProvider.getEngine();
     const logger = this.L;
+    let errorMsg;
     if (records?.created) {
       await AirtableUtils.updateMedataFileForNewlySyncedNotes({
         records: records.created,
@@ -191,7 +192,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
     const updatedCount = exportReturnValue.data?.updated?.length ?? 0;
 
     if (ResponseUtil.hasError(exportReturnValue)) {
-      const errorMsg = `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated. Error encountered: ${ErrorFactory.safeStringify(
+      errorMsg = `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated. Error encountered: ${ErrorFactory.safeStringify(
         exportReturnValue.error
       )}`;
 
@@ -201,6 +202,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
         `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated.`
       );
     }
+    return errorMsg;
   }
 
   /**

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -1,5 +1,5 @@
 import Airtable from "@dendronhq/airtable";
-import { ErrorFactory, NoteProps, ResponseUtil } from "@dendronhq/common-all";
+import { ErrorFactory, ResponseUtil } from "@dendronhq/common-all";
 import {
   AirtableConnection,
   AirtableExportPodV2,
@@ -170,19 +170,20 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
    */
   public async onExportComplete({
     exportReturnValue,
+    config,
   }: {
     exportReturnValue: AirtableExportReturnType;
     config: RunnableAirtableV2PodConfig;
-    payload: NoteProps[];
   }) {
     const records = exportReturnValue.data;
     const engine = ExtensionProvider.getEngine();
     const logger = this.L;
     if (records?.created) {
-      await AirtableUtils.updateAirtableIdForNewlySyncedNotes({
+      await AirtableUtils.updateMedataFileForNewlySyncedNotes({
         records: records.created,
         engine,
         logger,
+        podId: config.podId,
       });
     }
 

--- a/packages/plugin-core/src/components/lookup/HierarchySelector.ts
+++ b/packages/plugin-core/src/components/lookup/HierarchySelector.ts
@@ -15,10 +15,10 @@ import { NoteLookupProviderUtils } from "./NoteLookupProviderUtils";
 export interface HierarchySelector {
   /**
    * A method for getting the hierarchy in an async manner. Returning undefined
-   * should be interpreted that no hierarchy was selected. It also returns the 
+   * should be interpreted that no hierarchy was selected. It also returns the
    * vault of selected hierarchy.
    */
-  getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined>;
+  getHierarchy(): Promise<{ hierarchy: string; vault: DVault } | undefined>;
 }
 
 /**
@@ -26,68 +26,73 @@ export interface HierarchySelector {
  * controller V3.
  */
 export class QuickPickHierarchySelector implements HierarchySelector {
-  getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined> {
-    return new Promise<{hierarchy: string, vault: DVault} | undefined>((resolve) => {
-      const lookupCreateOpts: LookupControllerV3CreateOpts = {
-        nodeType: "note",
-        disableVaultSelection: true,
-      };
-      const extension = ExtensionProvider.getExtension();
-      const lc = extension.lookupControllerFactory.create(lookupCreateOpts);
+  getHierarchy(): Promise<{ hierarchy: string; vault: DVault } | undefined> {
+    return new Promise<{ hierarchy: string; vault: DVault } | undefined>(
+      (resolve) => {
+        const lookupCreateOpts: LookupControllerV3CreateOpts = {
+          nodeType: "note",
+          disableVaultSelection: true,
+        };
+        const extension = ExtensionProvider.getExtension();
+        const lc = extension.lookupControllerFactory.create(lookupCreateOpts);
 
-      const PROVIDER_ID: string = "HierarchySelector";
+        const PROVIDER_ID: string = "HierarchySelector";
 
-      const provider = extension.noteLookupProviderFactory.create(PROVIDER_ID, {
-        allowNewNote: false,
-        forceAsIsPickerValueUsage: true,
-      });
-
-      const defaultNoteName = path.basename(
-        VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath || "",
-        ".md"
-      );
-
-      NoteLookupProviderUtils.subscribe({
-        id: PROVIDER_ID,
-        controller: lc,
-        logger: Logger,
-        onHide: () => {
-          resolve(undefined);
-          NoteLookupProviderUtils.cleanup({
-            id: PROVIDER_ID,
-            controller: lc,
-          });
-        },
-        onDone: async (event: HistoryEvent) => {
-          const data = event.data;
-          if (data.cancel) {
-            resolve(undefined);
-          } else {
-            const hierarchy = data.selectedItems[0].fname;
-            const vault = data.selectedItems[0].vault;
-            resolve({hierarchy, vault});
+        const provider = extension.noteLookupProviderFactory.create(
+          PROVIDER_ID,
+          {
+            allowNewNote: false,
+            forceAsIsPickerValueUsage: true,
           }
-          NoteLookupProviderUtils.cleanup({
-            id: PROVIDER_ID,
-            controller: lc,
-          });
-        },
-        onError: (event: HistoryEvent) => {
-          const error = event.data.error as DendronError;
-          vscode.window.showErrorMessage(error.message);
-          resolve(undefined);
-          NoteLookupProviderUtils.cleanup({
-            id: PROVIDER_ID,
-            controller: lc,
-          });
-        },
-      });
-      lc.show({
-        placeholder: "Enter Hierarchy Name",
-        provider,
-        initialValue: defaultNoteName,
-        title: `Select Hierarchy for Export`,
-      });
-    });
+        );
+
+        const defaultNoteName = path.basename(
+          VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath || "",
+          ".md"
+        );
+
+        NoteLookupProviderUtils.subscribe({
+          id: PROVIDER_ID,
+          controller: lc,
+          logger: Logger,
+          onHide: () => {
+            resolve(undefined);
+            NoteLookupProviderUtils.cleanup({
+              id: PROVIDER_ID,
+              controller: lc,
+            });
+          },
+          onDone: async (event: HistoryEvent) => {
+            const data = event.data;
+            if (data.cancel) {
+              resolve(undefined);
+            } else {
+              const hierarchy = data.selectedItems[0].fname;
+              const vault = data.selectedItems[0].vault;
+              resolve({ hierarchy, vault });
+            }
+            NoteLookupProviderUtils.cleanup({
+              id: PROVIDER_ID,
+              controller: lc,
+            });
+          },
+          onError: (event: HistoryEvent) => {
+            const error = event.data.error as DendronError;
+            vscode.window.showErrorMessage(error.message);
+            resolve(undefined);
+            NoteLookupProviderUtils.cleanup({
+              id: PROVIDER_ID,
+              controller: lc,
+            });
+          },
+        });
+        lc.show({
+          placeholder: "Enter Hierarchy Name",
+          provider,
+          initialValue: defaultNoteName,
+          title: `Select Hierarchy`,
+        });
+      }
+    );
   }
 }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -531,4 +531,19 @@ export class PodUIControls {
         assertUnreachable(type);
     }
   }
+
+  // Promt user to select custom pod Id
+  public static async promptToSelectCustomPodId(): Promise<string | undefined> {
+    const configs = PodV2ConfigManager.getAllPodConfigs(
+      path.join(getExtension().podsDir, "custom")
+    );
+    const items = configs.map<QuickPickItem>((value) => {
+      return { label: value.podId, description: value.podType };
+    });
+    const podIdQuickPick = await VSCodeUtils.showQuickPick(items, {
+      title: "Pick a pod configuration Id",
+      ignoreFocusOut: true,
+    });
+    return podIdQuickPick?.label;
+  }
 }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -532,7 +532,7 @@ export class PodUIControls {
     }
   }
 
-  // Promt user to select custom pod Id
+  // Prompt user to select custom pod Id
   public static async promptToSelectCustomPodId(): Promise<string | undefined> {
     const configs = PodV2ConfigManager.getAllPodConfigs(
       path.join(getExtension().podsDir, "custom")

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -723,7 +723,7 @@ suite("UPDATE_AIRTABLE_METADATA", function () {
       ctx,
     },
     () => {
-      test.only("THEN remove airtableId from note FM and update metadata.json", async () => {
+      test("THEN remove airtableId from note FM and update metadata.json", async () => {
         const ext = ExtensionProvider.getExtension();
         const engine = ext.getEngine();
         const cmd = new DoctorCommand(ext);

--- a/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportCommand.test.ts
@@ -1,0 +1,122 @@
+import { PodExportScope, PodUtils } from "@dendronhq/pods-core";
+import { describe } from "mocha";
+import * as vscode from "vscode";
+import { expect, getNoteFromTextEditor } from "../../../testUtilsv2";
+import { describeSingleWS, setupBeforeAfter } from "../../../testUtilsV3";
+import { AirtableExportPodCommand } from "../../../../commands/pods/AirtableExportPodCommand";
+import { ExtensionProvider } from "../../../../ExtensionProvider";
+import fs from "fs-extra";
+import { vault2Path } from "@dendronhq/common-server";
+import path from "path";
+import { VSCodeUtils } from "../../../../vsCodeUtils";
+import { DendronError, DVault, ErrorFactory } from "@dendronhq/common-all";
+
+suite("AirtableExportCommand", function () {
+  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
+    beforeHook: () => {},
+  });
+  const setUpPod = (opts: { wsRoot: string; vaults: DVault[] }) => {
+    const { wsRoot, vaults } = opts;
+    const notePath = path.join(
+      vault2Path({ vault: vaults[0], wsRoot }),
+      "root.md"
+    );
+    const config = {
+      podId: "dendron.task",
+      exportScope: PodExportScope.Note,
+      apiKey: "fakeKey",
+      baseId: "fakeBase",
+      tableName: "fakeTable",
+      sourceFieldMapping: {},
+    };
+    return { notePath, config };
+  };
+
+  describe("GIVEN AirtableExportPodCommand is run with Note scope", () => {
+    const cmd = new AirtableExportPodCommand();
+    describeSingleWS(
+      "WHEN note is succesfully exported",
+      {
+        ctx,
+      },
+      () => {
+        test("THEN metadata file should be updated", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const { notePath, config } = setUpPod({ wsRoot, vaults });
+          await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+          const note = getNoteFromTextEditor();
+          const payload = await cmd.enrichInputs(config);
+          const airtableId = "airtable-proj.beta";
+          const DendronId = note.id;
+          const result = {
+            data: {
+              created: [
+                {
+                  fields: {
+                    DendronId,
+                  },
+                  id: airtableId,
+                },
+              ],
+              updated: [],
+            },
+            error: null,
+          };
+          await cmd.onExportComplete({
+            exportReturnValue: result as any,
+            config: payload?.config!,
+          });
+          const filePath = PodUtils.getPodMetadataJsonFilePath({
+            wsRoot,
+            vault: vaults[0],
+            podId: payload?.config.podId,
+          });
+          expect(fs.pathExistsSync(filePath)).toBeTruthy();
+          const data = PodUtils.readMetadataFromFilepath(filePath);
+          expect(data.length).toEqual(1);
+          expect(data[0].airtableId).toEqual(airtableId);
+          expect(data[0].dendronId).toEqual(DendronId);
+        });
+      }
+    );
+    describeSingleWS(
+      "AND WHEN there is an error in response",
+      {
+        ctx,
+      },
+      () => {
+        test("THEN metadata file should not be updated", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const { notePath, config } = setUpPod({ wsRoot, vaults });
+          await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+          const payload = await cmd.enrichInputs(config);
+          const result = {
+            data: {
+              created: [],
+              updated: [],
+            },
+            error: new DendronError({
+              message: "Request failed with status code 422",
+            }),
+          };
+          const resp = await cmd.onExportComplete({
+            exportReturnValue: result as any,
+            config: payload?.config!,
+          });
+          const filePath = PodUtils.getPodMetadataJsonFilePath({
+            wsRoot,
+            vault: vaults[0],
+            podId: payload?.config.podId,
+          });
+          const data = PodUtils.readMetadataFromFilepath(filePath);
+          expect(data).toEqual([]);
+          expect(resp).toEqual(
+            `Finished Airtable Export. 0 records created; 0 records updated. Error encountered: ${ErrorFactory.safeStringify(
+              result.error
+            )}`
+          );
+        });
+      }
+    );
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
@@ -10,7 +10,7 @@ suite("JSONExportPodCommand", function () {
     beforeHook: () => {},
   });
 
-  describe("GIVEN a GoogleDocsExportPodCommand is ran with Vault scope", () => {
+  describe("GIVEN a JSONExportPodCommand is ran with Vault scope", () => {
     describeSingleWS(
       "WHEN the destination is clipboard",
       {

--- a/packages/pods-core/src/utils.ts
+++ b/packages/pods-core/src/utils.ts
@@ -6,6 +6,8 @@ import {
   stringifyError,
   RespV3,
   ErrorFactory,
+  DVault,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { readYAML } from "@dendronhq/common-server";
 import Ajv, { JSONSchemaType } from "ajv";
@@ -17,6 +19,7 @@ import { PodClassEntryV4, PodItemV4 } from "./types";
 import { docs_v1 as docsV1 } from "googleapis";
 import download from "image-downloader";
 import axios from "axios";
+import { AirtableMetadata } from "./builtin/AirtablePod";
 
 export * from "./builtin";
 export * from "./types";
@@ -538,5 +541,24 @@ export class PodUtils {
     } catch (err: any) {
       throw new DendronError({ message: stringifyError(err) });
     }
+  }
+
+  static getPodMetadataJsonFilePath(opts: {
+    wsRoot: string;
+    vault: DVault;
+    podId?: string;
+  }) {
+    const { wsRoot, vault, podId = "default" } = opts;
+    const relPath = VaultUtils.getRelPath(vault);
+    return path.join(wsRoot, relPath, `${podId}.metadata.json`);
+  }
+
+  static readMetadataFromFilepath(filePath: string): AirtableMetadata[] {
+    if (!fs.pathExistsSync(filePath)) {
+      fs.ensureFileSync(filePath);
+      fs.writeJSONSync(filePath, []);
+      return [];
+    }
+    return fs.readJSONSync(filePath);
   }
 }

--- a/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
+++ b/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
@@ -36,9 +36,11 @@ export type PersistedAirtablePodConfig = AirtableV2PodConfig &
  */
 export type RunnableAirtableV2PodConfig = Omit<
   AirtableV2PodConfig,
-  "podId" | "podType"
+  "podId" | "podType" | "description"
 > &
-  Pick<AirtableConnection, "apiKey">;
+  Pick<AirtableConnection, "apiKey"> & {
+    podId?: string;
+  };
 
 /**
  * Helper function to perform a type check on an object to see if it's an
@@ -87,10 +89,6 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
       exportScope: {
         type: "string",
       },
-      description: {
-        type: "string",
-        nullable: true,
-      },
       filters: {
         type: "object",
         required: [],
@@ -103,6 +101,10 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
             },
           },
         },
+      },
+      podId: {
+        type: "string",
+        nullable: true,
       },
     },
   };

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -185,6 +185,7 @@ export class AirtableExportPodV2
       srcFieldMapping: this._config.sourceFieldMapping,
       logger,
       engine: this._engine,
+      podId: this._config.podId,
     });
     return resp;
   }


### PR DESCRIPTION
DRAFT: deferred implementation via metadata.json approach.
Related info: [[Pod Export Note to Multiple Destinations|dendron://private/user.joshi.async.pod-export-note-to-multiple-destinations]]

```
feat(pods): Airtable export v2 to support multiple IDs
```
- Airtable Export Pod now uses <podId>.metadata.json file to keep track of records.
- Doctor command to update the existing workspace.
- For the time being, the current workspace setup will work fine, eventually, we can update existing notes with Doctor(updateAirtableMetadata) command to use the new workflow.

NOTE: Docs pending

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)