### PR TITLE
feat: add doctor command for a more reliable keybinding resolution

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -40,10 +40,18 @@ export enum TutorialEvents {
   Tutorial_5_Show = "Tutorial_5_Show",
 }
 
+export enum KeybindingConflictDetectedSource {
+  activation = "activation",
+  doctor = "doctor",
+}
+
 export enum ExtensionEvents {
   VimExtensionInstalled = "Vim_Extension_Installed",
   IncompatibleExtensionsWarned = "Incompatible_Extensions_Warned",
   IncompatibleExtensionsPreviewDisplayed = "Incompatible_Extensions_Preview_Displayed",
+  KeybindingConflictDetected = "Keybinding_Conflict_Detected",
+  ShowKeybindingConflictAccepted = "Show_Keybinding_Conflict_Accepted",
+  ShowKeybindingConflictRejected = "Show_Keybinding_Conflict_Rejected",
 }
 
 export enum LookupEvents {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -134,6 +134,10 @@
         "title": "Dendron: Copy Note Ref"
       },
       {
+        "command": "dendron.copyToClipboard",
+        "title": "Dendron: Copy To Clipboard"
+      },
+      {
         "command": "dendron.deleteNode",
         "title": "Dendron: Delete Node"
       },
@@ -463,6 +467,10 @@
         {
           "command": "dendron.copyNoteRef",
           "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.copyToClipboard",
+          "when": "false"
         },
         {
           "command": "dendron.deleteNode",

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -184,6 +184,8 @@ export class KeybindingUtils {
       `1. Open [keybindings.json](${keybindingJSONCommandUri})`,
       `1. Paste the clipboard content to \`keybindings.json\``,
       "",
+      `[Video Guide](https://www.loom.com/embed/82d3fbccd126446bac7a4d16027c07aa)`,
+      "",
       "For more information on how to set keyboard rules in VSCode, visit [Keyboard Rules](https://code.visualstudio.com/docs/getstarted/keybindings#_keyboard-rules)",
       "",
       `Use [Default Keybindings](${defaultKeybindingJSONCommandUri}) to reference all default keybindings.`,

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -63,9 +63,8 @@ export class KeybindingUtils {
       return conflicts;
     }
 
-    const userKeybindingConfig = readJSONWithCommentsSync(keybindingConfigPath);
+    // const userKeybindingConfig = readJSONWithCommentsSync(keybindingConfigPath);
 
-    // TODO: check for existing user keybinding items
     return conflicts;
   }
 
@@ -208,6 +207,8 @@ export class KeybindingUtils {
       }
     );
     panel.webview.html = md.render(contents);
+
+    // TODO: add proper tracking
     // AnalyticsUtils.track(
     //   ExtensionEvents.IncompatibleExtensionsPreviewDisplayed
     // );
@@ -247,49 +248,6 @@ export class KeybindingUtils {
     return true;
   }
 
