### PR TITLE
enhance(pods): support null entries for dates in Airtable export v2

### DIFF
--- a/packages/engine-server/src/util/noteMetadataUtils.ts
+++ b/packages/engine-server/src/util/noteMetadataUtils.ts
@@ -153,7 +153,6 @@ export class NoteMetadataUtils {
     ...props
   }: NotemetadataExtractScalarProps): RespV3<string | undefined> {
     // TODO: we should validate
-    //val = _isNumber(val) ? DateTime.fromMillis(val).toLocaleString(DateTime.DATETIME_FULL) : val
     const val = _.get(note, key);
     if (_.isNumber(val)) {
       return {

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
@@ -572,3 +572,60 @@ describe("WHEN export note with linked record", () => {
     });
   });
 });
+
+describe("GIVEN export note with date ", () => {
+  describe("WHEN skipOnEmpty is not defined/true", () => {
+    const setupTest = setupTestFactoryForNote({
+      fname: "alpha",
+      srcFieldMapping: {
+        Tasks: {
+          type: "date",
+          to: "endDate",
+        },
+      },
+    });
+
+    describe("AND WHEN value is empty", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        return createTestNote(opts, { endDate: "" });
+      };
+      test("THEN field is skipped and no error is thrown", async () => {
+        const resp = await setupTest(preSetupHook);
+        expect(resp.data?.created).toEqual([genField()]);
+      });
+    });
+    describe("AND WHEN value is present", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        return createTestNote(opts, { endDate: "2022-03-05" });
+      };
+      test("THEN field is exported with value", async () => {
+        const resp = await setupTest(preSetupHook);
+        expect(resp.data?.created).toEqual([genField({ Tasks: "2022-03-05" })]);
+      });
+    });
+  });
+  describe("AND WHEN skipOnEmpty is set to false", () => {
+    const setupTest = setupTestFactoryForNote({
+      fname: "alpha",
+      srcFieldMapping: {
+        Tasks: {
+          type: "date",
+          to: "endDate",
+          skipOnEmpty: false,
+        },
+      },
+    });
+
+    describe("AND WHEN value is empty", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        return createTestNote(opts, { endDate: "" });
+      };
+      test("THEN error is thrown", async () => {
+        const resp = await setupTest(preSetupHook);
+        expect(resp.error?.message).toEqual(
+          "The value for endDate is found empty. Please provide a valid value or enable skipOnEmpty in the srcFieldMapping."
+        );
+      });
+    });
+  });
+});

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -213,9 +213,7 @@ export class AirtableUtils {
         });
       }
       case "date": {
-        return {
-          data: NoteMetadataUtils.extractDate({ note, key }),
-        };
+        return NoteMetadataUtils.extractDate({ note, key, ...props });
       }
       case "singleSelect": {
         if (fieldMapping.to === SpecialSrcFieldToKey.TAGS) {


### PR DESCRIPTION
```
enhance(pods): support null entries for dates in Airtable export v2
```
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)