### PR TITLE
fix(publish): better error messages when publishing

### DIFF
--- a/packages/dendron-cli/src/commands/pod.ts
+++ b/packages/dendron-cli/src/commands/pod.ts
@@ -9,6 +9,7 @@ import {
   HTMLPublishPod,
   JSONPublishPod,
   MarkdownPublishPod,
+  NextjsExportPod,
   PodClassEntryV4,
   PodKind,
   PodUtils,
@@ -183,6 +184,10 @@ export function enrichPodArgs(opts: {
         case JSONPublishPod.id:
         case HTMLPublishPod.id:
           cleanConfig["dest"] = "stdout";
+          break;
+        default:
+          // default is no-op
+          break;
       }
       // if vault is specified, then override config to pass in
       if (args.vault) {
@@ -191,7 +196,7 @@ export function enrichPodArgs(opts: {
       if (args.query) {
         cleanConfig["fname"] = args.query;
       }
-    } else {
+    } else if (podId !== NextjsExportPod.id) {
       // eslint-disable-next-line no-console
       console.log(
         `WARN: --query and --vault parameter not implemented for podType ${podType}`

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -280,7 +280,6 @@ export class SiteUtils {
         ctx: "filterByHiearchy",
         msg: "note not found",
         domain,
-        notesForHiearchy,
       });
       // TODO: add warning
       return;


### PR DESCRIPTION
fix(publish): better error messages when publishing

- don't throw podv2 warning when building a site
- don't dump engine state on bad vault warning