-  static getKeybindingConfig = ({
-    createIfMissing = false,
-  }: {
-    createIfMissing: boolean;
-  }): RespV3<CommentJSONArray<Keybindings>> => {
-    const ctx = "getKeybindingConfig";
-    const { keybindingConfigPath } = this.getKeybindingConfigPath();
-
-    if (!fs.existsSync(keybindingConfigPath) && createIfMissing) {
-      fs.ensureFileSync(keybindingConfigPath);
-      fs.writeFileSync(keybindingConfigPath, "[]");
-      Logger.info({ ctx, keybindingConfigPath, msg: "creating keybindings" });
-    }
-
-    if (!fs.existsSync(keybindingConfigPath)) {
-      return {
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.INVALID_STATE,
-          message: "no keybinding config found",
-        }),
-      };
-    }
-    try {
-      const keybindings = readJSONWithCommentsSync(keybindingConfigPath);
-      if (!KeybindingUtils.checkKeybindingsExist(keybindings)) {
-        return {
-          error: DendronError.createFromStatus({
-            status: ERROR_STATUS.INVALID_CONFIG,
-            message: "keybinding config invalid",
-          }),
-        };
-      }
-      return { data: keybindings };
-    } catch (err) {
-      return {
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.INVALID_CONFIG,
-          message: "keybinding config invalid",
-        }),
-      };
-    }
-  };
-
   static getKeybindingConfigPath = () => {
     const { userConfigDir, osName } = VSCodeUtils.getCodeUserConfigDir();
     return {
@@ -297,135 +255,6 @@ export class KeybindingUtils {
       osName,
     };
   };
-
-  static checkAndApplyVimKeybindingOverrideIfExists(): RespV3<{
-    keybindingConfigPath: string;
-    newKeybindings?: any;
-  }> {
-    // check where the keyboard shortcut is configured
-    const { keybindingConfigPath } = this.getKeybindingConfigPath();
-
-    const resp = this.getKeybindingConfig({ createIfMissing: true });
-    if (resp.error) {
-      return {
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.INVALID_STATE,
-          message: "no keybindings found",
-        }),
-      };
-    }
-    const keybindings = resp.data;
-
-    // check if override is already there
-    const alreadyHasOverride =
-      keybindings.filter((entry: any) => {
-        if (!_.isUndefined(entry.command)) {
-          return entry.command === "-extension.vim_navigateCtrlL";
-        } else {
-          return false;
-        }
-      }).length > 0;
-
-    if (alreadyHasOverride) {
-      return { data: { keybindingConfigPath } };
-    }
-
-    // add override if there isn't.
-    const OVERRIDE_EXPAND_LINE_SELECTION = {
-      key: `ctrl+l`,
-      command: "-extension.vim_navigateCtrlL",
-    };
-
-    const newKeybindings = assign(
-      keybindings,
-      keybindings.concat(OVERRIDE_EXPAND_LINE_SELECTION)
-    );
-    return { data: { keybindingConfigPath, newKeybindings } };
-  }
-
-  // static checkAndMigrateLookupKeybindingIfExists(): {
-  //   keybindingConfigPath: string;
-  //   migratedKeybindings?: any;
-  // } {
-  //   // check where the keyboard shortcut is configured
-  //   const { keybindingConfigPath } = this.getKeybindingConfigPath();
-
-  //   // do nothing if it didn't exist before
-  //   if (!fs.existsSync(keybindingConfigPath)) {
-  //     return { keybindingConfigPath };
-  //   }
-
-  //   const keybindings = readJSONWithCommentsSync(keybindingConfigPath);
-  //   if (!KeybindingUtils.keybindingsExist(keybindings)) {
-  //     return;
-  //   }
-
-  //   let needsMigration = false;
-  //   let migratedKeybindings = keybindings.map((entry: any) => {
-  //     if (!_.isUndefined(entry.command)) {
-  //       const newEntry = assign({}, entry);
-  //       if (entry.command === "dendron.lookup") {
-  //         needsMigration = true;
-  //         newEntry.command = DENDRON_COMMANDS.LOOKUP_NOTE.key;
-  //         if (_.isUndefined(entry.args)) {
-  //           // keybinding with no override (simple combo change)
-  //           // swap out command
-  //           return newEntry;
-  //         } else {
-  //           // keybinding with override. map them to new ones
-  //           const newArgs = assign({}, entry.args);
-  //           // delete obsolete
-  //           _.forEach(
-  //             [
-  //               "flavor",
-  //               "noteExistBehavior",
-  //               "filterType",
-  //               "value",
-  //               "effectType",
-  //             ],
-  //             (key: string) => {
-  //               if (!_.isUndefined(entry.args[key])) {
-  //                 delete newArgs[key];
-  //               }
-  //             }
-  //           );
-
-  //           // migrate overrides to new keys
-  //           if (!_.isUndefined(entry.args.filterType)) {
-  //             newArgs.filterMiddleware = [entry.args.filterType];
-  //           }
-
-  //           if (!_.isUndefined(entry.args.value)) {
-  //             newArgs.initialValue = entry.args.value;
-  //           }
-
-  //           if (!_.isUndefined(entry.args.effectType)) {
-  //             if (entry.args.effectType === "multiSelect") {
-  //               newArgs.multiSelect = true;
-  //             }
-  //             if (entry.args.effectType === "copyNoteLink") {
-  //               newArgs.copyNoteLink = true;
-  //             }
-  //           }
-
-  //           newEntry.args = newArgs;
-  //           return newEntry;
-  //         }
-  //       } else if (entry.command === "-dendron.lookup") {
-  //         needsMigration = true;
-  //         newEntry.command = `-${DENDRON_COMMANDS.LOOKUP_NOTE.key}`;
-  //         return newEntry;
-  //       }
-  //     }
-  //     // non-lookup keybinding. return as-is
-  //     return entry;
-  //   });
-
-  //   if (!needsMigration) return { keybindingConfigPath };
-
-  //   migratedKeybindings = assign(keybindings, migratedKeybindings);
-  //   return { keybindingConfigPath, migratedKeybindings };
-  // }
 
   /**
    * For the given pod ID, returns a user-configured shortcut (in VSCode

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -12,7 +12,7 @@ import {
   isOSType,
   KeybindingConflict,
   KNOWN_KEYBINDING_CONFLICTS,
-  KWOWN_CONFLICTING_EXTENSIONS,
+  KNOWN_CONFLICTING_EXTENSIONS,
 } from "./constants";
 import { VSCodeUtils } from "./vsCodeUtils";
 import * as vscode from "vscode";
@@ -35,7 +35,7 @@ export class KeybindingUtils {
   }
 
   static getConflictingKeybindings() {
-    const installStatus = KWOWN_CONFLICTING_EXTENSIONS.map((extId) => {
+    const installStatus = KNOWN_CONFLICTING_EXTENSIONS.map((extId) => {
       return {
         id: extId,
         installed: VSCodeUtils.isExtensionInstalled(extId),

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -53,7 +53,7 @@ export class KeybindingUtils {
     return globalKeybindingJSON;
   }
 
-  static getInstallStatus() {
+  static getInstallStatusForKnownConflictingExtensions() {
     return KNOWN_CONFLICTING_EXTENSIONS.map((extId) => {
       return {
         id: extId,
@@ -66,7 +66,8 @@ export class KeybindingUtils {
     knownConflicts: KeybindingConflict[];
   }) {
     const { knownConflicts } = opts;
-    const installStatus = KeybindingUtils.getInstallStatus();
+    const installStatus =
+      KeybindingUtils.getInstallStatusForKnownConflictingExtensions();
     const installed = installStatus
       .filter((status) => status.installed)
       .map((status) => status.id);

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -53,19 +53,25 @@ export class KeybindingUtils {
     return globalKeybindingJSON;
   }
 
-  static getConflictingKeybindings() {
-    const installStatus = KNOWN_CONFLICTING_EXTENSIONS.map((extId) => {
+  static getInstallStatus() {
+    return KNOWN_CONFLICTING_EXTENSIONS.map((extId) => {
       return {
         id: extId,
         installed: VSCodeUtils.isExtensionInstalled(extId),
       };
     });
+  }
 
+  static getConflictingKeybindings(opts: {
+    knownConflicts: KeybindingConflict[];
+  }) {
+    const { knownConflicts } = opts;
+    const installStatus = KeybindingUtils.getInstallStatus();
     const installed = installStatus
       .filter((status) => status.installed)
       .map((status) => status.id);
 
-    const conflicts = KNOWN_KEYBINDING_CONFLICTS.filter((conflict) => {
+    const conflicts = knownConflicts.filter((conflict) => {
       const isInstalled = installed.includes(conflict.extensionId);
       const osType = os.type();
       const conflictOSType = conflict.os || ["Darwin", "Linux", "Windows_NT"];
@@ -282,7 +288,9 @@ export class KeybindingUtils {
   }
 
   static async maybePromptKeybindingConflict() {
-    const conflicts = KeybindingUtils.getConflictingKeybindings();
+    const conflicts = KeybindingUtils.getConflictingKeybindings({
+      knownConflicts: KNOWN_KEYBINDING_CONFLICTS,
+    });
     if (conflicts.length > 0) {
       await KeybindingUtils.showKeybindingConflictConfirmationMessage({
         conflicts,

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -239,12 +239,6 @@ export class KeybindingUtils {
       }
     );
     panel.webview.html = md.render(contents);
-
-    // TODO: add proper tracking
-    // AnalyticsUtils.track(
-    //   ExtensionEvents.IncompatibleExtensionsPreviewDisplayed
-    // );
-    // return { installStatus, contents };
   }
 
   static async showKeybindingConflictConfirmationMessage(opts: {

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -18,6 +18,7 @@ import { Logger } from "./logger";
 import { VSCodeUtils } from "./vsCodeUtils";
 import * as vscode from "vscode";
 import os from "os";
+import path from "path";
 
 type Keybindings = Record<string, string>;
 export class KeybindingUtils {
@@ -248,10 +249,16 @@ export class KeybindingUtils {
     return true;
   }
 
+  /**
+   * This returns the path of user-level `keybindings.json`.
+   * This handles windows, linux and darwin, for both regular vscode and insider as well as portable mode.
+   * This does NOT handle the case where vscode is opened through cli with a custom `--user-data-dir` argument.
+   * @returns path of user defined `keybindings.json`
+   */
   static getKeybindingConfigPath = () => {
     const { userConfigDir, osName } = VSCodeUtils.getCodeUserConfigDir();
     return {
-      keybindingConfigPath: [userConfigDir, "keybindings.json"].join(""),
+      keybindingConfigPath: path.join(userConfigDir, "keybindings.json"),
       osName,
     };
   };

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -167,7 +167,7 @@ export class KeybindingUtils {
     const contents = [
       "# Known Keybinding Conflicts",
       "",
-      "The keybindings listed below are known to have conflicts with default keybindings for Dendron commands.",
+      "The keybindings listed at the bottom are known to have conflicts with default keybindings for Dendron commands.",
       "",
       "Neither Dendron nor the extension may function properly if the keybinding conflict is not resolved.",
       "",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -25,7 +25,7 @@ import {
   getOS,
   initializeSentry,
   SegmentClient,
-  writeJSONWithComments,
+  // writeJSONWithComments,
 } from "@dendronhq/common-server";
 import {
   FileAddWatcher,
@@ -41,7 +41,7 @@ import { ExecaChildProcess } from "execa";
 import fs from "fs-extra";
 import _ from "lodash";
 import { Duration } from "luxon";
-import os from "os";
+// import os from "os";
 import path from "path";
 import semver from "semver";
 import * as vscode from "vscode";
@@ -735,8 +735,8 @@ export async function _activate(
       }
     }
 
-    const backupPaths: string[] = [];
-    let keybindingPath: string;
+    // const backupPaths: string[] = [];
+    // let keybindingPath: string;
 
     // KeybindingUtils.
 

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -738,6 +738,7 @@ export async function _activate(
     }
 
     if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
+      // if keybinding conflict is detected, let the users know and guide them how to resolve  ^rikhd9cc0rwb
       await KeybindingUtils.maybePromptKeybindingConflict();
     }
 

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -25,7 +25,6 @@ import {
   getOS,
   initializeSentry,
   SegmentClient,
-  // writeJSONWithComments,
 } from "@dendronhq/common-server";
 import {
   FileAddWatcher,
@@ -41,7 +40,6 @@ import { ExecaChildProcess } from "execa";
 import fs from "fs-extra";
 import _ from "lodash";
 import { Duration } from "luxon";
-// import os from "os";
 import path from "path";
 import semver from "semver";
 import * as vscode from "vscode";
@@ -735,88 +733,13 @@ export async function _activate(
       }
     }
 
-    // const backupPaths: string[] = [];
-    // let keybindingPath: string;
-
-    // KeybindingUtils.
-
-    // check vim keybindings ^j7zygfkbxjnq
-    // if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
-    //   const vimInstalled = VSCodeUtils.isExtensionInstalled("vscodevim.vim");
-    //   // only need to run this for non-mac
-    //   if (vimInstalled && os.type() !== "Darwin") {
-    //     Logger.info({
-    //       ctx,
-    //       msg: "checkAndApplyVimKeybindingOverrideIfExists:pre",
-    //     });
-    //     AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled);
-    //     const keybindingPayload =
-    //       KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists();
-    //     if (keybindingPayload.data) {
-    //       const { keybindingConfigPath, newKeybindings: resolvedKeybindings } =
-    //         keybindingPayload.data;
-    //       keybindingPath = keybindingConfigPath;
-    //       if (!_.isUndefined(resolvedKeybindings)) {
-    //         const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-    //         const maybeBackupPath = `${keybindingConfigPath}.${today}.vim.old`;
-    //         if (!fs.existsSync(keybindingConfigPath)) {
-    //           fs.ensureFileSync(keybindingConfigPath);
-    //           fs.writeFileSync(keybindingConfigPath, "[]");
-    //         } else {
-    //           fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-    //           backupPaths.push(maybeBackupPath);
-    //         }
-    //         writeJSONWithComments(keybindingConfigPath, resolvedKeybindings);
-    //         AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled, {
-    //           fixApplied: true,
-    //         });
-    //       }
-    //     } else {
-    //       Logger.info({ ctx, msg: "unable to apply keybinding fix" });
-    //       // TODO: report error
-    //     }
-    //   }
-    // }
-
-    // // TODO: remove, we are not tracking this today
-    // // if (extensionInstallStatus === InstallStatus.UPGRADED) {
-    // //   const { keybindingConfigPath, migratedKeybindings } =
-    // //     KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
-    // //   keybindingPath = keybindingConfigPath;
-    // //   if (!_.isUndefined(migratedKeybindings)) {
-    // //     const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-    // //     const maybeBackupPath = `${keybindingConfigPath}.${today}.lookup.old`;
-    // //     fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-    // //     backupPaths.push(maybeBackupPath);
-    // //     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
-    // //   }
-    // // }
-
-    // if (backupPaths.length > 0) {
-    //   vscode.window
-    //     .showInformationMessage(
-    //       "Conflicting or outdated keybindings have been updated. Click the button below to see changes.",
-    //       ...["Open changes"]
-    //     )
-    //     .then(async (selection) => {
-    //       if (selection) {
-    //         const uri = vscode.Uri.file(keybindingPath);
-    //         await VSCodeUtils.openFileInEditor(uri);
-    //         backupPaths.forEach(async (backupPath) => {
-    //           const backupUri = vscode.Uri.file(backupPath);
-    //           await VSCodeUtils.openFileInEditor(backupUri, {
-    //             column: vscode.ViewColumn.Beside,
-    //           });
-    //         });
-    //       }
-    //     });
-    // }
-
     if (userOnOldVSCodeVer) {
       AnalyticsUtils.track(VSCodeEvents.UserOnOldVSCodeVerUnblocked);
     }
 
-    await KeybindingUtils.maybePromptKeybindingConflict();
+    if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
+      await KeybindingUtils.maybePromptKeybindingConflict();
+    }
 
     await showWelcomeOrWhatsNew({
       extensionInstallStatus,

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -738,81 +738,85 @@ export async function _activate(
     const backupPaths: string[] = [];
     let keybindingPath: string;
 
-    // check vim keybindings ^j7zygfkbxjnq
-    if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
-      const vimInstalled = VSCodeUtils.isExtensionInstalled("vscodevim.vim");
-      // only need to run this for non-mac
-      if (vimInstalled && os.type() !== "Darwin") {
-        Logger.info({
-          ctx,
-          msg: "checkAndApplyVimKeybindingOverrideIfExists:pre",
-        });
-        AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled);
-        const keybindingPayload =
-          KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists();
-        if (keybindingPayload.data) {
-          const { keybindingConfigPath, newKeybindings: resolvedKeybindings } =
-            keybindingPayload.data;
-          keybindingPath = keybindingConfigPath;
-          if (!_.isUndefined(resolvedKeybindings)) {
-            const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-            const maybeBackupPath = `${keybindingConfigPath}.${today}.vim.old`;
-            if (!fs.existsSync(keybindingConfigPath)) {
-              fs.ensureFileSync(keybindingConfigPath);
-              fs.writeFileSync(keybindingConfigPath, "[]");
-            } else {
-              fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-              backupPaths.push(maybeBackupPath);
-            }
-            writeJSONWithComments(keybindingConfigPath, resolvedKeybindings);
-            AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled, {
-              fixApplied: true,
-            });
-          }
-        } else {
-          Logger.info({ ctx, msg: "unable to apply keybinding fix" });
-          // TODO: report error
-        }
-      }
-    }
+    // KeybindingUtils.
 
