### PR TITLE
fix(sync): Better error message on Workspace Add and Commit

### DIFF
--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -32,6 +32,10 @@ import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 import { URI } from "vscode-uri";
+import {
+  SyncActionResult,
+  SyncActionStatus,
+} from "./workspaceServiceInterface";
 
 export class WorkspaceUtils {
   static isWorkspaceConfig(val: any): val is WorkspaceSettings {
@@ -316,5 +320,41 @@ export class WorkspaceUtils {
       }
     }
     return link;
+  }
+
+  /**
+   * @param results
+   * @returns number of repos that has Sync Action Status done.
+   */
+  static getCountForStatusDone(results: SyncActionResult[]): number {
+    return this.count(results, SyncActionStatus.DONE);
+  }
+
+  static count(results: SyncActionResult[], status: SyncActionStatus) {
+    return results.filter((result) => result.status === status).length;
+  }
+
+  /**
+   *
+   * @param results
+   * @param status
+   * @returns name of all the repos with status same as @param status.
+   */
+  static getFilteredRepoNames(
+    results: SyncActionResult[],
+    status: SyncActionStatus
+  ): string[] {
+    const matchingResults = results.filter(
+      (result) => result.status === status
+    );
+    if (matchingResults.length === 0) return [];
+    return matchingResults.map((result) => {
+      // Display the vault names for info/error messages
+      if (result.vaults.length === 1) {
+        return VaultUtils.getName(result.vaults[0]);
+      }
+      // But if there's more than one vault in the repo, then use the repo path which is easier to interpret
+      return result.repo;
+    });
   }
 }

--- a/packages/plugin-core/src/commands/AddAndCommit.ts
+++ b/packages/plugin-core/src/commands/AddAndCommit.ts
@@ -1,38 +1,112 @@
+import { DendronError, ERROR_SEVERITY } from "@dendronhq/common-all";
+import {
+  SyncActionResult,
+  SyncActionStatus,
+  WorkspaceUtils,
+} from "@dendronhq/engine-server";
 import _ from "lodash";
