### PR TITLE
fix(copynotelink): Allow user to run copyNoteLink without needing to save first

### DIFF
--- a/packages/common-test-utils/src/presets/notes.ts
+++ b/packages/common-test-utils/src/presets/notes.ts
@@ -1,4 +1,4 @@
-import { DVault } from "@dendronhq/common-all";
+import { DEngineClient, DVault } from "@dendronhq/common-all";
 import _ from "lodash";
 import { CreateNoteOptsV4, NoteTestUtilsV4 } from "../noteUtils";
 
@@ -50,8 +50,40 @@ export const CreateNoteFactory = (opts: CreateNoteFactoryOpts) => {
     }
     return NoteTestUtilsV4.createNote(_opts);
   };
+
+  const createWithEngineFunc = ({
+    vault,
+    wsRoot,
+    genRandomId,
+    noWrite,
+    body,
+    fname,
+    props,
+    engine,
+  }: CreateNotePresetOptsV4 & { engine: DEngineClient }) => {
+    const _opts: CreateNoteOptsV4 & { engine: DEngineClient } = {
+      ...opts,
+      vault,
+      wsRoot,
+      genRandomId,
+      noWrite,
+      engine,
+    };
+    if (!_.isUndefined(body)) {
+      _opts.body = body;
+    }
+    if (!_.isUndefined(props)) {
+      _opts.props = props;
+    }
+    if (!_.isUndefined(fname)) {
+      _opts.fname = fname;
+    }
+    return NoteTestUtilsV4.createNoteWithEngine(_opts);
+  };
+
   return {
     create: func,
+    createWithEngine: createWithEngineFunc,
     fname: opts.fname,
     selection: opts.selection || SIMPLE_SELECTION,
     body: opts.body,

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -44,6 +44,7 @@ import path from "path";
 import semver from "semver";
 import * as vscode from "vscode";
 import { ALL_COMMANDS } from "./commands";
+import { CopyNoteLinkCommand } from "./commands/CopyNoteLink";
 import { DoctorCommand, PluginDoctorActionsEnum } from "./commands/Doctor";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";
@@ -1080,6 +1081,20 @@ async function _setupCommands({
           await new ShowNoteGraphCommand(
             NoteGraphPanelFactory.create(ws)
           ).run();
+        })
+      )
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.COPY_NOTE_LINK.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.COPY_NOTE_LINK.key,
+        sentryReportingCallback(async (args) => {
+          if (args === undefined) {
+            args = {};
+          }
+          await new CopyNoteLinkCommand(ws.getEngine()).run(args);
         })
       )
     );

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1087,6 +1087,7 @@ async function _setupCommands({
   }
 
   if (!existingCommands.includes(DENDRON_COMMANDS.COPY_NOTE_LINK.key)) {
+    const copyNoteLinkCommand = new CopyNoteLinkCommand(ws.getEngine());
     context.subscriptions.push(
       vscode.commands.registerCommand(
         DENDRON_COMMANDS.COPY_NOTE_LINK.key,
@@ -1094,10 +1095,11 @@ async function _setupCommands({
           if (args === undefined) {
             args = {};
           }
-          await new CopyNoteLinkCommand(ws.getEngine()).run(args);
+          await copyNoteLinkCommand.run(args);
         })
       )
     );
+    context.subscriptions.push(copyNoteLinkCommand);
   }
 
   // NOTE: seed commands currently DO NOT take extension as a first argument

--- a/packages/plugin-core/src/commands/CopyNoteLink.ts
+++ b/packages/plugin-core/src/commands/CopyNoteLink.ts
@@ -4,15 +4,16 @@ import {
   genUUIDInsecure,
   isBlockAnchor,
   isLineAnchor,
+  NoteChangeEntry,
   NoteProps,
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
 import { isInsidePath } from "@dendronhq/common-server";
-import { AnchorUtils } from "@dendronhq/engine-server";
+import { AnchorUtils, EngineEventEmitter } from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
-import { TextEditor, window } from "vscode";
+import { Disposable, TextEditor, window } from "vscode";
 import { DendronClientUtilsV2 } from "../clientUtils";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
@@ -23,17 +24,27 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
-type CommandOutput = {
-  link: string;
-  type: string;
-  anchorType?: string;
-};
+type CommandOutput =
+  | {
+      link: string;
+      type: string;
+      anchorType?: string;
+    }
+  | undefined;
 
 export class CopyNoteLinkCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
   key = DENDRON_COMMANDS.COPY_NOTE_LINK.key;
+  private engineEvents: EngineEventEmitter;
+  private _onEngineNoteStateChangedDisposable: Disposable | undefined;
+
+  constructor(engineEvents: EngineEventEmitter) {
+    super();
+    this.engineEvents = engineEvents;
+  }
+
   async sanityCheck() {
     if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
       return "No document open";
@@ -175,13 +186,46 @@ export class CopyNoteLinkCommand extends BasicCommand<
     const editor = VSCodeUtils.getActiveTextEditor()!;
     const fname = NoteUtils.uri2Fname(editor.document.uri);
     const engine = ExtensionProvider.getEngine();
-
     const vault = PickerUtilsV2.getVaultForOpenEditor();
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    }) as NoteProps;
+
+    if (editor.document.isDirty) {
+      this._onEngineNoteStateChangedDisposable =
+        this.engineEvents.onEngineNoteStateChanged(
+          async (noteChangeEntries: NoteChangeEntry[]) => {
+            const savedNote = noteChangeEntries.filter(
+              (entry) => entry.note.fname === fname && entry.status === "update"
+            );
+            // Received event from engine about successful save
+            if (savedNote.length > 0) {
+              await this.executeCopyNoteLink(savedNote[0].note, editor);
+              this.dispose();
+            }
+          }
+        );
+      await editor.document.save();
+      return;
+    } else if (this._onEngineNoteStateChangedDisposable) {
+      // If this is not disposed, it means we are still listening on engine state change from previous CopyNoteLink.execute command
+      // Do nothing as engine may still not be up-to-date
+      return;
+    } else {
+      const note = NoteUtils.getNoteByFnameFromEngine({
+        fname,
+        vault,
+        engine,
+      }) as NoteProps;
+      return this.executeCopyNoteLink(note, editor);
+    }
+  }
+
+  dispose(): void {
+    if (this._onEngineNoteStateChangedDisposable) {
+      this._onEngineNoteStateChangedDisposable.dispose();
+      this._onEngineNoteStateChangedDisposable = undefined;
+    }
+  }
+
+  private async executeCopyNoteLink(note: NoteProps, editor: TextEditor) {
     let link: string;
     let type;
     let anchor;

--- a/packages/plugin-core/src/commands/CopyNoteLink.ts
+++ b/packages/plugin-core/src/commands/CopyNoteLink.ts
@@ -32,10 +32,10 @@ type CommandOutput =
     }
   | undefined;
 
