### PR TITLE
chore(analytics): add release and session to sentry

### DIFF
--- a/packages/api-server/src/Server.ts
+++ b/packages/api-server/src/Server.ts
@@ -1,4 +1,5 @@
 import {
+  AppNames,
   error2PlainObject,
   getStage,
   StatusCodes,
@@ -7,6 +8,7 @@ import {
   findInParent,
   SegmentClient,
   initializeSentry,
+  NodeJSUtils,
 } from "@dendronhq/common-server";
 import * as Sentry from "@sentry/node";
 import cors from "cors";
@@ -24,6 +26,10 @@ import {
   OauthService,
   registerOauthHandler,
 } from "./routes/oauth";
+
+function getSentryRelease() {
+  return `${AppNames.EXPRESS_SERVER}@${NodeJSUtils.getVersionFromPkg()}`;
+}
 
 export function appModule({
   logPath,
@@ -62,7 +68,7 @@ export function appModule({
   app.use(express.static(staticDir));
 
   if (!SegmentClient.instance().hasOptedOut && getStage() === "prod") {
-    initializeSentry(getStage());
+    initializeSentry({ environment: getStage(), release: getSentryRelease() });
   }
 
   // Re-use the id for error reporting too:

--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -91,7 +91,6 @@ export class NoteController {
   async info(): Promise<RespRequired<EngineInfoResp>> {
     const ctx = "NoteController:info";
     getLogger().info({ ctx, msg: "enter" });
-    // const engine = await getWS({ ws });
     try {
       const version = NodeJSUtils.getVersionFromPkg();
       return {

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -115,6 +115,12 @@ export enum NativeWorkspaceEvents {
   DetectedInNonDendronWS = "Native_Workspace_Detected_In_Non_Dendron_WS", // watcher has detected a Dendron workspace getting created inside a non-Dendron workspace
 }
 
+export enum AppNames {
+  CODE = "vscode",
+  CLI = "cli",
+  EXPRESS_SERVER = "express",
+}
+
 export const DendronEvents = {
   VSCodeEvents,
   CLIEvents,

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -1,4 +1,5 @@
 import {
+  AppNames,
   CONSTANTS,
   DendronError,
   env,
@@ -526,13 +527,13 @@ export class SegmentClient {
 
 // platform props
 type VSCodeProps = {
-  type: "vscode";
+  type: AppNames.CODE;
   ideVersion: string;
   ideFlavor: string;
 };
 
 type CLIProps = {
-  type: "cli";
+  type: AppNames.CLI;
   cliVersion: string;
 };
 
@@ -609,7 +610,7 @@ export class SegmentUtils {
     if (RuntimeUtils.isRunningInTestOrCI()) {
       return;
     }
-    if (identifyProps.type === "vscode") {
+    if (identifyProps.type === AppNames.CODE) {
       const { appVersion, userAgent, ...rest } = identifyProps;
       SegmentClient.instance().identifyAnonymous(
         {
@@ -630,7 +631,7 @@ export class SegmentUtils {
       );
     }
 
-    if (identifyProps.type === "cli") {
+    if (identifyProps.type === AppNames.CLI) {
       const { cliVersion } = identifyProps;
       SegmentClient.instance().identifyAnonymous(
         {

--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -1,6 +1,7 @@
 import { DendronError, Stage } from "@dendronhq/common-all";
 import { RewriteFrames } from "@sentry/integrations";
 import * as Sentry from "@sentry/node";
+import { CaptureContext } from "@sentry/types";
 import _ from "lodash";
 
 // Extracted to make testing easy
@@ -51,11 +52,16 @@ export function initializeSentry({
   release,
 }: {
   environment: Stage;
-  sessionId: number;
+  sessionId?: number;
   release: string;
 }): void {
   const dsn =
     "https://bc206b31a30a4595a2efb31e8cc0c04e@o949501.ingest.sentry.io/5898219";
+
+  const initialScope: CaptureContext = {};
+  if (sessionId) {
+    initialScope.tags = { sessionId };
+  }
 
   Sentry.init({
     dsn,
@@ -70,11 +76,7 @@ export function initializeSentry({
     release,
     attachStacktrace: true,
     beforeSend: eventModifier,
-    initialScope: {
-      tags: {
-        sessionId,
-      },
-    },
+    initialScope,
     integrations: [
       new RewriteFrames({
         iteratee: (frame) => {

--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -48,9 +48,11 @@ export function isBadErrorThatShouldBeSampled(
 export function initializeSentry({
   environment,
   sessionId,
+  release,
 }: {
   environment: Stage;
   sessionId: number;
+  release: string;
 }): void {
   const dsn =
     "https://bc206b31a30a4595a2efb31e8cc0c04e@o949501.ingest.sentry.io/5898219";
@@ -65,6 +67,7 @@ export function initializeSentry({
     tracesSampleRate: 0.0,
     enabled: true,
     environment,
+    release,
     attachStacktrace: true,
     beforeSend: eventModifier,
     initialScope: {

--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -39,7 +39,19 @@ export function isBadErrorThatShouldBeSampled(
   );
 }
 
-export function initializeSentry(environment: Stage): void {
+/**
+ * Initialize Sentry
+ * @param environment
+ * @returns
+ *  ^4wcl13fw6gub
+ */
+export function initializeSentry({
+  environment,
+  sessionId,
+}: {
+  environment: Stage;
+  sessionId: number;
+}): void {
   const dsn =
     "https://bc206b31a30a4595a2efb31e8cc0c04e@o949501.ingest.sentry.io/5898219";
 
@@ -55,6 +67,11 @@ export function initializeSentry(environment: Stage): void {
     environment,
     attachStacktrace: true,
     beforeSend: eventModifier,
+    initialScope: {
+      tags: {
+        sessionId,
+      },
+    },
     integrations: [
       new RewriteFrames({
         iteratee: (frame) => {

--- a/packages/dendron-cli/src/utils/analytics.ts
+++ b/packages/dendron-cli/src/utils/analytics.ts
@@ -1,4 +1,4 @@
-import { RuntimeUtils } from "@dendronhq/common-all";
+import { AppNames, RuntimeUtils } from "@dendronhq/common-all";
 import { SegmentUtils } from "@dendronhq/common-server";
 import { CLIUtils } from "./cli";
 
@@ -7,7 +7,7 @@ export class CLIAnalyticsUtils {
     const cliVersion = CLIUtils.getClientVersion();
     SegmentUtils.track({
       event,
-      platformProps: { type: "cli", cliVersion },
+      platformProps: { type: AppNames.CLI, cliVersion },
       properties: props,
     });
   }
@@ -16,14 +16,14 @@ export class CLIAnalyticsUtils {
     const cliVersion = CLIUtils.getClientVersion();
     await SegmentUtils.trackSync({
       event,
-      platformProps: { type: "cli", cliVersion },
+      platformProps: { type: AppNames.CLI, cliVersion },
       properties: props,
     });
   }
 
   static identify() {
     const cliVersion = CLIUtils.getClientVersion();
-    SegmentUtils.identify({ type: "cli", cliVersion });
+    SegmentUtils.identify({ type: AppNames.CLI, cliVersion });
   }
 
   /**

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -390,6 +390,7 @@ export async function _activate(
     initializeSentry({
       environment: getStage(),
       sessionId: AnalyticsUtils.getSessionId(),
+      release: AnalyticsUtils.getVSCodeSentryRelease(),
     });
   }
 

--- a/packages/plugin-core/src/logger.ts
+++ b/packages/plugin-core/src/logger.ts
@@ -124,6 +124,7 @@ export class Logger {
     Logger.log(payload, "error");
 
     if (payload.error) {
+      // if we log an error, also report it to sentry ^sf0k4z8hnvjo
       Sentry.captureException(payload.error, {
         extra: {
           ctx: payload.ctx,

--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -1,4 +1,4 @@
-import { ContextualUIEvents, Time } from "@dendronhq/common-all";
+import { AppNames, ContextualUIEvents, Time } from "@dendronhq/common-all";
 import { SegmentUtils, VSCodeIdentifyProps } from "@dendronhq/common-server";
 import { MetadataService } from "@dendronhq/engine-server";
 import * as Sentry from "@sentry/node";
@@ -18,7 +18,7 @@ export class AnalyticsUtils {
   static sessionStart = -1;
 
   static getVSCodeSentryRelease(): string {
-    return `code@${VersionProvider.version()}`;
+    return `${AppNames.CODE}@${VersionProvider.version()}`;
   }
 
   static getVSCodeIdentifyProps(): VSCodeIdentifyProps {
@@ -32,7 +32,7 @@ export class AnalyticsUtils {
     } = vscode.env;
 
     return {
-      type: "vscode" as const,
+      type: AppNames.CODE,
       ideVersion: vscode.version,
       ideFlavor: appName,
       appVersion: VersionProvider.version(),
@@ -85,7 +85,7 @@ export class AnalyticsUtils {
     SegmentUtils.track({
       event,
       platformProps: {
-        type: "vscode",
+        type: AppNames.CODE,
         ideVersion,
         ideFlavor,
       },

--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -17,6 +17,10 @@ export type SegmentContext = Partial<{
 export class AnalyticsUtils {
   static sessionStart = -1;
 
+  static getVSCodeSentryRelease(): string {
+    return `code@${VersionProvider.version()}`;
+  }
+
   static getVSCodeIdentifyProps(): VSCodeIdentifyProps {
     const {
       appName,


### PR DESCRIPTION
chore(analytics): add release and session to sentry

- this adds `sessionId` as a tag in sentry 
- this also adds `release` to sentry so we can start tracking [release health](https://docs.sentry.io/product/releases/health/)
- cleanup
    - converts app targets like "vscode" and "cli" into an enum
    - since we bumped the min version, updated the following
        - remove check for old version of vscode when checking for workspace trust
        - remove `VSCodeEvents.UserOnOldVSCodeVerUnblocked` event 
    - remove commented code

Next Items
- [ ] SOP on how to make use of release health data
- [ ] track `sessionId` in server (this is a bigger task and out of scope for this pr)
- [ ] add sentry to cli
***
# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)