### PR TITLE
fix(views): Pass in a port-forwarded URL to preview for remote workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-1
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-2
           restore-keys: |
-            ${{ runner.os }}-yarn-1
+            ${{ runner.os }}-yarn-2
 
       - name: Sets env vars for publish test
         run: |

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -219,6 +219,11 @@ export class APIUtils {
     return url + `?${str}`;
   }
 
+  /** Generate a localhost url to this API.
+   *
+   * Warning! In VSCode, the generated URL won't work if the user has a remote
+   * workspace. You'll need to use `vscode.env.asExternalUri` to make it remote.
+   */
   static getLocalEndpoint(port: number) {
     return `http://localhost:${port}`;
   }

--- a/packages/common-frontend/src/features/engine/hooks.ts
+++ b/packages/common-frontend/src/features/engine/hooks.ts
@@ -34,20 +34,18 @@ export const useEngine = ({
     }
     if (!engineSliceUtils.hasInitialized(engineState) || opts.force) {
       logger.info({ msg: "dispatch notes", force: opts.force });
-      if (_.isUndefined(opts.port)) {
+      if (_.isUndefined(opts.url)) {
         return;
       }
       if (!opts.ws) {
         return;
       }
       logger.info({ ctx: "useEffect", state: "initEngine" });
-      dispatch(
-        initNotes({ port: parseInt(opts.port as any, 10), ws: opts.ws })
-      );
+      dispatch(initNotes({ url: opts.url, ws: opts.ws }));
     }
     logger.info({ ctx: "useEffect", state: "exit", engineState });
     return;
-  }, [engineState.loading, opts.port, opts.ws]);
+  }, [engineState.loading, opts.url, opts.ws]);
 };
 
 /**
@@ -65,14 +63,14 @@ export const useConfig = ({
   useEffect(() => {
     logger.info({ ctx: "useEffect", state: "enter" });
 
-    if (_.isUndefined(opts.port)) {
+    if (_.isUndefined(opts.url)) {
       return;
     }
     if (!opts.ws) {
       return;
     }
     logger.info({ ctx: "useEffect", state: "syncConfig" });
-    dispatch(syncConfig({ port: parseInt(opts.port as any, 10), ws: opts.ws }));
+    dispatch(syncConfig({ url: opts.url, ws: opts.ws }));
     logger.info({ ctx: "useEffect", state: "exit" });
     return;
   }, []);

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -4,7 +4,6 @@ import {
   NoteProps,
   NotePropsDict,
   stringifyError,
-  APIUtils,
   NoteUtils,
   ConfigGetPayload,
 } from "@dendronhq/common-all";
@@ -19,9 +18,9 @@ import internal from "@reduxjs/toolkit/node_modules/immer/dist/internal";
  */
 export const initNotes = createAsyncThunk(
   "engine/init",
-  async ({ port, ws }: { port: number; ws: string }, { dispatch }) => {
+  async ({ url, ws }: { url: string; ws: string }, { dispatch }) => {
     const logger = createLogger("initNotesThunk");
-    const endpoint = APIUtils.getLocalEndpoint(port);
+    const endpoint = url;
     const api = new DendronApiV2({
       endpoint,
       apiPath: "api",
@@ -47,9 +46,9 @@ export const initNotes = createAsyncThunk(
  */
 export const syncConfig = createAsyncThunk(
   "engine/syncConfig",
-  async ({ port, ws }: { port: number; ws: string }, { dispatch }) => {
+  async ({ url, ws }: { url: string; ws: string }, { dispatch }) => {
     const logger = createLogger("syncConfigThunk");
-    const endpoint = APIUtils.getLocalEndpoint(port);
+    const endpoint = url;
     const api = new DendronApiV2({
       endpoint,
       apiPath: "api",
@@ -73,11 +72,11 @@ export const syncConfig = createAsyncThunk(
 export const syncNote = createAsyncThunk(
   "engine/sync",
   async (
-    { port, ws, note }: { port: number; ws: string; note: NoteProps },
+    { url, ws, note }: { url: string; ws: string; note: NoteProps },
     { dispatch }
   ) => {
     const logger = createLogger("syncNoteThunk");
-    const endpoint = APIUtils.getLocalEndpoint(port);
+    const endpoint = url;
     const api = new DendronApiV2({
       endpoint,
       apiPath: "api",
@@ -104,14 +103,14 @@ export const renderNote = createAsyncThunk(
   "engine/render",
   async (
     {
-      port,
+      url,
       ws,
       id,
       note,
-    }: { port: number; ws: string; id: string; note?: NoteProps },
+    }: { url: string; ws: string; id: string; note?: NoteProps },
     { dispatch }
   ) => {
-    const endpoint = APIUtils.getLocalEndpoint(port);
+    const endpoint = url;
     const logger = createLogger("renderNoteThunk");
     const api = new DendronApiV2({
       endpoint,

--- a/packages/common-frontend/src/types.ts
+++ b/packages/common-frontend/src/types.ts
@@ -11,7 +11,8 @@ export type EngineSliceState = {
   error: any;
   loading: LoadingStatus;
   currentRequestId: string | undefined;
-} & Partial<DEngineInitPayload> & Pick<DEngineInitPayload, "notes"|"schemas"|"vaults">;
+} & Partial<DEngineInitPayload> &
+  Pick<DEngineInitPayload, "notes" | "schemas" | "vaults">;
 
 export function verifyEngineSliceState(
   opts: Partial<EngineSliceState>
@@ -19,3 +20,13 @@ export function verifyEngineSliceState(
   const engineSliceKeys: (keyof EngineSliceState)[] = ["notes", "config"];
   return _.every(engineSliceKeys, (k) => !_.isUndefined(opts[k]));
 }
+
+export type WorkspaceProps = {
+  url: string;
+  ws: string;
+  theme?: string;
+  /**
+   * workspace loaded through browser
+   */
+  browser?: boolean;
+};

--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -23,7 +23,7 @@ export class WebViewCommonUtils {
   static genVSCodeHTMLIndex = ({
     jsSrc,
     cssSrc,
-    port,
+    url,
     wsRoot,
     browser,
     acquireVsCodeApi,
@@ -32,7 +32,7 @@ export class WebViewCommonUtils {
   }: {
     jsSrc: string;
     cssSrc: string;
-    port: number;
+    url: string;
     wsRoot: string;
     browser: boolean;
     acquireVsCodeApi: string;
@@ -202,7 +202,7 @@ export class WebViewCommonUtils {
     <body onload="onload()" class="vscode-${initialTheme || "light"}">
       <div id="main-content-wrap" class="main-content-wrap">
         <div id="main-content" class="main-content">
-          <div id="root" data-port="${port}" data-ws="${wsRoot}" data-browser="${browser}"></div>
+          <div id="root" data-url="${url}" data-ws="${wsRoot}" data-browser="${browser}"></div>
         </div>
       </div>
 

--- a/packages/dendron-next-server/lib/env.ts
+++ b/packages/dendron-next-server/lib/env.ts
@@ -3,19 +3,18 @@ import _ from "lodash";
 import { StageEnv } from "./types";
 
 export function getStage() {
-  return process.env.STAGE
+  return process.env.STAGE;
 }
 
 export function getEnv(key: keyof StageEnv): any {
-    // NOTE: this only works server side, not client side
-    const override = _.get(process.env, key)
-    return override;
+  // NOTE: this only works server side, not client side
+  const override = _.get(process.env, key);
+  return override;
 }
 
-
-export const getWsAndPort = () => {
-  const { port, ws } = querystring.parse(
-      window.location.search.slice(1)
-  ) as { port: string; ws: string };
-  return {port: parseInt(port, 10), ws}
-}
+export const getWsAndUrl = () => {
+  const { ws } = querystring.parse(window.location.search.slice(1)) as {
+    ws: string;
+  };
+  return { url: `${window.location.protocol}//${window.location.host}`, ws };
+};

--- a/packages/dendron-next-server/lib/types.ts
+++ b/packages/dendron-next-server/lib/types.ts
@@ -1,9 +1,12 @@
-
 // export type StageEnv = {
 //   ENGINE_ENDPOINT_PORT?: number;
 // };
 
-import { engineSlice, ideSlice } from "@dendronhq/common-frontend";
+import {
+  engineSlice,
+  ideSlice,
+  WorkspaceProps,
+} from "@dendronhq/common-frontend";
 
 export enum CONFIG_KEY {
   ENGINE_ENDPOINT_PORT = "ENGINE_ENDPOINT_PORT",
@@ -12,18 +15,9 @@ export enum CONFIG_KEY {
 
 export type StageEnv = typeof CONFIG_KEY;
 
-
-export type WorkspaceProps = {
-  port: number;
-  ws: string;
-  theme?: string;
-  /**
-   * workspace loaded through browser
-   */
-  browser?: boolean;
-};
+export type { WorkspaceProps };
 
 export type DendronProps = {
-  engine: engineSlice.EngineState,
+  engine: engineSlice.EngineState;
   ide: ideSlice.IDEState;
 };

--- a/packages/dendron-next-server/pages/_app.tsx
+++ b/packages/dendron-next-server/pages/_app.tsx
@@ -38,14 +38,16 @@ const themes = {
 const { useEngineAppSelector, useEngine } = engineHooks;
 
 const getWorkspaceParamsFromQueryString = (): WorkspaceProps => {
-  const { port, ws, theme, browser } = querystring.parse(
+  const { ws, theme, browser } = querystring.parse(
     window.location.search.slice(1)
   );
   return {
-    port: parseInt(port as string, 10),
+    url: `${window.location.protocol}//${window.location.host}`,
     ws,
     theme,
     browser,
+    // querystring.parse's type definition is pretty inaccurate, it just says
+    // `string | string[] | undefined` so we cast here to ignore that
   } as WorkspaceProps;
 };
 
@@ -87,7 +89,7 @@ function AppVSCode({ Component, pageProps }: any) {
     // when we get a msg from vscode, update our msg state
     logger.info({ ctx, msg, query });
     // NOTE: initial message, state might not be set
-    const { port, ws } = getWorkspaceParamsFromQueryString();
+    const { url, ws } = getWorkspaceParamsFromQueryString();
 
     if (msg.type === DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR) {
       const cmsg = msg as OnDidChangeActiveTextEditorMsg;
@@ -97,13 +99,13 @@ function AppVSCode({ Component, pageProps }: any) {
         logger.info({
           ctx,
           msg: "syncEngine:pre",
-          port,
+          url,
           ws,
         });
-        await ideDispatch(engineSlice.initNotes({ port, ws }));
+        await ideDispatch(engineSlice.initNotes({ url, ws }));
       }
       if (syncChangedNote && note) {
-        await ideDispatch(engineSlice.syncNote({ port, ws, note }));
+        await ideDispatch(engineSlice.syncNote({ url, ws, note }));
       }
       logger.info({ ctx, msg: "syncEngine:post" });
       ideDispatch(ideSlice.actions.setNoteActive(note));

--- a/packages/dendron-next-server/pages/vscode/mini-preview.tsx
+++ b/packages/dendron-next-server/pages/vscode/mini-preview.tsx
@@ -6,7 +6,7 @@ import {
 } from "@dendronhq/common-frontend";
 import { useRouter } from "next/router";
 import React from "react";
-import { getWsAndPort } from "../../lib/env";
+import { getWsAndUrl } from "../../lib/env";
 import { DendronProps } from "../../lib/types";
 
 export default function MiniPreview({ engine, ide }: DendronProps) {
@@ -29,7 +29,7 @@ export default function MiniPreview({ engine, ide }: DendronProps) {
     if (!maybeContent) {
       dispatch(
         engineSlice.renderNote({
-          ...getWsAndPort(),
+          ...getWsAndUrl(),
           id: noteId,
           note: ide.noteActive,
         })

--- a/packages/dendron-next-server/pages/vscode/note-preview.tsx
+++ b/packages/dendron-next-server/pages/vscode/note-preview.tsx
@@ -23,7 +23,7 @@ import _ from "lodash";
 import Head from "next/head";
 import * as React from "react";
 import { useThemeSwitcher } from "react-css-theme-switcher";
-import { getWsAndPort } from "../../lib/env";
+import { getWsAndUrl } from "../../lib/env";
 import { DendronProps, WorkspaceProps } from "../../lib/types";
 import { getThemeType } from "../../styles/theme";
 
@@ -73,14 +73,14 @@ function getMermaid(window: Window): Mermaid | undefined {
 function genThemeString(opts: {
   themeTarget: ThemeTarget;
   themeType: ThemeType;
-  port: number;
+  url: string;
   ws: string;
 }) {
   const themeRequest = {
     ...opts,
   } as AssetGetThemeRequest;
   const qs = querystring.stringify(themeRequest);
-  const base = `${APIUtils.getLocalEndpoint(opts.port)}/api/assets/theme?${qs}`;
+  const base = `${opts.url}/api/assets/theme?${qs}`;
   return base;
 }
 
@@ -157,7 +157,7 @@ const useMermaid = ({
   }, [config]);
 };
 
-function Note({ engine, ide, ws, port }: DendronProps & WorkspaceProps) {
+function Note({ engine, ide, ws, url }: DendronProps & WorkspaceProps) {
   const ctx = "Note";
 
   // apply initial hooks
@@ -185,7 +185,7 @@ function Note({ engine, ide, ws, port }: DendronProps & WorkspaceProps) {
       renderedNoteContentHash.current = contentHash;
       dispatch(
         engineSlice.renderNote({
-          ...getWsAndPort(),
+          ...getWsAndUrl(),
           id: noteId,
           note: noteActive,
         })
@@ -264,7 +264,7 @@ function Note({ engine, ide, ws, port }: DendronProps & WorkspaceProps) {
     themeTarget: ThemeTarget.PRISM,
     themeType: currentTheme as ThemeType,
     ws,
-    port,
+    url,
   });
   return (
     <AntLayout>

--- a/packages/dendron-plugin-views/src/hooks/index.tsx
+++ b/packages/dendron-plugin-views/src/hooks/index.tsx
@@ -25,13 +25,13 @@ export const useCurrentTheme = () => {
 
 export const useWorkspaceProps = (): [WorkspaceProps] => {
   const elem = window.document.getElementById("root")!;
-  const port = parseInt(elem.getAttribute("data-port")!, 10);
+  const url = elem.getAttribute("data-url")!;
   const ws = elem.getAttribute("data-ws")!;
   const isBrowser = elem.getAttribute("data-browser")! === "true";
   const theme = elem.getAttribute("data-browser")!;
   return [
     {
-      port,
+      url,
       ws,
       browser: isBrowser,
       theme,

--- a/packages/dendron-plugin-views/src/types/index.ts
+++ b/packages/dendron-plugin-views/src/types/index.ts
@@ -1,19 +1,15 @@
-import { engineSlice, ideSlice } from "@dendronhq/common-frontend";
+import {
+  engineSlice,
+  ideSlice,
+  WorkspaceProps,
+} from "@dendronhq/common-frontend";
 
-export type WorkspaceProps = {
-  port: number;
-  ws: string;
-  theme?: string;
-  /**
-   * workspace loaded through browser
-   */
-  browser?: boolean;
-};
+export type { WorkspaceProps };
 
 export type DendronComponent = React.FunctionComponent<DendronProps>;
 
 export type DendronProps = {
-  engine: engineSlice.EngineState,
+  engine: engineSlice.EngineState;
   ide: ideSlice.IDEState;
   workspace: WorkspaceProps;
 };

--- a/packages/engine-test-utils/src/__tests__/common-frontend/features/engine/slice.spec.tsx
+++ b/packages/engine-test-utils/src/__tests__/common-frontend/features/engine/slice.spec.tsx
@@ -1,3 +1,4 @@
+import { APIUtils } from "@dendronhq/common-all";
 import { combinedStore, engineSlice } from "@dendronhq/common-frontend";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { createEngineFromServer, runEngineTestV5 } from "../../../../engine";
@@ -24,10 +25,12 @@ describe("GIVEN syncNote", () => {
             },
           });
           await engine.updateNote(newNote, { newNode: true });
+          expect(port).toBeTruthy();
+          const url = APIUtils.getLocalEndpoint(port!);
 
           // --- setup engineSlice
           // sync new note to redux engine
-          const initNotesOpts = { ws: wsRoot, port: port! };
+          const initNotesOpts = { ws: wsRoot, url };
           await combinedStore.dispatch(engineSlice.initNotes(initNotesOpts));
           await combinedStore.dispatch(
             engineSlice.syncNote({ ...initNotesOpts, note: newNote })
@@ -57,8 +60,10 @@ describe("GIVEN syncNote", () => {
       await runEngineTestV5(
         async ({ port, wsRoot, engine }) => {
           const note = engine.notes["foo"];
+          expect(port).toBeTruthy();
+          const url = APIUtils.getLocalEndpoint(port!);
 
-          const initNotesOpts = { ws: wsRoot, port: port! };
+          const initNotesOpts = { ws: wsRoot, url };
           await combinedStore.dispatch(engineSlice.initNotes(initNotesOpts));
           await combinedStore.dispatch(
             engineSlice.syncNote({ ...initNotesOpts, note })

--- a/packages/plugin-core/src/components/views/PreviewPanel.ts
+++ b/packages/plugin-core/src/components/views/PreviewPanel.ts
@@ -110,7 +110,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
 
       const webViewAssets = WebViewUtils.getJsAndCss(name);
 
-      const html = WebViewUtils.getWebviewContent({
+      const html = await WebViewUtils.getWebviewContent({
         ...webViewAssets,
         port,
         wsRoot,

--- a/packages/plugin-core/src/views/DendronTreeViewV2.ts
+++ b/packages/plugin-core/src/views/DendronTreeViewV2.ts
@@ -102,7 +102,7 @@ export class DendronTreeViewV2 implements WebviewViewProvider, Disposable {
     const start = process.hrtime();
     Logger.info({ ctx, msg: "enter", start });
 
-    WebViewUtils.prepareTreeView({
+    await WebViewUtils.prepareTreeView({
       ext: this._ext,
       key: DendronTreeViewKey.TREE_VIEW_V2,
       webviewView,

--- a/packages/plugin-core/src/views/LookupView.ts
+++ b/packages/plugin-core/src/views/LookupView.ts
@@ -44,7 +44,7 @@ export class LookupView implements vscode.WebviewViewProvider {
   ) {
     this._view = webviewView;
 
-    WebViewUtils.prepareTreeView({
+    await WebViewUtils.prepareTreeView({
       ext: this._extension,
       key: DendronTreeViewKey.LOOKUP_VIEW,
       webviewView,


### PR DESCRIPTION
Instead of passing a port into the preview and having it generate a localhost URL, we instead generate a URL with the VSCode API and pass the generated URL in. This way VSCode can set up port forwarding in remote workspaces. For local workspaces, the API is a no-op and we just get a local connection.

#2606

Co-authored-by: jonathanyeung <jonathanyeung@users.noreply.github.com>


# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
  - Not affected
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
    - No, the API is a no-op for local workspaces, and port forwarding is required for remote workspaces.
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
  - Tested both locally and remotely
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)