### PR TITLE
chore: add analytics for how many notes have been moved

### DIFF
--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -309,6 +309,16 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     );
     panel.webview.html = md.render(contentLines.join("\n"));
   }
+
+  addAnalyticsPayload(_opts?: CommandOpts, out?: CommandOutput) {
+    return {
+      movedNotesCount:
+        // `out.changed` also includes the notes that had to be renamed in the
+        // process, but the created notes are the ones we moved
+        out?.changed?.filter((change) => change?.status === "create").length ||
+        0,
+    };
+  }
 }
 
 async function closeCurrentFileOpenMovedFile(


### PR DESCRIPTION
Adds analytics on how many notes have been moved with a "Move Note" command. If the user cancels the prompt, that is also tracked as 0 notes being moved.