-export class CopyNoteLinkCommand extends BasicCommand<
-  CommandOpts,
-  CommandOutput
-> {
+export class CopyNoteLinkCommand
+  extends BasicCommand<CommandOpts, CommandOutput>
+  implements Disposable
+{
   key = DENDRON_COMMANDS.COPY_NOTE_LINK.key;
   private engineEvents: EngineEventEmitter;
   private _onEngineNoteStateChangedDisposable: Disposable | undefined;
@@ -203,6 +203,10 @@ export class CopyNoteLinkCommand extends BasicCommand<
           }
         );
       await editor.document.save();
+      // Dispose of listener after 1 sec (if not already disposed) in case engine events never arrive
+      setTimeout(() => {
+        this.dispose();
+      }, 1000);
       return;
     } else if (this._onEngineNoteStateChangedDisposable) {
       // If this is not disposed, it means we are still listening on engine state change from previous CopyNoteLink.execute command

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -10,7 +10,6 @@ import { ConfigureWithUICommand } from "./ConfigureWithUI";
 import { ContributeCommand } from "./Contribute";
 import { ConvertCandidateLinkCommand } from "./ConvertCandidateLink";
 import { ConvertLinkCommand } from "./ConvertLink";
-import { CopyNoteLinkCommand } from "./CopyNoteLink";
 import { CopyNoteRefCommand } from "./CopyNoteRef";
 import { CopyNoteURLCommand } from "./CopyNoteURL";
 import { CreateDailyJournalCommand } from "./CreateDailyJournal";
@@ -88,7 +87,6 @@ const ALL_COMMANDS = [
   ConfigureExportPodV2,
   ConfigureGraphStylesCommand,
   ContributeCommand,
-  CopyNoteLinkCommand,
   CopyNoteRefCommand,
   CopyNoteURLCommand,
   CopyToClipboardCommand,

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -13,11 +13,14 @@ import * as vscode from "vscode";
 import { CopyNoteLinkCommand } from "../../commands/CopyNoteLink";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
-import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
+import {
+  describeMultiWS,
+  describeSingleWS,
+  toDendronEngineClient,
+} from "../testUtilsV3";
 import fs from "fs-extra";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import sinon from "sinon";
-import { DendronEngineClient } from "@dendronhq/engine-server";
 
 function openNote(note: NoteProps) {
   return ExtensionProvider.getExtension().wsUtils.openNote(note);
@@ -26,9 +29,9 @@ function openNote(note: NoteProps) {
 suite("CopyNoteLink", function () {
   let copyNoteLinkCommand: CopyNoteLinkCommand;
   beforeEach(() => {
-    const engine = ExtensionProvider.getEngine();
-    const engineClient = engine as unknown as DendronEngineClient;
-    copyNoteLinkCommand = new CopyNoteLinkCommand(engineClient);
+    copyNoteLinkCommand = new CopyNoteLinkCommand(
+      toDendronEngineClient(ExtensionProvider.getEngine())
+    );
   });
 
   describeSingleWS(

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -4,471 +4,420 @@ import {
   AssertUtils,
   NoteTestUtilsV4,
   NOTE_PRESETS_V4,
+  testAssertsInsideCallback,
 } from "@dendronhq/common-test-utils";
-import { ENGINE_HOOKS, TestConfigUtils } from "@dendronhq/engine-test-utils";
-import { describe } from "mocha";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { beforeEach, describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
 import { CopyNoteLinkCommand } from "../../commands/CopyNoteLink";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import {
-  expect,
-  LocationTestUtils,
-  runMultiVaultTest,
-  runSingleVaultTest,
-} from "../testUtilsv2";
-import { describeSingleWS, setupBeforeAfter } from "../testUtilsV3";
+import { expect, LocationTestUtils } from "../testUtilsv2";
+import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
 import fs from "fs-extra";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import sinon from "sinon";
+import { DendronEngineClient } from "@dendronhq/engine-server";
 
 function openNote(note: NoteProps) {
   return ExtensionProvider.getExtension().wsUtils.openNote(note);
 }
 
 suite("CopyNoteLink", function () {
-  const ctx = setupBeforeAfter(this, {});
-
-  describe("single", () => {
-    test("basic", (done) => {
-      runSingleVaultTest({
-        ctx,
-        onInit: async ({ wsRoot, vault }) => {
-          const notePath = path.join(vault2Path({ vault, wsRoot }), "foo.md");
-          await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual("[[Foo|foo]]");
-          done();
-        },
-        preSetupHook: ENGINE_HOOKS.setupBasic,
-      });
-    });
-
-    test("with a header that's a link", (done) => {
-      let noteWithLink: NoteProps;
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          noteWithLink = await NoteTestUtilsV4.createNote({
-            fname: "test",
-            vault: vaults[0],
-            wsRoot,
-            body: "## [[Foo Bar|foo.bar]]",
-          });
-        },
-        onInit: async () => {
-          // Open and select the header
-          const editor = await openNote(noteWithLink);
-          const start = LocationTestUtils.getPresetWikiLinkPosition();
-          const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
-          editor.selection = new vscode.Selection(start, end);
-          // generate a wikilink for it
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
-          done();
-        },
-      });
-    });
-
-    test("with a header link containing unicode characters", (done) => {
-      let noteWithLink: NoteProps;
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          noteWithLink = await NoteTestUtilsV4.createNote({
-            fname: "test",
-            vault: vaults[0],
-            wsRoot,
-            body: "## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum",
-          });
-        },
-        onInit: async () => {
-          // Open and select the header
-          const editor = await openNote(noteWithLink);
-          const start = LocationTestUtils.getPresetWikiLinkPosition();
-          const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
-          editor.selection = new vscode.Selection(start, end);
-          // generate a wikilink for it
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual(
-            `[[Lörem Foo：Bar🙂Baz Ipsum|test#lörem-foobarbaz-ipsum]]`
-          );
-          done();
-        },
-      });
-    });
-
-    test("with anchor", (done) => {
-      let noteWithTarget: NoteProps;
-
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          noteWithTarget = await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.create(
-            {
-              wsRoot,
-              vault: vaults[0],
-            }
-          );
-          await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.create({
-            wsRoot,
-            vault: vaults[0],
-          });
-        },
-        onInit: async () => {
-          const editor = await openNote(noteWithTarget);
-          const pos = LocationTestUtils.getPresetWikiLinkPosition();
-          const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
-            char: 12,
-          });
-          editor.selection = new vscode.Selection(pos, pos2);
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
-          );
-          const link2 = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link2).toEqual(`[[H2|${noteWithTarget.fname}#h2]]`);
-          done();
-        },
-      });
-    });
-
-    test("existing block anchor", (done) => {
-      let note: NoteProps;
-
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.create({
-            wsRoot,
-            vault: vaults[0],
-          });
-        },
-        onInit: async () => {
-          const editor = await openNote(note);
-          const cmd = new CopyNoteLinkCommand();
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
-          );
-          const link = (await cmd.execute({})).link;
-          const body = editor.document.getText();
-
-          // check that the link looks like what we expect
-          expect(link).toEqual("[[Anchor Target|anchor-target#^block-id]]");
-
-          // should not have inserted any more anchors into the note
-          AssertUtils.assertTimesInString({
-            body,
-            match: [[1, "^"]],
-          });
-
-          done();
-        },
-      });
-    });
-
-    test("doesn't confuse a footnote for a block anchor", (done) => {
-      let note: NoteProps;
-
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NoteTestUtilsV4.createNote({
-            fname: "test",
-            vault: vaults[0],
-            wsRoot,
-            body: "Sapiente accusantium omnis quia. [^est]\n\n[^est]: Quia iure tempore eum.",
-          });
-        },
-        onInit: async () => {
-          const editor = await openNote(note);
-          const cmd = new CopyNoteLinkCommand();
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition(),
-            LocationTestUtils.getPresetWikiLinkPosition({ char: 10 })
-          );
-          const link = (await cmd.execute({})).link;
-          const body = editor.document.getText();
-
-          // check that the link looks like what we expect
-          expect(link).toNotEqual("[[Test|test#^est]]");
-          const anchor = getAnchorFromLink(link);
-
-          // check that the anchor has been inserted into the note
-          AssertUtils.assertTimesInString({
-            body,
-            match: [[1, anchor]],
-          });
-
-          done();
-        },
-      });
-    });
-
-    test("generated block anchor", (done) => {
-      let note: NoteProps;
-
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.create({
-            wsRoot,
-            vault: vaults[0],
-          });
-        },
-        onInit: async () => {
-          const editor = await openNote(note);
-          const cmd = new CopyNoteLinkCommand();
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 12, char: 12 })
-          );
-          const link = (await cmd.execute({})).link;
-          const body = editor.document.getText();
-
-          // check that the link looks like what we expect
-          const anchor = getAnchorFromLink(link);
-
-          // check that the anchor has been inserted into the note
-          AssertUtils.assertTimesInString({
-            body,
-            match: [
-              [1, anchor],
-              [1, anchor],
-            ],
-          });
-
-          done();
-        },
-      });
-    });
-
-    test("tag note", (done) => {
-      let noteWithLink: NoteProps;
-      runSingleVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          noteWithLink = await NoteTestUtilsV4.createNote({
-            fname: "tags.foo.bar",
-            vault: vaults[0],
-            wsRoot,
-            body: "## [[Foo Bar|foo.bar]]",
-          });
-        },
-        onInit: async () => {
-          // Open and select the header
-          const editor = await openNote(noteWithLink);
-          const start = LocationTestUtils.getPresetWikiLinkPosition();
-          const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
-          editor.selection = new vscode.Selection(start, end);
-          // generate a wikilink for it
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual(`#foo.bar`);
-          done();
-        },
-      });
-    });
+  let copyNoteLinkCommand: CopyNoteLinkCommand;
+  beforeEach(() => {
+    const engine = ExtensionProvider.getEngine();
+    const engineClient = engine as unknown as DendronEngineClient;
+    copyNoteLinkCommand = new CopyNoteLinkCommand(engineClient);
   });
 
