### PR TITLE
enhance: provide a standard way to create and read backup files

### DIFF
--- a/packages/common-all/src/constants/index.ts
+++ b/packages/common-all/src/constants/index.ts
@@ -46,6 +46,7 @@ export const CONSTANTS = {
 };
 
 export enum ERROR_STATUS {
+  BACKUP_FAILED = "backup_failed",
   NODE_EXISTS = "node_exists",
   NO_SCHEMA_FOUND = "no_schema_found",
   NO_ROOT_SCHEMA_FOUND = "no_root_schema_found",

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -387,14 +387,17 @@ export class GitUtils {
       // if the .gitignore was missing, ignore it
       if (err?.code !== "ENOENT") throw err;
     }
+
+    // gitignore is missing but we are allowed to create it
+    const shouldCreate = contents === undefined && !noCreateIfMissing;
+
+    // gitignore exists, and the path is not in it yet
     // Avoid duplicating the gitignore line if it was already there
-    const pathExists = contents?.split("\n").indexOf(addPath) !== -1;
-    if (
-      // gitignore is missing but we are allowed to create it
-      (contents === undefined && noCreateIfMissing !== true) ||
-      // gitignore exists, and the path is not in it yet
-      (contents !== undefined && !pathExists)
-    ) {
+    const pathExists =
+      contents !== undefined &&
+      contents.match(new RegExp(`^${_.escapeRegExp(addPath)}/?$`, "m"));
+
+    if (shouldCreate || !pathExists) {
       await fs.appendFile(gitignore, `\n${addPath}`);
     }
   }

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -388,12 +388,12 @@ export class GitUtils {
       if (err?.code !== "ENOENT") throw err;
     }
     // Avoid duplicating the gitignore line if it was already there
+    const pathExists = contents?.split("\n").indexOf(addPath) !== -1;
     if (
       // gitignore is missing but we are allowed to create it
       (contents === undefined && noCreateIfMissing !== true) ||
       // gitignore exists, and the path is not in it yet
-      (contents !== undefined &&
-        !contents.match(new RegExp(`^${addPath}/?$`, "g")))
+      (contents !== undefined && !pathExists)
     ) {
       await fs.appendFile(gitignore, `\n${addPath}`);
     }

--- a/packages/engine-server/src/backup/backupServiceInterface.ts
+++ b/packages/engine-server/src/backup/backupServiceInterface.ts
@@ -2,20 +2,57 @@ import { RespV3 } from "@dendronhq/common-all";
 import { BackupKeyEnum } from ".";
 
 export interface IBackupService {
-  // root directory
+  /**
+   * getter for backup root path.
+   * returns regardless of the existence of the directory.
+   */
   backupRoot: string;
 
-  // create backup root if it doesn't exist, add to gitignore
+  /**
+   * Makes sure the backup root ({@link backupRoot})
+   * and directory for each defined key ({@link BackupKeyEnum}) exists.
+   * Creates one otherwise.
+   * Adds an entry to gitignore of workspace root if it isn't added already.
+   */
   ensureBackupDir(): Promise<void>;
 
-  // given the options, generate a basename for the backup file
+  /**
+   * Given some options and a file name, generate a new file name to use for the backup.
+   *
+   * The format would be:
+   *
+   * `{file name without extension}.{yyyy.MM.dd.HHmmssS, if enabled}.{infix, if enabled}.{extension}`
+   *
+   * e.g.) Given `dendron.yml`, timestamp, and infix `migrate-config`,
+   * the resulting backup file name is `dendron.2022.03.14.3239848.migrate-config.yml`
+   *
+   * Note that with `timestamp: false` and no infix, this will return the same inputted filename.
+   *
+   * @param opts.fileName file name to generate backup name for. Assumes existence of extension.
+   * @param opts.timestamp flag to enable adding timestamp to name.
+   * @param opts.infix optional custom infix to append right before the extension.
+   * @returns generated backup file name.
+   */
   generateBackupFileName(opts: {
     fileName: string;
     timestamp?: boolean;
     infix?: string;
   }): string;
 
-  // backup given file
+  /**
+   * Back up {@link opts.pathToBackup} to directory `{@link backupRoot}/{@link opts.key}`
+   * with optional {@link opts.timestamp} and {@link opts.infix} in its name.
+   * Or use {@link opts.nameOverride} as the backup name.
+   *
+   * See {@link generateBackupFileName} to see how backup names are generated.
+   *
+   * @param opts.key key to use for backup.
+   * @param opts.pathToBackup path of file to back up.
+   * @param opts.timestamp flag to enable timestamp in backup file name.
+   * @param opts.infix optional custom infix to append right before the extension.
+   * @param opts.nameOverride if given, it will be used instead of calling {@link generateBackupFileName}.
+   * @returns A promise of response containing either the path of the backup or a DendronError
+   */
   backup(opts: {
     key: BackupKeyEnum;
     pathToBackup: string;
@@ -23,10 +60,16 @@ export interface IBackupService {
     infix?: string;
   }): Promise<RespV3<string>>;
 
-  // get a list of backups given the key
+  /**
+   * Given a {@link opts.key}, return all backups created with this key.
+   * @param opts.key backup key to use. One of {@link BackupKeyEnum} as string.
+   * @returns list of backups with given key.
+   */
   getBackupsWithKey(opts: { key: string }): string[];
 
-  // get all backups.
+  /**
+   * @returns all backups grouped by backup key defined by {@link BackupKeyEnum}.
+   */
   getAllBackups(): {
     key: string;
     backups: string[];

--- a/packages/engine-server/src/backup/backupServiceInterface.ts
+++ b/packages/engine-server/src/backup/backupServiceInterface.ts
@@ -3,6 +3,11 @@ import { BackupKeyEnum } from ".";
 
 export interface IBackupService {
   /**
+   * dispose backup service.
+   */
+  dispose(): void;
+
+  /**
    * getter for backup root path.
    * returns regardless of the existence of the directory.
    */

--- a/packages/engine-server/src/backup/backupServiceInterface.ts
+++ b/packages/engine-server/src/backup/backupServiceInterface.ts
@@ -1,1 +1,34 @@
-export interface IBackupService {}
+import { RespV3 } from "@dendronhq/common-all";
+import { BackupKeyEnum } from ".";
+
+export interface IBackupService {
+  // root directory
+  backupRoot: string;
+
+  // create backup root if it doesn't exist, add to gitignore
+  ensureBackupDir(): Promise<void>;
+
+  // given the options, generate a basename for the backup file
+  generateBackupFileName(opts: {
+    fileName: string;
+    timestamp?: boolean;
+    infix?: string;
+  }): string;
+
+  // backup given file
+  backup(opts: {
+    key: BackupKeyEnum;
+    pathToBackup: string;
+    timestamp?: boolean;
+    infix?: string;
+  }): Promise<RespV3<string>>;
+
+  // get a list of backups given the key
+  getBackupsWithKey(opts: { key: string }): string[];
+
+  // get all backups.
+  getAllBackups(): {
+    key: string;
+    backups: string[];
+  }[];
+}

--- a/packages/engine-server/src/backup/backupServiceInterface.ts
+++ b/packages/engine-server/src/backup/backupServiceInterface.ts
@@ -1,0 +1,1 @@
+export interface IBackupService {}

--- a/packages/engine-server/src/backup/index.ts
+++ b/packages/engine-server/src/backup/index.ts
@@ -1,0 +1,1 @@
+export * from "./service";

--- a/packages/engine-server/src/backup/index.ts
+++ b/packages/engine-server/src/backup/index.ts
@@ -1,1 +1,2 @@
 export * from "./service";
+export * from "./backupServiceInterface";

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -1,0 +1,74 @@
+import {
+  DendronError,
+  Disposable,
+  ERROR_STATUS,
+  RespV3,
+  Time,
+} from "@dendronhq/common-all";
+import { createDisposableLogger, DLogger } from "@dendronhq/common-server";
+import path from "path";
+import fs from "fs-extra";
+import { IBackupService } from "./backupServiceInterface";
+
+export type BackupServiceOpts = {
+  wsRoot: string;
+};
+
+export enum BackupKeyEnum {
+  CONFIG = "config",
+}
+
+export const BACKUP_DIR_NAME = ".backup";
+
+export class BackupService implements Disposable, IBackupService {
+  public wsRoot: string;
+  public logger: DLogger;
+  private loggerDispose: () => any;
+
+  constructor({ wsRoot }: BackupServiceOpts) {
+    const { logger, dispose } = createDisposableLogger();
+    this.logger = logger;
+    this.loggerDispose = dispose;
+    this.wsRoot = wsRoot;
+  }
+
+  dispose() {
+    this.loggerDispose();
+  }
+
+  get backupRoot(): string {
+    return path.join(this.wsRoot, BACKUP_DIR_NAME);
+  }
+
+  generateBackupFileName(opts: { fileName: string }): string {
+    const { fileName } = opts;
+    const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
+    const fileNameSplit = fileName.split(".");
+    const extension = fileNameSplit.pop();
+    return [fileNameSplit.join("."), today, extension].join(".");
+  }
+
+  backup(opts: { key: BackupKeyEnum; pathToBackup: string }): RespV3<string> {
+    const { key, pathToBackup } = opts;
+    const backupDir = path.join(this.backupRoot, key);
+    const fileName = path.basename(pathToBackup);
+    const backupPath = path.join(
+      backupDir,
+      this.generateBackupFileName({ fileName })
+    );
+    fs.copyFileSync(pathToBackup, backupPath);
+    if (!fs.existsSync(backupPath)) {
+      return {
+        error: DendronError.createFromStatus({
+          status: ERROR_STATUS.BACKUP_FAILED,
+          message: `backup for ${pathToBackup} failed.`,
+        }),
+      };
+    }
+    return { data: backupPath };
+  }
+
+  getAllBackups() {
+    // TODO: return Map<string, string[]>
+  }
+}

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -41,16 +41,18 @@ export class BackupService implements Disposable, IBackupService {
   }
 
   /**
-   * returns backup root path.
+   * getter for backup root path.
+   * returns regardless of the existence of the directory.
    */
   get backupRoot(): string {
     return path.join(this.wsRoot, BACKUP_DIR_NAME);
   }
 
   /**
-   * Makes sure the backup root and directory for each defined key exists.
+   * Makes sure the backup root ({@link backupRoot})
+   * and directory for each defined key ({@link BackupKeyEnum}) exists.
    * Creates one otherwise.
-   * Add to gitignore if not already.
+   * Adds an entry to gitignore of workspace root if it isn't added already.
    */
   async ensureBackupDir(): Promise<void> {
     this.logger.info({ msg: "ensureBackupDir" });
@@ -66,9 +68,19 @@ export class BackupService implements Disposable, IBackupService {
 
   /**
    * Given some options and a file name, generate a new file name to use for the backup.
-   * @param fileName file name to generate backup name for. Assumes existence of extension.
-   * @param timestamp flag to enable adding timestamp to name.
-   * @param infix optional custom infix to append right before the extension.
+   *
+   * The format would be:
+   *
+   * `{file name without extension}.{yyyy.MM.dd.HHmmssS, if enabled}.{infix, if enabled}.{extension}`
+   *
+   * e.g.) Given `dendron.yml`, timestamp, and infix `migrate-config`,
+   * the resulting backup file name is `dendron.2022.03.14.3239848.migrate-config.yml`
+   *
+   * Note that with `timestamp: false` and no infix, this will return the same inputted filename.
+   *
+   * @param opts.fileName file name to generate backup name for. Assumes existence of extension.
+   * @param opts.timestamp flag to enable adding timestamp to name.
+   * @param opts.infix optional custom infix to append right before the extension.
    * @returns generated backup file name.
    */
   generateBackupFileName(opts: {
@@ -87,26 +99,35 @@ export class BackupService implements Disposable, IBackupService {
   }
 
   /**
+   * Back up {@link opts.pathToBackup} to directory `{@link backupRoot}/{@link opts.key}`
+   * with optional {@link opts.timestamp} and {@link opts.infix} in its name.
+   * Or use {@link opts.nameOverride} as the backup name.
    *
-   * @param key key to use for backup.
-   * @param pathToBackup path of file to back up.
-   * @param timestamp flag to enable timestamp in backup file name.
-   * @param infix optional custom infix to append right before the extension.
-   * @returns
+   * See {@link generateBackupFileName} to see how backup names are generated.
+   *
+   * @param opts.key key to use for backup.
+   * @param opts.pathToBackup path of file to back up.
+   * @param opts.timestamp flag to enable timestamp in backup file name.
+   * @param opts.infix optional custom infix to append right before the extension.
+   * @param opts.nameOverride if given, it will be used instead of calling {@link generateBackupFileName}.
+   * @returns A promise of response containing either the path of the backup or a DendronError
    */
   async backup(opts: {
     key: BackupKeyEnum;
     pathToBackup: string;
     timestamp?: boolean;
     infix?: string;
+    nameOverride?: string;
   }): Promise<RespV3<string>> {
-    const { key, pathToBackup, timestamp, infix } = opts;
+    const { key, pathToBackup, timestamp, infix, nameOverride } = opts;
     const backupDir = path.join(this.backupRoot, key);
     const fileName = path.basename(pathToBackup);
-    const backupPath = path.join(
-      backupDir,
-      this.generateBackupFileName({ fileName, timestamp, infix })
-    );
+    const backupPath =
+      nameOverride ||
+      path.join(
+        backupDir,
+        this.generateBackupFileName({ fileName, timestamp, infix })
+      );
     this.logger.info({ msg: "creating backup", backupPath, pathToBackup });
     await this.ensureBackupDir();
     fs.copyFileSync(pathToBackup, backupPath);
@@ -122,8 +143,8 @@ export class BackupService implements Disposable, IBackupService {
   }
 
   /**
-   *
-   * @param key backup key to use.
+   * Given a {@link opts.key}, return all backups created with this key.
+   * @param opts.key backup key to use. One of {@link BackupKeyEnum} as string.
    * @returns list of backups with given key.
    */
   getBackupsWithKey(opts: { key: string }): string[] {
@@ -141,8 +162,7 @@ export class BackupService implements Disposable, IBackupService {
   }
 
   /**
-   *
-   * @returns all backups grouped by backup key.
+   * @returns all backups grouped by backup key defined by {@link BackupKeyEnum}.
    */
   getAllBackups() {
     return Object.keys(BackupKeyEnum).map((key) => {

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -45,6 +45,7 @@ export class BackupService implements Disposable, IBackupService {
   }
 
   async ensureBackupDir(): Promise<void> {
+    this.logger.info({ msg: "ensureBackupDir" });
     await GitUtils.addToGitignore({
       addPath: BACKUP_DIR_NAME,
       root: this.wsRoot,
@@ -83,6 +84,7 @@ export class BackupService implements Disposable, IBackupService {
       backupDir,
       this.generateBackupFileName({ fileName, timestamp, infix })
     );
+    this.logger.info({ msg: "creating backup", backupPath, pathToBackup });
     await this.ensureBackupDir();
     fs.copyFileSync(pathToBackup, backupPath);
     if (!fs.existsSync(backupPath)) {

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -36,6 +36,9 @@ export class BackupService implements Disposable, IBackupService {
     this.wsRoot = wsRoot;
   }
 
+  /**
+   * dispose backup service.
+   */
   dispose() {
     this.loggerDispose();
   }

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -18,6 +18,10 @@ export type BackupServiceOpts = {
   wsRoot: string;
 };
 
+/**
+ * Predefined keys to be used for backups
+ * ^6ao9nojre6ai
+ */
 export enum BackupKeyEnum {
   config = "config",
 }
@@ -114,6 +118,7 @@ export class BackupService implements Disposable, IBackupService {
    * @param opts.infix optional custom infix to append right before the extension.
    * @param opts.nameOverride if given, it will be used instead of calling {@link generateBackupFileName}.
    * @returns A promise of response containing either the path of the backup or a DendronError
+   * ^b0jdi7ncbflr
    */
   async backup(opts: {
     key: BackupKeyEnum;

--- a/packages/engine-server/src/backup/service.ts
+++ b/packages/engine-server/src/backup/service.ts
@@ -63,9 +63,9 @@ export class BackupService implements Disposable, IBackupService {
       addPath: BACKUP_DIR_NAME,
       root: this.wsRoot,
     });
-    fs.ensureDirSync(this.backupRoot);
-    Object.keys(BackupKeyEnum).forEach((key) => {
-      fs.ensureDirSync(path.join(this.backupRoot, key));
+    await fs.ensureDir(this.backupRoot);
+    Object.keys(BackupKeyEnum).forEach(async (key) => {
+      await fs.ensureDir(path.join(this.backupRoot, key));
     });
   }
 

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -191,17 +191,20 @@ export class DConfig {
    */
   static async createBackup(wsRoot: string, infix?: string): Promise<string> {
     const backupService = new BackupService({ wsRoot });
-    const configPath = DConfig.configPath(wsRoot);
-    const backupResp = await backupService.backup({
-      key: BackupKeyEnum.config,
-      pathToBackup: configPath,
-      timestamp: true,
-      infix,
-    });
-    backupService.dispose();
-    if (backupResp.error) {
-      throw new DendronError({ ...backupResp.error });
+    try {
+      const configPath = DConfig.configPath(wsRoot);
+      const backupResp = await backupService.backup({
+        key: BackupKeyEnum.config,
+        pathToBackup: configPath,
+        timestamp: true,
+        infix,
+      });
+      if (backupResp.error) {
+        throw new DendronError({ ...backupResp.error });
+      }
+      return backupResp.data;
+    } finally {
+      backupService.dispose();
     }
-    return backupResp.data;
   }
 }

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -188,6 +188,7 @@ export class DConfig {
    * `dendron.yyyy.MM.dd.HHmmssS.foo.yml`
    * @param wsRoot workspace root
    * @param infix custom string used in the backup name
+   * ^fd66z8uiuczz
    */
   static async createBackup(wsRoot: string, infix?: string): Promise<string> {
     const backupService = new BackupService({ wsRoot });

--- a/packages/engine-server/src/index.ts
+++ b/packages/engine-server/src/index.ts
@@ -23,4 +23,5 @@ export * from "./util/inMemoryNoteCache";
 export * from "./util/noteMetadataUtils";
 export * from "./drivers";
 export * from "./doctor";
+export * from "./backup";
 export * from "./backfillV2";

--- a/packages/engine-server/src/migrations/migrations.ts
+++ b/packages/engine-server/src/migrations/migrations.ts
@@ -10,7 +10,6 @@ import {
   vault2Path,
 } from "@dendronhq/common-server";
 import _ from "lodash";
-import fs from "fs-extra";
 import { DConfig } from "../config";
 import { removeCache } from "../utils";
 import { Migrations } from "./types";
@@ -23,20 +22,18 @@ export const CONFIG_MIGRATIONS: Migrations = {
     {
       name: "migrate config",
       func: async ({ dendronConfig, wsConfig, wsService }) => {
-        const backupPath = DConfig.createBackup(
-          wsService.wsRoot,
-          "migrate-configs"
-        );
-        if (!fs.existsSync(backupPath)) {
+        try {
+          await DConfig.createBackup(wsService.wsRoot, "migrate-configs");
+        } catch (error) {
           return {
-            error: new DendronError({
-              message:
-                "Backup failed during config migration. Exiting without migration.",
-            }),
             data: {
               dendronConfig,
               wsConfig,
             },
+            error: new DendronError({
+              message:
+                "Backup failed during config migration. Exiting without migration.",
+            }),
           };
         }
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/backup.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/backup.spec.ts
@@ -1,0 +1,146 @@
+import {
+  BackupKeyEnum,
+  BackupService,
+  DConfig,
+} from "@dendronhq/engine-server";
+import { runEngineTestV5 } from "../..";
+import path from "path";
+import fs from "fs-extra";
+
+describe("GIVEN BackupService", () => {
+  test("THEN returns correct backup root", async () => {
+    await runEngineTestV5(
+      async ({ wsRoot }) => {
+        const backupService = new BackupService({ wsRoot });
+        const root = backupService.backupRoot;
+        expect(root).toEqual(path.join(wsRoot, ".backup"));
+      },
+      {
+        expect,
+      }
+    );
+  });
+
+  describe("WHEN backup root doesn't exist", () => {
+    test("THEN ensureBackupDir creates one and adds to gitignore", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot }) => {
+          const backupService = new BackupService({ wsRoot });
+          const root = backupService.backupRoot;
+          expect(fs.existsSync(root)).toBeFalsy();
+
+          await backupService.ensureBackupDir();
+
+          expect(fs.existsSync(root)).toBeTruthy();
+          const gitignore = path.join(wsRoot, ".gitignore");
+          const gitignoreContents = fs.readFileSync(gitignore, {
+            encoding: "utf-8",
+          });
+          expect(gitignoreContents.includes(".backup")).toBeTruthy();
+        },
+        {
+          expect,
+        }
+      );
+    });
+
+    test("THEN file is backed up successfully", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot }) => {
+          const backupService = new BackupService({ wsRoot });
+          const root = backupService.backupRoot;
+          expect(fs.existsSync(root)).toBeFalsy();
+
+          const configPath = DConfig.configPath(wsRoot);
+          const backupResp = await backupService.backup({
+            key: BackupKeyEnum.config,
+            pathToBackup: configPath,
+            timestamp: true,
+            infix: "migration",
+          });
+
+          expect(backupResp.data && fs.existsSync(backupResp.data));
+        },
+        {
+          expect,
+        }
+      );
+    });
+
+    test("THEN getBackupsWithKey returns an empty string", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot }) => {
+          const backupService = new BackupService({ wsRoot });
+
+          const configBackups = backupService.getBackupsWithKey({
+            key: BackupKeyEnum.config,
+          });
+
+          expect(configBackups).toEqual([]);
+        },
+        {
+          expect,
+        }
+      );
+    });
+
+    test("THEN getAllBackups returns a list of objects, one for each defined key, with empty list as backup", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot }) => {
+          const backupService = new BackupService({ wsRoot });
+
+          const allBackups = backupService.getAllBackups();
+
+          expect(allBackups).toEqual([
+            {
+              key: BackupKeyEnum.config,
+              backups: [],
+            },
+          ]);
+        },
+        {
+          expect,
+        }
+      );
+    });
+  });
+
+  test("THEN backup file name is created with optional timestamp and custom", async () => {
+    await runEngineTestV5(
+      async ({ wsRoot }) => {
+        const backupService = new BackupService({ wsRoot });
+
+        const noOptionOut = backupService.generateBackupFileName({
+          fileName: "foo.yml",
+        });
+        expect(noOptionOut).toEqual("foo.yml");
+
+        const timestampOut = backupService.generateBackupFileName({
+          fileName: "foo.yml",
+          timestamp: true,
+        });
+        expect(
+          /foo\.\d{4}\.\d{2}\.\d{2}\.\d*\.yml$/g.test(timestampOut)
+        ).toBeTruthy();
+
+        const infixOut = backupService.generateBackupFileName({
+          fileName: "foo.yml",
+          infix: "backup",
+        });
+        expect(infixOut).toEqual("foo.backup.yml");
+
+        const timestampInfixOut = backupService.generateBackupFileName({
+          fileName: "foo.yml",
+          timestamp: true,
+          infix: "backup",
+        });
+        expect(
+          /foo\.\d{4}\.\d{2}\.\d{2}\.\d*\.backup\.yml$/g.test(timestampInfixOut)
+        ).toBeTruthy();
+      },
+      {
+        expect,
+      }
+    );
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/engine-server/backup.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/backup.spec.ts
@@ -14,6 +14,7 @@ describe("GIVEN BackupService", () => {
         const backupService = new BackupService({ wsRoot });
         const root = backupService.backupRoot;
         expect(root).toEqual(path.join(wsRoot, ".backup"));
+        backupService.dispose();
       },
       {
         expect,
@@ -37,6 +38,7 @@ describe("GIVEN BackupService", () => {
             encoding: "utf-8",
           });
           expect(gitignoreContents.includes(".backup")).toBeTruthy();
+          backupService.dispose();
         },
         {
           expect,
@@ -60,6 +62,7 @@ describe("GIVEN BackupService", () => {
           });
 
           expect(backupResp.data && fs.existsSync(backupResp.data));
+          backupService.dispose();
         },
         {
           expect,
@@ -77,6 +80,7 @@ describe("GIVEN BackupService", () => {
           });
 
           expect(configBackups).toEqual([]);
+          backupService.dispose();
         },
         {
           expect,
@@ -97,6 +101,7 @@ describe("GIVEN BackupService", () => {
               backups: [],
             },
           ]);
+          backupService.dispose();
         },
         {
           expect,
@@ -137,6 +142,7 @@ describe("GIVEN BackupService", () => {
         expect(
           /foo\.\d{4}\.\d{2}\.\d{2}\.\d*\.backup\.yml$/g.test(timestampInfixOut)
         ).toBeTruthy();
+        backupService.dispose();
       },
       {
         expect,

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -432,6 +432,10 @@
       {
         "command": "dendron.launchTutorial",
         "title": "Dendron: Launch Tutorial"
+      },
+      {
+        "command": "dendron.openBackup",
+        "title": "Dendron: Open Backup"
       }
     ],
     "menus": {
@@ -706,6 +710,10 @@
         },
         {
           "command": "dendron.diagnosticsReport",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.openBackup",
           "when": "dendron:pluginActive"
         }
       ],

--- a/packages/plugin-core/src/commands/OpenBackupCommand.ts
+++ b/packages/plugin-core/src/commands/OpenBackupCommand.ts
@@ -79,7 +79,7 @@ export class OpenBackupCommand extends BasicCommand<
                 )
               )
             );
-            window.showTextDocument(backupFile);
+            await window.showTextDocument(backupFile);
           } else {
             window.showInformationMessage("No backup selected.");
           }

--- a/packages/plugin-core/src/commands/OpenBackupCommand.ts
+++ b/packages/plugin-core/src/commands/OpenBackupCommand.ts
@@ -95,9 +95,13 @@ export class OpenBackupCommand extends BasicCommand<
   }
 
   async execute(opts?: OpenBackupCommandOpts): Promise<void> {
-    const ctx = "execute";
-    this.L.info({ ctx, opts });
-    const allBackups = this.backupService.getAllBackups();
-    await this.promptBackupKeySelection({ allBackups });
+    try {
+      const ctx = "execute";
+      this.L.info({ ctx, opts });
+      const allBackups = this.backupService.getAllBackups();
+      await this.promptBackupKeySelection({ allBackups });
+    } finally {
+      this.backupService.dispose();
+    }
   }
 }

--- a/packages/plugin-core/src/commands/OpenBackupCommand.ts
+++ b/packages/plugin-core/src/commands/OpenBackupCommand.ts
@@ -1,0 +1,103 @@
+import { BackupService, IBackupService } from "@dendronhq/engine-server";
+import { QuickPickItem, Uri, window, workspace } from "vscode";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { BasicCommand } from "./base";
+import path from "path";
+
+type OpenBackupCommandOpts = {};
+
+export class OpenBackupCommand extends BasicCommand<
+  OpenBackupCommandOpts,
+  void
+> {
+  key = DENDRON_COMMANDS.OPEN_BACKUP.key;
+  private extension: IDendronExtension;
+  private backupService: IBackupService;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+    const ws = this.extension.getDWorkspace();
+    this.backupService = new BackupService({ wsRoot: ws.wsRoot });
+  }
+
+  async promptBackupEntrySelection(opts: { backups: string[] }) {
+    const { backups } = opts;
+    const options: QuickPickItem[] = backups.map((backupName) => {
+      return {
+        label: backupName,
+      };
+    });
+    const selectedBackupName = await VSCodeUtils.showQuickPick(options, {
+      title: "Pick which backup file you want to open.",
+      ignoreFocusOut: true,
+      canPickMany: false,
+    });
+    return selectedBackupName;
+  }
+
+  async promptBackupKeySelection(opts: {
+    allBackups: { key: string; backups: string[] }[];
+  }) {
+    const { allBackups } = opts;
+    const options: QuickPickItem[] = allBackups
+      .filter((keyEntry) => {
+        return keyEntry.backups.length > 0;
+      })
+      .map((keyEntry) => {
+        return {
+          label: keyEntry.key,
+          detail: `${keyEntry.backups.length} backup(s)`,
+        };
+      });
+
+    if (options.length > 0) {
+      const backupKey = await VSCodeUtils.showQuickPick(options, {
+        title: "Pick which kind of backup you want to open.",
+        ignoreFocusOut: true,
+        canPickMany: false,
+      });
+      if (backupKey) {
+        const selected = allBackups.find((keyEntry) => {
+          return keyEntry.key === backupKey.label;
+        });
+
+        if (selected) {
+          const selectedBackupName = await this.promptBackupEntrySelection({
+            backups: selected.backups,
+          });
+
+          if (selectedBackupName) {
+            const backupFile = await workspace.openTextDocument(
+              Uri.file(
+                path.join(
+                  this.backupService.backupRoot,
+                  selected.key,
+                  selectedBackupName.label
+                )
+              )
+            );
+            window.showTextDocument(backupFile);
+          } else {
+            window.showInformationMessage("No backup selected.");
+          }
+        } else {
+          window.showInformationMessage(
+            "There are no backups saved for this key."
+          );
+        }
+      }
+    } else {
+      window.showInformationMessage("There are no backups saved.");
+    }
+  }
+
+  async execute(opts?: OpenBackupCommandOpts): Promise<void> {
+    const ctx = "execute";
+    this.L.info({ ctx, opts });
+    const allBackups = this.backupService.getAllBackups();
+    await this.promptBackupKeySelection({ allBackups });
+  }
+}

--- a/packages/plugin-core/src/commands/OpenBackupCommand.ts
+++ b/packages/plugin-core/src/commands/OpenBackupCommand.ts
@@ -23,7 +23,7 @@ export class OpenBackupCommand extends BasicCommand<
     this.backupService = new BackupService({ wsRoot: ws.wsRoot });
   }
 
-  async promptBackupEntrySelection(opts: { backups: string[] }) {
+  private async promptBackupEntrySelection(opts: { backups: string[] }) {
     const { backups } = opts;
     const options: QuickPickItem[] = backups.map((backupName) => {
       return {
@@ -38,7 +38,7 @@ export class OpenBackupCommand extends BasicCommand<
     return selectedBackupName;
   }
 
-  async promptBackupKeySelection(opts: {
+  private async promptBackupKeySelection(opts: {
     allBackups: { key: string; backups: string[] }[];
   }) {
     const { allBackups } = opts;

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -70,6 +70,7 @@ import { UpgradeSettingsCommand } from "./UpgradeSettings";
 import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
+import { OpenBackupCommand } from "./OpenBackupCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -147,6 +148,7 @@ const ALL_COMMANDS = [
   CreateTaskCommand,
   RegisterNoteTraitCommand,
   CreateNoteWithUserDefinedTrait,
+  OpenBackupCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -756,6 +756,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.launchTutorial",
     title: `${CMD_PREFIX} Launch Tutorial`,
   },
+  OPEN_BACKUP: {
+    key: "dendron.openBackup",
+    title: `${CMD_PREFIX} Open Backup`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
 };
 
 export const DENDRON_CHANNEL_NAME = "Dendron";

--- a/packages/plugin-core/src/test/suite-integ/OpenBackupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenBackupCommand.test.ts
@@ -1,0 +1,1 @@
+suite("OpenBackupCommand", function () {});

--- a/packages/plugin-core/src/test/suite-integ/OpenBackupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OpenBackupCommand.test.ts
@@ -1,1 +1,80 @@
-suite("OpenBackupCommand", function () {});
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { OpenBackupCommand } from "../../commands/OpenBackupCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { describeMultiWS } from "../testUtilsV3";
+import { expect } from "../testUtilsv2";
+import { describe } from "mocha";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import path from "path";
+import fs from "fs-extra";
+
+suite("OpenBackupCommand", function () {
+  describeMultiWS(
+    "GIVEN workspace with no backup root",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    () => {
+      test("THEN command displays toast indicating no backups", async () => {
+        const windowSpy = sinon.spy(vscode.window, "showInformationMessage");
+        const ext = ExtensionProvider.getExtension();
+        const cmd = new OpenBackupCommand(ext);
+        await cmd.run();
+        expect(windowSpy.calledOnce).toBeTruthy();
+        const infoMessage = windowSpy.getCall(0).args[0];
+        expect(infoMessage).toEqual("There are no backups saved.");
+        windowSpy.restore();
+      });
+    }
+  );
+
+  describeMultiWS(
+    "GIVEN workspace with backup root",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    () => {
+      describe("WHEN there is a backup under key `config`", () => {
+        test("THEN quickpick shows the filename and selecting it will open the file", async () => {
+          const ext = ExtensionProvider.getExtension();
+          const wsRoot = ext.getDWorkspace().wsRoot;
+          const backupPath = path.join(
+            wsRoot,
+            ".backup",
+            "config",
+            "dendron.test.yml"
+          );
+          fs.ensureFileSync(backupPath);
+          fs.writeFileSync(backupPath, "test");
+          const quickpickStub = sinon.stub(VSCodeUtils, "showQuickPick");
+          quickpickStub.onCall(0).resolves({
+            label: "config",
+          });
+          quickpickStub.onCall(1).resolves({
+            label: "dendron.test.yml",
+          });
+
+          await VSCodeUtils.closeAllEditors();
+          const cmd = new OpenBackupCommand(ext);
+          await cmd.run();
+          const activeEditor = VSCodeUtils.getActiveTextEditor();
+          expect(quickpickStub.getCall(0).args[0]).toEqual([
+            {
+              label: "config",
+              detail: "1 backup(s)",
+            },
+          ]);
+          expect(quickpickStub.getCall(1).args[0]).toEqual([
+            {
+              label: "dendron.test.yml",
+            },
+          ]);
+          expect(activeEditor?.document.fileName).toEqual(backupPath);
+          expect(activeEditor?.document.getText()).toEqual("test");
+        });
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -448,10 +448,13 @@ suite("Migration", function () {
             });
 
             // backup of the original should exist.
-            const allWSRootFiles = fs.readdirSync(wsRoot, {
-              withFileTypes: true,
-            });
-            const maybeBackupFileName = allWSRootFiles
+            const allBackupFiles = fs.readdirSync(
+              path.join(wsRoot, ".backup", "config"),
+              {
+                withFileTypes: true,
+              }
+            );
+            const maybeBackupFileName = allBackupFiles
               .filter((ent) => ent.isFile())
               .filter((fileEnt) =>
                 fileEnt.name.includes("migrate-config")
@@ -460,7 +463,7 @@ suite("Migration", function () {
 
             // backup content should be identical to original deep copy.
             const backupContent = readYAML(
-              path.join(wsRoot, maybeBackupFileName)
+              path.join(wsRoot, ".backup", "config", maybeBackupFileName)
             ) as IntermediateDendronConfig;
 
             // need to omit these because they are set by default during ws init.
@@ -639,10 +642,13 @@ suite("Migration", function () {
             });
 
             // backup of the original should exist.
-            const allWSRootFiles = fs.readdirSync(wsRoot, {
-              withFileTypes: true,
-            });
-            const maybeBackupFileName = allWSRootFiles
+            const allBackupFiles = fs.readdirSync(
+              path.join(wsRoot, ".backup", "config"),
+              {
+                withFileTypes: true,
+              }
+            );
+            const maybeBackupFileName = allBackupFiles
               .filter((ent) => ent.isFile())
               .filter((fileEnt) =>
                 fileEnt.name.includes("migrate-config")
@@ -651,7 +657,7 @@ suite("Migration", function () {
 
             // backup content should be identical to original deep copy.
             const backupContent = readYAML(
-              path.join(wsRoot, maybeBackupFileName)
+              path.join(wsRoot, ".backup", "config", maybeBackupFileName)
             ) as IntermediateDendronConfig;
 
             // need to omit these because they are set by default during ws init.
@@ -794,10 +800,13 @@ suite("Migration", function () {
             });
 
             // backup of the original should exist.
-            const allWSRootFiles = fs.readdirSync(wsRoot, {
-              withFileTypes: true,
-            });
-            const maybeBackupFileName = allWSRootFiles
+            const allBackupFiles = fs.readdirSync(
+              path.join(wsRoot, ".backup", "config"),
+              {
+                withFileTypes: true,
+              }
+            );
+            const maybeBackupFileName = allBackupFiles
               .filter((ent) => ent.isFile())
               .filter((fileEnt) =>
                 fileEnt.name.includes("migrate-config")
@@ -806,7 +815,7 @@ suite("Migration", function () {
 
             // backup content should be identical to original deep copy.
             const backupContent = readYAML(
-              path.join(wsRoot, maybeBackupFileName)
+              path.join(wsRoot, ".backup", "config", maybeBackupFileName)
             ) as IntermediateDendronConfig;
 
             // need to omit these because they are set by default during ws init.
@@ -1015,10 +1024,13 @@ suite("Migration", function () {
             });
 
             // backup of the original should exist.
-            const allWSRootFiles = fs.readdirSync(wsRoot, {
-              withFileTypes: true,
-            });
-            const maybeBackupFileName = allWSRootFiles
+            const allBackupFiles = fs.readdirSync(
+              path.join(wsRoot, ".backup", "config"),
+              {
+                withFileTypes: true,
+              }
+            );
+            const maybeBackupFileName = allBackupFiles
               .filter((ent) => ent.isFile())
               .filter((fileEnt) =>
                 fileEnt.name.includes("migrate-config")
@@ -1027,7 +1039,7 @@ suite("Migration", function () {
 
             // backup content should be identical to original deep copy.
             const backupContent = readYAML(
-              path.join(wsRoot, maybeBackupFileName)
+              path.join(wsRoot, ".backup", "config", maybeBackupFileName)
             ) as IntermediateDendronConfig;
 
             // need to omit these because they are set by default during ws init.

--- a/test-workspace/.gitignore
+++ b/test-workspace/.gitignore
@@ -6,3 +6,4 @@ docs
 vault-generated/
 pods/*
 .history
+.backup

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -20,8 +20,9 @@ commands:
     insertNoteIndex:
         enableMarker: false
     randomNote: {}
+    copyNoteLink: {}
 workspace:
-    dendronVersion: 0.82.0
+    dendronVersion: 0.83.0
     vaults:
         -
             fsPath: vault3
@@ -81,6 +82,8 @@ preview:
     enablePrettyRefs: true
     enableKatex: true
     automaticallyShowPreview: false
+    enableFrontmatterTags: true
+    enableHashesForFMTags: false
 publishing:
     enableFMTitle: true
     enableNoteTitleForLink: true


### PR DESCRIPTION
# enhance: provide a standard way to create and read backup files

This PR:
- implements `BackupService` which can be generally used for various parts of Dendron where we need to back up a file.
  - backup root is created when if it doesn't exist, and added to gitignore
  - one directory for each key defined in `BackupKeyEnum` is created in the backup root, and holds all backups that were done under that key.
  - provides a generic way of creating backup file names, with an option to add timestamp and / or a custom infix right before the file extension.
- implements `OpenBackupCommand` which can be used to open individual backup files grouped by keys stored in the backup root directory.
- fixes an issue wigh `GitUtils.addToGitignore`, where dotfile/dotdirs were not checked for existence properly because the regular expression was not escaped and was using the `g` flag.
- Refactor `DConfig.createBackup` to use the backup service

Madge reports no diffs compared to master

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)