### PR TITLE
fix: add omitted migration entries

### DIFF
--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -18,6 +18,7 @@ import {
   ALL_MIGRATIONS,
   CONFIG_MIGRATIONS,
   DConfig,
+  MIGRATION_ENTRIES,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
@@ -133,9 +134,7 @@ export abstract class CLICommand<
       const instruction =
         reason === "client"
           ? "Please make sure dendron-cli is up to date by running the following: \n npm install @dendronhq/dendron-cli@latest"
-          : `Please make sure dendron.yml is up to date by running the following: \n dendron dev run_migration --migrationVersion=${
-              [CONFIG_MIGRATIONS, ...ALL_MIGRATIONS][0].version
-            }`;
+          : `Please make sure dendron.yml is up to date by running the following: \n dendron dev run_migration --migrationVersion=${MIGRATION_ENTRIES[0].version}`;
       const clientVersionOkay =
         reason === "client" ? DENDRON_EMOJIS.NOT_OKAY : DENDRON_EMOJIS.OKAY;
       const configVersionOkay =

--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -15,8 +15,6 @@ import {
   TelemetryStatus,
 } from "@dendronhq/common-server";
 import {
-  ALL_MIGRATIONS,
-  CONFIG_MIGRATIONS,
   DConfig,
   MIGRATION_ENTRIES,
   WorkspaceUtils,

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -457,7 +457,6 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   }
 
   showMigrations() {
-    // ALL_MIGRATIONS
     const headerMessage = [
       "",
       "Make note of the version number and use it in the run_migration command",

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -11,10 +11,10 @@ import {
   TelemetryStatus,
 } from "@dendronhq/common-server";
 import {
-  ALL_MIGRATIONS,
   DConfig,
   MigrationChangeSetStatus,
   MigrationService,
+  MIGRATION_ENTRIES,
   WorkspaceService,
 } from "@dendronhq/engine-server";
 import fs from "fs-extra";
@@ -126,7 +126,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     });
     args.option("migrationVersion", {
       describe: "migration version to run",
-      choices: ALL_MIGRATIONS.map((m) => m.version),
+      choices: MIGRATION_ENTRIES.map((m) => m.version),
     });
     args.option("wsRoot", {
       describe: "root directory of the Dendron workspace",
@@ -430,7 +430,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       return false;
     }
     if (opts.migrationVersion) {
-      return ALL_MIGRATIONS.map((m) => m.version).includes(
+      return MIGRATION_ENTRIES.map((m) => m.version).includes(
         opts.migrationVersion
       );
     }
@@ -468,7 +468,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     ].join("\n");
     const body: string[] = [];
     let maxLength = 0;
-    ALL_MIGRATIONS.forEach((migrations) => {
+    MIGRATION_ENTRIES.forEach((migrations) => {
       const version = migrations.version.padEnd(17);
       const changes = migrations.changes.map((set) => set.name).join(", ");
       const line = `${version}| ${changes}`;
@@ -489,7 +489,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
 
   async runMigration(opts: CommandOpts) {
     // grab the migration we want to run
-    const migrationsToRun = ALL_MIGRATIONS.filter(
+    const migrationsToRun = MIGRATION_ENTRIES.filter(
       (m) => m.version === opts.migrationVersion
     );
 

--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -130,7 +130,7 @@ export const CONFIG_MIGRATIONS: Migrations = {
 /**
  * Migrations are sorted by version numbers, from greatest to least
  */
-export const ALL_MIGRATIONS: Migrations[] = [
+const ALL_MIGRATIONS: Migrations[] = [
   // CONFIG_MIGRATIONS,
   {
     version: "0.55.2",

--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -295,3 +295,5 @@ export const ALL_MIGRATIONS: Migrations[] = [
     ],
   },
 ];
+
+export const MIGRATION_ENTRIES = [CONFIG_MIGRATIONS, ...ALL_MIGRATIONS];

--- a/packages/engine-server/src/migrations/service.ts
+++ b/packages/engine-server/src/migrations/service.ts
@@ -9,7 +9,7 @@ import { createDisposableLogger, DLogger } from "@dendronhq/common-server";
 import _ from "lodash";
 import semver from "semver";
 import { WorkspaceService } from "../workspace";
-import { ALL_MIGRATIONS } from "./migrations";
+import { MIGRATION_ENTRIES } from "./migrations";
 import { MigrationChangeSetStatus, Migrations } from "./types";
 
 type ApplyMigrationRuleOpts = {
@@ -34,7 +34,7 @@ export class MigrationService {
     const results: MigrationChangeSetStatus[][] = [];
     // run migrations from oldest to newest
     const migrationsToRun = _.reverse(
-      _.takeWhile(migrations || ALL_MIGRATIONS, (ent) => {
+      _.takeWhile(migrations || MIGRATION_ENTRIES, (ent) => {
         const out =
           semver.lte(previousVersion, ent.version) &&
           semver.gte(currentVersion, ent.version);

--- a/packages/plugin-core/src/commands/RunMigrationCommand.ts
+++ b/packages/plugin-core/src/commands/RunMigrationCommand.ts
@@ -1,6 +1,5 @@
 import {
-  ALL_MIGRATIONS,
-  CONFIG_MIGRATIONS,
+  MIGRATION_ENTRIES,
   MigrationChangeSetStatus,
   Migrations,
   MigrationService,
@@ -28,7 +27,7 @@ export class RunMigrationCommand extends BasicCommand<
 
   async gatherInputs(opts?: CommandInput): Promise<CommandInput | undefined> {
     const migrationItems: vscode.QuickPickItem[] = _.map(
-      [CONFIG_MIGRATIONS, ...ALL_MIGRATIONS],
+      MIGRATION_ENTRIES,
       (migration) => {
         return {
           label: migration.version,
@@ -61,7 +60,7 @@ export class RunMigrationCommand extends BasicCommand<
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const { version } = opts;
     const migrationsToRun: Migrations[] = _.filter(
-      [CONFIG_MIGRATIONS, ...ALL_MIGRATIONS],
+      MIGRATION_ENTRIES,
       (migration) => migration.version === version
     );
     const { wsRoot, config } = getDWorkspace();

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -22,14 +22,14 @@ import {
   InsertNoteLinkAliasModeEnum,
 } from "@dendronhq/common-all";
 import {
-  ALL_MIGRATIONS,
+  CONFIG_MIGRATIONS,
   Migrations,
   MigrateFunction,
   MigrationService,
   WorkspaceService,
   DConfig,
   MigrationUtils,
-  CONFIG_MIGRATIONS,
+  MIGRATION_ENTRIES,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { describe, test } from "mocha";
@@ -58,13 +58,15 @@ const getMigration = ({
   to,
 }: Partial<{ from: string; exact: string; to: string }>): Migrations[] => {
   if (exact) {
-    const maybeMigration = ALL_MIGRATIONS.find((ent) => ent.version === exact);
+    const maybeMigration = MIGRATION_ENTRIES.find(
+      (ent) => ent.version === exact
+    );
     if (_.isUndefined(maybeMigration)) {
       throw Error("no migration found");
     }
     return [maybeMigration];
   } else {
-    let migrations = ALL_MIGRATIONS;
+    let migrations = MIGRATION_ENTRIES;
     // eg. take all migrations greater than the `from`
     if (from) {
       migrations = _.takeWhile(migrations, (mig) => {


### PR DESCRIPTION
# fix: add omitted migration entries
This PR
- adds omitted migration.
- this resolves a regression with dendron-cli where `show_migration` would not display the latest (`0.83.0`) migration as an option.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)