### PR TITLE
chore(analytics): don't publish config data when reporting migration status

### DIFF
--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -14,6 +14,7 @@ import {
   DConfig,
   MigrationChangeSetStatus,
   MigrationService,
+  MigrationUtils,
   MIGRATION_ENTRIES,
   WorkspaceService,
 } from "@dendronhq/engine-server";
@@ -521,9 +522,10 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           ? CLIEvents.CLIMigrationSucceeded
           : CLIEvents.CLIMigrationFailed;
 
-        CLIAnalyticsUtils.track(event, {
-          data: change.data,
-        });
+        CLIAnalyticsUtils.track(
+          event,
+          MigrationUtils.getMigrationAnalyticProps(change)
+        );
 
         if (change.error) {
           this.print("Migration failed.");

--- a/packages/engine-server/src/migrations/utils.ts
+++ b/packages/engine-server/src/migrations/utils.ts
@@ -1,5 +1,6 @@
 import { HierarchyConfig, LegacyHierarchyConfig } from "@dendronhq/common-all";
 import _ from "lodash";
+import { MigrationChangeSetStatus } from "./types";
 
 type mappedConfigPath = {
   /**
@@ -263,5 +264,17 @@ export class MigrationUtils {
       }
     });
     return out;
+  }
+
+  static getMigrationAnalyticProps({
+    data: { changeName, status, version },
+  }: MigrationChangeSetStatus) {
+    return {
+      data: {
+        changeName,
+        status,
+        version,
+      },
+    };
   }
 }

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -32,6 +32,7 @@ import {
   HistoryService,
   MetadataService,
   MigrationChangeSetStatus,
+  MigrationUtils,
   WorkspaceService,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
@@ -522,9 +523,10 @@ export async function _activate(
             ? MigrationEvents.MigrationSucceeded
             : MigrationEvents.MigrationFailed;
 
-          AnalyticsUtils.track(event, {
-            data: change.data,
-          });
+          AnalyticsUtils.track(
+            event,
+            MigrationUtils.getMigrationAnalyticProps(change)
+          );
         });
       } else {
         // no migration changes.


### PR DESCRIPTION
chore(analytics): don't publish config data when reporting migration status

currently, we publish config data on migration status which is resulting in thousands of columns