### PR TITLE
chore: fast rebuild script when building dendron plugin locally

### DIFF
--- a/bootstrap/scripts/fastRebuild.sh
+++ b/bootstrap/scripts/fastRebuild.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "reset repo"
+git checkout package.json
+
+echo "remove compiled assets"
+npx lerna run clean --parallel --scope "@dendronhq/{dendron-plugin-views,dendron-next-server,plugin-core}"
+
+echo "link packages..."
+lerna bootstrap
+
+echo "re-building packages..."
+# NOTE: order matters, must run serially
+npx lerna run build --scope @dendronhq/dendron-next-server
+npx lerna run build --scope @dendronhq/dendron-plugin-views
+npx lerna run build --scope @dendronhq/plugin-core

--- a/bootstrap/scripts/fastRebuild.sh
+++ b/bootstrap/scripts/fastRebuild.sh
@@ -2,6 +2,7 @@
 
 echo "reset repo"
 git checkout package.json
+git checkout packages/plugin-core/package.json
 
 echo "remove compiled assets"
 npx lerna run clean --parallel --scope "@dendronhq/{dendron-plugin-views,dendron-next-server,plugin-core}"
@@ -9,8 +10,7 @@ npx lerna run clean --parallel --scope "@dendronhq/{dendron-plugin-views,dendron
 echo "link packages..."
 lerna bootstrap
 
-echo "re-building packages..."
-# NOTE: order matters, must run serially
+echo "re-building packages..." # NOTE: order matters, must run serially
 npx lerna run build --scope @dendronhq/dendron-next-server
 npx lerna run build --scope @dendronhq/dendron-plugin-views
 npx lerna run build --scope @dendronhq/plugin-core


### PR DESCRIPTION
chore: fast rebuild script when building dendron plugin locally

This adds the steps in [[Build|dendron://dendron.docs/pkg.plugin-core.dev.build]] into a script