-import path from "path";
-import { window } from "vscode";
+import { ProgressLocation, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
+import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
 const L = Logger;
 
 type CommandOpts = {};
+type CommandReturns =
+  | {
+      finalMessage: string;
+      committed: SyncActionResult[];
+    }
+  | undefined;
 
-export class AddAndCommit extends BasicCommand<CommandOpts, void> {
+export class AddAndCommit extends BasicCommand<CommandOpts, CommandReturns> {
   key = DENDRON_COMMANDS.ADD_AND_COMMIT.key;
+
+  private static generateReportMessage({
+    committed,
+  }: {
+    committed: SyncActionResult[];
+  }) {
+    const message = ["Finished Commit."];
+    // Report anything unusual the user probably should know about
+    let maxMessageSeverity: MessageSeverity = MessageSeverity.INFO;
+
+    const makeMessage = (
+      status: SyncActionStatus,
+      results: SyncActionResult[][],
+      fn: (repos: string) => {
+        msg: string;
+        severity: MessageSeverity;
+      }
+    ) => {
+      const uniqResults = _.uniq(_.flattenDeep(results));
+      const repos = WorkspaceUtils.getFilteredRepoNames(uniqResults, status);
+      if (repos.length === 0) return;
+      const { msg, severity } = fn(repos.join(", "));
+      message.push(msg);
+      if (severity > maxMessageSeverity) maxMessageSeverity = severity;
+    };
+
+    // Warnings, need user interaction to continue commit
+    makeMessage(SyncActionStatus.MERGE_CONFLICT, [committed], (repos) => {
+      return {
+        msg: `Skipped ${repos} because they have merge conflicts that must be resolved manually.`,
+        severity: MessageSeverity.WARN,
+      };
+    });
+
+    makeMessage(SyncActionStatus.NO_CHANGES, [committed], (repos) => {
+      return {
+        msg: `Skipped ${repos} because it has no new changes.`,
+        severity: MessageSeverity.INFO,
+      };
+    });
+
+    makeMessage(SyncActionStatus.REBASE_IN_PROGRESS, [committed], (repos) => {
+      return {
+        msg: `Skipped ${repos} because there's a rebase in progress that must be resolved.`,
+        severity: MessageSeverity.WARN,
+      };
+    });
+    return { message, maxMessageSeverity };
+  }
 
   async execute(opts?: CommandOpts) {
     const ctx = "execute";
     L.info({ ctx, opts });
     const engine = ExtensionProvider.getEngine();
     const workspaceService = ExtensionProvider.getExtension().workspaceService;
-    const resp = await workspaceService!.commitAndAddAll({
-      engine,
-    });
-    if (_.isEmpty(resp)) {
-      window.showInformationMessage(`no files to add or commit`);
-      return;
-    }
-    const respString = _.map(resp, (ent: string) => {
-      return path.basename(ent);
-    })
-      .filter((ent) => !_.isUndefined(ent))
-      .join(", ");
-    window.showInformationMessage(
-      `add and commit files in the following vaults: ${respString}`
+    if (_.isUndefined(workspaceService))
+      throw new DendronError({
+        message: "Workspace is not initialized",
+        severity: ERROR_SEVERITY.FATAL,
+      });
+    const committed = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Workspace Add and Commit",
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({ message: "staging changes" });
+        const committed = await workspaceService.commitAndAddAll({
+          engine,
+        });
+        L.info(committed);
+        return committed;
+      }
     );
-    return;
+    const { message, maxMessageSeverity } = AddAndCommit.generateReportMessage({
+      committed,
+    });
+    const committedDone = WorkspaceUtils.getCountForStatusDone(committed);
+    const repos = (count: number) => (count <= 1 ? "repo" : "repos");
+    message.push(`Committed ${committedDone} ${repos(committedDone)}`);
+    const finalMessage = message.join(" ");
+    VSCodeUtils.showMessage(maxMessageSeverity, finalMessage, {});
+    return { committed, finalMessage };
   }
 }

--- a/packages/plugin-core/src/commands/Sync.ts
+++ b/packages/plugin-core/src/commands/Sync.ts
@@ -1,9 +1,9 @@
+import { DendronError, ERROR_SEVERITY } from "@dendronhq/common-all";
 import {
-  DendronError,
-  ERROR_SEVERITY,
-  VaultUtils,
-} from "@dendronhq/common-all";
-import { SyncActionResult, SyncActionStatus } from "@dendronhq/engine-server";
+  SyncActionResult,
+  SyncActionStatus,
+  WorkspaceUtils,
+} from "@dendronhq/engine-server";
 import _ from "lodash";
 import { ProgressLocation, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
@@ -25,32 +25,6 @@ type CommandReturns =
 
 export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
   key = DENDRON_COMMANDS.SYNC.key;
-
-  static countDone(results: SyncActionResult[]): number {
-    return this.count(results, SyncActionStatus.DONE);
-  }
-
-  static count(results: SyncActionResult[], status: SyncActionStatus) {
-    return results.filter((result) => result.status === status).length;
-  }
-
-  private static filteredRepoNames(
-    results: SyncActionResult[],
-    status: SyncActionStatus
-  ): string[] {
-    const matchingResults = results.filter(
-      (result) => result.status === status
-    );
-    if (matchingResults.length === 0) return [];
-    return matchingResults.map((result) => {
-      // Display the vault names for info/error messages
-      if (result.vaults.length === 1) {
-        return VaultUtils.getName(result.vaults[0]);
-      }
-      // But if there's more than one vault in the repo, then use the repo path which is easier to interpret
-      return result.repo;
-    });
-  }
 
   private static generateReportMessage({
     committed,
@@ -74,7 +48,7 @@ export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
       }
     ) => {
       const uniqResults = _.uniq(_.flattenDeep(results));
-      const repos = SyncCommand.filteredRepoNames(uniqResults, status);
+      const repos = WorkspaceUtils.getFilteredRepoNames(uniqResults, status);
       if (repos.length === 0) return;
       const { msg, severity } = fn(repos.join(", "));
       message.push(msg);
@@ -208,9 +182,9 @@ export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
     });
 
     // Successful operations
-    const committedDone = SyncCommand.countDone(committed);
-    const pulledDone = SyncCommand.countDone(pulled);
-    const pushedDone = SyncCommand.countDone(pushed);
+    const committedDone = WorkspaceUtils.getCountForStatusDone(committed);
+    const pulledDone = WorkspaceUtils.getCountForStatusDone(pulled);
+    const pushedDone = WorkspaceUtils.getCountForStatusDone(pushed);
     const repos = (count: number) => (count === 1 ? "repo" : "repos");
     message.push(`Committed ${committedDone} ${repos(committedDone)},`);
     message.push(`tried pulling ${pulledDone}`);

