### PR TITLE
fix(markdown): support parenthesis in the image URL

### DIFF
--- a/packages/engine-server/src/markdown/remark/extendedImage.ts
+++ b/packages/engine-server/src/markdown/remark/extendedImage.ts
@@ -9,9 +9,9 @@ import YAML from "js-yaml";
 import { MDUtilsV5 } from "../utilsv5";
 
 export const EXTENDED_IMAGE_REGEX =
-  /^!\[(?<alt>[^[\]]*)\]\((?<url>[^()]+)\)(?<props>{[^{}]+})/;
+  /^!\[(?<alt>[^[\]]*)\]\((?<url>.*)\)(?<props>{[^{}]*})/;
 export const EXTENDED_IMAGE_REGEX_LOOSE =
-  /!\[(?<alt>[^[\]]*)\]\((?<url>[^()]+)\)(?<props>{[^{}]+})/;
+  /!\[(?<alt>[^[\]]*)\]\((?<url>.*)\)(?<props>{[^{}]*})/;
 
 export const matchExtendedImage = (
   text: string,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/extendedImage.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/extendedImage.spec.ts
@@ -42,6 +42,41 @@ function getExtendedImage(node: UnistNode): ExtendedImage {
 
 describe("extendedImage", () => {
   describe("parse", () => {
+    test("with alt", () => {
+      const resp = proc().parse(
+        `![this is the (alt) text](/assets/image.png){width: 50%}`
+      );
+      expect(getExtendedImage(resp).type).toEqual(
+        DendronASTTypes.EXTENDED_IMAGE
+      );
+      expect(getExtendedImage(resp).alt).toEqual("this is the (alt) text");
+      expect(getExtendedImage(resp).url).toEqual("/assets/image.png");
+      expect(getExtendedImage(resp).props?.width).toEqual("50%");
+    });
+
+    test("with parenthesis in url", () => {
+      const resp = proc().parse(
+        `![this is the (alt) text](/assets/image_(file).png){width: 50%}`
+      );
+      expect(getExtendedImage(resp).type).toEqual(
+        DendronASTTypes.EXTENDED_IMAGE
+      );
+      expect(getExtendedImage(resp).alt).toEqual("this is the (alt) text");
+      expect(getExtendedImage(resp).url).toEqual("/assets/image_(file).png");
+      expect(getExtendedImage(resp).props?.width).toEqual("50%");
+    });
+
+    test("with empty props", () => {
+      const resp = proc().parse(
+        `![this is the (alt) text](/assets/image.png){}`
+      );
+      expect(getExtendedImage(resp).type).toEqual(
+        DendronASTTypes.EXTENDED_IMAGE
+      );
+      expect(getExtendedImage(resp).alt).toEqual("this is the (alt) text");
+      expect(getExtendedImage(resp).url).toEqual("/assets/image.png");
+    });
+
     test("without alt", () => {
       const resp = proc().parse(`![](/assets/image.png){width: 50%}`);
       expect(getExtendedImage(resp).type).toEqual(

--- a/test-workspace/vault/dendron.ref.extended-images.md
+++ b/test-workspace/vault/dendron.ref.extended-images.md
@@ -23,3 +23,7 @@ This note contains some examples of extended image links. The next image will ha
 ![logo alt text](/assets/images/logo.png){max-height: 60px, width: 50%, opacity: 0.8, float: right, margin: 20px, border: "1px solid black"}
 
 The image should be floating on the right, allowing text to wrap around it. It will be slightly translucent, and will have a black border around it.
+
+extended image with parenthesis in URL:
+
+![flower](https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Pescatorea_(Plate_XXIII)_BHL36081367.jpg/411px-Pescatorea_(Plate_XXIII)_BHL36081367.jpg)


### PR DESCRIPTION
Adds support for `()` within extended image URLs, which is supported in regular image URLs.

#2564 

