### PR TITLE
chore: telemetry for number of remote vaults & repo contributor count

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -98,6 +98,10 @@ export enum SurveyEvents {
   InactiveUserSurveyPromptReason = "Inactive_User_Prompt_Reason",
 }
 
+export enum GitEvents {
+  ContributorsFound = "ContributorsFound",
+}
+
 export enum ConfigEvents {
   ConfigNotMigrated = "Config_Not_Migrated",
   EnabledExportPodV2 = "Enabled_Export_Pod_V2",
@@ -134,6 +138,7 @@ export enum AppNames {
 export const DendronEvents = {
   VSCodeEvents,
   CLIEvents,
+  GitEvents,
   TutorialEvents,
   ExtensionEvents,
   SurveyEvents,

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -42,6 +42,10 @@ export class VaultUtils {
     return vault.selfContained === true;
   }
 
+  static isRemote(vault: DVault): boolean {
+    return vault.remote !== undefined;
+  }
+
   /**
    * Path of vault relative to workspace root
    * @param vault

--- a/packages/engine-server/src/topics/git.ts
+++ b/packages/engine-server/src/topics/git.ts
@@ -388,6 +388,16 @@ export class Git {
     }
   }
 
+  /** Returns the number of contributors to this repository, or undefined if this is not a repository. */
+  async getNumContributors(): Promise<number | undefined> {
+    try {
+      const { stdout } = await this._execute("git shortlog -s HEAD");
+      return stdout.split("\n").length;
+    } catch {
+      return undefined;
+    }
+  }
+
   /**
    * @param nameOnly: If true, only return the file names. Otherwise the full diff including contents is returned.
    * @param oldCommit: The old identifier (e.g. commit, tag, branch) that we are diffing against.

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -17,6 +17,7 @@ import {
   FOLDERS,
   InstallStatus,
   IntermediateDendronConfig,
+  isNotUndefined,
   NoteUtils,
   SchemaUtils,
   SeedEntry,
@@ -639,6 +640,21 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       `Dendron version: ${version}`,
       `Hostname: ${os.hostname()}`,
     ].join("\n");
+  }
+
+  async getAllReposNumContributors() {
+    const repos = await this.getAllRepos();
+    const contributors = await Promise.all(
+      repos.map((repo) => {
+        const git = new Git({ localUrl: repo });
+        try {
+          return git.getNumContributors();
+        } catch {
+          return 0;
+        }
+      })
+    );
+    return contributors.filter(isNotUndefined);
   }
 
   async commitAndAddAll({

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -496,6 +496,8 @@ export async function _activate(
       }
 
       ws.workspaceService = wsService;
+      // Start early to do this in background while Dendron initializes
+      const numContributors = wsService.getAllReposNumContributors();
 
       // check for vaults with same name
       const vaults = ConfigUtils.getVaults(dendronConfig);
@@ -649,6 +651,9 @@ export async function _activate(
         numSelfContainedVaults: ws
           .getDWorkspace()
           .vaults.filter(VaultUtils.isSelfContained).length,
+        numRemoteVaults: ws.getDWorkspace().vaults.filter(VaultUtils.isRemote)
+          .length,
+        numContributors: await numContributors,
       };
 
       if (siteUrl !== undefined) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -653,7 +653,7 @@ export async function _activate(
           .vaults.filter(VaultUtils.isSelfContained).length,
         numRemoteVaults: ws.getDWorkspace().vaults.filter(VaultUtils.isRemote)
           .length,
-        numContributors: await numContributors,
+        numContributors: _.max(await numContributors),
       };
 
       if (siteUrl !== undefined) {


### PR DESCRIPTION
This telemetry is needed to measure the success of the self contained vaults project.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
    - The telemetry runs async while Dendron initialization is happening, and is only done during initialization.
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [x] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [x] display is correct for following browsers (across the various dimensions)
    - [x] safari
    - [x] firefox
    - [x] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)