-  function getAnchorFromLink(link: string): string {
-    const anchors = link.match(/\^[a-z0-9A-Z-_]+/g);
-    expect(anchors).toBeTruthy();
-    expect(anchors!.length).toEqual(1);
-    expect(anchors![0].length > 0).toBeTruthy();
-    return anchors![0];
-  }
-
-  describe("multi", () => {
-    test("basic", (done) => {
-      runMultiVaultTest({
-        ctx,
-        onInit: async ({ wsRoot, vaults }) => {
-          TestConfigUtils.withConfig(
-            (config) => {
-              ConfigUtils.setWorkspaceProp(
-                config,
-                "enableXVaultWikiLink",
-                true
-              );
-              return config;
-            },
-            { wsRoot }
-          );
-          const notePath = path.join(
-            vault2Path({ vault: vaults[0], wsRoot }),
-            "foo.md"
-          );
-          await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual("[[Foo|dendron://main/foo]]");
-          done();
-        },
-        preSetupHook: ENGINE_HOOKS.setupBasic,
+  describeSingleWS(
+    "GIVEN a basic setup on a single vault workspace",
+    {
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    () => {
+      test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const notePath = path.join(
+          vault2Path({ vault: vaults[0], wsRoot }),
+          "foo.md"
+        );
+        await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual("[[Foo|foo]]");
       });
-    });
 
-    test("with anchor", (done) => {
-      let noteWithTarget: NoteProps;
-      let noteWithAnchor: NoteProps;
+      test("WHEN the editor is on a dirty file, THEN CopyNoteLink should return undefined and cause an onDidSaveTextDocument to be fired", (done) => {
+        const engine = ExtensionProvider.getEngine();
+        const testNote = engine.notes["foo"];
+        // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
+        const disposable = vscode.workspace.onDidSaveTextDocument(
+          (textDocument) => {
+            testAssertsInsideCallback(() => {
+              expect(
+                textDocument.getText().includes("id: barbar")
+              ).toBeTruthy();
+              disposable.dispose();
+            }, done);
+          }
+        );
 
-      runMultiVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          noteWithTarget = await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.create(
-            {
-              wsRoot,
-              vault: vaults[0],
-            }
-          );
-          noteWithAnchor = await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.create({
+        ExtensionProvider.getWSUtils()
+          .openNote(testNote)
+          .then(async (editor) => {
+            editor
+              .edit(async (editBuilder) => {
+                // Replace id of frontmatter
+                const startPos = new vscode.Position(1, 4);
+                const endPos = new vscode.Position(1, 7);
+
+                editBuilder.replace(
+                  new vscode.Range(startPos, endPos),
+                  "barbar"
+                );
+              })
+              .then(async () => {
+                copyNoteLinkCommand.run();
+              });
+          });
+      });
+
+      test("WHEN the editor is selecting a header, THEN CopyNoteLink should return a link with that header", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const noteWithLink = await NoteTestUtilsV4.createNoteWithEngine({
+          fname: "testHeader",
+          vault: vaults[0],
+          wsRoot,
+          body: "## [[Foo Bar|foo.bar]]",
+          engine,
+        });
+        // Open and select the header
+        const editor = await openNote(noteWithLink);
+        const start = LocationTestUtils.getPresetWikiLinkPosition();
+        const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
+        editor.selection = new vscode.Selection(start, end);
+        // generate a wikilink for it
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
+      });
+
+      test("WHEN the editor is selecting a header with unicode characters, THEN CopyNoteLink should return a link with that header", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const noteWithLink = await NoteTestUtilsV4.createNoteWithEngine({
+          fname: "testUnicode",
+          vault: vaults[0],
+          wsRoot,
+          body: "## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum",
+          engine,
+        });
+        // Open and select the header
+        const editor = await openNote(noteWithLink);
+        const start = LocationTestUtils.getPresetWikiLinkPosition();
+        const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
+        editor.selection = new vscode.Selection(start, end);
+        // generate a wikilink for it
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual(
+          `[[Lörem Foo：Bar🙂Baz Ipsum|testUnicode#lörem-foobarbaz-ipsum]]`
+        );
+      });
+
+      test("WHEN the editor is selecting an anchor, THEN CopyNoteLink should return a link with that anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const noteWithTarget =
+          await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.createWithEngine({
+            wsRoot,
+            vault: vaults[0],
+            engine,
+          });
+        await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.createWithEngine({
+          wsRoot,
+          vault: vaults[0],
+          engine,
+        });
+
+        const editor = await openNote(noteWithTarget);
+        const pos = LocationTestUtils.getPresetWikiLinkPosition();
+        const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
+          char: 12,
+        });
+        editor.selection = new vscode.Selection(pos, pos2);
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
+        );
+        const link2 = (await copyNoteLinkCommand.run())?.link;
+        expect(link2).toEqual(`[[H2|${noteWithTarget.fname}#h2]]`);
+      });
+
+      test("WHEN the editor is selecting a block anchor, THEN CopyNoteLink should return a link with that block anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const note =
+          await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.createWithEngine({
+            wsRoot,
+            vault: vaults[0],
+            engine,
+          });
+
+        const editor = await openNote(note);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
+        );
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const body = editor.document.getText();
+
+        // check that the link looks like what we expect
+        expect(link).toEqual("[[Anchor Target|anchor-target#^block-id]]");
+
+        // should not have inserted any more anchors into the note
+        AssertUtils.assertTimesInString({
+          body,
+          match: [[1, "^"]],
+        });
+      });
+
+      test("WHEN the editor is selecting a footnote, THEN CopyNoteLink should not confuse it for a block anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const note = await NoteTestUtilsV4.createNoteWithEngine({
+          fname: "testFootnote",
+          vault: vaults[0],
+          wsRoot,
+          body: "Sapiente accusantium omnis quia. [^est]\n\n[^est]: Quia iure tempore eum.",
+          engine,
+        });
+
+        const editor = await openNote(note);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition(),
+          LocationTestUtils.getPresetWikiLinkPosition({ char: 10 })
+        );
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const body = editor.document.getText();
+
+        // check that the link looks like what we expect
+        expect(link).toNotEqual("[[testFootnote|testFootnote#^est]]");
+        const anchor = getAnchorFromLink(link!);
+
+        // check that the anchor has been inserted into the note
+        await AssertUtils.assertTimesInString({
+          body,
+          match: [[1, anchor]],
+        });
+      });
+
+      test("WHEN the note has a block anchor target, THEN CopyNoteLink should generate block anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const note =
+          await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.createWithEngine({
+            wsRoot,
+            vault: vaults[0],
+            engine,
+            fname: "generateBlockAnchorSingle",
+          });
+
+        const editor = await openNote(note);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 12, char: 12 })
+        );
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const body = editor.document.getText();
+
+        // check that the link looks like what we expect
+        const anchor = getAnchorFromLink(link!);
+
+        // check that the anchor has been inserted into the note
+        await AssertUtils.assertTimesInString({
+          body,
+          match: [[1, anchor]],
+        });
+      });
+
+      test("WHEN the editor is selecting a header of a tag note, THEN CopyNoteLink should return a link with that header", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const noteWithLink = await NoteTestUtilsV4.createNoteWithEngine({
+          fname: "tags.foo.bar",
+          vault: vaults[0],
+          wsRoot,
+          body: "## [[Foo Bar|foo.bar]]",
+          engine,
+        });
+
+        const editor = await openNote(noteWithLink);
+        const start = LocationTestUtils.getPresetWikiLinkPosition();
+        const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
+        editor.selection = new vscode.Selection(start, end);
+        // generate a wikilink for it
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual(`#foo.bar`);
+      });
+    }
+  );
+
+  describeMultiWS(
+    "GIVEN a basic setup on a multivault workspace with enableXVaultWikiLink enabled",
+    {
+      modConfigCb: (config) => {
+        ConfigUtils.setWorkspaceProp(config, "enableXVaultWikiLink", true);
+        return config;
+      },
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    () => {
+      test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const notePath = path.join(
+          vault2Path({ vault: vaults[0], wsRoot }),
+          "foo.md"
+        );
+        await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual("[[Foo|dendron://vault1/foo]]");
+      });
+
+      test("WHEN the editor is on a dirty file, THEN CopyNoteLink should return undefined and cause an onDidSaveTextDocument to be fired", (done) => {
+        const engine = ExtensionProvider.getEngine();
+        const testNote = engine.notes["foo"];
+        // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
+        const disposable = vscode.workspace.onDidSaveTextDocument(
+          (textDocument) => {
+            testAssertsInsideCallback(() => {
+              expect(
+                textDocument.getText().includes("id: barbar")
+              ).toBeTruthy();
+              disposable.dispose();
+            }, done);
+          }
+        );
+
+        ExtensionProvider.getWSUtils()
+          .openNote(testNote)
+          .then(async (editor) => {
+            editor
+              .edit(async (editBuilder) => {
+                // Replace id of frontmatter
+                const startPos = new vscode.Position(1, 4);
+                const endPos = new vscode.Position(1, 7);
+
+                editBuilder.replace(
+                  new vscode.Range(startPos, endPos),
+                  "barbar"
+                );
+              })
+              .then(async () => {
+                copyNoteLinkCommand.run();
+              });
+          });
+      });
+
+      test("WHEN the editor is selecting an anchor, THEN CopyNoteLink should return a link with that anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const noteWithTarget =
+          await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.createWithEngine({
+            wsRoot,
+            vault: vaults[0],
+            engine,
+          });
+        const noteWithAnchor =
+          await NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_LINK.createWithEngine({
             wsRoot,
             vault: vaults[1],
+            engine,
           });
-        },
-        onInit: async ({ wsRoot }) => {
-          TestConfigUtils.withConfig(
-            (config) => {
-              ConfigUtils.setWorkspaceProp(
-                config,
-                "enableXVaultWikiLink",
-                true
-              );
-              return config;
-            },
-            { wsRoot }
-          );
 
-          const editor = await openNote(noteWithTarget);
-          const pos = LocationTestUtils.getPresetWikiLinkPosition();
-          const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
-            char: 12,
-          });
-          editor.selection = new vscode.Selection(pos, pos2);
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link).toEqual(
-            `[[H1|dendron://main/${noteWithTarget.fname}#h1]]`
-          );
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
-          );
-          const link2 = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link2).toEqual(
-            `[[H2|dendron://main/${noteWithTarget.fname}#h2]]`
-          );
+        const editor = await openNote(noteWithTarget);
+        const pos = LocationTestUtils.getPresetWikiLinkPosition();
+        const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
+          char: 12,
+        });
+        editor.selection = new vscode.Selection(pos, pos2);
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(link).toEqual(
+          `[[H1|dendron://vault1/${noteWithTarget.fname}#h1]]`
+        );
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
+        );
+        const link2 = (await copyNoteLinkCommand.run())?.link;
+        expect(link2).toEqual(
+          `[[H2|dendron://vault1/${noteWithTarget.fname}#h2]]`
+        );
 
