### PR TITLE
enhance(pods): support exporting a note to multiple Airtable destination

### DIFF
--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -29,6 +29,10 @@ type CommandCLIOpts = {
    * so we don't want it to exit.
    */
   exit?: boolean;
+  /**
+   * pod Id used to export Note(s) to Airtable
+   */
+  podId?: string;
 } & SetupEngineCLIOpts;
 
 type CommandOpts = CommandCLIOpts & SetupEngineOpts & CommandCommonProps;
@@ -60,6 +64,10 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     args.option("dryRun", {
       describe: "dry run",
       type: "boolean",
+    });
+    args.option("podId", {
+      describe: "podId used to export note(s) to Airtable",
+      type: "string",
     });
   }
 

--- a/packages/dendron-cli/src/commands/exportPodV2.ts
+++ b/packages/dendron-cli/src/commands/exportPodV2.ts
@@ -156,7 +156,11 @@ export class ExportPodV2CLICommand extends CLICommand<
     const { exportReturnValue, podType, engine, config } = opts;
     switch (podType) {
       case PodV2Types.AirtableExportV2:
-        return this.onAirtableExportComplete({ exportReturnValue, engine });
+        return this.onAirtableExportComplete({
+          exportReturnValue,
+          engine,
+          config,
+        });
       case PodV2Types.GoogleDocsExportV2:
         return this.onGoogleDocsExportComplete({ exportReturnValue, engine });
       case PodV2Types.NotionExportV2:
@@ -173,14 +177,16 @@ export class ExportPodV2CLICommand extends CLICommand<
   async onAirtableExportComplete(opts: {
     exportReturnValue: AirtableExportReturnType;
     engine: DEngineClient;
+    config: any;
   }) {
-    const { exportReturnValue, engine } = opts;
+    const { exportReturnValue, engine, config } = opts;
     const records = exportReturnValue.data;
     if (records?.created) {
       await AirtableUtils.updateAirtableIdForNewlySyncedNotes({
         records: records.created,
         engine,
         logger: this.L,
+        podId: config.podId,
       });
     }
     const createdCount = exportReturnValue.data?.created?.length ?? 0;

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -1,4 +1,5 @@
 import {
+  assertInvalidState,
   DendronError,
   DEngineClient,
   Disposable,
@@ -29,6 +30,7 @@ export enum DoctorActionsEnum {
   REGENERATE_NOTE_ID = "regenerateNoteId",
   FIND_BROKEN_LINKS = "findBrokenLinks",
   FIX_REMOTE_VAULTS = "fixRemoteVaults",
+  FIX_AIRTABLE_METADATA = "fixAirtableMetadata",
 }
 
 export type DoctorServiceOpts = {
@@ -40,6 +42,7 @@ export type DoctorServiceOpts = {
   exit?: boolean;
   quiet?: boolean;
   engine: DEngineClient;
+  podId?: string;
 };
 
 /** DoctorService is a disposable, you **must** dispose instances you create
@@ -133,7 +136,7 @@ export class DoctorService implements Disposable {
   }
 
   async executeDoctorActions(opts: DoctorServiceOpts) {
-    const { action, engine, query, candidates, limit, dryRun, exit } =
+    const { action, engine, query, candidates, limit, dryRun, exit, podId } =
       _.defaults(opts, {
         limit: 99999,
         exit: true,
@@ -329,6 +332,31 @@ export class DoctorService implements Disposable {
           })
         );
         return { exit: true };
+      }
+      case DoctorActionsEnum.FIX_AIRTABLE_METADATA: {
+        // Converts the airtable id in note frontmatter from a single scalar value to a hashmap
+        if (!podId) {
+          assertInvalidState(
+            "Please provide pod Id to perform Doctor operation"
+          );
+        }
+        doctorAction = async (note: NoteProps) => {
+          //get airtable id from note
+          const airtableId = _.get(note.custom, "airtableId") as string;
+          const pods = {
+            airtable: {
+              [podId]: airtableId,
+            },
+          };
+          delete note.custom["airtableId"];
+          const updatedNote = {
+            ...note,
+            custom: { ...note.custom, pods },
+          };
+          // update note
+          engine.writeNote(updatedNote, { updateExisting: true });
+        };
+        break;
       }
       default:
         throw new DendronError({

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
@@ -49,6 +49,7 @@ function createPod({
     base: () => FakeAirtableBase,
   } as any;
   const cleanConfig: RunnableAirtableV2PodConfig = {
+    podId: "test",
     apiKey: "fakeKey",
     baseId: "fakeBase",
     tableName: "fakeTable",
@@ -89,6 +90,7 @@ const _setupTestFactoryCommon = ({
   srcFieldMapping,
   filters,
   cb,
+  podId,
 }: {
   srcFieldMapping: { [key: string]: SrcFieldMapping };
   filters?: ExportPodConfigurationFilterV2;
@@ -96,6 +98,7 @@ const _setupTestFactoryCommon = ({
     engine: DEngineClient;
     pod: AirtableExportPodV2;
   }) => Promise<AirtableExportReturnType>;
+  podId?: string;
 }) => {
   return async (preSetupHook: SetupHookFunction) => {
     let resp: Promise<AirtableExportReturnType>;
@@ -104,6 +107,7 @@ const _setupTestFactoryCommon = ({
         const { engine } = opts;
         const pod = createPod({
           config: {
+            podId,
             filters,
             sourceFieldMapping: {
               DendronId: {
@@ -136,6 +140,7 @@ const setupTestFactoryForNote = (opts: {
   srcFieldMapping: { [key: string]: SrcFieldMapping };
   filters?: ExportPodConfigurationFilterV2;
   fname: string;
+  podId?: string;
 }) => {
   return _setupTestFactoryCommon({
     ...opts,
@@ -625,6 +630,121 @@ describe("GIVEN export note with date ", () => {
         expect(resp.error?.message).toEqual(
           "The value for endDate is found empty. Please provide a valid value or enable skipOnEmpty in the srcFieldMapping."
         );
+      });
+    });
+  });
+});
+
+describe("GIVEN note has pods namespace in frontmatter", () => {
+  describe("WHEN export note with linked record", () => {
+    let resp: AirtableExportReturnType;
+
+    const setupTest = setupTestFactoryForNote({
+      fname: "proj.beta",
+      srcFieldMapping: {
+        Tasks: {
+          type: "linkedRecord",
+          to: "links",
+          podId: "dendron.task",
+          filter: "task.*",
+        },
+      },
+    });
+
+    describe("AND linked note does not have airtable id", () => {
+      test("THEN show error message", async () => {
+        const preSetupHook = async (opts: WorkspaceOpts) => {
+          await TestEngineUtils.createNoteByFname({
+            fname: "task.alpha",
+            body: "This is a task",
+            custom: {},
+            ...opts,
+          });
+          await TestEngineUtils.createNoteByFname({
+            fname: "proj.beta",
+            body: "[[task.alpha]]",
+            custom: {},
+            ...opts,
+          });
+        };
+        const resp = await setupTest(preSetupHook);
+        await checkString(
+          resp.error!.message,
+          "The following notes are missing airtable ids: dendron://vault1/task.alpha (task.alpha)"
+        );
+      });
+    });
+
+    describe("AND linked note has airtable id", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        await TestEngineUtils.createNoteByFname({
+          fname: "task.alpha",
+          body: "This is a task",
+          custom: { pods: { airtable: { "dendron.task": "airtableId-task" } } },
+          ...opts,
+        });
+        await TestEngineUtils.createNoteByFname({
+          fname: "proj.beta",
+          body: "[[task.alpha]]",
+          custom: {},
+          ...opts,
+        });
+      };
+
+      beforeAll(async () => {
+        resp = await setupTest(preSetupHook);
+      });
+
+      test("THEN create new record with task as foreign id", () => {
+        expect(resp).toEqual({
+          data: {
+            created: [
+              {
+                fields: {
+                  DendronId: "proj.beta",
+                  Tasks: ["airtableId-task"],
+                },
+                id: "airtable-proj.beta",
+              },
+            ],
+            updated: [],
+          },
+          error: null,
+        });
+      });
+    });
+  });
+  describe("WHEN export a note", () => {
+    const setupTest = setupTestFactoryForNote({
+      podId: "dendron.task",
+      fname: "alpha",
+      srcFieldMapping: {
+        Alpha: {
+          type: "number",
+          to: "custom.alpha",
+        },
+      },
+    });
+
+    describe("AND airtable id is present in frontmatter under pods namespace", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        return createTestNote(opts, {
+          alpha: 1,
+          pods: { airtable: { "dendron.task": "airtable-one" } },
+        });
+      };
+      test("THEN update the record", async () => {
+        const resp = await setupTest(preSetupHook);
+        expect(resp.data?.updated).toEqual([genField({ Alpha: 1 })]);
+      });
+    });
+    describe("AND airtable id is not present in frontmatter under pods namespace", () => {
+      const preSetupHook = async (opts: WorkspaceOpts) => {
+        return createTestNote(opts, { alpha: 1 });
+      };
+      test("THEN create the record", async () => {
+        const resp = await setupTest(preSetupHook);
+        expect(resp.data?.created).toEqual([genField({ Alpha: 1 })]);
       });
     });
   });

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -460,30 +460,20 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       }
       case DoctorActionsEnum.FIX_AIRTABLE_METADATA: {
         const selection = await this.getHierarchy();
+        // break if no hierarchy is selected.
         if (!selection) break;
         // get hierarchy of notes to be updated
         const { hierarchy, vault } = selection;
         // get podId used to export the notes
         const podId = await PodUIControls.promptToSelectCustomPodId();
         if (!podId) break;
-        const notes = engine.notes;
-        const candidates = Object.values(notes).filter(
-          (value) =>
-            value.fname.startsWith(hierarchy) &&
-            value.stub !== true &&
-            VaultUtils.isEqualV2(value.vault, vault) &&
-            value.custom.airtableId
-        );
-        this.L.info({
-          ctx,
-          msg: `${DoctorActionsEnum.FIX_FRONTMATTER} candidates: ${candidates.length}`,
-        });
         const ds = new DoctorService();
         await ds.executeDoctorActions({
           action: opts.action,
-          candidates,
           engine,
           podId,
+          hierarchy,
+          vault,
         });
         break;
       }

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -461,7 +461,9 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       case DoctorActionsEnum.FIX_AIRTABLE_METADATA: {
         const selection = await this.getHierarchy();
         if (!selection) break;
+        // get hierarchy of notes to be updated
         const { hierarchy, vault } = selection;
+        // get podId used to export the notes
         const podId = await PodUIControls.promptToSelectCustomPodId();
         if (!podId) break;
         const notes = engine.notes;

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -1,5 +1,5 @@
 import Airtable from "@dendronhq/airtable";
-import { ErrorFactory, NoteProps, ResponseUtil } from "@dendronhq/common-all";
+import { ErrorFactory, ResponseUtil } from "@dendronhq/common-all";
 import {
   AirtableConnection,
   AirtableExportPodV2,
@@ -173,10 +173,10 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
    */
   public async onExportComplete({
     exportReturnValue,
+    config,
   }: {
     exportReturnValue: AirtableExportReturnType;
     config: RunnableAirtableV2PodConfig;
-    payload: NoteProps[];
   }) {
     const records = exportReturnValue.data;
     const engine = this.extension.getEngine();
@@ -186,14 +186,15 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
         records: records.created,
         engine,
         logger,
+        podId: config.podId,
       });
     }
 
     const createdCount = exportReturnValue.data?.created?.length ?? 0;
     const updatedCount = exportReturnValue.data?.updated?.length ?? 0;
-
+    let errorMsg = "";
     if (ResponseUtil.hasError(exportReturnValue)) {
-      const errorMsg = `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated. Error encountered: ${ErrorFactory.safeStringify(
+      errorMsg = `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated. Error encountered: ${ErrorFactory.safeStringify(
         exportReturnValue.error
       )}`;
 
@@ -203,6 +204,7 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
         `Finished Airtable Export. ${createdCount} records created; ${updatedCount} records updated.`
       );
     }
+    return errorMsg;
   }
 
   /**

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -533,4 +533,18 @@ export class PodUIControls {
         assertUnreachable(type);
     }
   }
+  // Prompt user to select custom pod Id
+  public static async promptToSelectCustomPodId(): Promise<string | undefined> {
+    const configs = PodV2ConfigManager.getAllPodConfigs(
+      path.join(getExtension().podsDir, "custom")
+    );
+    const items = configs.map<QuickPickItem>((value) => {
+      return { label: value.podId, description: value.podType };
+    });
+    const podIdQuickPick = await VSCodeUtils.showQuickPick(items, {
+      title: "Pick a pod configuration Id",
+      ignoreFocusOut: true,
+    });
+    return podIdQuickPick?.label;
+  }
 }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -533,10 +533,14 @@ export class PodUIControls {
         assertUnreachable(type);
     }
   }
-  // Prompt user to select custom pod Id
+
+  /**
+   * Prompt user to select custom pod Id
+   */
   public static async promptToSelectCustomPodId(): Promise<string | undefined> {
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
     const configs = PodV2ConfigManager.getAllPodConfigs(
-      path.join(getExtension().podsDir, "custom")
+      path.join(PodUtils.getPodDir({ wsRoot }), "custom")
     );
     const items = configs.map<QuickPickItem>((value) => {
       return { label: value.podId, description: value.podType };

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -717,7 +717,7 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
 
 suite("FIX_AIRTABLE_METADATA", function () {
   describeMultiWS(
-    "GIVEN updateAirtableMetadata selected",
+    "GIVEN fixAirtableMetadata selected",
     {
       preSetupHook: async ({ vaults, wsRoot }) => {
         await NoteTestUtilsV4.createNote({

--- a/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
@@ -1,0 +1,147 @@
+import { PodExportScope } from "@dendronhq/pods-core";
+import { describe } from "mocha";
+import * as vscode from "vscode";
+import { expect, getNoteFromTextEditor } from "../../../testUtilsv2";
+import { describeSingleWS } from "../../../testUtilsV3";
+import { AirtableExportPodCommand } from "../../../../commands/pods/AirtableExportPodCommand";
+import { ExtensionProvider } from "../../../../ExtensionProvider";
+import { vault2Path } from "@dendronhq/common-server";
+import path from "path";
+import { VSCodeUtils } from "../../../../vsCodeUtils";
+import { DendronError, ErrorFactory, NoteUtils } from "@dendronhq/common-all";
+
+suite("AirtableExportCommand", function () {
+  const setUpPod = async () => {
+    const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+    const notePath = path.join(
+      vault2Path({ vault: vaults[0], wsRoot }),
+      "root.md"
+    );
+    const config = {
+      podId: "dendron.task",
+      exportScope: PodExportScope.Note,
+      apiKey: "fakeKey",
+      baseId: "fakeBase",
+      tableName: "fakeTable",
+      sourceFieldMapping: {},
+    };
+    await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+    return { config };
+  };
+
+  describe("GIVEN AirtableExportPodCommand is run with Note scope with podId dendron.task", () => {
+    describeSingleWS(
+      "WHEN note is succesfully exported for the first",
+      {},
+      () => {
+        test("THEN note frontmatter should be updated with airtable metadata", async () => {
+          const extension = ExtensionProvider.getExtension();
+          const cmd = new AirtableExportPodCommand(extension);
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { config } = await setUpPod();
+          const note = getNoteFromTextEditor();
+          const payload = await cmd.enrichInputs(config);
+          const airtableId = "airtable-proj.beta";
+          const DendronId = note.id;
+          const result = {
+            data: {
+              created: [
+                {
+                  fields: {
+                    DendronId,
+                  },
+                  id: airtableId,
+                },
+              ],
+              updated: [],
+            },
+            error: null,
+          };
+          await cmd.onExportComplete({
+            exportReturnValue: result as any,
+            config: payload?.config!,
+          });
+          const n = NoteUtils.getNoteByFnameFromEngine({
+            fname: "root",
+            vault: vaults[0],
+            engine,
+          });
+          expect(n?.custom.pods.airtable["dendron.task"]).toEqual(airtableId);
+        });
+      }
+    );
+    describeSingleWS(
+      "WHEN note is already exported to a table before and is now exported to a new table",
+      {},
+      () => {
+        test("THEN new airtable id should be appended in the note frontmatter", async () => {
+          const extension = ExtensionProvider.getExtension();
+          const cmd = new AirtableExportPodCommand(extension);
+          const { engine } = ExtensionProvider.getDWorkspace();
+          const { config } = await setUpPod();
+          const note = getNoteFromTextEditor();
+          note.custom = {
+            pods: {
+              airtable: {
+                "dendron.test": "airtable-1",
+              },
+            },
+          };
+          await engine.writeNote(note, { updateExisting: true });
+          const payload = await cmd.enrichInputs(config);
+          const airtableId = "airtable-proj.beta";
+          const DendronId = note.id;
+          const result = {
+            data: {
+              created: [
+                {
+                  fields: {
+                    DendronId,
+                  },
+                  id: airtableId,
+                },
+              ],
+              updated: [],
+            },
+            error: null,
+          };
+          await cmd.onExportComplete({
+            exportReturnValue: result as any,
+            config: payload?.config!,
+          });
+          const n = getNoteFromTextEditor();
+          expect(n?.custom.pods.airtable["dendron.task"]).toEqual(airtableId);
+          expect(n?.custom.pods.airtable["dendron.test"]).toEqual("airtable-1");
+          setTimeout(() => {}, 40000);
+        });
+      }
+    );
+    describeSingleWS("AND WHEN there is an error in response", {}, () => {
+      test("THEN error must be thrown", async () => {
+        const extension = ExtensionProvider.getExtension();
+        const cmd = new AirtableExportPodCommand(extension);
+        const { config } = await setUpPod();
+        const payload = await cmd.enrichInputs(config);
+        const result = {
+          data: {
+            created: [],
+            updated: [],
+          },
+          error: new DendronError({
+            message: "Request failed with status code 422",
+          }),
+        };
+        const resp = await cmd.onExportComplete({
+          exportReturnValue: result as any,
+          config: payload?.config!,
+        });
+
+        expect(resp).toEqual(
+          `Finished Airtable Export. 0 records created; 0 records updated. Error encountered: ${ErrorFactory.safeStringify(
+            result.error
+          )}`
+        );
+      });
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
@@ -8,7 +8,7 @@ import { ExtensionProvider } from "../../../../ExtensionProvider";
 import { vault2Path } from "@dendronhq/common-server";
 import path from "path";
 import { VSCodeUtils } from "../../../../vsCodeUtils";
-import { DendronError, ErrorFactory, NoteUtils } from "@dendronhq/common-all";
+import { DendronError, ErrorFactory } from "@dendronhq/common-all";
 
 suite("AirtableExportCommand", function () {
   const setUpPod = async () => {
@@ -31,13 +31,12 @@ suite("AirtableExportCommand", function () {
 
   describe("GIVEN AirtableExportPodCommand is run with Note scope with podId dendron.task", () => {
     describeSingleWS(
-      "WHEN note is succesfully exported for the first",
+      "WHEN note is succesfully exported for the first time",
       {},
       () => {
         test("THEN note frontmatter should be updated with airtable metadata", async () => {
           const extension = ExtensionProvider.getExtension();
           const cmd = new AirtableExportPodCommand(extension);
-          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const { config } = await setUpPod();
           const note = getNoteFromTextEditor();
           const payload = await cmd.enrichInputs(config);
@@ -61,11 +60,7 @@ suite("AirtableExportCommand", function () {
             exportReturnValue: result as any,
             config: payload?.config!,
           });
-          const n = NoteUtils.getNoteByFnameFromEngine({
-            fname: "root",
-            vault: vaults[0],
-            engine,
-          });
+          const n = getNoteFromTextEditor();
           expect(n?.custom.pods.airtable["dendron.task"]).toEqual(airtableId);
         });
       }
@@ -112,7 +107,6 @@ suite("AirtableExportCommand", function () {
           const n = getNoteFromTextEditor();
           expect(n?.custom.pods.airtable["dendron.task"]).toEqual(airtableId);
           expect(n?.custom.pods.airtable["dendron.test"]).toEqual("airtable-1");
-          setTimeout(() => {}, 40000);
         });
       }
     );

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -97,7 +97,14 @@ type MultiSelectField = {
 
 type LinkedRecordField = {
   type: "linkedRecord";
+  podId?: string;
 } & SelectField;
+
+type AirtablePodMetadata = {
+  airtable?: {
+    [key: string]: string;
+  };
+};
 
 export type AirtableFieldsMap = { fields: { [key: string]: string | number } };
 
@@ -127,8 +134,20 @@ export class AirtableUtils {
   static filterNotes(notes: NoteProps[], srcHierarchy: string) {
     return notes.filter((note) => note.fname.includes(srcHierarchy));
   }
-  static getAirtableIdFromNote(note: NoteProps): string {
-    return _.get(note.custom, "airtableId");
+  static getAirtableIdFromNote(
+    note: NoteProps,
+    podId?: string
+  ): string | undefined {
+    const airtableId = _.get(note.custom, "airtableId");
+    if (airtableId) {
+      return airtableId;
+    } else {
+      if (!podId) {
+        return undefined;
+      }
+      const airtableMetadata = _.get(note.custom, "pods.airtable");
+      return airtableMetadata ? airtableMetadata[podId] : undefined;
+    }
   }
 
   /***
@@ -273,7 +292,10 @@ export class AirtableUtils {
           });
           const _recordIds = _notes
             .map((n) => {
-              const id = AirtableUtils.getAirtableIdFromNote(n);
+              const id = AirtableUtils.getAirtableIdFromNote(
+                n,
+                fieldMapping.podId
+              );
               return {
                 note: n,
                 id,
@@ -325,8 +347,9 @@ export class AirtableUtils {
     srcFieldMapping: { [key: string]: SrcFieldMapping };
     logger: DLogger;
     engine: DEngineClient;
+    podId?: string;
   }): RespV3<SrcFieldMappingResp> {
-    const { notes, srcFieldMapping, logger, engine } = opts;
+    const { notes, srcFieldMapping, logger, engine, podId } = opts;
     const ctx = "notesToSrc";
     const recordSets: SrcFieldMappingResp = {
       create: [],
@@ -372,11 +395,12 @@ export class AirtableUtils {
           }
         }
       }
-      if (AirtableUtils.checkNoteHasAirtableId(note)) {
+      const airtableId = AirtableUtils.getAirtableIdFromNote(note, podId);
+      if (airtableId) {
         logger.debug({ ctx, noteId: note.id, msg: "updating" });
         recordSets.update.push({
           fields,
-          id: AirtableUtils.getAirtableIdFromNote(note),
+          id: airtableId,
         });
       } else {
         logger.debug({ ctx, noteId: note.id, msg: "creating" });
@@ -402,28 +426,50 @@ export class AirtableUtils {
     records,
     engine,
     logger,
+    podId,
   }: {
     records: Records<FieldSet>;
     engine: DEngineClient;
     logger: DLogger;
+    podId?: string;
   }) {
+    if (!podId) return;
     const out = await Promise.all(
       records.map(async (ent) => {
         const airtableId = ent.id;
         const dendronId = ent.fields["DendronId"] as string;
         const note = engine.notes[dendronId] as NotePropsWithOptionalCustom;
-        const noteAirtableId = _.get(note.custom, "airtableId");
-        if (!noteAirtableId) {
-          const updatedNote = {
-            ...note,
-            custom: { ...note.custom, airtableId },
+        let pods: AirtablePodMetadata = _.get(note.custom, "pods");
+        // return if the note is already exported ie. update query is ran.
+        if (pods && pods.airtable && pods.airtable[podId]) return undefined;
+
+        // if this is the first time a pod metadata is added to the note, add airtable pod metadata under pods namespace
+        if (!pods) {
+          pods = {
+            airtable: {
+              [podId]: airtableId,
+            },
           };
-          const out = await engine.writeNote(updatedNote, {
-            updateExisting: true,
-          });
-          return out;
+        } else if (pods.airtable) {
+          // if airtable namespace is already present in frontmatter, update hashmap with podId: airtableId
+          pods.airtable[podId] = airtableId;
+        } else {
+          // else update pods hashmap with airtable namespace for the newly exported record
+          pods = {
+            ...pods,
+            airtable: {
+              [podId]: airtableId,
+            },
+          };
         }
-        return undefined;
+        const updatedNote = {
+          ...note,
+          custom: { ...note.custom, pods },
+        };
+        const out = await engine.writeNote(updatedNote, {
+          updateExisting: true,
+        });
+        return out;
       })
     );
     logger.info({

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -127,10 +127,6 @@ export class AirtableUtils {
     return _map;
   }
 
-  static checkNoteHasAirtableId(note: NoteProps): boolean {
-    return !_.isUndefined(_.get(note.custom, "airtableId"));
-  }
-
   static filterNotes(notes: NoteProps[], srcHierarchy: string) {
     return notes.filter((note) => note.fname.includes(srcHierarchy));
   }
@@ -440,7 +436,7 @@ export class AirtableUtils {
         const dendronId = ent.fields["DendronId"] as string;
         const note = engine.notes[dendronId] as NotePropsWithOptionalCustom;
         let pods: AirtablePodMetadata = _.get(note.custom, "pods");
-        // return if the note is already exported ie. update query is ran.
+        // return if the note is already exported for this pod Id
         if (pods && pods.airtable && pods.airtable[podId]) return undefined;
 
         // if this is the first time a pod metadata is added to the note, add airtable pod metadata under pods namespace

--- a/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
+++ b/packages/pods-core/src/v2/podConfig/AirtablePodConfig.ts
@@ -36,7 +36,7 @@ export type PersistedAirtablePodConfig = AirtableV2PodConfig &
  */
 export type RunnableAirtableV2PodConfig = Omit<
   AirtableV2PodConfig,
-  "podId" | "podType"
+  "description" | "podType"
 > &
   Pick<AirtableConnection, "apiKey">;
 
@@ -69,6 +69,7 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
       "tableName",
       "sourceFieldMapping",
       "exportScope",
+      "podId",
     ],
     properties: {
       apiKey: {
@@ -87,10 +88,6 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
       exportScope: {
         type: "string",
       },
-      description: {
-        type: "string",
-        nullable: true,
-      },
       filters: {
         type: "object",
         required: [],
@@ -103,6 +100,9 @@ export function createRunnableAirtableV2PodConfigSchema(): JSONSchemaType<Runnab
             },
           },
         },
+      },
+      podId: {
+        type: "string",
       },
     },
   };

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -185,6 +185,7 @@ export class AirtableExportPodV2
       srcFieldMapping: this._config.sourceFieldMapping,
       logger,
       engine: this._engine,
+      podId: this._config.podId,
     });
     return resp;
   }


### PR DESCRIPTION
```
enhance(pods): support exporting a note to multiple Airtable destination
enhance(workspace):  Doctor command 'fixAirtableMetadata' to convert airtableId from single scalar value to a hashmap
```
This PR aims to support multiple Airtable Ids in note frontmatter on Airtable export v2 by storing airtable ids in a hashmap
[Airtable Docs](https://github.com/dendronhq/dendron-site/pull/447)

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices). No new dependencies added(17)
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [~] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)