### PR TITLE
chore: add sleep for building plugin locally

### DIFF
--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -359,8 +359,8 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       );
       await new Promise((r) => setTimeout(r, 120000));
     } else {
-      this.print("sleeping 5s for remote npm registry to have packages ready");
-      await new Promise((r) => setTimeout(r, 50000));
+      this.print("sleeping 3s for remote npm registry to have packages ready");
+      await new Promise((r) => setTimeout(r, 30000));
     }
 
     this.print("install deps...");

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -359,7 +359,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       );
       await new Promise((r) => setTimeout(r, 120000));
     } else {
-      this.print("sleeping 3s for remote npm registry to have packages ready");
+      this.print("sleeping 3s for local npm registry to have packages ready");
       await new Promise((r) => setTimeout(r, 30000));
     }
 

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -358,6 +358,9 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         "sleeping 2 mins for remote npm registry to have packages ready"
       );
       await new Promise((r) => setTimeout(r, 120000));
+    } else {
+      this.print("sleeping 5s for remote npm registry to have packages ready");
+      await new Promise((r) => setTimeout(r, 50000));
     }
 
     this.print("install deps...");


### PR DESCRIPTION
chore: add sleep for building plugin locally

sometimes npm assets aren't ready locally immediately after publishing