-          await openNote(noteWithAnchor);
-          const link3 = (await new CopyNoteLinkCommand().run())?.link;
-          expect(link3).toEqual(
-            `[[Beta|dendron://other/${noteWithAnchor.fname}]]`
-          );
-          done();
-        },
+        await openNote(noteWithAnchor);
+        const link3 = (await copyNoteLinkCommand.run())?.link;
+        expect(link3).toEqual(
+          `[[Beta|dendron://vault2/${noteWithAnchor.fname}]]`
+        );
       });
-    });
 
-    test("existing block anchor", (done) => {
-      let note: NoteProps;
-
-      runMultiVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.create({
+      test("WHEN the editor is selecting a block anchor, THEN CopyNoteLink should return a link with that block anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const note =
+          await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.createWithEngine({
             wsRoot,
             vault: vaults[0],
-          });
-        },
-        onInit: async ({ wsRoot }) => {
-          TestConfigUtils.withConfig(
-            (config) => {
-              ConfigUtils.setWorkspaceProp(
-                config,
-                "enableXVaultWikiLink",
-                true
-              );
-              return config;
-            },
-            { wsRoot }
-          );
-          const editor = await openNote(note);
-          const cmd = new CopyNoteLinkCommand();
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
-          );
-          const link = (await cmd.execute({})).link;
-          const body = editor.document.getText();
-
-          // check that the link looks like what we expect
-          expect(link).toEqual(
-            "[[Anchor Target|dendron://main/anchor-target#^block-id]]"
-          );
-
-          // should not have inserted any more anchors into the note
-          AssertUtils.assertTimesInString({
-            body,
-            match: [[1, "^"]],
+            engine,
           });
 
-          done();
-        },
+        const editor = await openNote(note);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
+        );
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const body = editor.document.getText();
+
+        // check that the link looks like what we expect
+        expect(link).toEqual(
+          "[[Anchor Target|dendron://vault1/anchor-target#^block-id]]"
+        );
+
+        // should not have inserted any more anchors into the note
+        AssertUtils.assertTimesInString({
+          body,
+          match: [[1, "^"]],
+        });
       });
