### PR TITLE
chore: base commands rethrows error during development for easier debugging

### DIFF
--- a/packages/plugin-core/src/commands/base.ts
+++ b/packages/plugin-core/src/commands/base.ts
@@ -1,4 +1,4 @@
-import { DendronError, isTSError } from "@dendronhq/common-all";
+import { DendronError, getStage, isTSError } from "@dendronhq/common-all";
 import { DLogger, getDurationMilliseconds } from "@dendronhq/common-server";
 import _ from "lodash";
 import { window } from "vscode";
@@ -135,6 +135,10 @@ export abstract class BaseCommand<
       });
 
       isError = true;
+      // During development only, rethrow the errors to make them easier to debug
+      if (getStage() === "dev") {
+        throw error;
+      }
       return;
     } finally {
       const payload = this.addAnalyticsPayload


### PR DESCRIPTION
Re-throws the errors from the base command class during development. This avoids the issue where a command will fail when running tests, but the base command class blackholes these errors so from the viewpoint of the test it looks like the command worked. This can be hard to debug as it looks like the command worked, but the results of the command are partial.