### PR TITLE
fix(lookup): lookup should be case-insensitive

### DIFF
--- a/packages/common-all/src/util/orderedMatchter.ts
+++ b/packages/common-all/src/util/orderedMatchter.ts
@@ -4,12 +4,12 @@ export class OrderedMatcher {
 
   constructor(tokens: string[]) {
     // https://regex101.com/r/eMTNJ0/1
-    this.regexPattern = tokens.join(".*");
+    this.regexPattern = tokens.join(".*").toLowerCase();
   }
 
   /** Checks whether the given strings matches all the tokens in order. */
   isMatch(str: string) {
-    const isMatch = str.match(this.regexPattern);
+    const isMatch = str.toLowerCase().match(this.regexPattern);
     return isMatch;
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -613,6 +613,18 @@ suite("NoteLookupCommand", function () {
         );
       });
     });
+
+    describe(`WHEN user look up a note (without using a space) where the query doesn't match the note's case`, () => {
+      test("THEN lookup result must cantain all matching values irrespective of case", (done) => {
+        runLookupInHierarchyTestWorkspace(
+          "bar.CH1",
+          (out) => {
+            expectQuickPick(out.quickpick).toIncludeFname("bar.ch1");
+          },
+          done
+        );
+      });
+    });
   });
 
   describe("onAccept", () => {
@@ -669,6 +681,24 @@ suite("NoteLookupCommand", function () {
           );
           expect(note?.fname).toEqual("learn.mdone.test");
           expect(note?.title).toEqual("Test");
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN user lookup a note where the query doesn't match the note's case in multi-vault setup ",
+      {
+        ctx,
+        preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
+      },
+      () => {
+        test("THEN result must include note irresepective of casing", async () => {
+          const cmd = new NoteLookupCommand();
+          const opts = (await cmd.run({
+            noConfirm: true,
+            initialValue: "FOOCH1",
+          }))!;
+          expectQuickPick(opts.quickpick).toIncludeFname("foo.ch1");
         });
       }
     );


### PR DESCRIPTION
Related Issue: https://github.com/dendronhq/dendron/issues/1654
This PR aims to solve the above-mentioned issue. It allows lookup to be case insensitive.  For a vault with below files, when user lookup for foo.CH1, the result should contain `foo.ch1.md` 
- foo.ch1.md
- bar.ch1.md
- root.md
# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices). no new dependencies added.
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)