### PR TITLE
fix(workspace): issue with notes not being saved on export

### DIFF
--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -174,6 +174,7 @@ export class TextDocumentService implements ITextDocumentService {
     if (event.document.isDirty === false) {
       return;
     }
+
     const document = event.document;
     const contentChanges = event.contentChanges;
 

--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -75,7 +75,7 @@ export class TextDocumentService implements ITextDocumentService {
   constructor(ext: IDendronExtension, textDocumentEvent: Event<TextDocument>) {
     this.L = Logger;
     this._extension = ext;
-    this._textDocumentEventHandle = textDocumentEvent(this.onDidSave);
+    this._textDocumentEventHandle = textDocumentEvent(this.onDidSave, this);
   }
 
   dispose() {
@@ -119,7 +119,7 @@ export class TextDocumentService implements ITextDocumentService {
    * @returns
    */
   private async onDidSave(document: TextDocument) {
-    const ctx = "TextDocumentService:onDidChange";
+    const ctx = "TextDocumentService:onDidSave";
     const uri = document.uri;
     const fname = path.basename(uri.fsPath, ".md");
 
@@ -174,7 +174,6 @@ export class TextDocumentService implements ITextDocumentService {
     if (event.document.isDirty === false) {
       return;
     }
-
     const document = event.document;
     const contentChanges = event.contentChanges;
 

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -1,10 +1,12 @@
 import {
   ConfigUtils,
   DEngineClient,
+  Disposable,
   DVault,
   InstallStatus,
   IntermediateDendronConfig,
   isNotUndefined,
+  NoteChangeEntry,
   VaultRemoteSource,
   WorkspaceFolderRaw,
   WorkspaceOpts,
@@ -26,6 +28,7 @@ import {
 } from "@dendronhq/common-test-utils";
 import {
   DConfig,
+  DendronEngineClient,
   DendronEngineV2,
   HistoryService,
   WorkspaceUtils,
@@ -59,6 +62,7 @@ import { DendronExtension, getDWorkspace } from "../workspace";
 import { BlankInitializer } from "../workspace/blankInitializer";
 import { WorkspaceInitFactory } from "../workspace/WorkspaceInitFactory";
 import { _activate } from "../_extension";
+import { ExtensionProvider } from "../ExtensionProvider";
 import {
   cleanupVSCodeContextSubscriptions,
   setupCodeConfiguration,
@@ -601,4 +605,19 @@ function cleanupWorkspaceStubs(ctx: ExtensionContext): void {
   HistoryService.instance().clearSubscriptions();
   cleanupVSCodeContextSubscriptions(ctx);
   sinon.restore();
+}
+
+/**
+ * Use this to test engine state changes through engine events. This can be used in
+ * situations where the engine state changes asynchorously from test logic (such as from vscode event callbacks)
+ *
+ * @param callback to handle engine state events
+ * @returns Disposable
+ */
+export function subscribeToEngineStateChange(
+  callback: (noteChangeEntries: NoteChangeEntry[]) => void
+): Disposable {
+  const engine = ExtensionProvider.getEngine();
+  const engineClient = engine as unknown as DendronEngineClient;
+  return engineClient.onEngineNoteStateChanged(callback);
 }


### PR DESCRIPTION
*Bug*
The `this` in `onDidSave` was undefined while the callback was called via the vscode save events. Was accidentally removed from latest previewpanel refactor.
Tested manually and with `ExportPodV2`

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)