### PR TITLE
chore: fix RunMigrationCommand test

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -49,17 +49,17 @@ suite("RunMigrationCommand", function () {
     }
   );
 
-  describeMultiWS(
-    "GIVEN Native workspace",
-    {
-      modConfigCb: (config) => {
-        _.unset(config.commands, "lookup");
-        return config;
+  runTestButSkipForWindows()("", () => {
+    describeMultiWS(
+      "GIVEN Native workspace",
+      {
+        modConfigCb: (config) => {
+          _.unset(config.commands, "lookup");
+          return config;
+        },
+        workspaceType: WorkspaceType.NATIVE,
       },
-      workspaceType: WorkspaceType.NATIVE,
-    },
-    () => {
-      runTestButSkipForWindows()("", () => {
+      () => {
         test("THEN migration runs as expected without looking for workspace config.", async () => {
           const ext = ExtensionProvider.getExtension();
           const cmd = new RunMigrationCommand(ext);
@@ -82,7 +82,7 @@ suite("RunMigrationCommand", function () {
           const lookupConfig = ConfigUtils.getLookup(config);
           expect(lookupConfig.note.selectionMode).toEqual("extract");
         });
-      });
-    }
-  );
+      }
+    );
+  });
 });

--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -59,7 +59,7 @@ suite("RunMigrationCommand", function () {
       workspaceType: WorkspaceType.NATIVE,
     },
     () => {
-      test.only("THEN migration runs as expected without looking for workspace config.", async () => {
+      test("THEN migration runs as expected without looking for workspace config.", async () => {
         const ext = ExtensionProvider.getExtension();
         const cmd = new RunMigrationCommand(ext);
         expect(ext.type).toEqual(WorkspaceType.NATIVE);

--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -50,7 +50,7 @@ suite("RunMigrationCommand", function () {
   );
 
   describeMultiWS(
-    "GIVEN Code workspace",
+    "GIVEN Native workspace",
     {
       modConfigCb: (config) => {
         _.unset(config.commands, "lookup");

--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -59,10 +59,10 @@ suite("RunMigrationCommand", function () {
       workspaceType: WorkspaceType.NATIVE,
     },
     () => {
-      test("THEN migration runs as expected without looking for workspace config.", async () => {
+      test.only("THEN migration runs as expected without looking for workspace config.", async () => {
         const ext = ExtensionProvider.getExtension();
         const cmd = new RunMigrationCommand(ext);
-
+        expect(ext.type).toEqual(WorkspaceType.NATIVE);
         // testing for explicitly delete key.
         const { wsRoot } = ext.getDWorkspace();
         const rawConfig = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;

--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -8,11 +8,11 @@ import sinon from "sinon";
 import { RunMigrationCommand } from "../../commands/RunMigrationCommand";
 import { CONFIG } from "../../constants";
 import { expect } from "../testUtilsv2";
-import { describeMultiWS } from "../testUtilsV3";
+import { describeMultiWS, runTestButSkipForWindows } from "../testUtilsV3";
 import { DConfig } from "@dendronhq/engine-server";
 import { ExtensionProvider } from "../../ExtensionProvider";
 
-suite("RunMigrationCommand: Code", function () {
+suite("RunMigrationCommand", function () {
   describeMultiWS(
     "GIVEN Code workspace",
     {
@@ -48,9 +48,7 @@ suite("RunMigrationCommand: Code", function () {
       });
     }
   );
-});
 
-suite("RunMigrationCommand: Native", function () {
   describeMultiWS(
     "GIVEN Native workspace",
     {
@@ -61,27 +59,29 @@ suite("RunMigrationCommand: Native", function () {
       workspaceType: WorkspaceType.NATIVE,
     },
     () => {
-      test("THEN migration runs as expected without looking for workspace config.", async () => {
-        const ext = ExtensionProvider.getExtension();
-        const cmd = new RunMigrationCommand(ext);
-        expect(ext.type).toEqual(WorkspaceType.NATIVE);
-        // testing for explicitly delete key.
-        const { wsRoot } = ext.getDWorkspace();
-        const rawConfig = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
-        expect(_.isUndefined(rawConfig.commands?.lookup)).toBeTruthy();
+      runTestButSkipForWindows()("", () => {
+        test("THEN migration runs as expected without looking for workspace config.", async () => {
+          const ext = ExtensionProvider.getExtension();
+          const cmd = new RunMigrationCommand(ext);
+          expect(ext.type).toEqual(WorkspaceType.NATIVE);
+          // testing for explicitly delete key.
+          const { wsRoot } = ext.getDWorkspace();
+          const rawConfig = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+          expect(_.isUndefined(rawConfig.commands?.lookup)).toBeTruthy();
 
-        sinon.stub(cmd, "gatherInputs").resolves({ version: "0.83.0" });
-        const out = await cmd.run();
-        expect(out!.length).toEqual(1);
-        expect(out![0].data.version === "0.83.0");
+          sinon.stub(cmd, "gatherInputs").resolves({ version: "0.83.0" });
+          const out = await cmd.run();
+          expect(out!.length).toEqual(1);
+          expect(out![0].data.version === "0.83.0");
 
-        // test if no wsConfig was passed to migration
-        expect(out![0].data.wsConfig).toEqual(undefined);
+          // test if no wsConfig was passed to migration
+          expect(out![0].data.wsConfig).toEqual(undefined);
 
-        // test for existence of default key in the place where it was deleted.
-        const config = ext.getDWorkspace().config;
-        const lookupConfig = ConfigUtils.getLookup(config);
-        expect(lookupConfig.note.selectionMode).toEqual("extract");
+          // test for existence of default key in the place where it was deleted.
+          const config = ext.getDWorkspace().config;
+          const lookupConfig = ConfigUtils.getLookup(config);
+          expect(lookupConfig.note.selectionMode).toEqual("extract");
+        });
       });
     }
   );

--- a/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RunMigrationCommand.test.ts
@@ -12,7 +12,7 @@ import { describeMultiWS } from "../testUtilsV3";
 import { DConfig } from "@dendronhq/engine-server";
 import { ExtensionProvider } from "../../ExtensionProvider";
 
-suite("RunMigrationCommand", function () {
+suite("RunMigrationCommand: Code", function () {
   describeMultiWS(
     "GIVEN Code workspace",
     {
@@ -48,7 +48,9 @@ suite("RunMigrationCommand", function () {
       });
     }
   );
+});
 
+suite("RunMigrationCommand: Native", function () {
   describeMultiWS(
     "GIVEN Native workspace",
     {

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -1,7 +1,6 @@
 import {
   ConfigUtils,
   DENDRON_VSCODE_CONFIG_KEYS,
-  DendronError,
   DEngineClient,
   Disposable,
   DVault,
@@ -531,6 +530,7 @@ export function describeMultiWS(
       }
 
       const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
+
       if (opts.preActivateHook) {
         await opts.preActivateHook({ ctx, ...out });
       }

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -530,7 +530,7 @@ export function describeMultiWS(
       }
 
       const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
-
+      console.log({ out });
       if (opts.preActivateHook) {
         await opts.preActivateHook({ ctx, ...out });
       }

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -1,6 +1,7 @@
 import {
   ConfigUtils,
   DENDRON_VSCODE_CONFIG_KEYS,
+  DendronError,
   DEngineClient,
   Disposable,
   DVault,
@@ -524,17 +525,23 @@ export function describeMultiWS(
     }
     let ctx: ExtensionContext;
     before(async () => {
-      ctx = opts.ctx ?? setupWorkspaceStubs(opts);
-      if (opts.beforeHook) {
-        await opts.beforeHook({ ctx });
-      }
+      try {
+        ctx = opts.ctx ?? setupWorkspaceStubs(opts);
+        if (opts.beforeHook) {
+          await opts.beforeHook({ ctx });
+        }
 
-      const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
-      console.log({ out });
-      if (opts.preActivateHook) {
-        await opts.preActivateHook({ ctx, ...out });
+        const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
+        if (opts.preActivateHook) {
+          await opts.preActivateHook({ ctx, ...out });
+        }
+        await _activate(ctx);
+      } catch (error) {
+        Logger.error({
+          ctx: `${title}: before`,
+          error: new DendronError({ message: "before", payload: error }),
+        });
       }
-      await _activate(ctx);
     });
 
     const result = fn();

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -525,23 +525,16 @@ export function describeMultiWS(
     }
     let ctx: ExtensionContext;
     before(async () => {
-      try {
-        ctx = opts.ctx ?? setupWorkspaceStubs(opts);
-        if (opts.beforeHook) {
-          await opts.beforeHook({ ctx });
-        }
-
-        const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
-        if (opts.preActivateHook) {
-          await opts.preActivateHook({ ctx, ...out });
-        }
-        await _activate(ctx);
-      } catch (error) {
-        Logger.error({
-          ctx: `${title}: before`,
-          error: new DendronError({ message: "before", payload: error }),
-        });
+      ctx = opts.ctx ?? setupWorkspaceStubs(opts);
+      if (opts.beforeHook) {
+        await opts.beforeHook({ ctx });
       }
+
+      const out = await setupLegacyWorkspaceMulti({ ...opts, ctx });
+      if (opts.preActivateHook) {
+        await opts.preActivateHook({ ctx, ...out });
+      }
+      await _activate(ctx);
     });
 
     const result = fn();


### PR DESCRIPTION
# chore: fix RunMigrationCommand test

This PR:
- Correctly name test for native workspace case
- disable native workspace test case for `RunMigrationCommand` in windows

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)