-    // TODO: remove, we are not tracking this today
-    // if (extensionInstallStatus === InstallStatus.UPGRADED) {
-    //   const { keybindingConfigPath, migratedKeybindings } =
-    //     KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
-    //   keybindingPath = keybindingConfigPath;
-    //   if (!_.isUndefined(migratedKeybindings)) {
-    //     const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
-    //     const maybeBackupPath = `${keybindingConfigPath}.${today}.lookup.old`;
-    //     fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
-    //     backupPaths.push(maybeBackupPath);
-    //     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
+    // check vim keybindings ^j7zygfkbxjnq
+    // if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
+    //   const vimInstalled = VSCodeUtils.isExtensionInstalled("vscodevim.vim");
+    //   // only need to run this for non-mac
+    //   if (vimInstalled && os.type() !== "Darwin") {
+    //     Logger.info({
+    //       ctx,
+    //       msg: "checkAndApplyVimKeybindingOverrideIfExists:pre",
+    //     });
+    //     AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled);
+    //     const keybindingPayload =
+    //       KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists();
+    //     if (keybindingPayload.data) {
+    //       const { keybindingConfigPath, newKeybindings: resolvedKeybindings } =
+    //         keybindingPayload.data;
+    //       keybindingPath = keybindingConfigPath;
+    //       if (!_.isUndefined(resolvedKeybindings)) {
+    //         const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
+    //         const maybeBackupPath = `${keybindingConfigPath}.${today}.vim.old`;
+    //         if (!fs.existsSync(keybindingConfigPath)) {
+    //           fs.ensureFileSync(keybindingConfigPath);
+    //           fs.writeFileSync(keybindingConfigPath, "[]");
+    //         } else {
+    //           fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
+    //           backupPaths.push(maybeBackupPath);
+    //         }
+    //         writeJSONWithComments(keybindingConfigPath, resolvedKeybindings);
+    //         AnalyticsUtils.track(ExtensionEvents.VimExtensionInstalled, {
+    //           fixApplied: true,
+    //         });
+    //       }
+    //     } else {
+    //       Logger.info({ ctx, msg: "unable to apply keybinding fix" });
+    //       // TODO: report error
+    //     }
     //   }
     // }
 
