### PR TITLE
fix(workspace): fix crash in updated fm field logic on doc save

### DIFF
--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -304,6 +304,11 @@ export class WorkspaceWatcher {
 
     // If we can't find the note, don't do anything
     if (!note) {
+      // Log at info level and not error level for now to reduce Sentry noise
+      Logger.info({
+        ctx,
+        msg: `Note with fname ${fname} not found in engine! Skipping updated field FM modification.`,
+      });
       return;
     }
 

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -300,7 +300,7 @@ export class WorkspaceWatcher {
       fname,
       vault: this._extension.wsUtils.getVaultFromUri(uri),
       engine,
-    }) as NoteProps;
+    });
 
     // If we can't find the note, don't do anything
     if (!note) {

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -244,9 +244,7 @@ export class WorkspaceWatcher {
    * @param event
    * @returns
    */
-  async onWillSaveTextDocument(
-    event: TextDocumentWillSaveEvent
-  ): Promise<{ changes: TextEdit[] }> {
+  async onWillSaveTextDocument(event: TextDocumentWillSaveEvent) {
     try {
       const ctx = "WorkspaceWatcher:onWillSaveTextDocument";
       const uri = event.document.uri;
@@ -303,6 +301,11 @@ export class WorkspaceWatcher {
       vault: this._extension.wsUtils.getVaultFromUri(uri),
       engine,
     }) as NoteProps;
+
+    // If we can't find the note, don't do anything
+    if (!note) {
+      return;
+    }
 
     const content = event.document.getText();
     const matchFM = NoteUtils.RE_FM;

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -2,7 +2,6 @@ import {
   ConfigUtils,
   ContextualUIEvents,
   DNodeUtils,
-  NoteProps,
   NoteUtils,
   SchemaUtils,
   Time,


### PR DESCRIPTION
## fix(workspace): fix crash in updated fm field logic on doc save

One of the top Sentry hitters right now is in `onWillSaveNote`, "Cannot read property 'updated' of undefined".

This happens when we can't find a particular note in the engine when it's being saved.  I think this is caused by a race condition between the vscode `onWillSaveNote` callback and our filewatcher logic of adding the note to the engine for the cases of a user adding a new note outside of the Lookup command.

We should just avoid modifying the `updated` property if we can't find it - according to VSCode's API docs, if your  `onWillSaveNote` logic crashes 3 times, it will no longer get invoked.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [N/A] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [N/A] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [N/A] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - via Sentry Data

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)