### PR TITLE
fix(lookup): autocomplete causes notes to be created in wrong vault 

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -164,6 +164,7 @@ export class NoteLookupCommand
     return this._provider;
   }
 
+  //  ^1h1dr08geo6c
   async onAutoComplete() {
     if (this._quickPick) {
       this._quickPick.value = AutoCompleter.getAutoCompletedValue(
@@ -172,7 +173,6 @@ export class NoteLookupCommand
 
       await this.provider.onUpdatePickerItems({
         picker: this._quickPick,
-        token: this.controller.createCancelSource().token,
       });
     }
   }
@@ -625,6 +625,7 @@ export class NoteLookupCommand
     }
   }
 
+  //  ^8jd6vr4qcsol
   private async getVaultForNewNote({
     fname,
     picker,

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -235,6 +235,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     };
   }
 
+  //  ^hlj1vvw48s2v
   async onUpdatePickerItems(opts: OnUpdatePickerItemsOpts) {
     const { picker, token } = opts;
     const ctx = "updatePickerItems";
@@ -307,7 +308,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       // initialize with current picker items without default items present
       const items: NoteQuickInput[] = [...picker.items];
       let updatedItems = PickerUtilsV2.filterDefaultItems(items);
-      if (token.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
         return;
       }
 
@@ -317,7 +318,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         originalQS: queryOrig,
       });
 
-      if (token.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
         return;
       }
 
@@ -414,9 +415,13 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         numberOfExactMatches;
 
       const shouldAddCreateNew =
+        // sometimes lookup is in mode where new notes are not allowed (eg. move an existing note, this option is manually passed in)
         this.opts.allowNewNote &&
+        // notes can't end with dot, invalid note
         !queryOrig.endsWith(".") &&
+        // if you can select mult notes, new note is not valid
         !picker.canSelectMany &&
+        // when you create lookup from selection, new note is not valid
         !transformedQuery.wasMadeFromWikiLink &&
         vaultsHaveSpaceForExactMatch;
 
@@ -467,7 +472,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         msg: "exit",
         queryOrig,
         profile,
-        cancelled: token.isCancellationRequested,
+        cancelled: token?.isCancellationRequested,
       });
       AnalyticsUtils.track(VSCodeEvents.NoteLookup_Update, {
         duration: profile,
@@ -671,7 +676,7 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
       // initialize with current picker items without default items present
       const items: NoteQuickInput[] = [...picker.items];
       let updatedItems = PickerUtilsV2.filterDefaultItems(items);
-      if (token.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
         return;
       }
 
@@ -680,7 +685,7 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         picker,
         qs: querystring,
       });
-      if (token.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
         return;
       }
 
@@ -721,7 +726,7 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         msg: "exit",
         queryOrig,
         profile,
-        cancelled: token.isCancellationRequested,
+        cancelled: token?.isCancellationRequested,
       });
       AnalyticsUtils.track(VSCodeEvents.SchemaLookup_Update, {
         duration: profile,

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -34,7 +34,7 @@ export type ProvideOpts = {
 
 export type OnUpdatePickerItemsOpts = {
   picker: DendronQuickPickerV2;
-  token: CancellationToken;
+  token?: CancellationToken;
   fuzzThreshold?: number;
   /**
    * force update even if picker vaule didn't change

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -628,11 +628,15 @@ suite("NoteLookupCommand", function () {
   });
 
   describe("onAccept", () => {
-    test("new node", (done) => {
-      runLegacyMultiWorkspaceTest({
+    describeMultiWS(
+      "WHEN new NODE",
+      {
         ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
-        onInit: async ({ vaults }) => {
+      },
+      () => {
+        test("THEN create new item has name of quickpick value", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const opts = (await cmd.run({
@@ -650,10 +654,9 @@ suite("NoteLookupCommand", function () {
               VSCodeUtils.getActiveTextEditorOrThrow().document
             )?.fname
           ).toEqual("foobar");
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
     describeMultiWS(
       "WHEN a new note with .md in its name is created",
@@ -703,8 +706,9 @@ suite("NoteLookupCommand", function () {
       }
     );
 
-    test("new node, stub", (done) => {
-      runLegacyMultiWorkspaceTest({
+    describeMultiWS(
+      "WHEN new node is stub",
+      {
         ctx,
         preSetupHook: async ({ vaults, wsRoot }) => {
           const vault = TestEngineUtils.vault1(vaults);
@@ -713,7 +717,10 @@ suite("NoteLookupCommand", function () {
             wsRoot,
           });
         },
-        onInit: async ({ vaults, engine, wsRoot }) => {
+      },
+      () => {
+        test("THEN stub is created", async () => {
+          const { vaults, engine, wsRoot } = ExtensionProvider.getDWorkspace();
           const cmd = new NoteLookupCommand();
           const vault = TestEngineUtils.vault1(vaults);
           stubVaultPick(vaults);
@@ -728,10 +735,9 @@ suite("NoteLookupCommand", function () {
             vault,
             wsRoot,
           });
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
     test("new domain", (done) => {
       runLegacyMultiWorkspaceTest({


### PR DESCRIPTION
fix(lookup): autocomplete causes notes to be created in wrong vault 

NoteLookupAutocomplete pre-emptively cancelling updatePicker results

***

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

NA

## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)