### PR TITLE
fix(basics): improve perf around reference rendering including hover

### DIFF
--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -845,13 +845,17 @@ function convertNoteRefHelperAST(
   } else {
     // Otherwise, just clone the existing proc instead of creating a new one.
     // This will largely preserve existing opts, we just need to change a few.
-    noteRefProc = proc();
-    // proc is the parser that was parsing the note the reference was in, so need to update fname to reflect that we are parsing the referred note
-    MDUtilsV5.setProcData(noteRefProc, {
-      fname: note.fname,
-      insideNoteRef: true,
-      vault: note.vault,
-    });
+
+    noteRefProc = MDUtilsV5.procRemarkFull(
+      {
+        ...MDUtilsV5.getProcData(proc),
+        insideNoteRef: true,
+        fname: note.fname,
+        vault: note.vault,
+        engine,
+      },
+      MDUtilsV5.getProcOpts(proc)
+    );
   }
   const wsRoot = engine.wsRoot;
   noteRefProc = noteRefProc.data("fm", MDUtilsV5.getFM({ note, wsRoot }));

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -821,42 +821,27 @@ function convertNoteRefHelperAST(
   opts: ConvertNoteRefHelperOpts & { procOpts: any }
 ): Required<RespV2<Parent>> {
   const { proc, refLvl, link, note } = opts;
-  const { dest } = MDUtilsV5.getProcData(proc);
   let noteRefProc: Processor;
   // Workaround until all usages of MDUtilsV4 are removed
   const engine =
     MDUtilsV5.getProcData(proc).engine ||
     MDUtilsV4.getEngineFromProc(proc).engine;
-  if (dest === DendronASTDest.HTML) {
-    // For HTML, we need to make sure that we don't use a processor with HTML
-    // target. Otherwise as we process recursive references, the HTML output
-    // from deeper levels is broken (everything gets converted into `<div>`s for
-    // some reason)
-    noteRefProc = MDUtilsV5.procRemarkFull(
-      {
-        ...MDUtilsV5.getProcData(proc),
-        insideNoteRef: true,
-        fname: note.fname,
-        vault: note.vault,
-        engine,
-      },
-      MDUtilsV5.getProcOpts(proc)
-    );
-  } else {
-    // Otherwise, just clone the existing proc instead of creating a new one.
-    // This will largely preserve existing opts, we just need to change a few.
 
-    noteRefProc = MDUtilsV5.procRemarkFull(
-      {
-        ...MDUtilsV5.getProcData(proc),
-        insideNoteRef: true,
-        fname: note.fname,
-        vault: note.vault,
-        engine,
-      },
-      MDUtilsV5.getProcOpts(proc)
-    );
-  }
+  // Create a new proc to parse the reference; set the fname accordingly.
+  // NOTE: a new proc is created here instead of using the proc() copy
+  // constructor, as that is an expensive op since it deep clones the entire
+  // engine state in proc.data
+  noteRefProc = MDUtilsV5.procRemarkFull(
+    {
+      ...MDUtilsV5.getProcData(proc),
+      insideNoteRef: true,
+      fname: note.fname,
+      vault: note.vault,
+      engine,
+    },
+    MDUtilsV5.getProcOpts(proc)
+  );
+
   const wsRoot = engine.wsRoot;
   noteRefProc = noteRefProc.data("fm", MDUtilsV5.getFM({ note, wsRoot }));
   MDUtilsV5.setNoteRefLvl(noteRefProc, refLvl);


### PR DESCRIPTION
## fix(basics): improve perf around reference rendering including hover

This change improves perf / reduces mem usage whenever a reference is being rendered. This includes hover preview, which uses the note reference rendering implementation.

The issue is with `proc()`, which is a copy constructor - this is actually an expensive call when you have a lot of notes in your workspace, because it does a deep copy of `proc.data` - in our case, this includes the entirety of `DEngineClient`, that is, all notes, schemas, vaults, etc.  We should make it a principle to not use `proc()` when we're in full mode and have `DEngineClient` in the data payload.

For org-private, this reduces hover preview time and reference preview rendering down from 500-1200ms range to < 50 ms.  From some profiling, the memory impact is not as significant as I expected (probably due to string interning), but this may also help a bit with some stability issues in the editing experience.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ N/A] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
N/A
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
N/A
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
N/A
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)