### PR TITLE
chore: update survey and various user properties for better analytics

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -70,6 +70,7 @@ export enum SurveyEvents {
   InitialSurveyPrompted = "Initial_Survey_Prompted",
   InitialSurveyAccepted = "Initial_Survey_Accepted",
   InitialSurveyRejected = "Initial_Survey_Rejected",
+  ContextSurveyConfirm = "contextSurveyConfirm",
   BackgroundAnswered = "Background_Answered",
   BackgroundRejected = "Background_Rejected",
   UseCaseAnswered = "Use_Case_Answered",

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -537,6 +537,7 @@ type UserProfileProps = {
    */
   numNotes?: number;
   useCases?: string[];
+  useContext?: string;
   publishingUseCase: string;
   priorTools?: string[];
   email?: string;

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -23,6 +23,7 @@ enum SiteEvents {
   UPDATE_STOP = "siteUpdateStop",
   VISIT_SITE = "siteVisit",
 }
+
 enum SubscriptionEvents {
   CREATED = "subscriptionCreated",
 }
@@ -525,21 +526,37 @@ export class SegmentClient {
   }
 }
 
-// user props
+/**
+ * User Profile.
+ */
 type UserProfileProps = {
-  /**
-   * User Role (Developer, Researcher, etc.)
-   */
-  role?: string;
-
   /**
    * The number of notes in the workspace
    */
   numNotes?: number;
+  /**
+   * The role of user. Retrieved from initial survey.
+   */
+  role?: string;
+  /**
+   * The use case of Dendron for the user. Retrieved from initial survey.
+   */
   useCases?: string[];
+  /**
+   * The context Dendron is used for the user. Retrieved from initial survey.
+   */
   useContext?: string;
+  /**
+   * Whether the user has intent for publishing. If so, how. Retrieved from initial survey.
+   */
   publishingUseCase?: string;
+  /**
+   * Prior tools the user has used before Dendron. Retrieved from initial survey.
+   */
   priorTools?: string[];
+  /**
+   * Email of user. Retrieved from initial survey.
+   */
   email?: string;
 };
 

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -536,6 +536,10 @@ type UserProfileProps = {
    * The number of notes in the workspace
    */
   numNotes?: number;
+  useCases?: string[];
+  publishingUseCase: string;
+  priorTools?: string[];
+  email?: string;
 };
 
 // platform props

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -538,7 +538,7 @@ type UserProfileProps = {
   numNotes?: number;
   useCases?: string[];
   useContext?: string;
-  publishingUseCase: string;
+  publishingUseCase?: string;
   priorTools?: string[];
   email?: string;
 };

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -25,6 +25,10 @@ type Metadata = Partial<{
    */
   inactiveUserMsgStatus: InactvieUserMsgStatusEnum;
   /**
+   * The status of initial survey.
+   */
+  initialSurveyStatus: InitialSurveyStatusEnum;
+  /**
    * Set if a user has activated a dendron workspace
    */
   dendronWorkspaceActivated: number;
@@ -39,6 +43,11 @@ type Metadata = Partial<{
 }>;
 
 export enum InactvieUserMsgStatusEnum {
+  submitted = "submitted",
+  cancelled = "cancelled",
+}
+
+export enum InitialSurveyStatusEnum {
   submitted = "submitted",
   cancelled = "cancelled",
 }
@@ -118,5 +127,9 @@ export class MetadataService {
 
   setInactiveUserMsgStatus(value: InactvieUserMsgStatusEnum) {
     return this.setMeta("inactiveUserMsgStatus", value);
+  }
+
+  setInitialSurveyStatus(value: InitialSurveyStatusEnum) {
+    return this.setMeta("initialSurveyStatus", value);
   }
 }

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -633,7 +633,11 @@ export async function _activate(
         path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME)
       );
       AnalyticsUtils.identify({ numNotes });
-      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, {
+
+      const publishigConfig = ConfigUtils.getPublishingConfig(dendronConfig);
+      const siteUrl = publishigConfig.siteUrl;
+
+      const trackProps = {
         duration: durationReloadWorkspace,
         noCaching: dendronConfig.noCaching || false,
         numNotes,
@@ -645,7 +649,12 @@ export async function _activate(
         numSelfContainedVaults: ws
           .getDWorkspace()
           .vaults.filter(VaultUtils.isSelfContained).length,
-      });
+      };
+      if (siteUrl !== undefined) {
+        _.set(trackProps, "siteUrl", siteUrl);
+      }
+
+      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, trackProps);
 
       // on first install, warn if extensions are incompatible ^dlx35gstwsun
       if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -637,7 +637,7 @@ export async function _activate(
       const publishigConfig = ConfigUtils.getPublishingConfig(dendronConfig);
       const siteUrl = publishigConfig.siteUrl;
 
-      const trackProps = {
+      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, {
         duration: durationReloadWorkspace,
         noCaching: dendronConfig.noCaching || false,
         numNotes,
@@ -649,12 +649,8 @@ export async function _activate(
         numSelfContainedVaults: ws
           .getDWorkspace()
           .vaults.filter(VaultUtils.isSelfContained).length,
-      };
-      if (siteUrl !== undefined) {
-        _.set(trackProps, "siteUrl", siteUrl);
-      }
-
-      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, trackProps);
+        hasSiteUrl: siteUrl !== undefined,
+      });
 
       // on first install, warn if extensions are incompatible ^dlx35gstwsun
       if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -637,7 +637,7 @@ export async function _activate(
       const publishigConfig = ConfigUtils.getPublishingConfig(dendronConfig);
       const siteUrl = publishigConfig.siteUrl;
 
-      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, {
+      const trackProps = {
         duration: durationReloadWorkspace,
         noCaching: dendronConfig.noCaching || false,
         numNotes,
@@ -649,8 +649,13 @@ export async function _activate(
         numSelfContainedVaults: ws
           .getDWorkspace()
           .vaults.filter(VaultUtils.isSelfContained).length,
-        hasSiteUrl: siteUrl !== undefined,
-      });
+      };
+
+      if (siteUrl !== undefined) {
+        _.set(trackProps, "siteUrl", siteUrl);
+      }
+
+      AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, trackProps);
 
       // on first install, warn if extensions are incompatible ^dlx35gstwsun
       if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {

--- a/packages/plugin-core/src/commands/DevTriggerCommand.ts
+++ b/packages/plugin-core/src/commands/DevTriggerCommand.ts
@@ -1,4 +1,5 @@
 import { DENDRON_COMMANDS } from "../constants";
+import { SurveyUtils } from "../survey";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -26,5 +27,6 @@ export class DevTriggerCommand extends BasicCommand<
   async execute() {
     // Place to add some temporary piece of code for development.
     // Please remember to remove the added code prior to pushing.
+    await SurveyUtils.showInitialSurvey();
   }
 }

