### PR TITLE
fix: error when adding a self contained vault inside a native workspace

### DIFF
--- a/packages/engine-server/src/workspace/utils.ts
+++ b/packages/engine-server/src/workspace/utils.ts
@@ -20,6 +20,7 @@ import {
 } from "@dendronhq/common-all";
 import {
   assignJSONWithComment,
+  CommentJSONValue,
   FileUtils,
   findDownTo,
   findUpTo,
@@ -51,12 +52,24 @@ export class WorkspaceUtils {
     wsRoot: string
   ): Promise<RespV3<WorkspaceSettings>> {
     const wsConfigPath = path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME);
-    const wsConfig = await readJSONWithComments(wsConfigPath);
+    let wsConfig: CommentJSONValue;
+    try {
+      wsConfig = await readJSONWithComments(wsConfigPath);
+    } catch (err) {
+      return {
+        error: DendronError.createFromStatus({
+          status: ERROR_STATUS.DOES_NOT_EXIST,
+          message: `Missing code-workspace file ${wsConfigPath}`,
+          payload: err,
+        }),
+      };
+    }
+
     if (!this.isWorkspaceConfig(wsConfig)) {
       return {
         error: DendronError.createFromStatus({
           status: ERROR_STATUS.INVALID_CONFIG,
-          message: `Bad or missing code-workspace file ${wsConfigPath}`,
+          message: `Bad code-workspace file ${wsConfigPath}`,
         }),
       };
     } else {

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -352,7 +352,7 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
     });
 
     const workspaceDir = path.join(wsRoot, workspace.name);
-    fs.ensureDir(workspaceDir);
+    await fs.ensureDir(workspaceDir);
     await GitUtils.addToGitignore({
       addPath: ".dendron.cache.*",
       root: workspaceDir,

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -238,6 +238,7 @@ export async function setupCodeWorkspaceV2(opts: SetupCodeWorkspaceV2) {
     skipOpenWs: true,
     ...setupWsOverride,
     workspaceInitializer: new BlankInitializer(),
+    selfContained: false,
   });
 
   await WorkspaceUtils.updateCodeWorkspaceSettings({


### PR DESCRIPTION
Fixes an error that happens when adding a self contained vault to a native workspace.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- [~] CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)