-    });
 
-    test("generated block anchor", (done) => {
-      let note: NoteProps;
-
-      runMultiVaultTest({
-        ctx,
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          note = await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.create({
+      test("WHEN the note has a block anchor target, THEN CopyNoteLink should generate block anchor", async () => {
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const note =
+          await NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.createWithEngine({
             wsRoot,
             vault: vaults[0],
-          });
-        },
-        onInit: async ({ wsRoot }) => {
-          TestConfigUtils.withConfig(
-            (config) => {
-              ConfigUtils.setWorkspaceProp(
-                config,
-                "enableXVaultWikiLink",
-                true
-              );
-              return config;
-            },
-            { wsRoot }
-          );
-          const editor = await openNote(note);
-          const cmd = new CopyNoteLinkCommand();
-          editor.selection = new vscode.Selection(
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
-            LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 12 })
-          );
-          const link = (await cmd.execute({})).link;
-          const body = editor.document.getText();
-
-          // check that the link looks like what we expect
-          const anchor = getAnchorFromLink(link);
-          expect(
-            link.startsWith("[[Anchor Target|dendron://main/anchor-target#^")
-          ).toBeTruthy();
-
-          // check that the anchor has been inserted into the note
-          AssertUtils.assertTimesInString({
-            body,
-            match: [[1, anchor]],
+            engine,
+            fname: "generateBlockAnchorMulti",
           });
 
-          done();
-        },
+        const editor = await openNote(note);
+        editor.selection = new vscode.Selection(
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
+          LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 12 })
+        );
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const body = editor.document.getText();
+
+        // check that the link looks like what we expect
+        const anchor = getAnchorFromLink(link!);
+        expect(
+          link!.startsWith(`[[${note.fname}|dendron://vault1/${note.fname}#^`)
+        ).toBeTruthy();
+
+        // check that the anchor has been inserted into the note
+        AssertUtils.assertTimesInString({
+          body,
+          match: [[1, anchor]],
+        });
       });
-    });
-  });
+    }
+  );
 