--- a/packages/plugin-core/src/commands/DevTriggerCommand.ts
+++ b/packages/plugin-core/src/commands/DevTriggerCommand.ts
@@ -1,5 +1,4 @@
 import { DENDRON_COMMANDS } from "../constants";
-import { SurveyUtils } from "../survey";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -27,6 +26,5 @@ export class DevTriggerCommand extends BasicCommand<
   async execute() {
     // Place to add some temporary piece of code for development.
     // Please remember to remove the added code prior to pushing.
-    await SurveyUtils.showInitialSurvey();
   }
 }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -790,6 +790,7 @@ export enum GLOBAL_STATE {
    */
   MRUDocs = "MRUDocs",
   /**
+   * @deprecated
    * Checks if initial survey was prompted and submitted.
    */
   INITIAL_SURVEY_SUBMITTED = "dendron.initial_survey_submitted",

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -107,30 +107,16 @@ export class DendronQuickPickSurvey {
 }
 
 export class ContextSurvey extends DendronQuickPickSurvey {
+  static CHOICES: { [index: string]: string } = {
+    "For work": "work",
+    "For personal use": "personal",
+    "All of the above": "all",
+    Other: "other",
+  };
+
   async onAnswer(result: vscode.QuickPickItem) {
     let maybeOtherResult: string | undefined;
-    let answer: string | undefined;
-    switch (result.label) {
-      case "For work": {
-        answer = "work";
-        break;
-      }
-      case "For personal use": {
-        answer = "use";
-        break;
-      }
-      case "All of the above": {
-        answer = "all";
-        break;
-      }
-      case "Other": {
-        answer = "other";
-        break;
-      }
-      default: {
-        break;
-      }
-    }
+    const answer = ContextSurvey.CHOICES[result.label];
     if (answer === "other") {
       maybeOtherResult = await vscode.window.showInputBox({
         ignoreFocusOut: true,
@@ -157,12 +143,9 @@ export class ContextSurvey extends DendronQuickPickSurvey {
 
   static create() {
     const title = "In what context do you intend to use Dendron?";
-    const choices = [
-      { label: "For work" },
-      { label: "For personal use" },
-      { label: "All of the above" },
-      { label: "Other" },
-    ];
+    const choices = Object.keys(ContextSurvey.CHOICES).map((key) => {
+      return { label: key };
+    });
     return new ContextSurvey({ title, choices, canPickMany: false });
   }
 }
@@ -288,30 +271,17 @@ export class PriorToolsSurvey extends DendronQuickPickSurvey {
 }
 
 export class PublishingUseCaseSurvey extends DendronQuickPickSurvey {
+  static CHOICES: { [index: string]: string } = {
+    "Yes, publishing is a very important use case for me.": "yes/important",
+    "Yes, but I would only like to publish my notes to people I choose to.":
+      "yes/restricted",
+    "I haven't considered publishing my notes, but I am willing to try if it's easy.":
+      "curious",
+    "No, I do not wish to publish my notes.": "no",
+  };
+
   async onAnswer(result: vscode.QuickPickItem) {
-    const label = result.label;
-    let answer: string | undefined;
-    switch (label) {
-      case "Yes, publishing is a very important use case for me.": {
-        answer = "yes/important";
-        break;
-      }
-      case "Yes, but I would only like to publish my notes to people I choose to.": {
-        answer = "yes/restricted";
-        break;
-      }
-      case "I haven't considered publishing my notes, but I am willing to try if it's easy.": {
-        answer = "curious";
-        break;
-      }
-      case "No, I do not wish to publish my notes.": {
-        answer = "no";
-        break;
-      }
-      default: {
-        break;
-      }
-    }
+    const answer = PublishingUseCaseSurvey.CHOICES[result.label];
     AnalyticsUtils.identify({ publishingUseCase: answer });
     AnalyticsUtils.track(SurveyEvents.PublishingUseCaseAnswered, {
       answer,
@@ -325,18 +295,9 @@ export class PublishingUseCaseSurvey extends DendronQuickPickSurvey {
   static create() {
     const title =
       "Dendron lets you easily publish your notes. Do you have any plans to publish your notes?";
-    const choices = [
-      { label: "Yes, publishing is a very important use case for me." },
-      {
-        label:
-          "Yes, but I would only like to publish my notes to people I choose to.",
-      },
-      {
-        label:
-          "I haven't considered publishing my notes, but I am willing to try if it's easy.",
-      },
-      { label: "No, I do not wish to publish my notes." },
-    ];
+    const choices = Object.keys(PublishingUseCaseSurvey.CHOICES).map((key) => {
+      return { label: key };
+    });
     return new PublishingUseCaseSurvey({ title, choices, canPickMany: false });
   }
 }

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -156,8 +156,10 @@ export class UseCaseSurvey extends DendronQuickPickSurvey {
         title: "What do you want to use Dendron for? - Other",
       });
     }
+    const resultsList = results.map((result) => result.label);
+    AnalyticsUtils.identify({ useCases: resultsList });
     AnalyticsUtils.track(SurveyEvents.UseCaseAnswered, {
-      results: results.map((result) => result.label),
+      results: resultsList,
       other: maybeOtherResult,
     });
   }
@@ -193,6 +195,8 @@ export class PriorToolsSurvey extends DendronQuickPickSurvey {
         title: "Are you coming from an existing tool? - Other",
       });
     }
+    const resultsList = results.map((result) => result.label);
+    AnalyticsUtils.identify({ priorTools: resultsList });
     AnalyticsUtils.track(SurveyEvents.PriorToolsAnswered, {
       results: results.map((result) => result.label),
       other: maybeOtherResult,
@@ -246,7 +250,7 @@ export class PublishingUseCaseSurvey extends DendronQuickPickSurvey {
         break;
       }
     }
-
+    AnalyticsUtils.identify({ publishingUseCase: answer });
     AnalyticsUtils.track(SurveyEvents.PublishingUseCaseAnswered, {
       answer,
     });
@@ -277,9 +281,8 @@ export class PublishingUseCaseSurvey extends DendronQuickPickSurvey {
 
 export class NewsletterSubscriptionSurvey extends DendronQuickInputSurvey {
   async onAnswer(result: string) {
-    AnalyticsUtils.track(SurveyEvents.NewsletterSubscriptionAnswered, {
-      result,
-    });
+    AnalyticsUtils.identify({ email: result });
+    AnalyticsUtils.track(SurveyEvents.NewsletterSubscriptionAnswered);
     resolve();
   }
 

--- a/packages/plugin-core/src/test/suite-integ/Survey.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Survey.test.ts
@@ -1,60 +1,183 @@
-import { describe } from "mocha";
-import sinon from "sinon";
+import {
+  InitialSurveyStatusEnum,
+  MetadataService,
+} from "@dendronhq/engine-server";
+import { TestEngineUtils } from "@dendronhq/engine-test-utils";
+import { describe, after, beforeEach, afterEach } from "mocha";
+import sinon, { SinonStub, SinonSpy } from "sinon";
 import * as vscode from "vscode";
+import { GLOBAL_STATE } from "../../constants";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { StateService } from "../../services/stateService";
 import { SurveyUtils } from "../../survey";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace } from "../../workspace";
 import { TutorialInitializer } from "../../workspace/tutorialInitializer";
 import { showLapsedUserMessage } from "../../_extension";
-import { expect } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { expect, resetCodeWorkspace } from "../testUtilsv2";
+import {
+  describeMultiWS,
+  runLegacyMultiWorkspaceTest,
+  setupBeforeAfter,
+} from "../testUtilsV3";
 
 suite("SurveyUtils", function () {
-  const ctx = setupBeforeAfter(this);
   describe("showInitialSurvey", () => {
-    describe("GIVEN: INITIAL_SURVEY_SUBMITTED is not set", () => {
-      test("THEN: showInitialSurvey is called", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async () => {},
-          onInit: async () => {
-            sinon
-              .stub(StateService.instance(), "getGlobalState")
-              .resolves(undefined);
-            const surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey");
+    let homeDirStub: SinonStub;
+    let stateStub: SinonStub;
+    let surveySpy: SinonSpy;
+    describeMultiWS(
+      "GIVEN INITIAL_SURVEY_SUBMITTED is not set",
+      {
+        beforeHook: async () => {
+          await resetCodeWorkspace();
+          homeDirStub = TestEngineUtils.mockHomeDir();
+        },
+      },
+      () => {
+        after(() => {
+          homeDirStub.restore();
+        });
+
+        beforeEach(() => {
+          stateStub = sinon
+            .stub(StateService.instance(), "getGlobalState")
+            .resolves(undefined);
+          surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey");
+        });
+
+        afterEach(() => {
+          stateStub.restore();
+          surveySpy.restore();
+        });
+
+        describe("AND initialSurveyStatus is not set", () => {
+          test("THEN showInitialSurvey is called", async () => {
             const tutorialInitializer = new TutorialInitializer();
-            const ws = getDWorkspace();
+            const ws = ExtensionProvider.getDWorkspace();
+            // MetadataService.instance().setInitialSurveyStatus(InitialSurveyStatusEnum)
+            expect(
+              MetadataService.instance().getMeta().initialSurveyStatus
+            ).toEqual(undefined);
+            expect(
+              await StateService.instance().getGlobalState(
+                GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED
+              )
+            ).toEqual(undefined);
             await tutorialInitializer.onWorkspaceOpen({ ws });
             expect(surveySpy.calledOnce).toBeTruthy();
-            done();
-          },
+          });
         });
-      });
-    });
 
-    describe("GIVEN: INITIAL_SURVEY_SUBMITTED is set", () => {
-      test("THEN: showInitialSurvey is not called", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook: async () => {},
-          onInit: async () => {
-            sinon
-              .stub(StateService.instance(), "getGlobalState")
-              .resolves("submitted");
-            const surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey");
+        describe("AND initialSurveyStatus is set to cancelled", () => {
+          test("THEN showInitialSurvey is called", async () => {
             const tutorialInitializer = new TutorialInitializer();
-            const ws = getDWorkspace();
+            const ws = ExtensionProvider.getDWorkspace();
+            MetadataService.instance().setInitialSurveyStatus(
+              InitialSurveyStatusEnum.cancelled
+            );
+            expect(
+              await StateService.instance().getGlobalState(
+                GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED
+              )
+            ).toEqual(undefined);
+            await tutorialInitializer.onWorkspaceOpen({ ws });
+            expect(surveySpy.calledOnce).toBeTruthy();
+          });
+        });
+
+        describe("AND initialSurveyStatus is set to submitted", () => {
+          test("THEN showInitialSurvey is not called", async () => {
+            const tutorialInitializer = new TutorialInitializer();
+            const ws = ExtensionProvider.getDWorkspace();
+            MetadataService.instance().setInitialSurveyStatus(
+              InitialSurveyStatusEnum.submitted
+            );
+            expect(
+              await StateService.instance().getGlobalState(
+                GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED
+              )
+            ).toEqual(undefined);
             await tutorialInitializer.onWorkspaceOpen({ ws });
             expect(surveySpy.calledOnce).toBeFalsy();
-            done();
-          },
+          });
         });
-      });
-    });
+      }
+    );
+
+    describeMultiWS(
+      "GIVEN INITIAL_SURVEY_SUBMITTED is set",
+      {
+        beforeHook: async () => {
+          await resetCodeWorkspace();
+          homeDirStub = TestEngineUtils.mockHomeDir();
+        },
+      },
+      () => {
+        after(() => {
+          homeDirStub.restore();
+        });
+
+        beforeEach(() => {
+          stateStub = sinon
+            .stub(StateService.instance(), "getGlobalState")
+            .resolves("submitted");
+          surveySpy = sinon.spy(SurveyUtils, "showInitialSurvey");
+        });
+
+        afterEach(() => {
+          stateStub.restore();
+          surveySpy.restore();
+        });
+
+        describe("AND initialSurveyStatus is not set", () => {
+          test("THEN metadata is backfilled AND showInitialSurvey is not called", async () => {
+            const tutorialInitializer = new TutorialInitializer();
+            const ws = ExtensionProvider.getDWorkspace();
+            // metadata is not set yet, we expect this to be backfilled
+            expect(
+              MetadataService.instance().getMeta().initialSurveyStatus
+            ).toEqual(undefined);
+            // global state is already set.
+            expect(
+              await StateService.instance().getGlobalState(
+                GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED
+              )
+            ).toEqual("submitted");
+
+            await tutorialInitializer.onWorkspaceOpen({ ws });
+
+            expect(surveySpy.calledOnce).toBeFalsy();
+
+            // metadata is backfilled.
+            expect(
+              MetadataService.instance().getMeta().initialSurveyStatus
+            ).toEqual(InitialSurveyStatusEnum.submitted);
+          });
+        });
+
+        describe("AND initialSurveyStatus is set to submitted", () => {
+          test("THEN showInitialSurvey is not called", async () => {
+            const tutorialInitializer = new TutorialInitializer();
+            const ws = ExtensionProvider.getDWorkspace();
+
+            MetadataService.instance().setInitialSurveyStatus(
+              InitialSurveyStatusEnum.submitted
+            );
+            expect(
+              await StateService.instance().getGlobalState(
+                GLOBAL_STATE.INITIAL_SURVEY_SUBMITTED
+              )
+            ).toEqual("submitted");
+            await tutorialInitializer.onWorkspaceOpen({ ws });
+            expect(surveySpy.calledOnce).toBeFalsy();
+          });
+        });
+      }
+    );
   });
 
   describe("showLapsedUserSurvey", () => {
+    const ctx = setupBeforeAfter(this);
     describe("GIVEN: user rejects lapsed user message", () => {
       describe("WHEN: Global state for lapsed user survey isn't set", () => {
         test("THEN: showLapsedUserSurvey is called", (done) => {

--- a/packages/plugin-core/src/test/suite-integ/Survey.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Survey.test.ts
@@ -54,7 +54,6 @@ suite("SurveyUtils", function () {
           test("THEN showInitialSurvey is called", async () => {
             const tutorialInitializer = new TutorialInitializer();
             const ws = ExtensionProvider.getDWorkspace();
-            // MetadataService.instance().setInitialSurveyStatus(InitialSurveyStatusEnum)
             expect(
               MetadataService.instance().getMeta().initialSurveyStatus
             ).toEqual(undefined);


### PR DESCRIPTION
# chore: update survey and various user properties for better analytics

This PR:
- Adds `siteUrl` as part of `InitializeWorkspace` event if present.
- Adds Initial survey question asking the context of Dendron use.
- Adds all initial survey answers as part of user trait
- Refactors initial survey prompt logic to use metadata service instead of state service
  - Prior state written to state service will be backfilled.

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [pending] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [pending] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)