### PR TITLE
chore(tests): Deprecate setupBeforeAfter

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
@@ -7,17 +7,15 @@ import sinon from "sinon";
 import { VaultConvertCommand } from "../../commands/VaultConvert";
 import { getDWorkspace } from "../../workspace";
 import { expect } from "../testUtilsv2";
-import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+import { describeMultiWS } from "../testUtilsV3";
 import fs from "fs-extra";
 import { before, after, describe } from "mocha";
 import { ConfigUtils, IntermediateDendronConfig } from "@dendronhq/common-all";
 
 suite("GIVEN VaultConvert", function () {
-  const ctx = setupBeforeAfter(this, {});
-
   describeMultiWS(
     "WHEN converting a local vault to a remote vault",
-    { ctx, preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
+    { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
     () => {
       let remote: string;
       before(async () => {
@@ -101,7 +99,7 @@ suite("GIVEN VaultConvert", function () {
 
   describeMultiWS(
     "WHEN given a bad remote URL",
-    { ctx, preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
+    { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
     () => {
       before(async () => {
         const { vaults } = getDWorkspace();

--- a/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/GoogleDocsExportCommand.test.ts
@@ -2,7 +2,7 @@ import { PodExportScope } from "@dendronhq/pods-core";
 import { describe } from "mocha";
 import * as vscode from "vscode";
 import { expect } from "../../../testUtilsv2";
-import { describeSingleWS, setupBeforeAfter } from "../../../testUtilsV3";
+import { describeSingleWS } from "../../../testUtilsV3";
 import { DendronError, ErrorFactory } from "@dendronhq/common-all";
 import { GoogleDocsExportPodCommand } from "../../../../commands/pods/GoogleDocsExportPodCommand";
 import { vault2Path } from "@dendronhq/common-server";
@@ -11,55 +11,45 @@ import { ExtensionProvider } from "../../../../ExtensionProvider";
 import { VSCodeUtils } from "../../../../vsCodeUtils";
 
 suite("GoogleDocsExportPodCommand", function () {
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
-    beforeHook: () => {},
-  });
-
   describe("GIVEN a GoogleDocsExportPodCommand is ran with Note scope", () => {
-    describeSingleWS(
-      "WHEN there is an error in response",
-      {
-        ctx,
-      },
-      () => {
-        const cmd = new GoogleDocsExportPodCommand();
-        test("THEN error message must be displayed", async () => {
-          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+    describeSingleWS("WHEN there is an error in response", {}, () => {
+      const cmd = new GoogleDocsExportPodCommand();
+      test("THEN error message must be displayed", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
 
-          const notePath = path.join(
-            vault2Path({ vault: vaults[0], wsRoot }),
-            "root.md"
-          );
-          await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-          const payload = await cmd.enrichInputs({
-            exportScope: PodExportScope.Note,
-            accessToken: "test",
-            refreshToken: "test",
-            expirationTime: 1234,
-            connectionId: "gdoc",
-          });
-          const result = {
-            data: {
-              created: [],
-              updated: [],
-            },
-            error: new DendronError({
-              status: "401",
-              message: "Request failed with status code 401",
-            }),
-          };
-          const resp = await cmd.onExportComplete({
-            exportReturnValue: result,
-            payload: payload?.payload!,
-            config: payload?.config!,
-          });
-          expect(resp).toEqual(
-            `Finished GoogleDocs Export. 0 docs created; 0 docs updated. Error encountered: ${ErrorFactory.safeStringify(
-              result.error?.message
-            )}`
-          );
+        const notePath = path.join(
+          vault2Path({ vault: vaults[0], wsRoot }),
+          "root.md"
+        );
+        await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+        const payload = await cmd.enrichInputs({
+          exportScope: PodExportScope.Note,
+          accessToken: "test",
+          refreshToken: "test",
+          expirationTime: 1234,
+          connectionId: "gdoc",
         });
-      }
-    );
+        const result = {
+          data: {
+            created: [],
+            updated: [],
+          },
+          error: new DendronError({
+            status: "401",
+            message: "Request failed with status code 401",
+          }),
+        };
+        const resp = await cmd.onExportComplete({
+          exportReturnValue: result,
+          payload: payload?.payload!,
+          config: payload?.config!,
+        });
+        expect(resp).toEqual(
+          `Finished GoogleDocs Export. 0 docs created; 0 docs updated. Error encountered: ${ErrorFactory.safeStringify(
+            result.error?.message
+          )}`
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
**Background**
We have a wide variety of ways to write test cases, some deprecated, some modern. Moving forward, we would like all tests in `plugin-core` to use `describeSingleWS` or `describeMultiWS`. In order to make that possible, we need to make sure that the new test functions support existing use cases.

**Changes**
- Move functionality from `setupBeforeAfter` into both `describeSingleWS` or `describeMultiWS`
- Deprecate setupBeforeAfter
- See [[Issues with plugin test harness|dendron://private/meet.async.2022.02.25.describe-ws-updates]]

**Next changes**
- Update all tests using `describeSingleWS` or `describeMultiWS` to no longer use `setupBeforeAfter` 
# Dendron Extended PR Checklist
- Migrate tests in plugin-core to use `describeSingleWS` or `describeMultiWS`

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)