-  describeSingleWS("WHEN in a non-note file", { ctx }, () => {
+  describeSingleWS("WHEN in a non-note file", {}, () => {
     test("THEN creates a link to that file", async () => {
       const { wsRoot } = ExtensionProvider.getDWorkspace();
       const fsPath = path.join(wsRoot, "test.js");
@@ -477,7 +426,7 @@ suite("CopyNoteLink", function () {
         "const x = 'Pariatur officiis voluptatem molestiae.'"
       );
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-      const link = (await new CopyNoteLinkCommand().run())?.link;
+      const link = (await copyNoteLinkCommand.run())?.link;
       expect(link).toEqual("[[test.js]]");
     });
 
@@ -487,7 +436,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(wsRoot, ".config.yaml");
         await fs.writeFile(fsPath, "x: 1");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await new CopyNoteLinkCommand().run())?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual("[[.config.yaml]]");
       });
     });
@@ -507,7 +456,7 @@ suite("CopyNoteLink", function () {
           "x = 'Pariatur officiis voluptatem molestiae.'"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await new CopyNoteLinkCommand().run())?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join("[[assets", "test.py]]"));
       });
     });
@@ -519,7 +468,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(path.join(wsRoot, vaultPath), "test.rs");
         await fs.writeFile(fsPath, "let x = 123;");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await new CopyNoteLinkCommand().run())?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join(`[[${vaultPath}`, "test.rs]]"));
       });
     });
