### PR TITLE
feat(workspace): option to gen title using full hierarchy

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -752,6 +752,9 @@
         "enableHashTags": {
           "type": "boolean"
         },
+        "enableFullHierarchyNoteTitle": {
+          "type": "boolean"
+        },
         "maxPreviewsCached": {
           "type": "number"
         },
@@ -781,6 +784,7 @@
         "enableAutoFoldFrontmatter",
         "enableUserTags",
         "enableHashTags",
+        "enableFullHierarchyNoteTitle",
         "maxPreviewsCached",
         "maxNoteLength",
         "enableEditorDecorations"

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -208,4 +208,8 @@ export const WORKSPACE: DendronConfigEntryCollection<DendronWorkspaceConfig> = {
     label: "Enable hashtags",
     desc: "Enable hashtags, which allows #word to link to the note tags.word",
   },
+  enableFullHierarchyNoteTitle: {
+    label: "Enable FullHierarchyNoteTitle mode",
+    desc: "When enabled, the full hierarchy position of a note is used to generate the note title",
+  },
 };

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -733,6 +733,11 @@ export class NoteUtils {
     return titleFromBasename;
   }
 
+  static genTitleFromFullFname(fname: string): string {
+    const formatted = fname.replace(/\./g, " ");
+    return title(formatted);
+  }
+
   static genUpdateTime() {
     const now = Time.now().toMillis();
     return now;

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -30,6 +30,7 @@ export type DendronWorkspaceConfig = {
   enableAutoFoldFrontmatter: boolean;
   enableUserTags: boolean;
   enableHashTags: boolean;
+  enableFullHierarchyNoteTitle: boolean;
   // performance related
   maxPreviewsCached: number;
   maxNoteLength: number;
@@ -73,5 +74,6 @@ export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
     enableEditorDecorations: true,
     maxPreviewsCached: 10,
     maxNoteLength: 204800,
+    enableFullHierarchyNoteTitle: false,
   };
 }

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -752,6 +752,9 @@
         "enableHashTags": {
           "type": "boolean"
         },
+        "enableFullHierarchyNoteTitle": {
+          "type": "boolean"
+        },
         "maxPreviewsCached": {
           "type": "number"
         },
@@ -781,6 +784,7 @@
         "enableAutoFoldFrontmatter",
         "enableUserTags",
         "enableHashTags",
+        "enableFullHierarchyNoteTitle",
         "maxPreviewsCached",
         "maxNoteLength",
         "enableEditorDecorations"

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -100,6 +100,18 @@ describe(`NoteUtils tests:`, () => {
       );
     });
   });
+
+  describe("WHEN generating note titles with the full hierarchy format", () => {
+    test("THEN title is formatted correctly for single level hierarchy note", () => {
+      expect(NoteUtils.genTitleFromFullFname("foo")).toEqual("Foo");
+    });
+
+    test("THEN title is formatted correctly for multi-level hierarchy note", () => {
+      expect(NoteUtils.genTitleFromFullFname("foo.bar.test")).toEqual(
+        "Foo Bar Test"
+      );
+    });
+  });
 });
 
 describe(`SchemaUtil tests:`, () => {

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -86,6 +86,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds:
         dendron.foo: {}
 preview:
@@ -234,6 +235,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds:
         dendron.foo:
             site:
@@ -372,6 +374,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -477,6 +480,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -599,6 +603,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -80,6 +80,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds:
         dendron.foo: {}
 preview:
@@ -228,6 +229,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds:
         dendron.foo:
             site:
@@ -366,6 +368,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -471,6 +474,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -593,6 +597,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -722,6 +727,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds: {}
 preview:
     enableFMTitle: true
@@ -838,6 +844,7 @@ workspace:
     enableEditorDecorations: true
     maxPreviewsCached: 10
     maxNoteLength: 204800
+    enableFullHierarchyNoteTitle: false
     seeds: {}
 preview:
     enableFMTitle: true

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -420,6 +420,10 @@ export class NoteLookupCommand
                 item.traits = [journalTrait];
               }
             }
+          } else if (
+            ConfigUtils.getWorkspace(ws.config).enableFullHierarchyNoteTitle
+          ) {
+            item.title = NoteUtils.genTitleFromFullFname(item.fname);
           }
           return this.acceptItem(item);
         })

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -329,6 +329,7 @@ suite("GIVEN SetupWorkspace Command", function () {
             enableEditorDecorations: true,
             maxPreviewsCached: 10,
             maxNoteLength: 204800,
+            enableFullHierarchyNoteTitle: false,
           },
           preview: {
             enableFMTitle: true,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -75,6 +75,7 @@ import {
   waitInMilliseconds,
   withConfig,
 } from "../testUtilsV3";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 
 const stubVaultPick = (vaults: DVault[]) => {
   const vault = _.find(vaults, { fsPath: "vault1" });
@@ -836,6 +837,39 @@ suite("NoteLookupCommand", function () {
         },
       });
     });
+
+    describeMultiWS(
+      "WHEN user creates new note with enableFullHierarchyNoteTitle == true",
+      {
+        modConfigCb: (config) => {
+          ConfigUtils.setWorkspaceProp(
+            config,
+            "enableFullHierarchyNoteTitle",
+            true
+          );
+          return config;
+        },
+        ctx,
+        preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
+      },
+
+      () => {
+        test("THEN the new note title should reflect the full hierarchy name", async () => {
+          const cmd = new NoteLookupCommand();
+          await cmd.run({
+            noConfirm: true,
+            initialValue: "one.two.three",
+          });
+
+          const editor = VSCodeUtils.getActiveTextEditor()!;
+          const activeNote = WSUtilsV2.instance().getNoteFromDocument(
+            editor.document
+          );
+
+          expect(activeNote?.title).toEqual("One Two Three");
+        });
+      }
+    );
 
     test("new node with schema template", (done) => {
       runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -725,6 +725,7 @@ suite("Migration", function () {
               enableEditorDecorations: true,
               feedback: true,
               apiEndpoint: "foobar.com",
+              enableFullHierarchyNoteTitle: false,
             };
 
             expect(postMigrationDendronConfig.workspace).toEqual(


### PR DESCRIPTION
## feat(workspace): option to gen title using full hierarchy

Gives a new workspace config setting to allow users to utilize the full hierarchy to generate the note title upon note creation. For example,  a new note named `one.two.three` will generate a note title of `One Two Three` as opposed to just `Three`. 

Docs PR: https://github.com/dendronhq/dendron-site/pull/453

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
https://github.com/dendronhq/dendron-site/pull/453
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)