### PR TITLE
enhance: use a link instead of a clickable item for the tree view menu

### DIFF
--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -4,6 +4,7 @@ import { createLogger, TreeViewUtils } from "@dendronhq/common-frontend";
 import { Typography } from "antd";
 import _ from "lodash";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { DataNode } from "rc-tree/lib/interface";
 import React, { useCallback, useEffect, useState } from "react";
 import { useCombinedSelector } from "../features";
@@ -99,6 +100,7 @@ export default function DendronTreeMenu(
 
   return (
     <MenuView
+      {...props}
       roots={roots}
       expandKeys={expandKeys}
       onSelect={onSelect}
@@ -116,6 +118,7 @@ function MenuView({
   onExpand,
   collapsed,
   activeNote,
+  noteIndex,
 }: {
   roots: DataNode[];
   expandKeys: string[];
@@ -123,7 +126,7 @@ function MenuView({
   onExpand: (noteId: string) => void;
   collapsed: boolean;
   activeNote: string | undefined;
-}) {
+} & Partial<NoteData>) {
   const ExpandIcon = useCallback(
     ({ isOpen, ...rest }: { isOpen: boolean }) => {
       const UncollapsedIcon = isOpen ? UpOutlined : DownOutlined;
@@ -151,14 +154,7 @@ function MenuView({
             menu.key === activeNote ? "dendron-ant-menu-submenu-selected" : ""
           }
           key={menu.key}
-          title={
-            <Typography.Text
-              style={{ width: "100%" }}
-              ellipsis={{ tooltip: menu.title }}
-            >
-              {menu.title}
-            </Typography.Text>
-          }
+          title={<MenuItemTitle menu={menu} noteIndex={noteIndex!} />}
           onTitleClick={(event) => {
             const target = event.domEvent.target as HTMLElement;
             const isArrow = target.dataset.expandedicon;
@@ -177,12 +173,7 @@ function MenuView({
     }
     return (
       <MenuItem key={menu.key} icon={menu.icon}>
-        <Typography.Text
-          style={{ width: "100%" }}
-          ellipsis={{ tooltip: menu.title }}
-        >
-          {menu.title}
-        </Typography.Text>
+        <MenuItemTitle menu={menu} noteIndex={noteIndex!} />
       </MenuItem>
     );
   };
@@ -200,7 +191,6 @@ function MenuView({
         openKeys: expandKeys,
         selectedKeys: expandKeys,
       })}
-      onClick={({ key }) => onSelect(key as string)}
       inlineIndent={DENDRON_STYLE_CONSTANTS.SIDER.INDENT}
       expandIcon={ExpandIcon}
       inlineCollapsed={collapsed}
@@ -209,5 +199,21 @@ function MenuView({
         return createMenu(menu);
       })}
     </Menu>
+  );
+}
+
+function MenuItemTitle(props: Partial<NoteData> & { menu: DataNode }) {
+  const { getNoteUrl } = useDendronRouter();
+
+  return (
+    <Typography.Text>
+      <Link
+        href={getNoteUrl(props.menu.key as string, {
+          noteIndex: props.noteIndex!,
+        })}
+      >
+        {props.menu.title}
+      </Link>
+    </Typography.Text>
   );
 }

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -206,7 +206,7 @@ function MenuItemTitle(props: Partial<NoteData> & { menu: DataNode }) {
   const { getNoteUrl } = useDendronRouter();
 
   return (
-    <Typography.Text>
+    <Typography.Text ellipsis={{ tooltip: props.menu.title }}>
       <Link
         href={getNoteUrl(props.menu.key as string, {
           noteIndex: props.noteIndex!,

--- a/packages/nextjs-template/styles/scss/main.scss
+++ b/packages/nextjs-template/styles/scss/main.scss
@@ -38,7 +38,7 @@ hr {
 
 // from from packages/dendron-next-server/assets/themes/light-theme.less
 $layout-header-background: #f5f7f9; // @layout-header-background
-$text-color: "rgba(0,0,0,.85)"; // @text-color
+$text-color: rgba(0, 0, 0, 0.85); // @text-color
 
 .site-layout-sidebar.ant-layout {
   background-color: $layout-header-background;
@@ -110,6 +110,10 @@ $text-color: "rgba(0,0,0,.85)"; // @text-color
       transform: scaleY(1);
       opacity: 1;
     }
+  }
+
+  .ant-menu-title-content a {
+    color: $text-color;
   }
 }
 

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -19,11 +19,14 @@ export type DendronRouterProps = ReturnType<typeof useDendronRouter>;
 export function useDendronRouter() {
   const router = useRouter();
   const query = getNoteRouterQuery(router);
-  const changeActiveNote = (id: string, opts: { noteIndex: NoteProps }) => {
+  const getNoteUrl = (id: string, opts: { noteIndex: NoteProps }) => {
     if (id === opts.noteIndex.id) {
-      return router.push(`/`);
+      return `/`;
     }
-    router.push(`/notes/${id}`);
+    return `/notes/${id}`;
+  };
+  const changeActiveNote = (id: string, opts: { noteIndex: NoteProps }) => {
+    router.push(getNoteUrl(id, opts));
   };
 
   const getActiveNote = ({
@@ -48,6 +51,7 @@ export function useDendronRouter() {
     router,
     query,
     changeActiveNote,
+    getNoteUrl,
     getActiveNote,
     getActiveNoteId,
   };


### PR DESCRIPTION
Uses a link instead of a clickable item on the side bar, making it possible to right click on them, and open them in a new tab.

For the links, I matched the style of the old clickable text areas, except for the underline when hovered. I left that in but I'm not sure either way, so let me know if you, the reviewer, would prefer it removed.

On Firefox, right clicking an item:

![firefox-right-click](https://user-images.githubusercontent.com/1008124/161013250-7770ed74-c2e3-4b11-b61a-08813a79d3da.png)

On Firefox, hovering over an item:

![firefox-hover](https://user-images.githubusercontent.com/1008124/161013324-d4b4d24e-bdca-479c-b484-a51f9497797a.png)

On Chrome, hovering over an item:

![chrome-hover](https://user-images.githubusercontent.com/1008124/161013374-a243c37a-4fd2-4c56-9627-e4a40a927af5.png)

#2615 

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [x] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [x] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [x] firefox
    - [x] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)