### PR TITLE
chore: add validation for enableFrontmatterTags and enableHashesForFMTags

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -992,6 +992,12 @@
         "enableNoteTitleForLink": {
           "type": "boolean"
         },
+        "enableFrontmatterTags": {
+          "type": "boolean"
+        },
+        "enableHashesForFMTags": {
+          "type": "boolean"
+        },
         "enableMermaid": {
           "type": "boolean"
         },
@@ -1008,6 +1014,8 @@
       "required": [
         "enableFMTitle",
         "enableNoteTitleForLink",
+        "enableFrontmatterTags",
+        "enableHashesForFMTags",
         "enableMermaid",
         "enablePrettyRefs",
         "enableKatex",

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -992,6 +992,12 @@
         "enableNoteTitleForLink": {
           "type": "boolean"
         },
+        "enableFrontmatterTags": {
+          "type": "boolean"
+        },
+        "enableHashesForFMTags": {
+          "type": "boolean"
+        },
         "enableMermaid": {
           "type": "boolean"
         },
@@ -1008,6 +1014,8 @@
       "required": [
         "enableFMTitle",
         "enableNoteTitleForLink",
+        "enableFrontmatterTags",
+        "enableHashesForFMTags",
         "enableMermaid",
         "enablePrettyRefs",
         "enableKatex",


### PR DESCRIPTION
# chore: add validation for enableFrontmatterTags and enableHashesForFMTags
This PR:
- adds json schema validation for `preview.enableFrontmatterTags` and `preview.enableHashesForFMTags`