### PR TITLE
chore(view): note preview catches and displays error messages

### DIFF
--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -36,6 +36,7 @@ export const initNotes = createAsyncThunk(
     const data = resp.data!;
     logger.info({ state: "pre:setNotes" });
     dispatch(setFromInit(data));
+    dispatch(setError(undefined));
     logger.info({ state: "post:setNotes" });
     return resp;
   }
@@ -64,6 +65,7 @@ export const syncConfig = createAsyncThunk(
     const data = resp.data!;
     logger.info({ state: "pre:setConfig" });
     dispatch(setConfig(data));
+    dispatch(setError(undefined));
     logger.info({ state: "post:setConfig" });
     return resp;
   }
@@ -93,6 +95,7 @@ export const syncNote = createAsyncThunk(
     logger.info({ state: "pre:setNotes" });
     if (data?.length) {
       dispatch(updateNote(data[0]));
+      dispatch(setError(undefined));
     }
     logger.info({ state: "post:setNotes" });
     return resp;
@@ -124,6 +127,7 @@ export const renderNote = createAsyncThunk(
     }
     const data = resp.data!;
     dispatch(setRenderNote({ id, body: data }));
+    dispatch(setError(undefined));
     return resp;
   }
 );

--- a/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePage.tsx
@@ -110,6 +110,14 @@ const DendronNotePage: DendronComponent = (props) => {
   const { currentTheme: themeType } = useCurrentTheme();
   useMermaid({ config, themeType, mermaid, noteRenderedBody });
 
+  if (props.engine.error) {
+    return (
+      <div>
+        <h1>Error</h1>
+        <div>{props.engine.error}</div>
+      </div>
+    );
+  }
   if (!noteRenderedBody || !config) {
     return <div>Loading...</div>;
   }

--- a/packages/dendron-plugin-views/src/hooks/index.tsx
+++ b/packages/dendron-plugin-views/src/hooks/index.tsx
@@ -53,7 +53,7 @@ export const useRenderedNoteBody = ({
     id: undefined,
     contentHash: undefined,
   };
-  const noteContent = engine.notesRendered[noteId || ""];
+  const noteContent = noteId ? engine.notesRendered[noteId] : undefined;
   const renderedNoteContentHash = React.useRef<string>();
   const dispatch = engineHooks.useEngineAppDispatch();
 

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -594,11 +594,23 @@ export class DendronEngineV2 implements DEngine {
     // Either we don't have have the cached preview or the version that is
     // cached has gotten stale, hence we will re-render the note and cache
     // the new value.
-    const data = await this._renderNote({
-      note,
-      flavor: flavor || ProcFlavor.PREVIEW,
-      dest: dest || DendronASTDest.HTML,
-    });
+    let data: string;
+    try {
+      data = await this._renderNote({
+        note,
+        flavor: flavor || ProcFlavor.PREVIEW,
+        dest: dest || DendronASTDest.HTML,
+      });
+    } catch (error) {
+      return ResponseUtil.createUnhappyResponse({
+        error: new DendronError({
+          message: `Unable to render note ${note.fname} in ${VaultUtils.getName(
+            note.vault
+          )}`,
+          payload: error,
+        }),
+      });
+    }
 
     this.renderedCache.set(id, {
       updated: note.updated,


### PR DESCRIPTION
Discovered this error path in the Sentry logs: if rendering a note fails, Dendron throws an error which would end up in Sentry. With this PR:

- Any errors thrown during rendering a note is caught
- If there is an error, the note preview will display the error (see below for how this looks)
- The error state in the preview is cleared once a preview action succeeds. Otherwise the preview would be stuck displaying the error.

![image](https://user-images.githubusercontent.com/1008124/161224295-b6def2c1-8b42-41b8-ad75-f7f9e791917d.png)

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- [~] CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~] is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)