### PR TITLE
chore: mark treeview v2 and related code as deprecated

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -10,6 +10,7 @@ export enum VSCodeEvents {
   SchemaLookup_Update = "SchemaLookup_Update",
   NoteLookup_Accept = "NoteLookup_Accept",
   SchemaLookup_Accept = "SchemaLookup_Accept",
+  /** @deprecated: treeview v2 is deprecated. */
   TreeView_Ready = "TreeView_Ready",
   Upgrade = "Upgrade",
   DisableTelemetry = "DisableTelemetry",

--- a/packages/common-all/src/constants/configs/dev.ts
+++ b/packages/common-all/src/constants/configs/dev.ts
@@ -14,6 +14,7 @@ export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
     label: "Engine Server Port",
     desc: "What port to use for the engine server. Defaults to creating on startup.",
   },
+  /** @deprecated */
   enableWebUI: {
     label: "Enable web UI",
     desc: "Enable experimental web ui. Defaults to false.",

--- a/packages/common-all/src/constants/views.ts
+++ b/packages/common-all/src/constants/views.ts
@@ -25,6 +25,7 @@ export enum DendronEditorViewKey {
 export enum DendronTreeViewKey {
   SAMPLE_VIEW = "dendron.sample",
   TREE_VIEW = "dendron.treeView",
+  /** @deprecated: We will be deprecating treeview v2 and going back to v1 **/
   TREE_VIEW_V2 = "dendron.tree-view",
   BACKLINKS = "dendron.backlinks",
   CALENDAR_VIEW = "dendron.calendar-view",

--- a/packages/common-all/src/types/configs/dev/dev.ts
+++ b/packages/common-all/src/types/configs/dev/dev.ts
@@ -20,6 +20,7 @@ export type DendronDevConfig = {
   engineServerPort?: number;
   /**
    * Enable experimental web ui. Default is false
+   * @deprecated
    */
   enableWebUI?: boolean;
   /**

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -751,6 +751,7 @@ export enum DMessageEnum {
   MESSAGE_DISPATCHER_READY = "messageDispatcherReady",
 }
 
+/** @deprecated: Tree view v2 is deprecated */
 export enum TreeViewMessageEnum {
   "onSelect" = "onSelect",
   "onExpand" = "onExpand",
@@ -814,6 +815,8 @@ export type OnDidChangeActiveTextEditorData = {
 };
 
 export type NoteViewMessageType = DMessageEnum | NoteViewMessageEnum;
+
+/** @deprecated: Tree view v2 is deprecated */
 export type TreeViewMessageType = DMessageEnum | TreeViewMessageEnum;
 
 export type VSCodeMessage = DMessage;
@@ -836,6 +839,8 @@ export type NoteViewMessage = DMessage<
   NoteViewMessageType,
   { id?: string; href?: string }
 >;
+
+/** @deprecated: Tree view v2 is deprecated */
 export type TreeViewMessage = DMessage<TreeViewMessageType, { id: string }>;
 
 export type SeedBrowserMessage = DMessage<

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -400,6 +400,7 @@ export type DendronDevConfig = {
   engineServerPort?: number;
   /**
    * Enable experimental web ui. Default is false
+   * @deprecated
    */
   enableWebUI?: boolean;
   /**

--- a/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronTreeExplorerPanel.tsx
@@ -19,6 +19,8 @@ import { DendronComponent } from "../types";
 import { postVSCodeMessage } from "../utils/vscode";
 type OnExpandFunc = TreeProps["onExpand"];
 type OnSelectFunc = TreeProps["onSelect"];
+
+/** @deprecated: Tree view v2 is deprecated */
 const DendronTreeExplorerPanel: DendronComponent = (props) => {
   const logger = createLogger("DendronTreeExplorerPanel");
   const engine = props.engine;

--- a/packages/plugin-core/src/views/DendronTreeViewV2.ts
+++ b/packages/plugin-core/src/views/DendronTreeViewV2.ts
@@ -32,6 +32,8 @@ import { WebViewUtils } from "./utils";
  * Class managing the webview version of the Dendron tree view (currently called
  * TreeViewV2) - this is the side panel UI that gives the webview/react/antd
  * based tree view of the Dendron note hierarchy
+ *
+ * @deprecated We are going back to using VSCode native tree views.
  */
 export class DendronTreeViewV2 implements WebviewViewProvider, Disposable {
   public static readonly viewType = DendronTreeViewKey.TREE_VIEW_V2;


### PR DESCRIPTION
# chore: mark treeview v2 and related code as deprecated
This PR:
- Marks code related to treeview v2 as deprecated.
- Treeview V2 will be removed once we give a one week deprecation notice.
## Code

### Basics

- [~] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [~] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [~] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [~] check whether code be simplified
  - [~] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [~] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)