@@ -532,7 +481,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(dirPath, "test.clj");
         await fs.writeFile(fsPath, "(set! x 1)");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await new CopyNoteLinkCommand().run())?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join("[[src", "clj", "test.clj]]"));
       });
     });
@@ -542,7 +491,6 @@ suite("CopyNoteLink", function () {
     describeSingleWS(
       "AND there's an existing block anchor",
       {
-        ctx,
         modConfigCb: (config) => {
           ConfigUtils.setNonNoteLinkAnchorType(config, "block");
           return config;
@@ -551,7 +499,7 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a block anchor", async () => {
           await prepFileAndSelection(" ^my-block-anchor");
-          const link = (await new CopyNoteLinkCommand().run())?.link;
+          const link = (await copyNoteLinkCommand.run())?.link;
           expect(
             await linkHasAnchor(
               "block",
@@ -567,7 +515,6 @@ suite("CopyNoteLink", function () {
     describeSingleWS(
       "AND config is set to line anchor",
       {
-        ctx,
         modConfigCb: (config) => {
           ConfigUtils.setNonNoteLinkAnchorType(config, "line");
           return config;
@@ -576,7 +523,7 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a line anchor", async () => {
           await prepFileAndSelection();
-          const link = (await new CopyNoteLinkCommand().run())?.link;
+          const link = (await copyNoteLinkCommand.run())?.link;
           // Link should contain an anchor
           expect(
             await linkHasAnchor("line", ["src", "test.hs"], link)
@@ -588,7 +535,6 @@ suite("CopyNoteLink", function () {
     describeSingleWS(
       "AND config is set to block anchor",
       {
-        ctx,
         modConfigCb: (config) => {
           ConfigUtils.setNonNoteLinkAnchorType(config, "block");
           return config;
@@ -597,7 +543,7 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a block anchor", async () => {
           await prepFileAndSelection();
-          const link = (await new CopyNoteLinkCommand().run())?.link;
+          const link = (await copyNoteLinkCommand.run())?.link;
           expect(
             await linkHasAnchor("block", ["src", "test.hs"], link)
           ).toBeTruthy();
@@ -605,27 +551,20 @@ suite("CopyNoteLink", function () {
       }
     );
 
-    describeSingleWS(
-      "AND config is set unset",
-      {
-        ctx,
-      },
-      () => {
-        test("THEN creates a link to that file with a block anchor", async () => {
-          await prepFileAndSelection();
-          const link = (await new CopyNoteLinkCommand().run())?.link;
-          expect(
-            await linkHasAnchor("block", ["src", "test.hs"], link)
-          ).toBeTruthy();
-        });
-      }
-    );
+    describeSingleWS("AND config is set unset", {}, () => {
+      test("THEN creates a link to that file with a block anchor", async () => {
+        await prepFileAndSelection();
+        const link = (await copyNoteLinkCommand.run())?.link;
+        expect(
+          await linkHasAnchor("block", ["src", "test.hs"], link)
+        ).toBeTruthy();
+      });
+    });
 
     describe("AND config is set to prompt", () => {
       describeSingleWS(
         "AND user picks line in the prompt",
         {
-          ctx,
           modConfigCb: (config) => {
             ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
             return config;
@@ -637,7 +576,7 @@ suite("CopyNoteLink", function () {
             const pick = sinon
               .stub(vscode.window, "showQuickPick")
               .resolves({ label: "line" });
-            const link = (await new CopyNoteLinkCommand().run())?.link;
+            const link = (await copyNoteLinkCommand.run())?.link;
             expect(pick.calledOnce).toBeTruthy();
             expect(
               await linkHasAnchor("line", ["src", "test.hs"], link)
@@ -649,7 +588,6 @@ suite("CopyNoteLink", function () {
       describeSingleWS(
         "AND user picks block in the prompt",
         {
-          ctx,
           modConfigCb: (config) => {
             ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
             return config;
@@ -661,7 +599,7 @@ suite("CopyNoteLink", function () {
             const pick = sinon
               .stub(vscode.window, "showQuickPick")
               .resolves({ label: "block" });
-            const link = (await new CopyNoteLinkCommand().run())?.link;
+            const link = (await copyNoteLinkCommand.run())?.link;
             expect(pick.calledOnce).toBeTruthy();
             expect(
               await linkHasAnchor("block", ["src", "test.hs"], link)
@@ -673,7 +611,6 @@ suite("CopyNoteLink", function () {
       describeSingleWS(
         "AND user cancels the prompt",
         {
-          ctx,
           modConfigCb: (config) => {
             ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
             return config;
@@ -685,7 +622,7 @@ suite("CopyNoteLink", function () {
             const pick = sinon
               .stub(vscode.window, "showQuickPick")
               .resolves(undefined);
-            const link = (await new CopyNoteLinkCommand().run())?.link;
+            const link = (await copyNoteLinkCommand.run())?.link;
             expect(pick.calledOnce).toBeTruthy();
             expect(
               await linkHasAnchor("line", ["src", "test.hs"], link)
@@ -696,6 +633,14 @@ suite("CopyNoteLink", function () {
     });
   });
 });
+
+function getAnchorFromLink(link: string): string {
+  const anchors = link.match(/\^[a-z0-9A-Z-_]+/g);
+  expect(anchors).toBeTruthy();
+  expect(anchors!.length).toEqual(1);
+  expect(anchors![0].length > 0).toBeTruthy();
+  return anchors![0];
+}
 
 async function prepFileAndSelection(appendText?: string) {
   const { wsRoot } = ExtensionProvider.getDWorkspace();

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -72,6 +72,7 @@ import {
   stubWorkspaceFile,
   stubWorkspaceFolders,
 } from "./testUtilsv2";
+import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
 
 const TIMEOUT = 60 * 1000 * 5;
 
@@ -654,7 +655,10 @@ export function cleanupWorkspaceStubs(ctx: ExtensionContext): void {
 export function subscribeToEngineStateChange(
   callback: (noteChangeEntries: NoteChangeEntry[]) => void
 ): Disposable {
-  const engine = ExtensionProvider.getEngine();
-  const engineClient = engine as unknown as DendronEngineClient;
+  const engineClient = toDendronEngineClient(ExtensionProvider.getEngine());
   return engineClient.onEngineNoteStateChanged(callback);
+}
+
+export function toDendronEngineClient(engine: IEngineAPIService) {
+  return engine as unknown as DendronEngineClient;
 }


### PR DESCRIPTION
**Bug**
If user updates note title without saving and runs CopyNoteLink command, it grabs the previous note title. This is because the engine note has not been updated

**Changes**
1. Save document if dirty before executing rest of command
2. Subscribe to engine on`onEngineNoteStateChanged` to make sure execution happens after engine is updated
3. Dispose after command is executed
4. Refactored `CopyNoteLink.test.ts` to use latest test suites
5. Expanded test util to allow creation of preset notes after engine is running in test harness

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)