### PR TITLE
chore(views): report exceptions for treeview

### DIFF
--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -6,6 +6,7 @@ import {
   NoteUtils,
 } from "@dendronhq/common-all";
 import { EngineEventEmitter } from "@dendronhq/engine-server";
+import * as Sentry from "@sentry/node";
 import _ from "lodash";
 import {
   Disposable,
@@ -66,46 +67,61 @@ export class EngineNoteProvider
   }
 
   getTreeItem(noteProps: NoteProps): TreeItem {
-    return this._tree[noteProps.id];
+    try {
+      return this._tree[noteProps.id];
+    } catch (error) {
+      Sentry.captureException(error);
+      throw error;
+    }
   }
 
   getChildren(noteProps?: NoteProps): ProviderResult<NoteProps[]> {
-    const ctx = "TreeView:getChildren";
-    Logger.debug({ ctx, id: noteProps });
-    const { engine } = ExtensionProvider.getDWorkspace();
-    const roots = _.filter(_.values(engine.notes), DNodeUtils.isRoot);
-    if (!roots) {
-      window.showInformationMessage("No notes found");
-      return Promise.resolve([]);
-    }
-    if (noteProps) {
-      const childrenIds = noteProps.children;
+    try {
+      const ctx = "TreeView:getChildren";
+      Logger.debug({ ctx, id: noteProps });
+      const { engine } = ExtensionProvider.getDWorkspace();
+      const roots = _.filter(_.values(engine.notes), DNodeUtils.isRoot);
+      if (!roots) {
+        window.showInformationMessage("No notes found");
+        return Promise.resolve([]);
+      }
+      if (noteProps) {
+        const childrenIds = noteProps.children;
 
-      const childrenNoteProps = childrenIds.map((id) => {
-        return engine.notes[id];
-      });
+        const childrenNoteProps = childrenIds.map((id) => {
+          return engine.notes[id];
+        });
 
-      // Sort the listing order by title:
-      _.sortBy(childrenNoteProps, (props) => props.title);
-      return Promise.resolve(childrenNoteProps);
-    } else {
-      Logger.info({ ctx, msg: "reconstructing tree: enter" });
-      const out = Promise.all(
-        roots.flatMap(async (root) => {
-          const treeNote = await this.parseTree(root, engine.notes);
-          return treeNote.note;
-        })
-      );
-      Logger.info({ ctx, msg: "reconstructing tree: exit" });
-      return out;
+        // Sort the listing order by title:
+        _.sortBy(childrenNoteProps, (props) => props.title);
+        return Promise.resolve(childrenNoteProps);
+      } else {
+        Logger.info({ ctx, msg: "reconstructing tree: enter" });
+        const out = Promise.all(
+          roots.flatMap(async (root) => {
+            const treeNote = await this.parseTree(root, engine.notes);
+            return treeNote.note;
+          })
+        );
+        Logger.info({ ctx, msg: "reconstructing tree: exit" });
+        return out;
+      }
+    } catch (error) {
+      Sentry.captureException(error);
+      throw error;
     }
   }
 
   getParent(id: NoteProps): ProviderResult<NoteProps> {
-    const { engine: client } = ExtensionProvider.getDWorkspace();
+    try {
+      const { engine: client } = ExtensionProvider.getDWorkspace();
 
-    const maybeParent = client.notes[id.parent || ""];
-    return maybeParent || null;
+      const maybeParent = client.notes[id.parent || ""];
+      return maybeParent || null;
+    } catch (error) {
+      Sentry.captureException(error);
+      throw error;
+    }
   }
 
   private setupSubscriptions(): Disposable {


### PR DESCRIPTION
## chore(views): report exceptions for treeview 

There's code execution done by vs code in the native tree view that wasn't covered by Sentry - this change fixes that and also adds reporting for the backlinks view as well.

This should point us at the issue behind the following:
- https://github.com/dendronhq/dendron/issues/2534
- https://github.com/dendronhq/dendron/issues/2451

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [N/A] check if this change adversely impact performance
- Operations
  - [N/A] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [N/A] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)