### PR TITLE
enhance(basics): getting started tutorial updates

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -32,6 +32,7 @@ export enum CLIEvents {
 
 export enum TutorialEvents {
   WelcomeShow = "WelcomeShow",
+  ClickStart = "ClickStart",
   Tutorial_0_Show = "Tutorial_0_Show",
   Tutorial_1_Show = "Tutorial_1_Show",
   Tutorial_2_Show = "Tutorial_2_Show",

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -32,7 +32,7 @@ export enum CLIEvents {
 
 export enum TutorialEvents {
   WelcomeShow = "WelcomeShow",
-  ClickStart = "ClickStart",
+  ClickStart = "Getting_Started_Clicked",
   Tutorial_0_Show = "Tutorial_0_Show",
   Tutorial_1_Show = "Tutorial_1_Show",
   Tutorial_2_Show = "Tutorial_2_Show",

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -23,7 +23,7 @@ import path from "path";
 import SparkMD5 from "spark-md5";
 // @ts-ignore
 import tmp, { DirResult, dirSync } from "tmp";
-import { resolvePath } from "./files";
+import { resolvePath, resolveTilde } from "./files";
 import { SchemaParserV2 } from "./parser";
 
 /** Dendron should ignore any of these folders when watching or searching folders.
@@ -569,6 +569,26 @@ export async function findNonNoteFile(opts: {
 }
 
 class FileUtils {
+  /**
+   * Keep incrementing a numerical suffix until we find a path name that does not correspond to an existing file
+   * @param param0
+   */
+  static genFilePathWithSuffixThatDoesNotExist({
+    fpath,
+    sep = "-",
+  }: {
+    fpath: string;
+    sep?: string;
+  }) {
+    // Try to put into a eefault '~/Dendron' folder first. If path is occupied, create a new folder with an numbered suffix
+    let acc = 0;
+    let tryPath = fpath;
+    while (fs.pathExistsSync(tryPath)) {
+      acc += 1;
+      tryPath = [fpath, acc].join(sep);
+    }
+    return { filePath: tryPath, acc };
+  }
   /**
    * Check if a file starts with a prefix string
    * @param fpath: full path to the file

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -23,7 +23,7 @@ import path from "path";
 import SparkMD5 from "spark-md5";
 // @ts-ignore
 import tmp, { DirResult, dirSync } from "tmp";
-import { resolvePath, resolveTilde } from "./files";
+import { resolvePath } from "./files";
 import { SchemaParserV2 } from "./parser";
 
 /** Dendron should ignore any of these folders when watching or searching folders.

--- a/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
@@ -6,10 +6,10 @@ import {
 import {
   file2Note,
   file2Schema,
+  FileUtils,
   goUpTo,
   schemaModuleProps2File,
   tmpDir,
-  FileUtils,
 } from "@dendronhq/common-server";
 import { FileTestUtils } from "@dendronhq/common-test-utils";
 import fs from "fs-extra";
@@ -157,6 +157,52 @@ describe("file2Schema", () => {
     );
     const schema = await file2Schema(fpath, root);
     expect(_.values(schema.schemas).length).toEqual(8);
+  });
+});
+
+describe("GIVEN createFileWithSuffixThatDoesNotExist", () => {
+  let root: string;
+  let fpath: string;
+
+  describe("WHEN orig file does not exist", () => {
+    beforeEach(() => {
+      root = FileTestUtils.tmpDir().name;
+      fpath = path.join(root, "foo");
+    });
+    test("THEN create file", () => {
+      expect(
+        FileUtils.genFilePathWithSuffixThatDoesNotExist({ fpath })
+      ).toEqual({ filePath: path.join(root, "foo"), acc: 0 });
+    });
+  });
+
+  describe("WHEN orig file does exist", () => {
+    beforeEach(async () => {
+      root = FileTestUtils.tmpDir().name;
+      fpath = path.join(root, "foo");
+      await FileTestUtils.createFiles(root, [{ path: "foo" }]);
+    });
+    test("THEN increment suffix", () => {
+      expect(
+        FileUtils.genFilePathWithSuffixThatDoesNotExist({ fpath })
+      ).toEqual({ filePath: path.join(root, "foo-1"), acc: 1 });
+    });
+  });
+
+  describe("WHEN orig file and one prefix exists", () => {
+    beforeEach(async () => {
+      root = FileTestUtils.tmpDir().name;
+      fpath = path.join(root, "foo");
+      await FileTestUtils.createFiles(root, [
+        { path: "foo" },
+        { path: "foo-1" },
+      ]);
+    });
+    test("THEN increment suffix", () => {
+      expect(
+        FileUtils.genFilePathWithSuffixThatDoesNotExist({ fpath })
+      ).toEqual({ filePath: path.join(root, "foo-2"), acc: 2 });
+    });
   });
 });
 

--- a/packages/plugin-core/src/WelcomeUtils.ts
+++ b/packages/plugin-core/src/WelcomeUtils.ts
@@ -43,24 +43,12 @@ export function showWelcome(assetUri: vscode.Uri) {
             // Try to put into a Default '~/Dendron' folder first. Only prompt
             // if that path and the backup path already exist to lower
             // onboarding friction
-            let wsPath;
-            const wsPathPrimary = path.join(resolveTilde("~"), "Dendron");
-            const wsPathBackup = path.join(
-              resolveTilde("~"),
-              "Dendron-Tutorial"
-            );
-
-            if (!fs.pathExistsSync(wsPathPrimary)) {
-              wsPath = wsPathPrimary;
-            } else if (!fs.pathExistsSync(wsPathBackup)) {
-              wsPath = wsPathBackup;
-            } else {
-              wsPath = await VSCodeUtils.gatherFolderPath({
-                default: path.join(resolveTilde("~"), "Dendron"),
-                override: {
-                  title: "Path for new Dendron Code Workspace",
-                },
-              });
+            let wsPath = path.join(resolveTilde("~"), "Dendron");
+            let acc = 0;
+            while (fs.pathExistsSync(wsPath)) {
+              acc += 1;
+              wsPath = path.join(resolveTilde("~"), `Dendron-${acc}`);
+              // TODO: telemetry if acc > 99
             }
 
             // User didn't pick a path, abort

--- a/packages/plugin-core/src/WelcomeUtils.ts
+++ b/packages/plugin-core/src/WelcomeUtils.ts
@@ -1,5 +1,5 @@
 import { TutorialEvents, WorkspaceType } from "@dendronhq/common-all";
-import { readMD, resolveTilde } from "@dendronhq/common-server";
+import { FileUtils, readMD, resolveTilde } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -40,24 +40,14 @@ export function showWelcome(assetUri: vscode.Uri) {
             return;
 
           case "initializeWorkspace": {
-            // Try to put into a Default '~/Dendron' folder first. Only prompt
-            // if that path and the backup path already exist to lower
-            // onboarding friction
-            let wsPath = path.join(resolveTilde("~"), "Dendron");
-            let acc = 0;
-            while (fs.pathExistsSync(wsPath)) {
-              acc += 1;
-              wsPath = path.join(resolveTilde("~"), `Dendron-${acc}`);
-              // TODO: telemetry if acc > 99
-            }
-
-            // User didn't pick a path, abort
-            if (!wsPath) {
-              return;
-            }
+            // Try to put into a eefault '~/Dendron' folder first. If path is occupied, create a new folder with an numbered suffix
+            const { filePath } =
+              FileUtils.genFilePathWithSuffixThatDoesNotExist({
+                fpath: path.join(resolveTilde("~"), "Dendron"),
+              });
 
             await new SetupWorkspaceCommand().execute({
-              rootDirRaw: wsPath,
+              rootDirRaw: filePath,
               workspaceInitializer: new TutorialInitializer(),
               workspaceType: WorkspaceType.CODE,
             });

--- a/packages/plugin-core/src/WelcomeUtils.ts
+++ b/packages/plugin-core/src/WelcomeUtils.ts
@@ -1,6 +1,5 @@
 import { TutorialEvents, WorkspaceType } from "@dendronhq/common-all";
 import { FileUtils, readMD, resolveTilde } from "@dendronhq/common-server";
-import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 import * as vscode from "vscode";
@@ -40,6 +39,7 @@ export function showWelcome(assetUri: vscode.Uri) {
             return;
 
           case "initializeWorkspace": {
+            AnalyticsUtils.track(TutorialEvents.ClickStart);
             // Try to put into a eefault '~/Dendron' folder first. If path is occupied, create a new folder with an numbered suffix
             const { filePath } =
               FileUtils.genFilePathWithSuffixThatDoesNotExist({

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -8,7 +8,6 @@ import {
   ConfigUtils,
   CONSTANTS,
   DendronError,
-  DWorkspaceV2,
   ExtensionEvents,
   getStage,
   InstallStatus,
@@ -18,7 +17,6 @@ import {
   Time,
   VaultUtils,
   VSCodeEvents,
-  WorkspaceType,
 } from "@dendronhq/common-all";
 import {
   getDurationMilliseconds,
@@ -82,7 +80,6 @@ import { EngineAPIService } from "./services/EngineAPIService";
 import { StateService } from "./services/stateService";
 import { Extensions } from "./settings";
 import { SurveyUtils } from "./survey";
-import { setupSegmentClient } from "./telemetry";
 import { IBaseCommand } from "./types";
 import { GOOGLE_OAUTH_ID, GOOGLE_OAUTH_SECRET } from "./types/global";
 import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
@@ -95,8 +92,7 @@ import { NativeTreeView } from "./views/NativeTreeView";
 import { VSCodeUtils } from "./vsCodeUtils";
 import { showWelcome } from "./WelcomeUtils";
 import { DendronExtension, getDWorkspace, getExtension } from "./workspace";
-import { DendronCodeWorkspace } from "./workspace/codeWorkspace";
-import { DendronNativeWorkspace } from "./workspace/nativeWorkspace";
+import { WorkspaceActivator } from "./workspace/workspaceActivater";
 import { WorkspaceInitFactory } from "./workspace/WorkspaceInitFactory";
 import { WSUtils } from "./WSUtils";
 
@@ -108,38 +104,6 @@ class ExtensionUtils {
    * Setup segment client
    * Also setup cache flushing in case of missed uploads
    */
-  static setupSegmentWithCacheFlush({
-    context,
-    ws,
-  }: {
-    context: vscode.ExtensionContext;
-    ws: DWorkspaceV2;
-  }) {
-    if (getStage() === "prod") {
-      const segmentResidualCacheDir = context.globalStorageUri.fsPath;
-      fs.ensureDir(segmentResidualCacheDir);
-      setupSegmentClient(
-        ws,
-        path.join(segmentResidualCacheDir, "segmentresidualcache.log")
-      );
-
-      // Try to flush the Segment residual cache every hour:
-      (function tryFlushSegmentCache() {
-        SegmentClient.instance()
-          .tryFlushResidualCache()
-          .then((result) => {
-            Logger.info(
-              `Segment Residual Cache flush attempted. ${JSON.stringify(
-                result
-              )}`
-            );
-          });
-
-        // Repeat once an hour:
-        setTimeout(tryFlushSegmentCache, 3600000);
-      })();
-    }
-  }
 
   static async startServerProcess({
     context,
@@ -198,41 +162,6 @@ export function activate(context: vscode.ExtensionContext) {
     });
   }
   return;
-}
-
-/** Prompts the user to pick a wsRoot if there are more than one. */
-async function getOrPromptWSRoot(workspaceFolders: string[]) {
-  if (!workspaceFolders) {
-    Logger.error({ msg: "No dendron.yml found in any workspace folder" });
-    return undefined;
-  }
-  if (workspaceFolders.length === 1) {
-    return workspaceFolders[0];
-  } else {
-    const selectedRoot = await VSCodeUtils.showQuickPick(
-      workspaceFolders.map((folder): vscode.QuickPickItem => {
-        return {
-          label: folder,
-        };
-      }),
-      {
-        ignoreFocusOut: true,
-        canPickMany: false,
-        title: "Select Dendron workspace to load",
-      }
-    );
-    if (!selectedRoot) {
-      await vscode.window.showInformationMessage(
-        "You skipped loading any Dendron workspace, Dendron is not active. You can run the 'Developer: Reload Window' command to reactivate Dendron."
-      );
-      Logger.info({
-        msg: "User skipped loading a Dendron workspace",
-        workspaceFolders,
-      });
-      return null;
-    }
-    return selectedRoot.label;
-  }
 }
 
 async function reloadWorkspace() {
@@ -455,37 +384,14 @@ export async function _activate(
     });
 
     if (await DendronExtension.isDendronWorkspace()) {
-      if (ws.type === WorkspaceType.NATIVE) {
-        const workspaceFolders =
-          await WorkspaceUtils.findWSRootsInWorkspaceFolders(
-            DendronExtension.workspaceFolders()!
-          );
-        if (!workspaceFolders) {
-          return false;
-        }
-        const wsRoot = await getOrPromptWSRoot(workspaceFolders);
-        if (!wsRoot) return false;
-
-        ws.workspaceImpl = new DendronNativeWorkspace({
-          wsRoot,
-          logUri: context.logUri,
-          assetUri,
-        });
-      } else {
-        ws.workspaceImpl = new DendronCodeWorkspace({
-          wsRoot: path.dirname(DendronExtension.workspaceFile().fsPath),
-          logUri: context.logUri,
-          assetUri,
-        });
+      const activator = new WorkspaceActivator();
+      const maybeWs = await activator.activate({ ext: ws, context });
+      if (!maybeWs) {
+        return false;
       }
-      const wsImpl = getDWorkspace();
+      const wsImpl = maybeWs;
       const start = process.hrtime();
       const dendronConfig = wsImpl.config;
-
-      // Only set up note traits after workspaceImpl has been set, so that the
-      // wsRoot path is known for locating the note trait definition location.
-      // TODO: Unwind and simplify dependency ordering logic
-      ws.setupTraits();
 
       // --- Get Version State
       const workspaceInstallStatus = VSCodeUtils.getInstallStatusForWorkspace({
@@ -496,8 +402,8 @@ export async function _activate(
       const wsService = new WorkspaceService({ wsRoot });
       const maybeWsSettings = wsService.getCodeWorkspaceSettingsSync();
 
-      // initialize Segment client
-      ExtensionUtils.setupSegmentWithCacheFlush({ context, ws: wsImpl });
+      // // initialize Segment client
+      AnalyticsUtils.setupSegmentWithCacheFlush({ context, ws: wsImpl });
 
       // see [[Migration|dendron://dendron.docs/pkg.plugin-core.t.migration]] for overview of migration process
       const changes = await wsService.runMigrationsIfNecessary({

--- a/packages/plugin-core/src/workspace/workspaceActivater.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivater.ts
@@ -1,0 +1,96 @@
+import { DWorkspaceV2, WorkspaceType } from "@dendronhq/common-all";
+import { WorkspaceUtils } from "@dendronhq/engine-server";
+import { Logger } from "../logger";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { DendronExtension } from "../workspace";
+import * as vscode from "vscode";
+import { DendronNativeWorkspace } from "./nativeWorkspace";
+import { DendronCodeWorkspace } from "./codeWorkspace";
+import path from "path";
+
+async function getOrPromptWSRoot(workspaceFolders: string[]) {
+  if (!workspaceFolders) {
+    Logger.error({ msg: "No dendron.yml found in any workspace folder" });
+    return undefined;
+  }
+  if (workspaceFolders.length === 1) {
+    return workspaceFolders[0];
+  } else {
+    const selectedRoot = await VSCodeUtils.showQuickPick(
+      workspaceFolders.map((folder): vscode.QuickPickItem => {
+        return {
+          label: folder,
+        };
+      }),
+      {
+        ignoreFocusOut: true,
+        canPickMany: false,
+        title: "Select Dendron workspace to load",
+      }
+    );
+    if (!selectedRoot) {
+      await vscode.window.showInformationMessage(
+        "You skipped loading any Dendron workspace, Dendron is not active. You can run the 'Developer: Reload Window' command to reactivate Dendron."
+      );
+      Logger.info({
+        msg: "User skipped loading a Dendron workspace",
+        workspaceFolders,
+      });
+      return null;
+    }
+    return selectedRoot.label;
+  }
+}
+
+type WorkspaceActivatorOpts = {
+  ext: DendronExtension;
+  context: vscode.ExtensionContext;
+};
+
+export class WorkspaceActivator {
+  async activate({ ext, context }: WorkspaceActivatorOpts) {
+    // --- Setup workspace
+    let workspace: DWorkspaceV2 | boolean;
+    if (ext.type === WorkspaceType.NATIVE) {
+      workspace = await this.activateNativeWorkspace({ ext, context });
+      if (!workspace) {
+        return;
+      }
+    } else {
+      workspace = await this.activateCodeWorkspace({ ext, context });
+    }
+
+    // --- Setup Traits
+    ext.workspaceImpl = workspace;
+    // Only set up note traits after workspaceImpl has been set, so that the
+    // wsRoot path is known for locating the note trait definition location.
+    ext.setupTraits();
+    return workspace;
+  }
+
+  async activateCodeWorkspace({ context }: WorkspaceActivatorOpts) {
+    const assetUri = VSCodeUtils.getAssetUri(context);
+    return new DendronCodeWorkspace({
+      wsRoot: path.dirname(DendronExtension.workspaceFile().fsPath),
+      logUri: context.logUri,
+      assetUri,
+    });
+  }
+
+  async activateNativeWorkspace({ context }: WorkspaceActivatorOpts) {
+    const workspaceFolders = await WorkspaceUtils.findWSRootsInWorkspaceFolders(
+      DendronExtension.workspaceFolders()!
+    );
+    if (!workspaceFolders) {
+      return false;
+    }
+    const wsRoot = await getOrPromptWSRoot(workspaceFolders);
+    if (!wsRoot) return false;
+    const assetUri = VSCodeUtils.getAssetUri(context);
+    return new DendronNativeWorkspace({
+      wsRoot,
+      logUri: context.logUri,
+      assetUri,
+    });
+  }
+}


### PR DESCRIPTION
enhance(basics): getting started tutorial updates

- if default folder for Dendron already exist, generate new folder with an incrementing suffix to avoid overriding original folder
- add telemetry event `ClickStart` to track if getting started gets clicked

This also refactors some of the workspace activation logic into a separate file

***

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)
