### PR TITLE
Chore: pre push hook for circular dependencies

### DIFF
--- a/hooks/pre-push.js
+++ b/hooks/pre-push.js
@@ -9,19 +9,26 @@ const path = require("path");
  * circular dependencies detected
  */
 function checkCircularDependencies() {
+  const CIRCULAR_DEP_THRESHOLD = 2; // Lower this each time we fix a circular dependency
   const rootPath = exec("git rev-parse --show-toplevel").stdout;
   const filePath = path.resolve(rootPath, "packages/plugin-core");
   madge(filePath, {
     fileExtensions: ["ts"],
   }).then((res) => {
-    if (res.circular().length === 0) {
+    const circDepCount = res.circular().length;
+    if (circDepCount === 0) {
       console.log("No circular dependencies detected");
-    } else {
-      console.warn(
-        `WARNING: ${
-          res.circular().length
-        } circular dependencies detected in plugin-core. Please ensure you are not introducing new circular dependencies by running the following on the commit prior to your change: \nnpm -g install madge && cd $DENDRON_REPO_ROOT/packages/plugin-core && madge --circular --extensions ts .\n\nFor more details, see https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e/#avoiding-circular-dependencies`
+    } else if (circDepCount <= CIRCULAR_DEP_THRESHOLD) {
+      console.log(
+        `Circular dependency count of ${circDepCount} is lower than or equal threshold of ${CIRCULAR_DEP_THRESHOLD}`
       );
+    } else {
+      console.error(
+        `ERROR: ${
+          res.circular().length
+        } circular dependencies detected in plugin-core, which exceeds the threshold of ${CIRCULAR_DEP_THRESHOLD}. Please ensure you are not introducing new circular dependencies by running the following on the commit prior to your change: \nnpm -g install madge && cd $DENDRON_REPO_ROOT/packages/plugin-core && madge --circular --extensions ts .\n\nFor more details, see https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e/#avoiding-circular-dependencies`
+      );
+      process.exit(1);
     }
   });
 }


### PR DESCRIPTION
## Chore: pre push hook for circular dependencies

Adds a pre push hook to check that the circular dependency count in plugin-core is <= 2; push will fail otherwise.  This will absolve our need to run the madge checks manually.

Update made to dendron-docs: https://github.com/dendronhq/dendron-docs/commit/51d5f6679bee2edc0a442d64191380edf8cbda2a

---

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.