-    if (backupPaths.length > 0) {
-      vscode.window
-        .showInformationMessage(
-          "Conflicting or outdated keybindings have been updated. Click the button below to see changes.",
-          ...["Open changes"]
-        )
-        .then(async (selection) => {
-          if (selection) {
-            const uri = vscode.Uri.file(keybindingPath);
-            await VSCodeUtils.openFileInEditor(uri);
-            backupPaths.forEach(async (backupPath) => {
-              const backupUri = vscode.Uri.file(backupPath);
-              await VSCodeUtils.openFileInEditor(backupUri, {
-                column: vscode.ViewColumn.Beside,
-              });
-            });
-          }
-        });
-    }
+    // // TODO: remove, we are not tracking this today
+    // // if (extensionInstallStatus === InstallStatus.UPGRADED) {
+    // //   const { keybindingConfigPath, migratedKeybindings } =
+    // //     KeybindingUtils.checkAndMigrateLookupKeybindingIfExists();
+    // //   keybindingPath = keybindingConfigPath;
+    // //   if (!_.isUndefined(migratedKeybindings)) {
+    // //     const today = Time.now().toFormat("yyyy.MM.dd.HHmmssS");
+    // //     const maybeBackupPath = `${keybindingConfigPath}.${today}.lookup.old`;
+    // //     fs.copyFileSync(keybindingConfigPath, maybeBackupPath);
+    // //     backupPaths.push(maybeBackupPath);
+    // //     writeJSONWithComments(keybindingConfigPath, migratedKeybindings);
+    // //   }
+    // // }
+
+    // if (backupPaths.length > 0) {
+    //   vscode.window
+    //     .showInformationMessage(
+    //       "Conflicting or outdated keybindings have been updated. Click the button below to see changes.",
+    //       ...["Open changes"]
+    //     )
+    //     .then(async (selection) => {
+    //       if (selection) {
+    //         const uri = vscode.Uri.file(keybindingPath);
+    //         await VSCodeUtils.openFileInEditor(uri);
+    //         backupPaths.forEach(async (backupPath) => {
+    //           const backupUri = vscode.Uri.file(backupPath);
+    //           await VSCodeUtils.openFileInEditor(backupUri, {
+    //             column: vscode.ViewColumn.Beside,
+    //           });
+    //         });
+    //       }
+    //     });
+    // }
 
     if (userOnOldVSCodeVer) {
       AnalyticsUtils.track(VSCodeEvents.UserOnOldVSCodeVerUnblocked);
     }
