### PR TITLE
feat: doctor command keybinding conflict resolution

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -736,81 +736,85 @@ export async function _activate(
     const backupPaths: string[] = [];
     let keybindingPath: string;
 
-    // check vim keybindings ^j7zygfkbxjnq
-    if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
-      const vimInstalled = VSCodeUtils.isExtensionInstalled("vscodevim.vim");
-      // only need to run this for non-mac
-      if (vimInstalled && os.type() !== "Darwin") {
-        Logger.info({
-          ctx,
-          msg: "checkAndApplyVimKeybindingOverrideIfExists:pre",
-        });
-        AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled);
-        const keybindingPayload =
-          KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists();
-        if (keybindingPayload.data) {
-          const { keybindingConfigPath, newKeybindings: resolvedKeybindings } =
-            keybindingPayload.data;
-          keybindingPath = keybindingConfigPath;
-          if (!_.isUndefined(resolvedKeybindings)) {
-            const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-            const maybeBackupPath = `${keybindingConfigPath}.${today}.vim.old`;
-            if (!fs.existsSync(keybindingConfigPath)) {
-              fs.ensureFileSync(keybindingConfigPath);
-              fs.writeFileSync(keybindingConfigPath, "[]");
-            } else {
-              fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-              backupPaths.push(maybeBackupPath);
-            }
-            writeJSONWithComments(keybindingConfigPath, resolvedKeybindings);
-            AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled, {
-              fixApplied: true,
-            });
-          }
-        } else {
-          Logger.info({ ctx, msg: "unable to apply keybinding fix" });
-          // TODO: report error
-        }
-      }
-    }
+    // KeybindingUtils.
 
-    // TODO: remove, we are not tracking this today
-    // if (extensionInstallStatus === InstallStatus.UPGRADED) {
-    //   const { keybindingConfigPath, migratedKeybindings } =
-    //     KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
-    //   keybindingPath = keybindingConfigPath;
-    //   if (!_.isUndefined(migratedKeybindings)) {
-    //     const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-    //     const maybeBackupPath = `${keybindingConfigPath}.${today}.lookup.old`;
-    //     fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-    //     backupPaths.push(maybeBackupPath);
-    //     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
+    // check vim keybindings ^j7zygfkbxjnq
+    // if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
+    //   const vimInstalled = VSCodeUtils.isExtensionInstalled("vscodevim.vim");
+    //   // only need to run this for non-mac
+    //   if (vimInstalled && os.type() !== "Darwin") {
+    //     Logger.info({
+    //       ctx,
+    //       msg: "checkAndApplyVimKeybindingOverrideIfExists:pre",
+    //     });
+    //     AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled);
+    //     const keybindingPayload =
+    //       KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists();
+    //     if (keybindingPayload.data) {
+    //       const { keybindingConfigPath, newKeybindings: resolvedKeybindings } =
+    //         keybindingPayload.data;
+    //       keybindingPath = keybindingConfigPath;
+    //       if (!_.isUndefined(resolvedKeybindings)) {
+    //         const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
+    //         const maybeBackupPath = `${keybindingConfigPath}.${today}.vim.old`;
+    //         if (!fs.existsSync(keybindingConfigPath)) {
+    //           fs.ensureFileSync(keybindingConfigPath);
+    //           fs.writeFileSync(keybindingConfigPath, "[]");
+    //         } else {
+    //           fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
+    //           backupPaths.push(maybeBackupPath);
+    //         }
+    //         writeJSONWithComments(keybindingConfigPath, resolvedKeybindings);
+    //         AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled, {
+    //           fixApplied: true,
+    //         });
+    //       }
+    //     } else {
+    //       Logger.info({ ctx, msg: "unable to apply keybinding fix" });
+    //       // TODO: report error
+    //     }
     //   }
     // }
 
-    if (backupPaths.length > 0) {
-      vscode.window
-        .showInformationMessage(
-          "Conflicting or outdated keybindings have been updated. Click the button below to see changes.",
-          ...["Open changes"]
-        )
-        .then(async (selection) => {
-          if (selection) {
-            const uri = vscode.Uri.file(keybindingPath);
-            await VSCodeUtils.openFileInEditor(uri);
-            backupPaths.forEach(async (backupPath) => {
-              const backupUri = vscode.Uri.file(backupPath);
-              await VSCodeUtils.openFileInEditor(backupUri, {
-                column: vscode.ViewColumn.Beside,
-              });
-            });
-          }
-        });
-    }
+    // // TODO: remove, we are not tracking this today
+    // // if (extensionInstallStatus === InstallStatus.UPGRADED) {
+    // //   const { keybindingConfigPath, migratedKeybindings } =
+    // //     KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
+    // //   keybindingPath = keybindingConfigPath;
+    // //   if (!_.isUndefined(migratedKeybindings)) {
+    // //     const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
+    // //     const maybeBackupPath = `${keybindingConfigPath}.${today}.lookup.old`;
+    // //     fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
+    // //     backupPaths.push(maybeBackupPath);
+    // //     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
+    // //   }
+    // // }
+
+    // if (backupPaths.length > 0) {
+    //   vscode.window
+    //     .showInformationMessage(
+    //       "Conflicting or outdated keybindings have been updated. Click the button below to see changes.",
+    //       ...["Open changes"]
+    //     )
+    //     .then(async (selection) => {
+    //       if (selection) {
+    //         const uri = vscode.Uri.file(keybindingPath);
+    //         await VSCodeUtils.openFileInEditor(uri);
+    //         backupPaths.forEach(async (backupPath) => {
+    //           const backupUri = vscode.Uri.file(backupPath);
+    //           await VSCodeUtils.openFileInEditor(backupUri, {
+    //             column: vscode.ViewColumn.Beside,
+    //           });
+    //         });
+    //       }
+    //     });
+    // }
 
     if (userOnOldVSCodeVer) {
       AnalyticsUtils.track(VSCodeEvents.UserOnOldVSCodeVerUnblocked);
     }
+
+    await KeybindingUtils.maybePromptKeybindingConflict();
 
     await showWelcomeOrWhatsNew({
       extensionInstallStatus,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -996,3 +996,5 @@ export const INCOMPATIBLE_EXTENSIONS = [
   "maxedmands.vscode-zettel-markdown-notes",
   "tchayen.markdown-links",
 ];
+
+export const KEYBINDING_CONFLICT_EXTENSIONS = ["vscodevim.vim"];


### PR DESCRIPTION
This PR:
- removes automatic keybinding conflict resolution and keybinding migration logic from the activation lifecycle
- adds a doctor command to detect known keybinding conflicts
- adds a doctor command to detect potential keybinding conflicts

note

currently in draft and need some design discussions.