### PR TITLE
fix(workspace): race condition when loading native workspace

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -580,7 +580,7 @@ class FileUtils {
     fpath: string;
     sep?: string;
   }) {
-    // Try to put into a eefault '~/Dendron' folder first. If path is occupied, create a new folder with an numbered suffix
+    // Try to put into `fpath`. If `fpath` exists, create a new folder with an numbered suffix
     let acc = 0;
     let tryPath = fpath;
     while (fs.pathExistsSync(tryPath)) {


### PR DESCRIPTION
fix(workspace): race condition when loading native workspace

To load up a workspace, we call the `reloadWorkspace` function which calls Dendron's `reloadIndex` function.
`reloadIndex` is registered after `reloadWorkspace`. If initialization of workspace finishes too quickly, Dendron will try to call `reloadIndex` before it is registered.
Fixed by registering `reloadIndex` ahead of calling `reloadWorkspace`

Also fix an issue where `getCodeWorkspaceSettingsSync` would be called in native workspaces