### PR TITLE
enhance(refactor): improve title and "create new" description for the move note command

### DIFF
--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -310,6 +310,16 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     );
     panel.webview.html = md.render(contentLines.join("\n"));
   }
+
+  addAnalyticsPayload(_opts?: CommandOpts, out?: CommandOutput) {
+    return {
+      movedNotesCount:
+        // `out.changed` also includes the notes that had to be renamed in the
+        // process, but the created notes are the ones we moved
+        out?.changed?.filter((change) => change?.status === "create").length ||
+        0,
+    };
+  }
 }
 
 async function closeCurrentFileOpenMovedFile(

--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -105,6 +105,7 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     const provider = extension.noteLookupProviderFactory.create("move", {
       allowNewNote: true,
       forceAsIsPickerValueUsage: true,
+      newNoteDetail: "Move current note and rename it",
     });
     provider.registerOnAcceptHook(ProviderAcceptHooks.oldNewLocationHook);
     const initialValue = path.basename(
@@ -136,7 +137,7 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
         },
       });
       lc.show({
-        title: "Move note",
+        title: "Move note - select the note to move",
         placeholder: "foo",
         provider,
         initialValue: opts?.initialValue || initialValue,

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3.ts
@@ -425,7 +425,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       if (shouldAddCreateNew) {
         const entryCreateNew = NotePickerUtils.createNoActiveItem({
           fname: queryOrig,
-          detail: CREATE_NEW_NOTE_DETAIL,
+          detail: this.opts.newNoteDetail ?? CREATE_NEW_NOTE_DETAIL,
         });
 
         const bubbleUpCreateNew = ConfigUtils.getLookup(ws.config).note

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -53,6 +53,9 @@ export type ILookupProviderOptsV3 = {
    * when (and only when) nothing is queried.
    */
   extraItems?: DNodePropsQuickInputV2[];
+  /** If given, override the default "Note does not exists, create?" detail for
+   * the create new note option. */
+  newNoteDetail?: string;
 };
 
 export type NoteLookupProviderSuccessResp<T = never> = {


### PR DESCRIPTION
In the "Move Note" command, changes the title and the description for the "Create New" item to be more descriptive.

![image](https://user-images.githubusercontent.com/1008124/160064956-8dd6c9ea-b577-426d-8413-2c47360cf779.png)

The "Create New" label is hard to change because our code uses it to recognize that the create new option is selected, so I opted to leave that as it is.

Not exactly what #2603 asked for, but I think it's a step in the right direction.

Also added analytics to check for how many items have been actually moved.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - we can track usage analytics for move note to see if there's any uptick after this is released
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)