### PR TITLE
fix: Re-enable inactive user survey and store prompt status in filesystem for prompt reliability.

### DIFF
--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -21,6 +21,10 @@ type Metadata = Partial<{
    */
   inactiveUserMsgSendTime: number;
   /**
+   * The status of inactive user message. If submitted, we don't prompt again. If cancelled, we wait 2 weeks to send again.
+   */
+  inactiveUserMsgStatus: "submitted" | "cancelled";
+  /**
    * Set if a user has activated a dendron workspace
    */
   dendronWorkspaceActivated: number;
@@ -105,5 +109,9 @@ export class MetadataService {
 
   setInactiveUserMsgSendTime() {
     return this.setMeta("inactiveUserMsgSendTime", Time.now().toSeconds());
+  }
+
+  setInactiveUserMsgStatus(value: "submitted" | "cancelled") {
+    return this.setMeta("inactiveUserMsgStatus", value);
   }
 }

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -23,7 +23,7 @@ type Metadata = Partial<{
   /**
    * The status of inactive user message. If submitted, we don't prompt again. If cancelled, we wait 2 weeks to send again.
    */
-  inactiveUserMsgStatus: "submitted" | "cancelled";
+  inactiveUserMsgStatus: InactvieUserMsgStatusEnum;
   /**
    * Set if a user has activated a dendron workspace
    */
@@ -37,6 +37,11 @@ type Metadata = Partial<{
    */
   lastLookupTime: number;
 }>;
+
+export enum InactvieUserMsgStatusEnum {
+  submitted = "submitted",
+  cancelled = "cancelled",
+}
 
 let _singleton: MetadataService | undefined;
 
@@ -111,7 +116,7 @@ export class MetadataService {
     return this.setMeta("inactiveUserMsgSendTime", Time.now().toSeconds());
   }
 
-  setInactiveUserMsgStatus(value: "submitted" | "cancelled") {
+  setInactiveUserMsgStatus(value: InactvieUserMsgStatusEnum) {
     return this.setMeta("inactiveUserMsgStatus", value);
   }
 }

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -30,6 +30,7 @@ import {
 import {
   FileAddWatcher,
   HistoryService,
+  InactvieUserMsgStatusEnum,
   MetadataService,
   MigrationChangeSetStatus,
   MigrationUtils,
@@ -981,7 +982,7 @@ export function shouldDisplayInactiveUserSurvey(): boolean {
   const metaData = MetadataService.instance().getMeta();
 
   const inactiveSurveyMsgStatus = metaData.inactiveUserMsgStatus;
-  if (inactiveSurveyMsgStatus === "submitted") {
+  if (inactiveSurveyMsgStatus === InactvieUserMsgStatusEnum.submitted) {
     return false;
   }
 
@@ -1034,7 +1035,7 @@ export function shouldDisplayInactiveUserSurvey(): boolean {
     CUR_TIME.minus(LAST_LOOKUP_TIME) >= FOUR_WEEKS;
 
   // if they have cancelled last time, we should be waiting another four weeks.
-  if (inactiveSurveyMsgStatus === "cancelled") {
+  if (inactiveSurveyMsgStatus === InactvieUserMsgStatusEnum.cancelled) {
     const shouldSendAgain =
       INACTIVE_USER_MSG_SEND_TIME !== undefined &&
       CUR_TIME.minus(INACTIVE_USER_MSG_SEND_TIME) >= FOUR_WEEKS &&

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -979,12 +979,10 @@ export async function showLapsedUserMessage(assetUri: vscode.Uri) {
 }
 
 export async function shouldDisplayInactiveUserSurvey(): Promise<boolean> {
-  const inactiveSurveySubmitted = await StateService.instance().getGlobalState(
-    GLOBAL_STATE.INACTIVE_USER_SURVEY_SUBMITTED
-  );
+  const metaData = MetadataService.instance().getMeta();
 
-  // don't display if they have submitted before.
-  if (inactiveSurveySubmitted === "submitted") {
+  const inactiveSurveyMsgStatus = metaData.inactiveUserMsgStatus;
+  if (inactiveSurveyMsgStatus === "submitted") {
     return false;
   }
 
@@ -992,7 +990,6 @@ export async function shouldDisplayInactiveUserSurvey(): Promise<boolean> {
   const TWO_WEEKS = Duration.fromObject({ weeks: 2 });
   const currentTime = Time.now().toSeconds();
   const CUR_TIME = Duration.fromObject({ seconds: currentTime });
-  const metaData = MetadataService.instance().getMeta();
 
   const FIRST_INSTALL =
     metaData.firstInstall !== undefined
@@ -1020,14 +1017,14 @@ export async function shouldDisplayInactiveUserSurvey(): Promise<boolean> {
     FIRST_LOOKUP_TIME !== undefined &&
     FIRST_LOOKUP_TIME.minus(FIRST_INSTALL) <= ONE_WEEK;
 
-  // was the user active on the first week but has been inactive for a two weeks?
+  // was the user active on the first week but has been inactive for more than two weeks?
   const isInactive =
     isFirstWeekActive &&
     LAST_LOOKUP_TIME !== undefined &&
     CUR_TIME.minus(LAST_LOOKUP_TIME) >= TWO_WEEKS;
 
   // if they have cancelled last time, we should be waiting another 2 weeks.
-  if (inactiveSurveySubmitted === "cancelled") {
+  if (inactiveSurveyMsgStatus === "cancelled") {
     const shouldSendAgain =
       INACTIVE_USER_MSG_SEND_TIME !== undefined &&
       CUR_TIME.minus(INACTIVE_USER_MSG_SEND_TIME) >= TWO_WEEKS &&

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -937,8 +937,7 @@ async function showWelcomeOrWhatsNew({
 
   // Show inactive users (users who were active on first week but have not used lookup in 2 weeks)
   // a reminder prompt to re-engage them.
-  // TODO: there is a bug in the current logic. disabling until we fix it
-  if (false) {
+  if (shouldDisplayInactiveUserSurvey()) {
     await showInactiveUserMessage();
   }
 }
@@ -978,7 +977,7 @@ export async function showLapsedUserMessage(assetUri: vscode.Uri) {
     });
 }
 
-export async function shouldDisplayInactiveUserSurvey(): Promise<boolean> {
+export function shouldDisplayInactiveUserSurvey(): boolean {
   const metaData = MetadataService.instance().getMeta();
 
   const inactiveSurveyMsgStatus = metaData.inactiveUserMsgStatus;

--- a/packages/plugin-core/src/services/stateService.ts
+++ b/packages/plugin-core/src/services/stateService.ts
@@ -12,6 +12,8 @@ type ExtensionGlobalState = ExtensionContext["globalState"];
 type ExtensionWorkspaceState = ExtensionContext["workspaceState"];
 
 /**
+ * @deprecated All state service logic will be consolidated to {@link MetadataService}.
+ * Consider using it instead if you need to add a new state to track.
  * Keeps track of workspace state
  */
 export class StateService {

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -7,7 +7,10 @@ import { StateService } from "./services/stateService";
 import { GLOBAL_STATE } from "./constants";
 import { resolve } from "path";
 import { VSCodeUtils } from "./vsCodeUtils";
-import { MetadataService } from "@dendronhq/engine-server";
+import {
+  InactvieUserMsgStatusEnum,
+  MetadataService,
+} from "@dendronhq/engine-server";
 
 export class DendronQuickInputSurvey {
   opts: {
@@ -608,13 +611,17 @@ export class SurveyUtils {
             "https://airtable.com/shry4eLgvVE6WR0Or?prefill_SurveyName=InactiveFeedback";
           VSCodeUtils.openLink(AIRTABLE_URL);
 
-          MetadataService.instance().setInactiveUserMsgStatus("submitted");
+          MetadataService.instance().setInactiveUserMsgStatus(
+            InactvieUserMsgStatusEnum.submitted
+          );
           vscode.window.showInformationMessage(
             "Thanks for helping us make Dendron better 🌱"
           );
           AnalyticsUtils.track(SurveyEvents.InactiveUserSurveyAccepted);
         } else {
-          MetadataService.instance().setInactiveUserMsgStatus("cancelled");
+          MetadataService.instance().setInactiveUserMsgStatus(
+            InactvieUserMsgStatusEnum.cancelled
+          );
           vscode.window.showInformationMessage("Survey cancelled.");
           AnalyticsUtils.track(SurveyEvents.InactiveUserSurveyRejected);
         }

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -7,6 +7,7 @@ import { StateService } from "./services/stateService";
 import { GLOBAL_STATE } from "./constants";
 import { resolve } from "path";
 import { VSCodeUtils } from "./vsCodeUtils";
+import { MetadataService } from "@dendronhq/engine-server";
 
 export class DendronQuickInputSurvey {
   opts: {
@@ -607,19 +608,13 @@ export class SurveyUtils {
             "https://airtable.com/shry4eLgvVE6WR0Or?prefill_SurveyName=InactiveFeedback";
           VSCodeUtils.openLink(AIRTABLE_URL);
 
-          await StateService.instance().updateGlobalState(
-            GLOBAL_STATE.INACTIVE_USER_SURVEY_SUBMITTED,
-            "submitted"
-          );
+          MetadataService.instance().setInactiveUserMsgStatus("submitted");
           vscode.window.showInformationMessage(
             "Thanks for helping us make Dendron better 🌱"
           );
           AnalyticsUtils.track(SurveyEvents.InactiveUserSurveyAccepted);
         } else {
-          await StateService.instance().updateGlobalState(
-            GLOBAL_STATE.INACTIVE_USER_SURVEY_SUBMITTED,
-            "cancelled"
-          );
+          MetadataService.instance().setInactiveUserMsgStatus("cancelled");
           vscode.window.showInformationMessage("Survey cancelled.");
           AnalyticsUtils.track(SurveyEvents.InactiveUserSurveyRejected);
         }

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1018,7 +1018,7 @@ suite("GIVEN Dendron plugin activation", function () {
   });
 });
 
-describe.only("shouldDisplayInactiveUserSurvey", () => {
+describe("shouldDisplayInactiveUserSurvey", () => {
   const ONE_WEEK = 604800;
   const NOW = Time.now().toSeconds();
   const ONE_WEEK_BEFORE = NOW - ONE_WEEK;

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -108,31 +108,28 @@ async function inactiveMessageTest(opts: {
   done: mocha.Done;
   firstInstall?: number;
   firstWsInitialize?: number;
+  inactiveUserMsgStatus?: "submitted" | "cancelled";
   inactiveUserMsgSendTime?: number;
   workspaceActivated?: boolean;
   firstLookupTime?: number;
   lastLookupTime?: number;
-  state: string | undefined;
   shouldDisplayMessage: boolean;
 }) {
   const {
     done,
     firstInstall,
     firstWsInitialize,
+    inactiveUserMsgStatus,
     inactiveUserMsgSendTime,
     shouldDisplayMessage,
     firstLookupTime,
     lastLookupTime,
-    state,
     workspaceActivated,
   } = opts;
   const svc = MetadataService.instance();
-  sinon
-    .stub(StateService.instance(), "getGlobalState")
-    .resolves(_.isUndefined(state) ? undefined : state);
-
   svc.setMeta("firstInstall", firstInstall);
   svc.setMeta("firstWsInitialize", firstWsInitialize);
+  svc.setMeta("inactiveUserMsgStatus", inactiveUserMsgStatus);
   svc.setMeta("inactiveUserMsgSendTime", inactiveUserMsgSendTime);
   svc.setMeta("dendronWorkspaceActivated", workspaceActivated);
   svc.setMeta("firstLookupTime", firstLookupTime);
@@ -543,93 +540,6 @@ suite("GIVEN SetupWorkspace Command", function () {
             const actual = AnalyticsUtils.isFirstWeek();
             expect(actual).toBeFalsy();
             done();
-          });
-        });
-      });
-
-      describe("shouldDisplayInactiveUserSurvey", () => {
-        const ONE_WEEK = 604800;
-        const NOW = Time.now().toSeconds();
-        const ONE_WEEK_BEFORE = NOW - ONE_WEEK;
-        const TWO_WEEKS_BEFORE = NOW - 2 * ONE_WEEK;
-        const THREE_WEEKS_BEFORE = NOW - 3 * ONE_WEEK;
-        const FOUR_WEEKS_BEFORE = NOW - 4 * ONE_WEEK;
-        const FIVE_WEEKS_BEFORE = NOW - 5 * ONE_WEEK;
-        describe("GIVEN not prompted yet", () => {
-          describe("WHEN is first week active user AND inactive for less than two weeks", () => {
-            test("THEN should not display inactive user survey", (done) => {
-              inactiveMessageTest({
-                done,
-                firstInstall: ONE_WEEK_BEFORE,
-                firstWsInitialize: ONE_WEEK_BEFORE,
-                firstLookupTime: ONE_WEEK_BEFORE,
-                lastLookupTime: ONE_WEEK_BEFORE,
-                workspaceActivated: true,
-                state: undefined,
-                shouldDisplayMessage: false,
-              });
-            });
-          });
-          describe("WHEN is first week active user AND inactive for at two weeks", () => {
-            test("THEN should display inactive user survey", (done) => {
-              inactiveMessageTest({
-                done,
-                firstInstall: THREE_WEEKS_BEFORE,
-                firstWsInitialize: THREE_WEEKS_BEFORE,
-                firstLookupTime: THREE_WEEKS_BEFORE,
-                lastLookupTime: TWO_WEEKS_BEFORE,
-                workspaceActivated: true,
-                state: undefined,
-                shouldDisplayMessage: true,
-              });
-            });
-          });
-        });
-        describe("GIVEN already prompted", () => {
-          describe("WHEN user has submitted", () => {
-            test("THEN should never display inactive user survey", (done) => {
-              inactiveMessageTest({
-                done,
-                firstInstall: FIVE_WEEKS_BEFORE,
-                firstWsInitialize: FIVE_WEEKS_BEFORE,
-                firstLookupTime: FIVE_WEEKS_BEFORE,
-                lastLookupTime: FOUR_WEEKS_BEFORE,
-                inactiveUserMsgSendTime: TWO_WEEKS_BEFORE,
-                workspaceActivated: true,
-                state: "submitted",
-                shouldDisplayMessage: false,
-              });
-            });
-          });
-          describe("WHEN it has been another two weeks since user rejected survey", () => {
-            test("THEN should display inactive user survey", (done) => {
-              inactiveMessageTest({
-                done,
-                firstInstall: FIVE_WEEKS_BEFORE,
-                firstWsInitialize: FIVE_WEEKS_BEFORE,
-                firstLookupTime: FIVE_WEEKS_BEFORE,
-                lastLookupTime: FOUR_WEEKS_BEFORE,
-                inactiveUserMsgSendTime: TWO_WEEKS_BEFORE,
-                workspaceActivated: true,
-                state: "cancelled",
-                shouldDisplayMessage: true,
-              });
-            });
-          });
-          describe("WHEN it hasn't been another two weeks since rejected prompt", () => {
-            test("THEN should not display inactive user survey", (done) => {
-              inactiveMessageTest({
-                done,
-                firstInstall: FIVE_WEEKS_BEFORE,
-                firstWsInitialize: FIVE_WEEKS_BEFORE,
-                firstLookupTime: FIVE_WEEKS_BEFORE,
-                lastLookupTime: FOUR_WEEKS_BEFORE,
-                inactiveUserMsgSendTime: ONE_WEEK_BEFORE,
-                workspaceActivated: true,
-                state: "cancelled",
-                shouldDisplayMessage: false,
-              });
-            });
           });
         });
       });
@@ -1105,5 +1015,90 @@ suite("GIVEN Dendron plugin activation", function () {
         });
       }
     );
+  });
+});
+
+describe.only("shouldDisplayInactiveUserSurvey", () => {
+  const ONE_WEEK = 604800;
+  const NOW = Time.now().toSeconds();
+  const ONE_WEEK_BEFORE = NOW - ONE_WEEK;
+  const TWO_WEEKS_BEFORE = NOW - 2 * ONE_WEEK;
+  const THREE_WEEKS_BEFORE = NOW - 3 * ONE_WEEK;
+  const FOUR_WEEKS_BEFORE = NOW - 4 * ONE_WEEK;
+  const FIVE_WEEKS_BEFORE = NOW - 5 * ONE_WEEK;
+  describe("GIVEN not prompted yet", () => {
+    describe("WHEN is first week active user AND inactive for less than two weeks", () => {
+      test("THEN should not display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: ONE_WEEK_BEFORE,
+          firstWsInitialize: ONE_WEEK_BEFORE,
+          firstLookupTime: ONE_WEEK_BEFORE,
+          lastLookupTime: ONE_WEEK_BEFORE,
+          workspaceActivated: true,
+          shouldDisplayMessage: false,
+        });
+      });
+    });
+    describe("WHEN is first week active user AND inactive for at two weeks", () => {
+      test("THEN should display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: THREE_WEEKS_BEFORE,
+          firstWsInitialize: THREE_WEEKS_BEFORE,
+          firstLookupTime: THREE_WEEKS_BEFORE,
+          lastLookupTime: TWO_WEEKS_BEFORE,
+          workspaceActivated: true,
+          shouldDisplayMessage: true,
+        });
+      });
+    });
+  });
+  describe("GIVEN already prompted", () => {
+    describe("WHEN user has submitted", () => {
+      test("THEN should never display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: FIVE_WEEKS_BEFORE,
+          firstWsInitialize: FIVE_WEEKS_BEFORE,
+          firstLookupTime: FIVE_WEEKS_BEFORE,
+          lastLookupTime: FOUR_WEEKS_BEFORE,
+          inactiveUserMsgSendTime: TWO_WEEKS_BEFORE,
+          workspaceActivated: true,
+          inactiveUserMsgStatus: "submitted",
+          shouldDisplayMessage: false,
+        });
+      });
+    });
+    describe("WHEN it has been another two weeks since user rejected survey", () => {
+      test("THEN should display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: FIVE_WEEKS_BEFORE,
+          firstWsInitialize: FIVE_WEEKS_BEFORE,
+          firstLookupTime: FIVE_WEEKS_BEFORE,
+          lastLookupTime: FOUR_WEEKS_BEFORE,
+          inactiveUserMsgSendTime: TWO_WEEKS_BEFORE,
+          workspaceActivated: true,
+          inactiveUserMsgStatus: "cancelled",
+          shouldDisplayMessage: true,
+        });
+      });
+    });
+    describe("WHEN it hasn't been another two weeks since rejected prompt", () => {
+      test("THEN should not display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: FIVE_WEEKS_BEFORE,
+          firstWsInitialize: FIVE_WEEKS_BEFORE,
+          firstLookupTime: FIVE_WEEKS_BEFORE,
+          lastLookupTime: FOUR_WEEKS_BEFORE,
+          inactiveUserMsgSendTime: ONE_WEEK_BEFORE,
+          workspaceActivated: true,
+          inactiveUserMsgStatus: "cancelled",
+          shouldDisplayMessage: false,
+        });
+      });
+    });
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -134,7 +134,7 @@ async function inactiveMessageTest(opts: {
   svc.setMeta("dendronWorkspaceActivated", workspaceActivated);
   svc.setMeta("firstLookupTime", firstLookupTime);
   svc.setMeta("lastLookupTime", lastLookupTime);
-  const expected = await shouldDisplayInactiveUserSurvey();
+  const expected = shouldDisplayInactiveUserSurvey();
   expect(expected).toEqual(shouldDisplayMessage);
   sinon.restore();
   done();

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1026,28 +1026,30 @@ describe("shouldDisplayInactiveUserSurvey", () => {
   const THREE_WEEKS_BEFORE = NOW - 3 * ONE_WEEK;
   const FOUR_WEEKS_BEFORE = NOW - 4 * ONE_WEEK;
   const FIVE_WEEKS_BEFORE = NOW - 5 * ONE_WEEK;
+  const SIX_WEEKS_BEFORE = NOW - 6 * ONE_WEEK;
+  const SEVEN_WEEKS_BEFORE = NOW - 7 * ONE_WEEK;
   describe("GIVEN not prompted yet", () => {
-    describe("WHEN is first week active user AND inactive for less than two weeks", () => {
+    describe("WHEN is first week active user AND inactive for less than four weeks", () => {
       test("THEN should not display inactive user survey", (done) => {
-        inactiveMessageTest({
-          done,
-          firstInstall: ONE_WEEK_BEFORE,
-          firstWsInitialize: ONE_WEEK_BEFORE,
-          firstLookupTime: ONE_WEEK_BEFORE,
-          lastLookupTime: ONE_WEEK_BEFORE,
-          workspaceActivated: true,
-          shouldDisplayMessage: false,
-        });
-      });
-    });
-    describe("WHEN is first week active user AND inactive for at two weeks", () => {
-      test("THEN should display inactive user survey", (done) => {
         inactiveMessageTest({
           done,
           firstInstall: THREE_WEEKS_BEFORE,
           firstWsInitialize: THREE_WEEKS_BEFORE,
           firstLookupTime: THREE_WEEKS_BEFORE,
-          lastLookupTime: TWO_WEEKS_BEFORE,
+          lastLookupTime: THREE_WEEKS_BEFORE,
+          workspaceActivated: true,
+          shouldDisplayMessage: false,
+        });
+      });
+    });
+    describe("WHEN is first week active user AND inactive for at least four weeks", () => {
+      test("THEN should display inactive user survey", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: FIVE_WEEKS_BEFORE,
+          firstWsInitialize: FIVE_WEEKS_BEFORE,
+          firstLookupTime: FIVE_WEEKS_BEFORE,
+          lastLookupTime: FOUR_WEEKS_BEFORE,
           workspaceActivated: true,
           shouldDisplayMessage: true,
         });
@@ -1070,30 +1072,43 @@ describe("shouldDisplayInactiveUserSurvey", () => {
         });
       });
     });
-    describe("WHEN it has been another two weeks since user rejected survey", () => {
-      test("THEN should display inactive user survey", (done) => {
+    describe("WHEN it has been another four weeks since user rejected survey", () => {
+      test("THEN should display inactive user survey if inactive", (done) => {
         inactiveMessageTest({
           done,
-          firstInstall: FIVE_WEEKS_BEFORE,
-          firstWsInitialize: FIVE_WEEKS_BEFORE,
-          firstLookupTime: FIVE_WEEKS_BEFORE,
-          lastLookupTime: FOUR_WEEKS_BEFORE,
-          inactiveUserMsgSendTime: TWO_WEEKS_BEFORE,
+          firstInstall: SEVEN_WEEKS_BEFORE,
+          firstWsInitialize: SEVEN_WEEKS_BEFORE,
+          firstLookupTime: SEVEN_WEEKS_BEFORE,
+          lastLookupTime: SIX_WEEKS_BEFORE,
+          inactiveUserMsgSendTime: FOUR_WEEKS_BEFORE,
           workspaceActivated: true,
           inactiveUserMsgStatus: "cancelled",
           shouldDisplayMessage: true,
         });
       });
+      test("THEN should not display inactive user survey if active", (done) => {
+        inactiveMessageTest({
+          done,
+          firstInstall: SEVEN_WEEKS_BEFORE,
+          firstWsInitialize: SEVEN_WEEKS_BEFORE,
+          firstLookupTime: SEVEN_WEEKS_BEFORE,
+          lastLookupTime: ONE_WEEK_BEFORE,
+          inactiveUserMsgSendTime: FOUR_WEEKS_BEFORE,
+          workspaceActivated: true,
+          inactiveUserMsgStatus: "cancelled",
+          shouldDisplayMessage: false,
+        });
+      });
     });
-    describe("WHEN it hasn't been another two weeks since rejected prompt", () => {
+    describe("WHEN it hasn't been another four weeks since rejected prompt", () => {
       test("THEN should not display inactive user survey", (done) => {
         inactiveMessageTest({
           done,
-          firstInstall: FIVE_WEEKS_BEFORE,
-          firstWsInitialize: FIVE_WEEKS_BEFORE,
-          firstLookupTime: FIVE_WEEKS_BEFORE,
-          lastLookupTime: FOUR_WEEKS_BEFORE,
-          inactiveUserMsgSendTime: ONE_WEEK_BEFORE,
+          firstInstall: SEVEN_WEEKS_BEFORE,
+          firstWsInitialize: SEVEN_WEEKS_BEFORE,
+          firstLookupTime: SEVEN_WEEKS_BEFORE,
+          lastLookupTime: SIX_WEEKS_BEFORE,
+          inactiveUserMsgSendTime: THREE_WEEKS_BEFORE,
           workspaceActivated: true,
           inactiveUserMsgStatus: "cancelled",
           shouldDisplayMessage: false,


### PR DESCRIPTION
# fix: Re-enable inactive user survey and store prompt status in filesystem for prompt reliability.
This PR:
- Removes the use of state service when storing prompt status of inactive user survey.
  - Use metadata service instead
- Re-enables inactive user survey prompt during activation.
- Change re-prompt cadence to 4 weeks from 2 weeks.
- Ignores a rare case where first install time is later than first lookup time
  - this has caused issues in around 4% of the observed prompted users
- Handle case for recently-prompted users that have `inactiveUserMsgSendTime` set, but does not yet have the new metadata `inactiveUserMsgStatus` set.
  - In a similar case, where we introduced the global state and didn't backfill the in-between cases, 12% of the total observed prompted users were prompted prematurely.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)