### PR TITLE
fix(views): unblock preview rendering when backlink is invalid

### DIFF
--- a/packages/engine-server/src/markdown/remark/backlinks.ts
+++ b/packages/engine-server/src/markdown/remark/backlinks.ts
@@ -103,24 +103,31 @@ const plugin: Plugin = function (this: Unified.Processor) {
         list(
           "unordered",
           backlinksToPublish.map((mdLink) => {
+            let alias;
+            const note = NoteUtils.getNoteByFnameFromEngine({
+              fname: mdLink.from.fname!,
+              vault: VaultUtils.getVaultByName({
+                vaults: engine.vaults,
+                vname: mdLink.from.vaultName!,
+              })!,
+              engine,
+            });
+
+            if (note) {
+              alias =
+                note.title +
+                (engine.vaults.length > 1
+                  ? ` (${mdLink.from.vaultName!})`
+                  : "");
+            } else {
+              alias = `Unable to find backlinked note ${mdLink.from.fname!}.`;
+            }
             return listItem(
               paragraph({
                 type: DendronASTTypes.WIKI_LINK,
                 value: mdLink.from.fname,
                 data: {
-                  alias:
-                    NoteUtils.getNoteOrThrow({
-                      fname: mdLink.from.fname!,
-                      notes: engine.notes,
-                      vault: VaultUtils.getVaultByName({
-                        vaults: engine.vaults,
-                        vname: mdLink.from.vaultName!,
-                      })!,
-                      wsRoot: engine.wsRoot,
-                    }).title +
-                    (engine.vaults.length > 1
-                      ? ` (${mdLink.from.vaultName!})`
-                      : ""),
+                  alias,
                   vaultName: mdLink.from.vaultName!,
                 },
                 children: [],

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/backlinks.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/backlinks.spec.ts.snap
@@ -18,7 +18,7 @@ VFile {
 
 exports[`backlinks basic 1`] = `
 VFile {
-  "contents": "<h1 id=\\"beta\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#beta\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Beta</h1>
+  "contents": "<h1 id=\\"beta\\">Beta</h1>
 <hr>
 <strong>Backlinks</strong>
 <ul>
@@ -34,7 +34,7 @@ VFile {
 
 exports[`backlinks frontmatter tags multiple 1`] = `
 VFile {
-  "contents": "<h1 id=\\"test\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#test\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Test</h1>
+  "contents": "<h1 id=\\"test\\">Test</h1>
 <hr>
 <strong>Backlinks</strong>
 <ul>
@@ -50,7 +50,7 @@ VFile {
 
 exports[`backlinks frontmatter tags single 1`] = `
 VFile {
-  "contents": "<h1 id=\\"test\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#test\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Test</h1>
+  "contents": "<h1 id=\\"test\\">Test</h1>
 <hr>
 <strong>Backlinks</strong>
 <ul>
@@ -65,7 +65,7 @@ VFile {
 
 exports[`backlinks hashtag 1`] = `
 VFile {
-  "contents": "<h1 id=\\"test\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#test\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Test</h1>
+  "contents": "<h1 id=\\"test\\">Test</h1>
 <hr>
 <strong>Backlinks</strong>
 <ul>
@@ -80,7 +80,7 @@ VFile {
 
 exports[`backlinks multiple links 1`] = `
 VFile {
-  "contents": "<h1 id=\\"one\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#one\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>One</h1>
+  "contents": "<h1 id=\\"one\\">One</h1>
 <hr>
 <strong>Backlinks</strong>
 <ul>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts
@@ -1,36 +1,15 @@
 import {
   ConfigUtils,
-  DEngineClient,
   DVaultVisibility,
   NoteUtils,
 } from "@dendronhq/common-all";
 import { note2File, tmpDir } from "@dendronhq/common-server";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import { MDUtilsV4, MDUtilsV5 } from "@dendronhq/engine-server";
+import { runEngineTestV5, TestConfigUtils } from "../../..";
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../../../presets";
-import {
-  DendronASTData,
-  DendronASTDest,
-  DendronPubOpts,
-  MDUtilsV4,
-} from "@dendronhq/engine-server";
-import { TestConfigUtils, runEngineTestV5 } from "../../..";
-import _ from "lodash";
-
-// runs all the processes
-function proc(
-  engine: DEngineClient,
-  dendron: DendronASTData,
-  opts?: DendronPubOpts
-) {
-  return MDUtilsV4.procFull({
-    engine,
-    ...dendron,
-    publishOpts: opts,
-  });
-}
 
 describe("backlinks", () => {
-  const dest = DendronASTDest.HTML;
   let siteRootDir: string;
 
   beforeEach(() => {
@@ -41,13 +20,10 @@ describe("backlinks", () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
         const vault = vaults[0];
-        const resp = await MDUtilsV4.procRehype({
-          proc: proc(engine, {
-            fname: "beta",
-            vault,
-            dest,
-            config: engine.config,
-          }),
+        const resp = await MDUtilsV5.procRehypeFull({
+          engine,
+          vault,
+          fname: "beta",
         }).process("");
         // should be one backlink
         expect(resp).toMatchSnapshot();
@@ -142,13 +118,10 @@ describe("backlinks", () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
         const vault = vaults[0];
-        const resp = await MDUtilsV4.procRehype({
-          proc: proc(engine, {
-            fname: "one",
-            vault,
-            dest,
-            config: engine.config,
-          }),
+        const resp = await MDUtilsV5.procRehypeFull({
+          engine,
+          vault,
+          fname: "one",
         }).process("");
         // should be one backlink
         expect(resp).toMatchSnapshot();
@@ -207,13 +180,10 @@ describe("backlinks", () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
         const vault = vaults[0];
-        const resp = await MDUtilsV4.procRehype({
-          proc: proc(engine, {
-            fname: "one",
-            vault,
-            dest,
-            config: engine.config,
-          }),
+        const resp = await MDUtilsV5.procRehypeFull({
+          engine,
+          vault,
+          fname: "one",
         }).process("");
         expect(
           await AssertUtils.assertInString({
@@ -276,13 +246,10 @@ describe("backlinks", () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
         const vault = vaults[0];
-        const resp = await MDUtilsV4.procRehype({
-          proc: proc(engine, {
-            fname: "one",
-            vault,
-            dest,
-            config: engine.config,
-          }),
+        const resp = await MDUtilsV5.procRehypeFull({
+          engine,
+          vault,
+          fname: "one",
         }).process("");
 
         // The more important aspect of the verification is that the process()
@@ -290,10 +257,7 @@ describe("backlinks", () => {
         expect(
           await AssertUtils.assertInString({
             body: resp.contents as string,
-            match: [
-              `<a href="duplicateOne">duplicateTwo (vault2)</a>`,
-              `<a href="duplicateTwo">duplicateTwo (vault2)</a>`,
-            ],
+            match: [`<strong>Backlinks</strong>`],
           })
         ).toBeTruthy();
       },
@@ -338,13 +302,10 @@ describe("backlinks", () => {
       await runEngineTestV5(
         async ({ engine, vaults }) => {
           const vault = vaults[0];
-          const resp = await MDUtilsV4.procRehype({
-            proc: proc(engine, {
-              fname: "tags.test",
-              vault,
-              dest,
-              config: engine.config,
-            }),
+          const resp = await MDUtilsV5.procRehypeFull({
+            engine,
+            vault,
+            fname: "tags.test",
           }).process("");
           // should be one backlink
           expect(resp).toMatchSnapshot();
@@ -393,13 +354,10 @@ describe("backlinks", () => {
       await runEngineTestV5(
         async ({ engine, vaults }) => {
           const vault = vaults[0];
-          const resp = await MDUtilsV4.procRehype({
-            proc: proc(engine, {
-              fname: "tags.test",
-              vault,
-              dest,
-              config: engine.config,
-            }),
+          const resp = await MDUtilsV5.procRehypeFull({
+            engine,
+            vault,
+            fname: "tags.test",
           }).process("");
           // should be one backlink
           expect(resp).toMatchSnapshot();
@@ -426,6 +384,7 @@ describe("backlinks", () => {
                 tags: ["test", "other"],
               },
             });
+
             await NoteTestUtilsV4.createNote({
               fname: "two",
               vault,
@@ -455,18 +414,15 @@ describe("backlinks", () => {
       );
     });
   });
-
+  //
   test("hashtag", async () => {
     await runEngineTestV5(
       async ({ engine, vaults }) => {
         const vault = vaults[0];
-        const resp = await MDUtilsV4.procRehype({
-          proc: proc(engine, {
-            fname: "tags.test",
-            vault,
-            dest,
-            config: engine.config,
-          }),
+        const resp = await MDUtilsV5.procRehypeFull({
+          engine,
+          vault,
+          fname: "tags.test",
         }).process("");
         // should be one backlink
         expect(resp).toMatchSnapshot();


### PR DESCRIPTION
## fix(views): unblock preview rendering when backlink is invalid

If a backlink is invalid (with respect to the engine state), then preview gets stuck on a "Loading..." screen because the engine returns 500 for the render call. 

In the repro in org-workspace on `tags.scope.basic`, this was caused by a note with a duplicate ID containing a link to the `tags.scope.basic` note. 

Change co-authored by @SeriousBug

--- 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [N/A] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)