### PR TITLE
chore(internal): remove deprecated getExtension and runLegacyWorkspaceTest from some files

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1877,6 +1877,7 @@ export class SchemaUtils {
     });
   }
 
+  //  ^dtaatxvjb4s3
   static matchPath(opts: {
     notePath: string;
     schemaModDict: SchemaModuleDict;

--- a/packages/dendron-cli/src/commands/podsV2.ts
+++ b/packages/dendron-cli/src/commands/podsV2.ts
@@ -14,7 +14,6 @@ import {
   PodUtils,
 } from "@dendronhq/pods-core";
 import _ from "lodash";
-import path from "path";
 import yargs from "yargs";
 import { setupEngine, SetupEngineCLIOpts, SetupEngineResp } from "./utils";
 
@@ -75,7 +74,6 @@ export async function enrichPodArgs(
   let { configValues = {} } = args;
   const engineArgs = await setupEngine(args);
   const wsRoot = engineArgs.wsRoot;
-  const podsDir = PodUtils.getPodDir({ wsRoot });
 
   // return if no config is given
   if (!args.podId && !args.podConfig && !args.inlineConfig) {
@@ -89,11 +87,10 @@ export async function enrichPodArgs(
 
   // if podId is provided, get configValues from the config.{podId}.yml
   if (args.podId) {
-    const podConfigPath = path.join(
-      podsDir,
-      "custom",
-      `config.${args.podId}.yml`
-    );
+    const podConfigPath = PodUtils.getCustomConfigPath({
+      wsRoot,
+      podId: args.podId,
+    });
     try {
       const resp = ConfigFileUtils.getConfigByFPath({
         fPath: podConfigPath,
@@ -129,11 +126,10 @@ export async function enrichPodArgs(
 
   // If the config has a connectionId, read the sevice connection config file.
   if (configValues.connectionId) {
-    const serviceConnectionPath = path.join(
-      podsDir,
-      "service-connections",
-      `svcconfig.${configValues.connectionId}.yml`
-    );
+    const serviceConnectionPath = PodUtils.getServiceConfigPath({
+      wsRoot,
+      connectionId: configValues.connectionId,
+    });
     try {
       const resp = ConfigFileUtils.getConfigByFPath({
         fPath: serviceConnectionPath,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/exportPodV2CLI.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/exportPodV2CLI.spec.ts
@@ -3,30 +3,17 @@ import { ExportPodV2CLICommand } from "@dendronhq/dendron-cli";
 import {
   ExternalService,
   PodExportScope,
+  PodUtils,
   PodV2Types,
 } from "@dendronhq/pods-core";
-import path from "path";
 import { runEngineTestV5 } from "../../..";
 import fs from "fs-extra";
 import { ERROR_SEVERITY, Time } from "@dendronhq/common-all";
+import path from "path";
 
 /**
  * Export Pod V2
  */
-
-const getCustomConfigPath = (wsRoot: string, podId: string) => {
-  const podsDir = path.join(wsRoot, "pods", "custom");
-  const configPath = path.join(podsDir, `config.${podId}.yml`);
-  fs.ensureDirSync(podsDir);
-  return configPath;
-};
-
-const getSvcConfigPath = (wsRoot: string, connectionId: string) => {
-  const podsDir = path.join(wsRoot, "pods", "service-connections");
-  const configPath = path.join(podsDir, `svcconfig.${connectionId}.yml`);
-  fs.ensureDirSync(podsDir);
-  return configPath;
-};
 
 // dendron exportPodV2 --podId  dendron.markdown
 describe("GIVEN export pod V2 is run ", () => {
@@ -35,7 +22,8 @@ describe("GIVEN export pod V2 is run ", () => {
       await runEngineTestV5(
         async ({ wsRoot }) => {
           const podId = "dendron.markdown";
-          const configPath = getCustomConfigPath(wsRoot, podId);
+          const configPath = PodUtils.getCustomConfigPath({ wsRoot, podId });
+          await fs.ensureDir(path.dirname(configPath));
           writeYAML(configPath, {
             exportScope: "Workspace",
             podType: PodV2Types.MarkdownExportV2,
@@ -113,7 +101,8 @@ describe("GIVEN export pod V2 is run ", () => {
         async ({ wsRoot }) => {
           const cmd = new ExportPodV2CLICommand();
           const podId = "dendron.markdown";
-          const configPath = getCustomConfigPath(wsRoot, podId);
+          const configPath = PodUtils.getCustomConfigPath({ wsRoot, podId });
+          await fs.ensureDir(path.dirname(configPath));
           writeYAML(configPath, {
             exportScope: "Workspace",
             podType: PodV2Types.MarkdownExportV2,
@@ -142,8 +131,13 @@ describe("GIVEN export pod V2 is run ", () => {
           const cmd = new ExportPodV2CLICommand();
           const podId = "dendron.gdoc";
           const connectionId = "gdoc-main";
-          const configPath = getCustomConfigPath(wsRoot, podId);
-          const svcCongingPath = getSvcConfigPath(wsRoot, connectionId);
+          const configPath = PodUtils.getCustomConfigPath({ wsRoot, podId });
+          const svcCongingPath = PodUtils.getServiceConfigPath({
+            wsRoot,
+            connectionId,
+          });
+          await fs.ensureDir(path.dirname(configPath));
+          await fs.ensureDir(path.dirname(svcCongingPath));
           writeYAML(configPath, {
             exportScope: "Workspace",
             podType: PodV2Types.GoogleDocsExportV2,
@@ -177,7 +171,8 @@ describe("GIVEN export pod V2 is run ", () => {
         async ({ wsRoot }) => {
           const cmd = new ExportPodV2CLICommand();
           const podId = "dendron.foo";
-          const configPath = getCustomConfigPath(wsRoot, podId);
+          const configPath = PodUtils.getCustomConfigPath({ wsRoot, podId });
+          await fs.ensureDir(path.dirname(configPath));
           const resp = await cmd.enrichArgs({
             wsRoot,
             inlineConfig: ["Key=exportScope,Value=Vault"],

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -13,18 +13,17 @@ import {
   ExternalService,
   isRunnableAirtableV2PodConfig,
   JSONSchemaType,
+  PodUtils,
   PodV2Types,
   RunnableAirtableV2PodConfig,
 } from "@dendronhq/pods-core";
 import _ from "lodash";
-import path from "path";
 import * as vscode from "vscode";
 import { window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { ExtensionProvider } from "../../ExtensionProvider";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
 
 /**
@@ -37,9 +36,11 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
   AirtableExportReturnType
 > {
   public key = "dendron.airtableexport";
+  private extension: IDendronExtension;
 
-  public constructor() {
+  public constructor(extension: IDendronExtension) {
     super(new QuickPickHierarchySelector());
+    this.extension = extension;
   }
 
   public createPod(
@@ -48,7 +49,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
     return new AirtableExportPodV2({
       airtable: new Airtable({ apiKey: config.apiKey }),
       config,
-      engine: ExtensionProvider.getEngine(),
+      engine: this.extension.getEngine(),
     });
   }
 
@@ -61,10 +62,12 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
   ): Promise<RunnableAirtableV2PodConfig | undefined> {
     let apiKey: string | undefined = opts?.apiKey;
     let connectionId: string | undefined = opts?.connectionId;
-
+    const { wsRoot } = this.extension.getDWorkspace();
     // Get an Airtable API Key
     if (!apiKey) {
-      const mngr = new ExternalConnectionManager(getExtension().podsDir);
+      const mngr = new ExternalConnectionManager(
+        PodUtils.getPodDir({ wsRoot })
+      );
 
       // If the apiKey doesn't exist, see if we can first extract it from the connectedServiceId:
       if (opts?.connectionId) {
@@ -141,7 +144,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
       }
 
       const configPath = ConfigFileUtils.genConfigFileV2({
-        fPath: path.join(getExtension().podsDir, "custom", `config.${id}.yml`),
+        fPath: PodUtils.getCustomConfigPath({ wsRoot, podId: id }),
         configSchema: AirtableExportPodV2.config(),
         setProperties: _.merge(inputs, {
           podId: id,
@@ -176,7 +179,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
     payload: NoteProps[];
   }) {
     const records = exportReturnValue.data;
-    const engine = ExtensionProvider.getEngine();
+    const engine = this.extension.getEngine();
     const logger = this.L;
     if (records?.created) {
       await AirtableUtils.updateAirtableIdForNewlySyncedNotes({

--- a/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
@@ -8,16 +8,16 @@ import {
   JSONExportReturnType,
   JSONSchemaType,
   JSONV2PodConfig,
+  PodUtils,
   PodV2Types,
   RunnableJSONV2PodConfig,
 } from "@dendronhq/pods-core";
 import _ from "lodash";
-import path from "path";
 import * as vscode from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
 
 /**
@@ -30,9 +30,10 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
   JSONExportReturnType
 > {
   public key = "dendron.jsonexportv2";
-
-  public constructor() {
+  private extension: IDendronExtension;
+  public constructor(extension: IDendronExtension) {
     super(new QuickPickHierarchySelector());
+    this.extension = extension;
   }
 
   public async gatherInputs(
@@ -77,14 +78,10 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
     // want to save as a new config or just run it one-time
     if (!opts?.podId) {
       const choice = await PodUIControls.promptToSaveInputChoicesAsNewConfig();
-
+      const { wsRoot } = this.extension.getDWorkspace();
       if (choice !== undefined && choice !== false) {
         const configPath = ConfigFileUtils.genConfigFileV2({
-          fPath: path.join(
-            getExtension().podsDir,
-            "custom",
-            `config.${choice}.yml`
-          ),
+          fPath: PodUtils.getCustomConfigPath({ wsRoot, podId: choice }),
           configSchema: JSONExportPodV2.config(),
           setProperties: _.merge(config, {
             podId: choice,

--- a/packages/plugin-core/src/commands/pods/NotionExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/NotionExportPodCommand.ts
@@ -14,19 +14,18 @@ import {
   NotionUtils,
   NotionV2PodConfig,
   Page,
+  PodUtils,
   PodV2Types,
   RunnableNotionV2PodConfig,
   TitlePropertyValue,
 } from "@dendronhq/pods-core";
 import _ from "lodash";
-import path from "path";
 import * as vscode from "vscode";
 import { ProgressLocation, window } from "vscode";
 import { QuickPickHierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { ExtensionProvider } from "../../ExtensionProvider";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import { BaseExportPodCommand } from "./BaseExportPodCommand";
 
 /**
@@ -39,9 +38,10 @@ export class NotionExportPodCommand extends BaseExportPodCommand<
   NotionExportReturnType
 > {
   public key = "dendron.notionexport";
-
-  public constructor() {
+  private extension: IDendronExtension;
+  public constructor(extension: IDendronExtension) {
     super(new QuickPickHierarchySelector());
+    this.extension = extension;
   }
 
   public createPod(
@@ -62,10 +62,12 @@ export class NotionExportPodCommand extends BaseExportPodCommand<
     if (isRunnableNotionV2PodConfig(opts)) return opts;
     let apiKey: string | undefined = opts?.apiKey;
     let connectionId: string | undefined = opts?.connectionId;
-
+    const { wsRoot } = this.extension.getDWorkspace();
     // Get an Notion API Key
     if (!apiKey) {
-      const mngr = new ExternalConnectionManager(getExtension().podsDir);
+      const mngr = new ExternalConnectionManager(
+        PodUtils.getPodDir({ wsRoot })
+      );
       // If the apiKey doesn't exist, see if we can first extract it from the connectedServiceId:
       if (opts?.connectionId) {
         const config = mngr.getConfigById<NotionConnection>({
@@ -127,11 +129,7 @@ export class NotionExportPodCommand extends BaseExportPodCommand<
 
       if (choice !== undefined && choice !== false) {
         const configPath = ConfigFileUtils.genConfigFileV2({
-          fPath: path.join(
-            getExtension().podsDir,
-            "custom",
-            `config.${choice}.yml`
-          ),
+          fPath: PodUtils.getCustomConfigPath({ wsRoot, podId: choice }),
           configSchema: NotionExportPodV2.config(),
           setProperties: _.merge(inputs, {
             podId: choice,
@@ -163,7 +161,7 @@ export class NotionExportPodCommand extends BaseExportPodCommand<
     config: RunnableNotionV2PodConfig;
     payload: NoteProps[];
   }) {
-    const engine = ExtensionProvider.getEngine();
+    const engine = this.extension.getEngine();
     const { data } = exportReturnValue;
     if (data?.created) {
       await NotionUtils.updateNotionIdForNewlyCreatedNotes(

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -12,6 +12,7 @@ import { GoogleDocsExportPodCommand } from "../../commands/pods/GoogleDocsExport
 import { JSONExportPodCommand } from "../../commands/pods/JSONExportPodCommand";
 import { MarkdownExportPodCommand } from "../../commands/pods/MarkdownExportPodCommand";
 import { NotionExportPodCommand } from "../../commands/pods/NotionExportPodCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { getExtension } from "../../workspace";
 
 export class PodCommandFactory {
@@ -40,10 +41,10 @@ export class PodCommandFactory {
       storedConfig.exportScope = exportScope;
     }
     let cmdWithArgs: CodeCommandInstance;
-
+    const extension = ExtensionProvider.getExtension();
     switch (storedConfig.podType) {
       case PodV2Types.AirtableExportV2: {
-        const airtableCmd = new AirtableExportPodCommand();
+        const airtableCmd = new AirtableExportPodCommand(extension);
         cmdWithArgs = {
           key: airtableCmd.key,
           run(): Promise<void> {
@@ -53,7 +54,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand();
+        const cmd = new MarkdownExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -63,7 +64,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand();
+        const cmd = new GoogleDocsExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -73,7 +74,7 @@ export class PodCommandFactory {
         break;
       }
       case PodV2Types.NotionExportV2: {
-        const cmd = new NotionExportPodCommand();
+        const cmd = new NotionExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -84,7 +85,7 @@ export class PodCommandFactory {
       }
 
       case PodV2Types.JSONExportV2: {
-        const cmd = new JSONExportPodCommand();
+        const cmd = new JSONExportPodCommand(extension);
         cmdWithArgs = {
           key: cmd.key,
           run(): Promise<void> {
@@ -111,9 +112,10 @@ export class PodCommandFactory {
   public static createPodCommandForPodType(
     podType: PodV2Types
   ): CodeCommandInstance {
+    const extension = ExtensionProvider.getExtension();
     switch (podType) {
       case PodV2Types.AirtableExportV2: {
-        const cmd = new AirtableExportPodCommand();
+        const cmd = new AirtableExportPodCommand(extension);
 
         return {
           key: cmd.key,
@@ -124,7 +126,7 @@ export class PodCommandFactory {
       }
 
       case PodV2Types.MarkdownExportV2: {
-        const cmd = new MarkdownExportPodCommand();
+        const cmd = new MarkdownExportPodCommand(extension);
 
         return {
           key: cmd.key,
@@ -134,7 +136,7 @@ export class PodCommandFactory {
         };
       }
       case PodV2Types.GoogleDocsExportV2: {
-        const cmd = new GoogleDocsExportPodCommand();
+        const cmd = new GoogleDocsExportPodCommand(extension);
         return {
           key: cmd.key,
           run(): Promise<void> {
@@ -143,7 +145,7 @@ export class PodCommandFactory {
         };
       }
       case PodV2Types.NotionExportV2: {
-        const cmd = new NotionExportPodCommand();
+        const cmd = new NotionExportPodCommand(extension);
         return {
           key: cmd.key,
           run(): Promise<void> {
@@ -153,7 +155,7 @@ export class PodCommandFactory {
       }
 
       case PodV2Types.JSONExportV2: {
-        const cmd = new JSONExportPodCommand();
+        const cmd = new JSONExportPodCommand(extension);
         return {
           key: cmd.key,
           run(): Promise<void> {

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -7,6 +7,7 @@ import {
   ExternalService,
   ExternalTarget,
   PodExportScope,
+  PodUtils,
   PodV2ConfigManager,
   PodV2Types,
 } from "@dendronhq/pods-core";
@@ -210,7 +211,8 @@ export class PodUIControls {
   public static async promptForExternalServiceConnectionOrNew<
     T extends ExternalTarget
   >(connectionType: ExternalService): Promise<undefined | T> {
-    const mngr = new ExternalConnectionManager(getExtension().podsDir);
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const mngr = new ExternalConnectionManager(PodUtils.getPodDir({ wsRoot }));
 
     const existingConnections = await mngr.getAllConfigsByType(connectionType);
 

--- a/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
@@ -22,8 +22,9 @@ suite("GoogleDocsExportPodCommand", function () {
         ctx,
       },
       () => {
-        const cmd = new GoogleDocsExportPodCommand();
         test("THEN error message must be displayed", async () => {
+          const ext = ExtensionProvider.getExtension();
+          const cmd = new GoogleDocsExportPodCommand(ext);
           const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
 
           const notePath = path.join(

--- a/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
@@ -13,8 +13,10 @@ import { VSCodeUtils } from "../../../../vsCodeUtils";
 suite("GoogleDocsExportPodCommand", function () {
   describe("GIVEN a GoogleDocsExportPodCommand is ran with Note scope", () => {
     describeSingleWS("WHEN there is an error in response", {}, () => {
-      const cmd = new GoogleDocsExportPodCommand();
       test("THEN error message must be displayed", async () => {
+        const cmd = new GoogleDocsExportPodCommand(
+          ExtensionProvider.getExtension()
+        );
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
           vault2Path({ vault: vaults[0], wsRoot }),

--- a/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/JSONExportCommand.test.ts
@@ -4,21 +4,23 @@ import * as vscode from "vscode";
 import { describeSingleWS, setupBeforeAfter } from "../../../testUtilsV3";
 import { JSONExportPodCommand } from "../../../../commands/pods/JSONExportPodCommand";
 import { expect } from "../../../testUtilsv2";
+import { ExtensionProvider } from "../../../../ExtensionProvider";
 
 suite("JSONExportPodCommand", function () {
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
-  describe("GIVEN a GoogleDocsExportPodCommand is ran with Vault scope", () => {
+  describe("GIVEN a JSONExportPodCommand is ran with Vault scope", () => {
     describeSingleWS(
       "WHEN the destination is clipboard",
       {
         ctx,
       },
       () => {
-        const cmd = new JSONExportPodCommand();
         test("THEN multi notes export error message must be displayed", async () => {
+          const ext = ExtensionProvider.getExtension();
+          const cmd = new JSONExportPodCommand(ext);
           await expect(async () =>
             cmd.gatherInputs({
               exportScope: PodExportScope.Vault,

--- a/packages/pods-core/src/utils.ts
+++ b/packages/pods-core/src/utils.ts
@@ -34,6 +34,10 @@ export const podClassEntryToPodItemV4 = (p: PodClassEntryV4): PodItemV4 => {
 };
 
 export class PodUtils {
+  /**
+   * @param param0
+   * @returns config for v1 pods
+   */
   static getConfig({
     podsDir,
     podClass,
@@ -45,6 +49,10 @@ export class PodUtils {
     return PodUtils.readPodConfigFromDisk<any>(podConfigPath);
   }
 
+  /**
+   * @param param0
+   * @returns config path for v1 pods
+   */
   static getConfigPath({
     podsDir,
     podClass,
@@ -539,4 +547,30 @@ export class PodUtils {
       throw new DendronError({ message: stringifyError(err) });
     }
   }
+
+  /**
+   * @param opts
+   * @returns custom config file path for pods v2
+   */
+  static getCustomConfigPath = (opts: { wsRoot: string; podId: string }) => {
+    const { wsRoot, podId } = opts;
+    const podsDir = PodUtils.getPodDir({ wsRoot });
+    return path.join(podsDir, "custom", `config.${podId}.yml`);
+  };
+  /**
+   * @param opts
+   * @returns service config file path for pods v2
+   */
+  static getServiceConfigPath = (opts: {
+    wsRoot: string;
+    connectionId: string;
+  }) => {
+    const { wsRoot, connectionId } = opts;
+    const podsDir = PodUtils.getPodDir({ wsRoot });
+    return path.join(
+      podsDir,
+      "service-connections",
+      `svcconfig.${connectionId}.yml`
+    );
+  };
 }


### PR DESCRIPTION
```
chore(internal): remove deprecated getExtension and runLegacyWorkspaceTest from some files
```
This PR attempts to
- remove some getExtension() and runLegacyWorkspaceTest from files
- create two new utilities to get file path of pod custom config and service connection config.
***
madge report
no new dependency added(18 circular dependencies)
***
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)