--- a/packages/plugin-core/src/test/suite-integ/AddAndCommitCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddAndCommitCommand.test.ts
@@ -21,7 +21,7 @@ suite("GIVEN Workspace Add And Commit command is run", function () {
         ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
         return config;
       },
-      timeout: 1e6,
+      timeout: 1e4,
     },
     () => {
       test("THEN skip committing AND show no new changes message", async () => {
@@ -50,7 +50,7 @@ suite("GIVEN Workspace Add And Commit command is run", function () {
         ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
         return config;
       },
-      timeout: 1e6,
+      timeout: 1e4,
     },
     () => {
       test("THEN skip committing files AND show merge conflict message", async () => {
@@ -78,7 +78,7 @@ suite("GIVEN Workspace Add And Commit command is run", function () {
         ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
         return config;
       },
-      timeout: 1e6,
+      timeout: 1e4,
     },
     () => {
       test("THEN skip committing files AND show rebase conflict message", async () => {
@@ -113,7 +113,7 @@ suite("GIVEN Workspace Add And Commit command is run", function () {
         ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
         return config;
       },
-      timeout: 1e6,
+      timeout: 1e4,
     },
     () => {
       test("THEN Dendron commit files successfully", async () => {

--- a/packages/plugin-core/src/test/suite-integ/AddAndCommitCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddAndCommitCommand.test.ts
@@ -1,0 +1,215 @@
+import { ConfigUtils, NoteUtils } from "@dendronhq/common-all";
+import { tmpDir } from "@dendronhq/common-server";
+import {
+  Git,
+  SyncActionStatus,
+  WorkspaceUtils,
+} from "@dendronhq/engine-server";
+import { GitTestUtils } from "@dendronhq/engine-test-utils";
+import _ from "lodash";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS } from "../testUtilsV3";
+import fs from "fs-extra";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { AddAndCommit } from "../../commands/AddAndCommit";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+
+const TIMEOUT = 60 * 1000 * 5;
+
+suite("GIVEN Workspace Add And Commit command is run", function () {
+  this.timeout(TIMEOUT);
+  describeSingleWS(
+    "WHEN there are no changes",
+    {
+      modConfigCb: (config) => {
+        ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
+        return config;
+      },
+    },
+    () => {
+      test("THEN Dendron skips committing", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        // Add everything and push, so that there's no changes
+        const git = new Git({ localUrl: wsRoot });
+        await git.addAll();
+        await git.commit({ msg: "add all and commit" });
+        const out = await new AddAndCommit().execute();
+        const { committed, finalMessage } = out;
+        expect(WorkspaceUtils.getCountForStatusDone(committed)).toEqual(0);
+        expect(committed[0].status).toEqual(SyncActionStatus.NO_CHANGES);
+        expect(finalMessage).toEqual(
+          "Finished Commit. Skipped vault because it has no new changes. Committed 0 repo"
+        );
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN there is a merge conflict",
+    {
+      modConfigCb: (config) => {
+        ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
+        return config;
+      },
+    },
+    () => {
+      test("THEN Dendron skips committing files", async () => {
+        const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        const rootNote = NoteUtils.getNoteByFnameFromEngine({
+          fname: "root",
+          vault: vaults[0],
+          engine,
+        })!;
+        // Add everything and push, so that there's no untracked changes
+        const git = new Git({ localUrl: wsRoot, remoteUrl: remoteDir });
+        await git.addAll();
+        await git.commit({ msg: "first commit" });
+        await git.push();
+        // Update root note and add a commit that's not in remote, so there'll be something to rebase
+        const fpath = NoteUtils.getFullPath({
+          note: rootNote,
+          wsRoot,
+        });
+        await fs.appendFile(fpath, "Deserunt culpa in expedita\n");
+        await git.addAll();
+        await git.commit({ msg: "second commit" });
+
+        // Clone to a second location, then push a change through that
+        const secondaryDir = tmpDir().name;
+        const secondaryGit = new Git({
+          localUrl: secondaryDir,
+          remoteUrl: remoteDir,
+        });
+        await secondaryGit.clone(".");
+        const secondaryFpath = NoteUtils.getFullPath({
+          note: rootNote,
+          wsRoot: secondaryDir,
+        });
+        await fs.appendFile(secondaryFpath, "Aut ut nisi dolores quae et\n");
+        await secondaryGit.addAll();
+        await secondaryGit.commit({ msg: "secondary" });
+        await secondaryGit.push();
+
+        // Cause an ongoing rebase
+        try {
+          await git.pull();
+        } catch {
+          // deliberately ignored
+        }
+
+        const out = await new AddAndCommit().execute();
+        const { committed, finalMessage } = out;
+        expect(WorkspaceUtils.getCountForStatusDone(committed)).toEqual(0);
+        expect(committed[0].status).toEqual(SyncActionStatus.MERGE_CONFLICT);
+        expect(finalMessage).toEqual(
+          "Finished Commit. Skipped vault because they have merge conflicts that must be resolved manually. Committed 0 repo"
+        );
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN there is a rebase in progress",
+    {
+      modConfigCb: (config) => {
+        ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
+        return config;
+      },
+    },
+    () => {
+      test("THEN Dendron skips committing files", async () => {
+        const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        const rootNote = NoteUtils.getNoteByFnameFromEngine({
+          fname: "root",
+          vault: vaults[0],
+          engine,
+        })!;
+        // Add everything and push, so that there's no untracked changes
+        const git = new Git({ localUrl: wsRoot, remoteUrl: remoteDir });
+        await git.addAll();
+        await git.commit({ msg: "first commit" });
+        await git.push();
+        // Update root note and add a commit that's not in remote, so there'll be something to rebase
+        const fpath = NoteUtils.getFullPath({
+          note: rootNote,
+          wsRoot,
+        });
+        await fs.appendFile(fpath, "Deserunt culpa in expedita\n");
+        await git.addAll();
+        await git.commit({ msg: "second commit" });
+
+        // Clone to a second location, then push a change through that
+        const secondaryDir = tmpDir().name;
+        const secondaryGit = new Git({
+          localUrl: secondaryDir,
+          remoteUrl: remoteDir,
+        });
+        await secondaryGit.clone(".");
+        const secondaryFpath = NoteUtils.getFullPath({
+          note: rootNote,
+          wsRoot: secondaryDir,
+        });
+        await fs.appendFile(secondaryFpath, "Aut ut nisi dolores quae et\n");
+        await secondaryGit.addAll();
+        await secondaryGit.commit({ msg: "secondary" });
+        await secondaryGit.push();
+
+        // Cause an ongoing rebase
+        try {
+          await git.pull();
+        } catch {
+          // deliberately ignored
+        }
+        // Mark the conflict as resolved
+        await git.add(fpath);
+
+        const out = await new AddAndCommit().execute();
+        const { committed, finalMessage } = out;
+        // Should skip everything since there's an ongoing rebase the user needs to resolve
+        expect(WorkspaceUtils.getCountForStatusDone(committed)).toEqual(0);
+        expect(committed[0].status).toEqual(
+          SyncActionStatus.REBASE_IN_PROGRESS
+        );
+        expect(finalMessage).toEqual(
+          "Finished Commit. Skipped vault because there's a rebase in progress that must be resolved. Committed 0 repo"
+        );
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN there are unstaged changes",
+    {
+      modConfigCb: (config) => {
+        ConfigUtils.setWorkspaceProp(config, "workspaceVaultSyncMode", "sync");
+        return config;
+      },
+    },
+    () => {
+      test("THEN Dendron commit files successfully", async () => {
+        const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        // Create a new note so there are some changes
+        await NoteTestUtilsV4.createNote({
+          fname: "my-new-note",
+          body: "Lorem ipsum",
+          wsRoot,
+          vault: vaults[0],
+        });
+
+        const out = await new AddAndCommit().execute();
+        const { committed, finalMessage } = out;
+        // Should try to commit since there are changes
+        expect(WorkspaceUtils.getCountForStatusDone(committed)).toEqual(1);
+        expect(finalMessage).toEqual("Finished Commit. Committed 1 repo");
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -526,10 +526,21 @@ export function describeMultiWS(
  */
 export function describeSingleWS(
   title: string,
-  opts: SetupLegacyWorkspaceOpts,
+  opts: SetupLegacyWorkspaceOpts & {
+    /**
+     * Custom timeout for test in milleseconds
+     * You will need to set this when stepping through mocha tests using breakpoints
+     * otherwise the test will timeout during debugging
+     * See [[Breakpoints|dendron://dendron.docs/pkg.plugin-core.qa.debug#breakpoints]] for more details
+     */
+    timeout?: number;
+  },
   fn: () => void
 ) {
-  describe(title, () => {
+  describe(title, function () {
+    if (opts.timeout) {
+      this.timeout(opts.timeout);
+    }
     let ctx: ExtensionContext;
     before(async () => {
       ctx = opts.ctx ?? setupWorkspaceStubs(opts);


### PR DESCRIPTION
```
fix(sync): Better error message on Workspace Add and Commit
```

This PR aims to solve the issue linked below. It also improves error messages when there is an in-progress rebase, merge conflicts or no new changes.
Related issue: https://github.com/dendronhq/dendron/issues/1297
# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: No new dependencies added (17)
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)