### PR TITLE
fix(pods): Google Docs Export pod displays Bad Request error on export.

### DIFF
--- a/packages/pods-core/src/v2/pods/export/GoogleDocsExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/GoogleDocsExportPodV2.ts
@@ -83,7 +83,8 @@ export class GoogleDocsExportPodV2
 
   async exportNotes(notes: NoteProps[]): Promise<GoogleDocsExportReturnType> {
     const resp = await this.getPayloadForNotes(notes);
-    let { accessToken, expirationTime, refreshToken } = this._config;
+    let { accessToken } = this._config;
+    const { expirationTime, refreshToken } = this._config;
     try {
       accessToken = await this.checkTokenExpiry(
         expirationTime,
@@ -169,13 +170,15 @@ export class GoogleDocsExportPodV2
           convertLinks: false,
         };
         // converts markdown to html using HTMLPublish pod. The Drive API supports converting MIME types while creating a file.
-        const data = await pod.plant({
+        let data = await pod.plant({
           config,
           engine: this._engine,
           note: input,
           vaults: this._vaults,
           wsRoot: this._wsRoot,
         });
+        // wrap data in html tags
+        data = `<html>${data}</html>`;
         const content = Buffer.from(data);
         const documentId = input.custom.documentId;
         return {


### PR DESCRIPTION
```
fix(pods): Google Docs Export pod displays Bad Request error on export
```

This PR aims to resolve a `Bad Request 400` error thrown by Goggle Docs Export Pod. The GDoc export pod uses HTML Publish pod to perform the Md --> HTML conversion of note and send the data to google drive API. For some notes, the google API regards the content as invalid HTML and rejects it as bad request. 
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)