### PR TITLE
chore(internal): ShowNoteGraph to use engine events

### DIFF
--- a/packages/dendron-next-server/hooks/useGraphElements.tsx
+++ b/packages/dendron-next-server/hooks/useGraphElements.tsx
@@ -52,6 +52,12 @@ const getLocalNoteGraphElements = ({
   }
 
   const activeNote = notes[noteActive.id];
+  if (_.isUndefined(activeNote)) {
+    return {
+      nodes: [],
+      edges: {},
+    };
+  }
   const parentNote = activeNote.parent ? notes[activeNote.parent] : undefined;
   const connectedNotes = NoteUtils.getNotesWithLinkTo({
     note: activeNote,
@@ -135,29 +141,31 @@ const getLocalNoteGraphElements = ({
 
   activeNote.children.forEach((child) => {
     const childNote = notes[child];
-    nodes.push({
-      data: {
-        id: child,
-        label: childNote.title,
-        group: "nodes",
-        color: getNoteColor({ fname: childNote.fname, notes }),
-        fname: childNote.fname,
-        stub: _.isUndefined(childNote.stub) ? false : childNote.stub,
-      },
-      classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(childNote.vault)}`,
-    });
+    if (childNote) {
+      nodes.push({
+        data: {
+          id: child,
+          label: childNote.title,
+          group: "nodes",
+          color: getNoteColor({ fname: childNote.fname, notes }),
+          fname: childNote.fname,
+          stub: _.isUndefined(childNote.stub) ? false : childNote.stub,
+        },
+        classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(childNote.vault)}`,
+      });
 
-    edges.hierarchy.push({
-      data: {
-        group: "edges",
-        id: `${activeNote.id}_${child}`,
-        source: activeNote.id,
-        target: child,
-        fname: activeNote.fname,
-        stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
-      },
-      classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
-    });
+      edges.hierarchy.push({
+        data: {
+          group: "edges",
+          id: `${activeNote.id}_${child}`,
+          source: activeNote.id,
+          target: child,
+          fname: activeNote.fname,
+          stub: _.isUndefined(activeNote.stub) ? false : activeNote.stub,
+        },
+        classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
+      });
+    }
   });
 
   // Get notes linking to active note
@@ -312,6 +320,7 @@ const getFullNoteGraphElements = ({
     edges.hierarchy.push(
       ...note.children.map((child) => {
         const childNote = notes[child];
+        // eslint-disable-next-line no-nested-ternary
         const isStub = childNote
           ? _.isUndefined(note.stub) && _.isUndefined(childNote.stub)
             ? false
@@ -495,7 +504,7 @@ const getSchemaGraphElements = (
           nodes.push({
             data: {
               id: SUBSCHEMA_ID,
-              label: label,
+              label,
               group: "nodes",
               fname: schema.fname,
             },
@@ -587,7 +596,7 @@ const useGraphElements = ({
 
   // Get new elements if active note changes
   useEffect(() => {
-    if (type === "note" && engine.notes && isLocalGraph) {
+    if (type === "note" && engine.notes && isLocalGraph && noteActive) {
       setElements(
         getLocalNoteGraphElements({
           notes: engine.notes,

--- a/packages/dendron-next-server/pages/_app.tsx
+++ b/packages/dendron-next-server/pages/_app.tsx
@@ -91,7 +91,7 @@ function AppVSCode({ Component, pageProps }: any) {
 
     if (msg.type === DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR) {
       const cmsg = msg as OnDidChangeActiveTextEditorMsg;
-      const { sync, note, syncChangedNote } = cmsg.data;
+      const { sync, note, syncChangedNote, activeNote } = cmsg.data;
       if (sync) {
         // skip the initial ?
         logger.info({
@@ -106,8 +106,11 @@ function AppVSCode({ Component, pageProps }: any) {
         await ideDispatch(engineSlice.syncNote({ port, ws, note }));
       }
       logger.info({ ctx, msg: "syncEngine:post" });
-      ideDispatch(ideSlice.actions.setNoteActive(note));
-      logger.info({ ctx, msg: "setNote:post" });
+      logger.info({ ctx, msg: "setNoteActive:pre" });
+      // If activeNote is in the data payload, set that as active note. Otherwise default to changed note
+      const noteToSetActive = activeNote || note;
+      ideDispatch(ideSlice.actions.setNoteActive(noteToSetActive));
+      logger.info({ ctx, msg: "setNoteActive:post" });
     } else if (msg.type === ThemeMessageType.onThemeChange) {
       const cmsg = msg;
       const { theme } = cmsg.data;

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1078,7 +1078,7 @@ async function _setupCommands({
         DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key,
         sentryReportingCallback(async () => {
           await new ShowNoteGraphCommand(
-            NoteGraphPanelFactory.create(ws)
+            NoteGraphPanelFactory.create(ws, ws.getEngine())
           ).run();
         })
       )

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -147,6 +147,7 @@ export class NoteGraphPanelFactory {
         data: {
           note,
           syncChangedNote: true,
+          activeNote: this._ext.wsUtils.getActiveNote(),
         },
         source: "vscode",
       } as OnDidChangeActiveTextEditorMsg);

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -59,6 +59,7 @@ export class NoteGraphPanelFactory {
           }
         });
 
+      // listener
       this._panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
         const ctx = "ShowNoteGraph:onDidReceiveMessage";
         Logger.debug({ ctx, msgType: msg.type });
@@ -140,6 +141,10 @@ export class NoteGraphPanelFactory {
     return this._panel;
   }
 
+  /**
+   * Post message to the webview content.
+   * @param note
+   */
   static refresh(note: NoteProps): any {
     if (this._panel) {
       this._panel.webview.postMessage({
@@ -153,7 +158,10 @@ export class NoteGraphPanelFactory {
       } as OnDidChangeActiveTextEditorMsg);
     }
   }
-
+  /**
+   * If the user changes focus, then the newly in-focus Dendron note
+   * should be shown in the graph.
+   */
   static async onOpenTextDocument(editor: TextEditor | undefined) {
     if (_.isUndefined(editor) || _.isUndefined(this._panel)) {
       return;

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -1,26 +1,33 @@
 import {
-  assertUnreachable,
   DendronError,
   DMessageEnum,
   GraphViewMessage,
   GraphViewMessageType,
+  NoteProps,
+  NoteUtils,
   OnDidChangeActiveTextEditorMsg,
 } from "@dendronhq/common-all";
+import { EngineEventEmitter, WorkspaceUtils } from "@dendronhq/engine-server";
+import _ from "lodash";
+import path from "path";
 import * as vscode from "vscode";
-import { ViewColumn, window } from "vscode";
+import { Disposable, TextEditor, ViewColumn, window } from "vscode";
 import { GotoNoteCommand } from "../../commands/GotoNote";
 import { Logger } from "../../logger";
 import { GraphStyleService } from "../../styles";
-import { sentryReportingCallback } from "../../utils/analytics";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { DendronExtension, getEngine, getExtension } from "../../workspace";
-import { WSUtils } from "../../WSUtils";
+import { DendronExtension } from "../../workspace";
 
 export class NoteGraphPanelFactory {
   private static _panel: vscode.WebviewPanel | undefined = undefined;
-  private static _vsCodeCallback: vscode.Disposable | undefined = undefined;
+  private static _onEngineNoteStateChangedDisposable: Disposable | undefined;
+  private static _engineEvents: EngineEventEmitter;
+  private static _ext: DendronExtension;
 
-  static create(ext: DendronExtension): vscode.WebviewPanel {
+  static create(
+    ext: DendronExtension,
+    engineEvents: EngineEventEmitter
+  ): vscode.WebviewPanel {
     if (!this._panel) {
       this._panel = window.createWebviewPanel(
         "dendronIframe", // Identifies the type of the webview. Used internally
@@ -35,15 +42,31 @@ export class NoteGraphPanelFactory {
           enableFindWidget: false,
         }
       );
+      this._ext = ext;
+      this._engineEvents = engineEvents;
+      this._ext.context.subscriptions.push(
+        window.onDidChangeActiveTextEditor(this.onOpenTextDocument, this)
+      );
+
+      this._onEngineNoteStateChangedDisposable =
+        this._engineEvents.onEngineNoteStateChanged((noteChangeEntry) => {
+          const ctx = "NoteGraphViewFactoryEngineNoteStateChanged";
+          Logger.info({ ctx });
+          if (this._panel && this._panel.visible) {
+            noteChangeEntry.map((changeEntry) =>
+              this.refresh(changeEntry.note)
+            );
+          }
+        });
 
       this._panel.webview.onDidReceiveMessage(async (msg: GraphViewMessage) => {
-        const ctx = "ShowSchemaGraph:onDidReceiveMessage";
+        const ctx = "ShowNoteGraph:onDidReceiveMessage";
         Logger.debug({ ctx, msgType: msg.type });
 
         switch (msg.type) {
           case GraphViewMessageType.onSelect: {
-            const note = getEngine().notes[msg.data.id];
-            await new GotoNoteCommand(getExtension()).execute({
+            const note = this._ext.getEngine().notes[msg.data.id];
+            await new GotoNoteCommand(this._ext).execute({
               qs: note.fname,
               vault: note.vault,
               column: ViewColumn.One,
@@ -51,19 +74,32 @@ export class NoteGraphPanelFactory {
             break;
           }
           case GraphViewMessageType.onGetActiveEditor: {
-            const activeTextEditor = VSCodeUtils.getActiveTextEditor();
-            const note =
-              activeTextEditor &&
-              WSUtils.getNoteFromDocument(activeTextEditor.document);
-            if (note) {
-              this._panel!.webview.postMessage({
-                type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-                data: {
-                  note,
-                  sync: true,
-                },
-                source: "vscode",
-              });
+            const document = VSCodeUtils.getActiveTextEditor()?.document;
+            const { vaults, wsRoot } = this._ext.getDWorkspace();
+            if (document) {
+              if (
+                !WorkspaceUtils.isPathInWorkspace({
+                  wsRoot,
+                  vaults,
+                  fpath: document.uri.fsPath,
+                })
+              ) {
+                Logger.info({
+                  ctx,
+                  uri: document.uri.fsPath,
+                  msg: "not in workspace",
+                });
+                return;
+              }
+              const note = this._ext.wsUtils.getNoteFromDocument(document);
+              if (note) {
+                Logger.info({
+                  ctx: "onDidReceiveMessage",
+                  msg: "refresh note",
+                  note: NoteUtils.toLogObj(note),
+                });
+                this.refresh(note);
+              }
             }
             break;
           }
@@ -90,45 +126,53 @@ export class NoteGraphPanelFactory {
               },
             });
           default:
-            assertUnreachable(msg.type);
+            break;
         }
       });
 
-      this._vsCodeCallback = vscode.window.onDidChangeActiveTextEditor(
-        sentryReportingCallback((editor: vscode.TextEditor | undefined) => {
-          if (
-            NoteGraphPanelFactory._panel &&
-            NoteGraphPanelFactory._panel.visible
-          ) {
-            if (!editor) {
-              return;
-            }
-
-            const note = WSUtils.getNoteFromDocument(editor.document);
-
-            NoteGraphPanelFactory._panel.webview.postMessage({
-              type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
-              data: {
-                note,
-                sync: true,
-              },
-              source: "vscode",
-            } as OnDidChangeActiveTextEditorMsg);
-          }
-        })
-      );
-
-      ext.addDisposable(this._vsCodeCallback);
-
       this._panel.onDidDispose(() => {
         this._panel = undefined;
-
-        if (this._vsCodeCallback) {
-          this._vsCodeCallback.dispose();
-          this._vsCodeCallback = undefined;
+        if (this._onEngineNoteStateChangedDisposable) {
+          this._onEngineNoteStateChangedDisposable.dispose();
         }
       });
     }
     return this._panel;
+  }
+
+  static refresh(note: NoteProps): any {
+    if (this._panel) {
+      this._panel.webview.postMessage({
+        type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+        data: {
+          note,
+          syncChangedNote: true,
+        },
+        source: "vscode",
+      } as OnDidChangeActiveTextEditorMsg);
+    }
+  }
+
+  static async onOpenTextDocument(editor: TextEditor | undefined) {
+    if (_.isUndefined(editor) || _.isUndefined(this._panel)) {
+      return;
+    }
+    if (!this._panel.visible) {
+      return;
+    }
+    const uri = editor.document.uri;
+    const basename = path.basename(uri.fsPath);
+    const { wsRoot, vaults } = this._ext.getDWorkspace();
+    if (
+      !WorkspaceUtils.isPathInWorkspace({ wsRoot, vaults, fpath: uri.fsPath })
+    ) {
+      return;
+    }
+    if (basename.endsWith(".md")) {
+      const note = this._ext.wsUtils.getNoteFromDocument(editor.document);
+      if (note) {
+        this.refresh(note);
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR aims to hook Graph View with Engine Events. It also fixes rendering issues on ShowNoteGraph.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: No new dependencies added (14)
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)