### PR TITLE
fix: Prevent fatal errors in Open Backup Command and Run Migration Command in native workspaces

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -59,7 +59,7 @@ suite("RunMigrationCommand", function () {
       workspaceType: WorkspaceType.NATIVE,
     },
     () => {
-      test("THEN migration runs as expected", async () => {
+      test("THEN migration runs as expected without looking for workspace config.", async () => {
         const ext = ExtensionProvider.getExtension();
         const cmd = new RunMigrationCommand(ext);
 


### PR DESCRIPTION
# fix: Prevent fatal errors in Open Backup Command and Run Migration Command in native workspaces

This PR:
- Fixes an error that happens during `_setupCommands` with `OpenBackupCommand` by defering backup service initialization to execute-time
- Fixes an error which causes `Run Migration` command to crash if user is in a native workspace.
  - Correctly handles the case when workspace settings do not exist.
- Adds test to verify `Run Migration` works in native workspaces
- Removes the use of legacy testing harness in `RunMigrationCommand.test.ts`