### PR TITLE
fix(views): fix race condition in tree view v2 initialization logic

### DIFF
--- a/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
@@ -8,6 +8,7 @@ import {
   createLogger,
   TreeViewUtils,
   engineHooks,
+  engineSliceUtils,
 } from "@dendronhq/common-frontend";
 import { Spin, Tree, TreeProps } from "antd";
 import _ from "lodash";
@@ -43,7 +44,7 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
 
   // update active notes in tree
   React.useEffect(() => {
-    if (!_.isUndefined(noteActive)) {
+    if (!_.isUndefined(noteActive) && engineSliceUtils.hasInitialized(engine)) {
       logger.info({ msg: "calcActiveNoteIds:pre" });
       const _activeNoteIds = TreeViewUtils.getAllParents({
         notes,
@@ -54,11 +55,17 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
       logger.info({ msg: "setActiveNoteIds:post" });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [numNotes, noteActive?.id]);
+  }, [engine.loading, numNotes, noteActive?.id]);
 
   // calculate the tree data
   React.useEffect(() => {
     logger.info({ msg: "calcRoots:pre", numNotes, notePrevId: notePrev?.id });
+    if (!engineSliceUtils.hasInitialized(engine)) {
+      logger.info({
+        msg: "calcRoots:engine not yet initialized",
+      });
+      return;
+    }
     // Avoid recomputing if it's just that the active note changed
     if (
       roots.length !== 0 &&
@@ -89,6 +96,7 @@ const DendronTreeExplorerPanel: DendronComponent = (props) => {
     logger.info({ msg: "calcRoots:post:setRoots", numNotes });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    engine.loading,
     // update if there are new notes
     numNotes,
     // update if something that may reorder the active note changes


### PR DESCRIPTION
## fix(views): fix race condition in tree view v2 initialization logic

There's a race condition in the Tree View V2 which may cause the Tree View to not initialize properly.  This change makes the data fetching operations on Tree View wait for the engine to be initialized first.

--- 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [N/A] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Tests

### Basics

Tested via loading org-workspace under the debugger.  I'll test again on nightly in case timings are different in the fully packaged extension. 

- [N/A] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [N/A] 1-2 Edge cases tested
- [N/A] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Close the Loop

### Extended
N/A
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)