+
+    await KeybindingUtils.maybePromptKeybindingConflict();
 
     await showWelcomeOrWhatsNew({
       extensionInstallStatus,

--- a/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
+++ b/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
@@ -1,0 +1,41 @@
+import { window } from "vscode";
+import { DENDRON_COMMANDS } from "../constants";
+import { clipboard } from "../utils";
+import { BasicCommand } from "./base";
+
+type CopyToClipboardCommandOpts = {
+  text: string;
+  message?: string;
+};
+
+/**
+ * This command is not accessible through the VSCode UI,
+ * and only intended to be used as a proxy for copying arbitrary
+ * text from the webview.
+ *
+ * e.g.)
+ *
+ * // you can use this in a markdown link to invoke commands
+ * const commandUri = `command:dendron.copyToClipboard?${encodeURIComponent({
+ *   text: "some text",
+ *   message: "copied!"
+ * })}`
+ *
+ * ...
+ *
+ * content = `[click this](${commandUri})`
+ *
+ */
+export class CopyToClipboardCommand extends BasicCommand<
+  CopyToClipboardCommandOpts,
+  void
+> {
+  key = DENDRON_COMMANDS.COPY_TO_CLIPBOARD.key;
+  async execute(opts: CopyToClipboardCommandOpts) {
+    const ctx = "execute";
+    this.L.info({ ctx, opts });
+    const { text, message } = opts;
+    clipboard.writeText(text);
+    window.showInformationMessage(message || "Text copied to clipboard");
+  }
+}

--- a/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
+++ b/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
@@ -9,6 +9,7 @@ export type CopyToClipboardCommandOpts = {
   message?: string;
 };
 
+//  ^0joacbz2nblu
 export enum CopyToClipboardSourceEnum {
   keybindingConflictPreview = "keybindingConflictPreview",
 }

--- a/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
+++ b/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
@@ -1,7 +1,7 @@
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { clipboard } from "../utils";
-import { BasicCommand } from "./base";
+import { InputArgCommand } from "./base";
 
 export type CopyToClipboardCommandOpts = {
   text: string;
@@ -31,11 +31,16 @@ export enum CopyToClipboardSourceEnum {
  * content = `[click this](${commandUri})`
  *
  */
-export class CopyToClipboardCommand extends BasicCommand<
+export class CopyToClipboardCommand extends InputArgCommand<
   CopyToClipboardCommandOpts,
   void
 > {
   key = DENDRON_COMMANDS.COPY_TO_CLIPBOARD.key;
+
+  addAnalyticsPayload(opts: CopyToClipboardCommandOpts) {
+    return { source: opts.source };
+  }
+
   async execute(opts: CopyToClipboardCommandOpts) {
     const ctx = "execute";
     this.L.info({ ctx, opts });

--- a/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
+++ b/packages/plugin-core/src/commands/CopyToClipboardCommand.ts
@@ -3,10 +3,15 @@ import { DENDRON_COMMANDS } from "../constants";
 import { clipboard } from "../utils";
 import { BasicCommand } from "./base";
 
-type CopyToClipboardCommandOpts = {
+export type CopyToClipboardCommandOpts = {
   text: string;
+  source: CopyToClipboardSourceEnum;
   message?: string;
 };
+
+export enum CopyToClipboardSourceEnum {
+  keybindingConflictPreview = "keybindingConflictPreview",
+}
 
 /**
  * This command is not accessible through the VSCode UI,

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -4,6 +4,7 @@ import {
   DVault,
   ExtensionEvents,
   isNotUndefined,
+  KeybindingConflictDetectedSource,
   NoteProps,
   NoteUtils,
   Position,
@@ -369,6 +370,9 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         });
         if (conflicts.length > 0) {
           await KeybindingUtils.showKeybindingConflictPreview({ conflicts });
+          AnalyticsUtils.track(ExtensionEvents.KeybindingConflictDetected, {
+            source: KeybindingConflictDetectedSource.doctor,
+          });
         } else {
           window.showInformationMessage(`There are no keybinding conflicts!`);
         }

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -32,6 +32,7 @@ import { BasicCommand } from "./base";
 import { ReloadIndexCommand } from "./ReloadIndex";
 import { AnalyticsUtils } from "../utils/analytics";
 import { IDendronExtension } from "../dendronExtensionInterface";
+import { KeybindingUtils } from "../KeybindingUtils";
 
 const md = _md();
 type Finding = {
@@ -80,6 +81,7 @@ type DoctorQuickPickItem = QuickPick<DoctorQuickInput>;
 
 export enum PluginDoctorActionsEnum {
   FIND_INCOMPATIBLE_EXTENSIONS = "findIncompatibleExtensions",
+  FIX_KEYBINDING_CONFLICTS = "fixKeybindingConflicts",
 }
 
 export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
@@ -355,6 +357,15 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
             };
           });
         await this.showIncompatibleExtensionPreview({ installStatus });
+        break;
+      }
+      case PluginDoctorActionsEnum.FIX_KEYBINDING_CONFLICTS: {
+        const conflicts = KeybindingUtils.getConflictingKeybindings();
+        if (conflicts.length > 0) {
+          await KeybindingUtils.showKeybindingConflictPreview({ conflicts });
+        } else {
+          window.showInformationMessage(`There are no keybinding conflicts!`);
+        }
         break;
       }
       case DoctorActionsEnum.FIX_FRONTMATTER: {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -25,7 +25,11 @@ import {
   IDoctorQuickInputButton,
 } from "../components/doctor/buttons";
 import { DoctorScopeType } from "../components/doctor/types";
-import { INCOMPATIBLE_EXTENSIONS, DENDRON_COMMANDS } from "../constants";
+import {
+  INCOMPATIBLE_EXTENSIONS,
+  DENDRON_COMMANDS,
+  KNOWN_KEYBINDING_CONFLICTS,
+} from "../constants";
 import { delayedUpdateDecorations } from "../features/windowDecorations";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
@@ -360,7 +364,9 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         break;
       }
       case PluginDoctorActionsEnum.FIX_KEYBINDING_CONFLICTS: {
-        const conflicts = KeybindingUtils.getConflictingKeybindings();
+        const conflicts = KeybindingUtils.getConflictingKeybindings({
+          knownConflicts: KNOWN_KEYBINDING_CONFLICTS,
+        });
         if (conflicts.length > 0) {
           await KeybindingUtils.showKeybindingConflictPreview({ conflicts });
         } else {

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -71,6 +71,7 @@ import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { OpenBackupCommand } from "./OpenBackupCommand";
+import { CopyToClipboardCommand } from "./CopyToClipboardCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -90,6 +91,7 @@ const ALL_COMMANDS = [
   CopyNoteLinkCommand,
   CopyNoteRefCommand,
   CopyNoteURLCommand,
+  CopyToClipboardCommand,
   CreateDailyJournalCommand,
   CreateHookCommand,
   CreateSchemaFromHierarchyCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1001,3 +1001,5 @@ export const INCOMPATIBLE_EXTENSIONS = [
   "maxedmands.vscode-zettel-markdown-notes",
   "tchayen.markdown-links",
 ];
+
+export const KEYBINDING_CONFLICT_EXTENSIONS = ["vscodevim.vim"];

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1045,9 +1045,11 @@ export const KNOWN_KEYBINDING_CONFLICTS: KeybindingConflict[] = [
     conflictsWith: "dendron.lookupNote",
     os: ["Linux", "Windows_NT"],
   },
-  {
-    extensionId: "vscodevim.vim",
-    commandId: "extension.vim_tab",
-    conflictsWith: "dendron.lookupNoteAutoComplete",
-  },
+  // This is left here so it could be tested in Darwin.
+  // This is not an actual conflict.
+  // {
+  //   extensionId: "vscodevim.vim",
+  //   commandId: "extension.vim_tab",
+  //   conflictsWith: "dendron.lookupNoteAutoComplete",
+  // },
 ];

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1017,7 +1017,7 @@ export type KeybindingConflict = {
   /**
    * extension id of the extension that has keybinding conflict
    */
-  extensionId: typeof KNOWN_CONFLICTING_EXTENSIONS[number];
+  extensionId: string;
   /**
    * command id of the command contributed by `extensionId` that conflicts
    */
@@ -1033,7 +1033,7 @@ export type KeybindingConflict = {
   os?: osType[];
 };
 
-export const KNOWN_CONFLICTING_EXTENSIONS = ["vscodevim.vim"] as const;
+export const KNOWN_CONFLICTING_EXTENSIONS = ["vscodevim.vim"];
 
 /**
  * List of known keybinding conflicts

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -300,6 +300,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     },
     when: DendronContext.PLUGIN_ACTIVE,
   },
+  COPY_TO_CLIPBOARD: {
+    key: "dendron.copyToClipboard",
+    title: `${CMD_PREFIX} Copy To Clipboard`,
+    when: "false",
+  },
   DELETE_NODE: {
     key: "dendron.deleteNode",
     title: `${CMD_PREFIX} Delete Node`,
@@ -1002,4 +1007,47 @@ export const INCOMPATIBLE_EXTENSIONS = [
   "tchayen.markdown-links",
 ];
 
-export const KEYBINDING_CONFLICT_EXTENSIONS = ["vscodevim.vim"];
+export type osType = "Linux" | "Darwin" | "Windows_NT";
+
+export function isOSType(str: string): str is osType {
+  return str === "Linux" || str === "Darwin" || str === "Windows_NT";
+}
+
+export type KeybindingConflict = {
+  /**
+   * extension id of the extension that has keybinding conflict
+   */
+  extensionId: typeof KWOWN_CONFLICTING_EXTENSIONS[number];
+  /**
+   * command id of the command contributed by `extensionId` that conflicts
+   */
+  commandId: string;
+  /**
+   * command id of Dendron command that conflicts with `commandId`
+   */
+  conflictsWith: string;
+  /**
+   * os in which this conflict exists. assume all platforms if undefined.
+   * this is the os type returned by {@link os.type}
+   */
+  os?: osType[];
+};
+
+export const KWOWN_CONFLICTING_EXTENSIONS = ["vscodevim.vim"] as const;
+
+/**
+ * List of known keybinding conflicts
+ */
+export const KNOWN_KEYBINDING_CONFLICTS: KeybindingConflict[] = [
+  {
+    extensionId: "vscodevim.vim",
+    commandId: "extension.vim_navigateCtrlL",
+    conflictsWith: "dendron.lookupNote",
+    os: ["Linux", "Windows_NT"],
+  },
+  {
+    extensionId: "vscodevim.vim",
+    commandId: "extension.vim_tab",
+    conflictsWith: "dendron.lookupNoteAutoComplete",
+  },
+];

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1017,7 +1017,7 @@ export type KeybindingConflict = {
   /**
    * extension id of the extension that has keybinding conflict
    */
-  extensionId: typeof KWOWN_CONFLICTING_EXTENSIONS[number];
+  extensionId: typeof KNOWN_CONFLICTING_EXTENSIONS[number];
   /**
    * command id of the command contributed by `extensionId` that conflicts
    */
@@ -1033,7 +1033,7 @@ export type KeybindingConflict = {
   os?: osType[];
 };
 
-export const KWOWN_CONFLICTING_EXTENSIONS = ["vscodevim.vim"] as const;
+export const KNOWN_CONFLICTING_EXTENSIONS = ["vscodevim.vim"] as const;
 
 /**
  * List of known keybinding conflicts

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -777,7 +777,10 @@ suite("keybindings", function () {
       let installStatusStub: SinonStub;
       beforeEach(() => {
         installStatusStub = sinon
-          .stub(KeybindingUtils, "getInstallStatus")
+          .stub(
+            KeybindingUtils,
+            "getInstallStatusForKnownConflictingExtensions"
+          )
           .returns([{ id: "dummyExt", installed: true }]);
       });
 
@@ -806,7 +809,10 @@ suite("keybindings", function () {
       let installStatusStub: SinonStub;
       beforeEach(() => {
         installStatusStub = sinon
-          .stub(KeybindingUtils, "getInstallStatus")
+          .stub(
+            KeybindingUtils,
+            "getInstallStatusForKnownConflictingExtensions"
+          )
           .returns([{ id: "dummyExt", installed: true }]);
       });
 

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -56,7 +56,6 @@ import {
 } from "../testUtilsv2";
 import {
   describeMultiWS,
-  describeSingleWS,
   runLegacySingleWorkspaceTest,
   runTestButSkipForWindows,
   setupBeforeAfter,

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -762,71 +762,71 @@ suite("GIVEN a native workspace", function () {
   });
 });
 
-suite("keybindings", function () {
-  let homeDirStub: SinonStub;
-  let userConfigDirStub: SinonStub;
+// suite("keybindings", function () {
+//   let homeDirStub: SinonStub;
+//   let userConfigDirStub: SinonStub;
 
-  setupBeforeAfter(this, {
-    beforeHook: async (ctx) => {
-      // eslint-disable-next-line no-new
-      new StateService(ctx);
-      await resetCodeWorkspace();
-      await new ResetConfigCommand().execute({ scope: "all" });
-      homeDirStub = TestEngineUtils.mockHomeDir();
-      userConfigDirStub = mockUserConfigDir();
-    },
-    afterHook: async () => {
-      homeDirStub.restore();
-      userConfigDirStub.restore();
-    },
-    noSetInstallStatus: true,
-  });
+//   setupBeforeAfter(this, {
+//     beforeHook: async (ctx) => {
+//       // eslint-disable-next-line no-new
+//       new StateService(ctx);
+//       await resetCodeWorkspace();
+//       await new ResetConfigCommand().execute({ scope: "all" });
+//       homeDirStub = TestEngineUtils.mockHomeDir();
+//       userConfigDirStub = mockUserConfigDir();
+//     },
+//     afterHook: async () => {
+//       homeDirStub.restore();
+//       userConfigDirStub.restore();
+//     },
+//     noSetInstallStatus: true,
+//   });
 
-  describe("keyboard shortcut conflict resolution", () => {
-    test("vim extension expandLineSelection override", (done) => {
-      const { keybindingConfigPath } =
-        KeybindingUtils.getKeybindingConfigPath();
-      fs.ensureFileSync(keybindingConfigPath);
-      const config = `// This is my awesome Dendron Keybinding
-      [
-        { // look up note to the side
-          "key": "ctrl+k l",
-          "command": "dendron.lookupNote",
-          "args": {
-            "splitType": "horizontal"
-          }
-        }
-      ]`;
-      fs.writeFileSync(keybindingConfigPath, config);
-      const resp = KeybindingUtils.getKeybindingConfig({
-        createIfMissing: false,
-      });
-      const existingConfig = resp.data!;
-      const beforeAllSymbol = Object.getOwnPropertySymbols(existingConfig)[0];
-      const beforeKeySymbol = Object.getOwnPropertySymbols(
-        existingConfig[0]
-      )[0];
-      const { newKeybindings } =
-        KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists().data!;
-      const override = newKeybindings[1];
-      expect(_.isArray(newKeybindings)).toBeTruthy();
-      // override config exists after migration
-      expect(override).toEqual({
-        key: `ctrl+l`,
-        command: "-extension.vim_navigateCtrlL",
-      });
+//   describe("keyboard shortcut conflict resolution", () => {
+//     test("vim extension expandLineSelection override", (done) => {
+//       const { keybindingConfigPath } =
+//         KeybindingUtils.getKeybindingConfigPath();
+//       fs.ensureFileSync(keybindingConfigPath);
+//       const config = `// This is my awesome Dendron Keybinding
+//       [
+//         { // look up note to the side
+//           "key": "ctrl+k l",
+//           "command": "dendron.lookupNote",
+//           "args": {
+//             "splitType": "horizontal"
+//           }
+//         }
+//       ]`;
+//       fs.writeFileSync(keybindingConfigPath, config);
+//       const resp = KeybindingUtils.getKeybindingConfig({
+//         createIfMissing: false,
+//       });
+//       const existingConfig = resp.data!;
+//       const beforeAllSymbol = Object.getOwnPropertySymbols(existingConfig)[0];
+//       const beforeKeySymbol = Object.getOwnPropertySymbols(
+//         existingConfig[0]
+//       )[0];
+//       const { newKeybindings } =
+//         KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists().data!;
+//       const override = newKeybindings[1];
+//       expect(_.isArray(newKeybindings)).toBeTruthy();
+//       // override config exists after migration
+//       expect(override).toEqual({
+//         key: `ctrl+l`,
+//         command: "-extension.vim_navigateCtrlL",
+//       });
 
-      // existing comments are preserved
-      expect(Object.getOwnPropertySymbols(newKeybindings)[0]).toEqual(
-        beforeAllSymbol
-      );
-      expect(Object.getOwnPropertySymbols(newKeybindings[0])[0]).toEqual(
-        beforeKeySymbol
-      );
-      done();
-    });
-  });
-});
+//       // existing comments are preserved
+//       expect(Object.getOwnPropertySymbols(newKeybindings)[0]).toEqual(
+//         beforeAllSymbol
+//       );
+//       expect(Object.getOwnPropertySymbols(newKeybindings[0])[0]).toEqual(
+//         beforeKeySymbol
+//       );
+//       done();
+//     });
+//   });
+// });
 
 suite(
   "temporary testing of Dendron version compatibility downgrade sequence",

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -17,10 +17,10 @@ import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
 import * as mocha from "mocha";
-import { afterEach, beforeEach, describe, it } from "mocha";
+import { afterEach, beforeEach, describe, it, after } from "mocha";
 import path from "path";
 import semver from "semver";
-import sinon, { SinonStub } from "sinon";
+import sinon, { SinonStub, SinonSpy } from "sinon";
 import * as vscode from "vscode";
 import { ExtensionContext, window } from "vscode";
 import { ResetConfigCommand } from "../../commands/ResetConfig";
@@ -34,7 +34,7 @@ import {
   WORKSPACE_ACTIVATION_CONTEXT,
 } from "../../constants";
 import { ExtensionProvider } from "../../ExtensionProvider";
-// import { KeybindingUtils } from "../../KeybindingUtils";
+import { KeybindingUtils } from "../../KeybindingUtils";
 import { StateService } from "../../services/stateService";
 import { AnalyticsUtils } from "../../utils/analytics";
 import { ConfigMigrationUtils } from "../../utils/ConfigMigration";
@@ -56,6 +56,7 @@ import {
 } from "../testUtilsv2";
 import {
   describeMultiWS,
+  describeSingleWS,
   runLegacySingleWorkspaceTest,
   runTestButSkipForWindows,
   setupBeforeAfter,
@@ -762,71 +763,68 @@ suite("GIVEN a native workspace", function () {
   });
 });
 
-// suite("keybindings", function () {
-//   let homeDirStub: SinonStub;
-//   let userConfigDirStub: SinonStub;
+suite("keybindings", function () {
+  let promptSpy: SinonSpy;
+  describeMultiWS(
+    "GIVEN initial install",
+    {
+      beforeHook: async ({ ctx }) => {
+        ctx.globalState.update(GLOBAL_STATE.VERSION, undefined);
+        promptSpy = sinon.spy(KeybindingUtils, "maybePromptKeybindingConflict");
+      },
+      noSetInstallStatus: true,
+    },
+    () => {
+      let installStatusStub: SinonStub;
+      beforeEach(() => {
+        installStatusStub = sinon
+          .stub(KeybindingUtils, "getInstallStatus")
+          .returns([{ id: "dummyExt", installed: true }]);
+      });
 
-//   setupBeforeAfter(this, {
-//     beforeHook: async (ctx) => {
-//       // eslint-disable-next-line no-new
-//       new StateService(ctx);
-//       await resetCodeWorkspace();
-//       await new ResetConfigCommand().execute({ scope: "all" });
-//       homeDirStub = TestEngineUtils.mockHomeDir();
-//       userConfigDirStub = mockUserConfigDir();
-//     },
-//     afterHook: async () => {
-//       homeDirStub.restore();
-//       userConfigDirStub.restore();
-//     },
-//     noSetInstallStatus: true,
-//   });
+      afterEach(() => {
+        installStatusStub.restore();
+      });
 
-//   describe("keyboard shortcut conflict resolution", () => {
-//     test("vim extension expandLineSelection override", (done) => {
-//       const { keybindingConfigPath } =
-//         KeybindingUtils.getKeybindingConfigPath();
-//       fs.ensureFileSync(keybindingConfigPath);
-//       const config = `// This is my awesome Dendron Keybinding
-//       [
-//         { // look up note to the side
-//           "key": "ctrl+k l",
-//           "command": "dendron.lookupNote",
-//           "args": {
-//             "splitType": "horizontal"
-//           }
-//         }
-//       ]`;
-//       fs.writeFileSync(keybindingConfigPath, config);
-//       const resp = KeybindingUtils.getKeybindingConfig({
-//         createIfMissing: false,
-//       });
-//       const existingConfig = resp.data!;
-//       const beforeAllSymbol = Object.getOwnPropertySymbols(existingConfig)[0];
-//       const beforeKeySymbol = Object.getOwnPropertySymbols(
-//         existingConfig[0]
-//       )[0];
-//       const { newKeybindings } =
-//         KeybindingUtils.checkAndApplyVimKeybindingOverrideIfExists().data!;
-//       const override = newKeybindings[1];
-//       expect(_.isArray(newKeybindings)).toBeTruthy();
-//       // override config exists after migration
-//       expect(override).toEqual({
-//         key: `ctrl+l`,
-//         command: "-extension.vim_navigateCtrlL",
-//       });
+      after(() => {
+        promptSpy.restore();
+      });
 
-//       // existing comments are preserved
-//       expect(Object.getOwnPropertySymbols(newKeybindings)[0]).toEqual(
-//         beforeAllSymbol
-//       );
-//       expect(Object.getOwnPropertySymbols(newKeybindings[0])[0]).toEqual(
-//         beforeKeySymbol
-//       );
-//       done();
-//     });
-//   });
-// });
+      test("THEN maybePromptKeybindingConflict is called", async () => {
+        expect(promptSpy.called).toBeTruthy();
+      });
+    }
+  );
+
+  describeMultiWS(
+    "GIVEN not initial install",
+    {
+      beforeHook: async () => {
+        promptSpy = sinon.spy(KeybindingUtils, "maybePromptKeybindingConflict");
+      },
+    },
+    () => {
+      let installStatusStub: SinonStub;
+      beforeEach(() => {
+        installStatusStub = sinon
+          .stub(KeybindingUtils, "getInstallStatus")
+          .returns([{ id: "dummyExt", installed: true }]);
+      });
+
+      afterEach(() => {
+        installStatusStub.restore();
+      });
+
+      after(() => {
+        promptSpy.restore();
+      });
+
+      test("THEN maybePromptKeybindingConflict is not called", async () => {
+        expect(promptSpy.called).toBeFalsy();
+      });
+    }
+  );
+});
 
 suite(
   "temporary testing of Dendron version compatibility downgrade sequence",

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -34,7 +34,7 @@ import {
   WORKSPACE_ACTIVATION_CONTEXT,
 } from "../../constants";
 import { ExtensionProvider } from "../../ExtensionProvider";
-import { KeybindingUtils } from "../../KeybindingUtils";
+// import { KeybindingUtils } from "../../KeybindingUtils";
 import { StateService } from "../../services/stateService";
 import { AnalyticsUtils } from "../../utils/analytics";
 import { ConfigMigrationUtils } from "../../utils/ConfigMigration";

--- a/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
@@ -43,7 +43,10 @@ suite("KeybindingUtils", function () {
       beforeEach(() => {
         userConfigDirStub = mockUserConfigDir();
         installStatusStub = sinon
-          .stub(KeybindingUtils, "getInstallStatus")
+          .stub(
+            KeybindingUtils,
+            "getInstallStatusForKnownConflictingExtensions"
+          )
           .returns([{ id: "dummyExt", installed: true }]);
       });
 

--- a/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
@@ -1,0 +1,139 @@
+import { describe, beforeEach, afterEach } from "mocha";
+import { KeybindingUtils } from "../../KeybindingUtils";
+import { describeMultiWS } from "../testUtilsV3";
+import sinon, { SinonStub } from "sinon";
+import fs from "fs-extra";
+import { expect } from "../testUtilsv2";
+import { KNOWN_KEYBINDING_CONFLICTS } from "../../constants";
+import { tmpDir } from "@dendronhq/common-server";
+import { VSCodeUtils } from "../../vsCodeUtils";
+
+function mockUserConfigDir() {
+  const dir = tmpDir().name;
+  const getCodeUserConfigDurStub = sinon.stub(
+    VSCodeUtils,
+    "getCodeUserConfigDir"
+  );
+  getCodeUserConfigDurStub.callsFake(() => {
+    const wrappedMethod = getCodeUserConfigDurStub.wrappedMethod;
+    const originalOut = wrappedMethod();
+    return {
+      userConfigDir: [dir, originalOut.delimiter].join(""),
+      delimiter: originalOut.delimiter,
+      osName: originalOut.osName,
+    };
+  });
+  return getCodeUserConfigDurStub;
+}
+
+suite("KeybindingUtils", function () {
+  const DUMMY_KEYBINDING_CONFLICTS = [
+    {
+      extensionId: "dummyExt",
+      commandId: "dummyExt.cmd",
+      conflictsWith: "dendron.lookupNote",
+    },
+  ];
+  describeMultiWS(
+    "GIVEN conflicting extension installed AND keybinding exists",
+    {},
+    () => {
+      let installStatusStub: SinonStub;
+      let userConfigDirStub: SinonStub;
+      beforeEach(() => {
+        userConfigDirStub = mockUserConfigDir();
+        installStatusStub = sinon
+          .stub(KeybindingUtils, "getInstallStatus")
+          .returns([{ id: "dummyExt", installed: true }]);
+      });
+
+      afterEach(() => {
+        installStatusStub.restore();
+        userConfigDirStub.restore();
+      });
+
+      test("THEN conflict is detected", async () => {
+        const out = KeybindingUtils.getConflictingKeybindings({
+          knownConflicts: DUMMY_KEYBINDING_CONFLICTS,
+        });
+        expect(out).toEqual(DUMMY_KEYBINDING_CONFLICTS);
+      });
+
+      test("THEN conflict is not detected if resolution exists in keybindings.json", async () => {
+        const { keybindingConfigPath, osName } =
+          KeybindingUtils.getKeybindingConfigPath();
+        const keyCombo = osName === "Darwin" ? "cmd+l" : "ctrl+l";
+        const remapCombo = osName === "Darwin" ? "cmd+shift+l" : "ctrl+shift+l";
+        const disableConflictCaseConfig = `// This is my awesome Dendron Keybinding
+        [
+          {
+            "key": "${keyCombo}",
+            "command": "-dummyExt.cmd",
+          }
+        ]`;
+        const remapConflictCaseConfig = `// This is my awesome Dendron Keybinding
+        [
+          {
+            "key": "${remapCombo}",
+            "command": "dummyExt.cmd",
+          }
+        ]`;
+        const remapDendronCaseConfig = `// This is my awesome Dendron Keybinding
+        [
+          {
+            "key": "${remapCombo}",
+            "command": "dendron.lookupNote",
+          }
+        ]`;
+        [
+          disableConflictCaseConfig,
+          remapConflictCaseConfig,
+          remapDendronCaseConfig,
+        ].forEach((config) => {
+          fs.ensureFileSync(keybindingConfigPath);
+          fs.writeFileSync(keybindingConfigPath, config);
+          const out = KeybindingUtils.getConflictingKeybindings({
+            knownConflicts: DUMMY_KEYBINDING_CONFLICTS,
+          });
+          expect(out).toEqual([]);
+          fs.removeSync(keybindingConfigPath);
+        });
+      });
+    }
+  );
+
+  describeMultiWS("GIVEN no conflicting extension installed", {}, () => {
+    test("THEN no conflict is detected", async () => {
+      const out = KeybindingUtils.getConflictingKeybindings({
+        knownConflicts: KNOWN_KEYBINDING_CONFLICTS,
+      });
+      expect(out).toEqual([]);
+    });
+  });
+
+  describe("GIVEN a keybinding entry", () => {
+    test("THEN correct JSON for disable block is generated", () => {
+      const disableBlock = KeybindingUtils.generateKeybindingBlockForCopy({
+        entry: {
+          key: "ctrl+l",
+          command: "dummyExt.cmd",
+        },
+        disable: true,
+      });
+      expect(disableBlock).toEqual(
+        `{\n  "key": "ctrl+l",\n  "command": "-dummyExt.cmd",\n}\n`
+      );
+    });
+    test("THEN correct JSON for remap block is generated", () => {
+      const disableBlock = KeybindingUtils.generateKeybindingBlockForCopy({
+        entry: {
+          key: "ctrl+l",
+          command: "dummyExt.cmd",
+        },
+      });
+      expect(disableBlock).toEqual(
+        `{\n  "key": "",\n  "command": "dummyExt.cmd",\n}\n`
+      );
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Keybinding.test.ts
@@ -62,23 +62,27 @@ suite("KeybindingUtils", function () {
         expect(out).toEqual(DUMMY_KEYBINDING_CONFLICTS);
       });
 
-      test("THEN conflict is not detected if resolution exists in keybindings.json", async () => {
+      test("THEN conflict is detected if a non-resolving remap is in keybindings.json", async () => {
         const { keybindingConfigPath, osName } =
           KeybindingUtils.getKeybindingConfigPath();
         const keyCombo = osName === "Darwin" ? "cmd+l" : "ctrl+l";
         const remapCombo = osName === "Darwin" ? "cmd+shift+l" : "ctrl+shift+l";
-        const disableConflictCaseConfig = `// This is my awesome Dendron Keybinding
-        [
-          {
-            "key": "${keyCombo}",
-            "command": "-dummyExt.cmd",
-          }
-        ]`;
+
         const remapConflictCaseConfig = `// This is my awesome Dendron Keybinding
         [
           {
             "key": "${remapCombo}",
             "command": "dummyExt.cmd",
+          }
+        ]`;
+        const conflictWithMoreArgsCaseConfig = `// This is my awesome Dendron Keybinding
+        [
+          {
+            "key": "${keyCombo}",
+            "command": "dummyExt.cmd",
+            "args": {
+              "foo": "bar"
+            }
           }
         ]`;
         const remapDendronCaseConfig = `// This is my awesome Dendron Keybinding
@@ -88,19 +92,50 @@ suite("KeybindingUtils", function () {
             "command": "dendron.lookupNote",
           }
         ]`;
+        const dendronWithMoreArgsCaseConfig = `// This is my awesome Dendron Keybinding
         [
-          disableConflictCaseConfig,
+          {
+            "key": "${keyCombo}",
+            "command": "dendron.lookupNote",
+            "args": {
+              "initialValue": "foo"
+            }
+          }
+        ]`;
+        [
           remapConflictCaseConfig,
+          conflictWithMoreArgsCaseConfig,
           remapDendronCaseConfig,
+          dendronWithMoreArgsCaseConfig,
         ].forEach((config) => {
           fs.ensureFileSync(keybindingConfigPath);
           fs.writeFileSync(keybindingConfigPath, config);
           const out = KeybindingUtils.getConflictingKeybindings({
             knownConflicts: DUMMY_KEYBINDING_CONFLICTS,
           });
-          expect(out).toEqual([]);
+          expect(out).toEqual(DUMMY_KEYBINDING_CONFLICTS);
           fs.removeSync(keybindingConfigPath);
         });
+      });
+
+      test("THEN conflict is not detected if conflicting keybinding is disabled in keybindings.json", async () => {
+        const { keybindingConfigPath, osName } =
+          KeybindingUtils.getKeybindingConfigPath();
+        const keyCombo = osName === "Darwin" ? "cmd+l" : "ctrl+l";
+        const disableConflictCaseConfig = `// This is my awesome Dendron Keybinding
+        [
+          {
+            "key": "${keyCombo}",
+            "command": "-dummyExt.cmd",
+          }
+        ]`;
+        fs.ensureFileSync(keybindingConfigPath);
+        fs.writeFileSync(keybindingConfigPath, disableConflictCaseConfig);
+        const out = KeybindingUtils.getConflictingKeybindings({
+          knownConflicts: DUMMY_KEYBINDING_CONFLICTS,
+        });
+        expect(out).toEqual([]);
+        fs.removeSync(keybindingConfigPath);
       });
     }
   );

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -489,6 +489,7 @@ export function describeMultiWS(
      * See [[Breakpoints|dendron://dendron.docs/pkg.plugin-core.qa.debug#breakpoints]] for more details
      */
     timeout?: number;
+    noSetInstallStatus?: boolean;
   },
   fn: () => void
 ) {

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -570,7 +570,15 @@ export class VSCodeUtils {
         break;
       }
     }
-    // return [userConfigDir, delimiter, osName];
+
+    // if vscode is in portable mode, we need to handle it differently
+    // there is also a case where the user opens vscode with a custom `--user-data-dir` args through the CLI,
+    // but there is no reliable way for the extension authors to identify that through the node env or vscode API
+    const portableDir = process.env["VSCODE_PORTABLE"];
+    if (portableDir) {
+      userConfigDir = path.join(portableDir, "user-data", "User");
+    }
+
     return {
       userConfigDir,
       delimiter,


### PR DESCRIPTION
# feat: add doctor command for a more reliable keybinding resolution

This PR:
- Removes automatic keybinding conflict resolution in favor of manual resolution.
- The main goal of this PR is to give back user agency while also providing a streamlined way of manually resolving conflicts.

- adds doctor command `fixKeybindingConflicts`
  - detects known extensions that have keybinding conflicts
  - provide detailed instructions on how to resolve them
- removes automatic keybinding conflict resolution that happens during extension activation

## Notes

- `dendron.copyToClipboard`
  - This is a command that is added to provide a way to copy arbitrary text to system clipboard within a webview.
  - This command is not accessible from any user-facing VSCode UI. (`when` clause is `false`)

- `KNOWN_KEYBINDING_CONFLICTS`
  - This holds all the mappings between a known pair of conflicting keybindings.

- `VSCodeUtils.getCodeUserConfigDir`
  - Currently there isn't a straightforward way to know for sure what the exact user data directory is when given a vscode session. (We are making a best guess)
  - As such, moving forward _we should not try to automatically create a `keybindings.json` file if it doesn't exist._
    - This used to be the case but not anymore since we are not automatically resolving keybinding conflicts anymore.
    - If we absolutely have to, we should do so by doing `vscode.commands.executeCommand("workbench.action.openGlobalKeybindingsFile")`, and delegating the creation to VSCode. 
      - At this point we can figure out the exact path of user-data-dir, but unfortunately the file has to be opened in the editor. This would be fine if we incorporate the file open in the user experience flow.
 
## Flow

> To manually test this, pull this branch in and `Run Extension: Remote (plugin-core)` with an extension that has conflicts installed. Currently the only one is `vscodevim`. If you are on a mac there won't be any conflicts, but you can uncomment [this](https://github.com/dendronhq/dendron/pull/2578/files#diff-248f919f41b45daa5d918842ab7dc039c336356b37665bc387826e4048922fe5R1048) to try it out.

1. During activation (only on initial install), we try to detect known keybinding conflicts. This takes into account both default and user defined keybindings.
2. If a conflict is detected, a toast message will appear with a button that will trigger the doctor command.
  ![image](https://user-images.githubusercontent.com/1219789/158598186-0802149d-fe77-4b29-b6ec-e712349783b7.png)
3. When the button is clicked, the default keybinding (JSON), and a webview will be opened. (_**note that `extension.vim_tab` is not actually a conflict. This is for demonstration purposes only**_)
  ![image](https://user-images.githubusercontent.com/1219789/158598474-d28e9aad-e6b0-4781-98da-4379d0e9e4c0.png)
4. Instructions on how to resolve the detected conflicts is described on the top of the webview (above the thematic break)
  ![image](https://user-images.githubusercontent.com/1219789/158598981-13aa6739-b18f-49ab-9632-d98995ad09d3.png)
5. The link `keybindings.json` is linking to a command uri that will open `keybindings.json`
6. List of detected conflicts and a set of links that will copy a JSON block is presented below
  ![image](https://user-images.githubusercontent.com/1219789/158599328-578a1b5b-0930-485f-92f7-f989b7f03e87.png)
7. When clicked, a toast message will be shown
  ![image](https://user-images.githubusercontent.com/1219789/158599621-861ae7fc-b62c-4240-8480-dc2d5dc72fc0.png)
8. This could be pasted into `keybindings.json` directly as the necessary disable (or remap) entry is already in the clipboard.
   ![image](https://user-images.githubusercontent.com/1219789/158599935-dd567db2-d51f-4823-8af5-22cc96a2bf9c.png)

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)
