### PR TITLE
fix(airtable): Exporting to airtable automatically saves current document

### DIFF
--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -334,7 +334,6 @@ export class WorkspaceWatcher {
       // eslint-disable-next-line  no-async-promise-executor
       const p = new Promise(async (resolve) => {
         note.updated = now;
-        await engine.updateNote(note);
         return resolve(changes);
       });
       event.waitUntil(p);

--- a/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/AirtableExportPodCommand.ts
@@ -36,11 +36,9 @@ export class AirtableExportPodCommand extends BaseExportPodCommand<
   AirtableExportReturnType
 > {
   public key = "dendron.airtableexport";
-  private extension: IDendronExtension;
 
   public constructor(extension: IDendronExtension) {
-    super(new QuickPickHierarchySelector());
-    this.extension = extension;
+    super(new QuickPickHierarchySelector(), extension);
   }
 
   public createPod(

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -4,6 +4,7 @@ import {
   DendronError,
   DNodeProps,
   DVault,
+  NoteChangeEntry,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -21,7 +22,7 @@ import path from "path";
 import * as vscode from "vscode";
 import { HierarchySelector } from "../../components/lookup/HierarchySelector";
 import { PodUIControls } from "../../components/pods/PodControls";
-import { ExtensionProvider } from "../../ExtensionProvider";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { BaseCommand } from "../base";
 
@@ -44,9 +45,11 @@ export abstract class BaseExportPodCommand<
     Config,
     Partial<Config>
   >
-  implements ExportPodFactory<Config, R>
+  implements ExportPodFactory<Config, R>, vscode.Disposable
 {
   private hierarchySelector: HierarchySelector;
+  private _onEngineNoteStateChangedDisposable: vscode.Disposable | undefined;
+  public extension: IDendronExtension;
 
   /**
    *
@@ -54,9 +57,13 @@ export abstract class BaseExportPodCommand<
    * hierarchy to export. Should use {@link QuickPickHierarchySelector} by
    * default
    */
-  constructor(hierarchySelector: HierarchySelector) {
+  constructor(
+    hierarchySelector: HierarchySelector,
+    extension: IDendronExtension
+  ) {
     super();
     this.hierarchySelector = hierarchySelector;
+    this.extension = extension;
   }
 
   /**
@@ -86,6 +93,13 @@ export abstract class BaseExportPodCommand<
         message:
           "Multi Note Export cannot have clipboard as destination. Please configure your destination by using Dendron: Configure Export Pod V2 command",
       });
+    }
+  }
+
+  public dispose(): void {
+    if (this._onEngineNoteStateChangedDisposable) {
+      this._onEngineNoteStateChangedDisposable.dispose();
+      this._onEngineNoteStateChangedDisposable = undefined;
     }
   }
 
@@ -188,21 +202,16 @@ export abstract class BaseExportPodCommand<
           return;
         });
 
-        const pod = this.createPod(opts.config);
-
         switch (opts.config.exportScope) {
           case PodExportScope.Note:
+            this.saveActiveDocumentBeforeExporting(opts);
+            break;
           case PodExportScope.Vault:
           case PodExportScope.Lookup:
           case PodExportScope.LinksInSelection:
           case PodExportScope.Hierarchy:
           case PodExportScope.Workspace: {
-            const result = await pod.exportNotes(opts.payload);
-            await this.onExportComplete({
-              exportReturnValue: result,
-              payload: opts.payload,
-              config: opts.config,
-            });
+            await this.executeExportNotes(opts);
 
             break;
           }
@@ -240,16 +249,80 @@ export abstract class BaseExportPodCommand<
         if (!selection) {
           return resolve(undefined);
         }
-        const { hierarchy, vault } = selection
-        const notes = ExtensionProvider.getEngine().notes;
+        const { hierarchy, vault } = selection;
+        const notes = this.extension.getEngine().notes;
 
         resolve(
           Object.values(notes).filter(
-            (value) => value.fname.startsWith(hierarchy) && value.stub !== true &&
-             VaultUtils.isEqualV2(value.vault, vault)
+            (value) =>
+              value.fname.startsWith(hierarchy) &&
+              value.stub !== true &&
+              VaultUtils.isEqualV2(value.vault, vault)
           )
         );
       });
+    });
+  }
+
+  /**
+   * If the active text editor document has dirty changes, save first before exporting
+   * @returns True if document is dirty, false otherwise
+   */
+  private async saveActiveDocumentBeforeExporting(opts: {
+    config: Config;
+    payload: NoteProps[];
+  }): Promise<boolean> {
+    const editor = VSCodeUtils.getActiveTextEditor();
+    if (editor && editor.document.isDirty) {
+      const fname = NoteUtils.uri2Fname(editor.document.uri);
+      this._onEngineNoteStateChangedDisposable = this.extension
+        .getEngine()
+        .getEngineEmitter()
+        .onEngineNoteStateChanged(
+          async (noteChangeEntries: NoteChangeEntry[]) => {
+            const updateNoteEntries = noteChangeEntries.filter(
+              (entry) => entry.note.fname === fname && entry.status === "update"
+            );
+            // Received event from engine about successful save
+            if (updateNoteEntries.length > 0) {
+              const savedNote = updateNoteEntries[0].note;
+              // Remove notes that match saved note as they contain old content
+              const filteredPayload = opts.payload.filter(
+                (note) => note.fname !== savedNote.fname
+              );
+              await this.executeExportNotes({
+                ...opts,
+                payload: filteredPayload.concat(savedNote),
+              });
+              this.dispose();
+            }
+          }
+        );
+      await editor.document.save();
+      // Dispose of listener after 1 sec (if not already disposed) in case engine events never arrive
+      setTimeout(() => {
+        this.dispose();
+      }, 1000);
+
+      return true;
+    } else {
+      // Save is not needed. Go straight to exporting
+      await this.executeExportNotes(opts);
+      return false;
+    }
+  }
+
+  private async executeExportNotes(opts: {
+    config: Config;
+    payload: NoteProps[];
+  }): Promise<string | void> {
+    const pod = this.createPod(opts.config);
+
+    const result = await pod.exportNotes(opts.payload);
+    return this.onExportComplete({
+      exportReturnValue: result,
+      payload: opts.payload,
+      config: opts.config,
     });
   }
 
@@ -263,7 +336,7 @@ export abstract class BaseExportPodCommand<
       return;
     }
 
-    const { vaults, engine, wsRoot } = ExtensionProvider.getDWorkspace();
+    const { vaults, engine, wsRoot } = this.extension.getDWorkspace();
 
     const vault = VaultUtils.getVaultByFilePath({
       vaults,
@@ -291,7 +364,7 @@ export abstract class BaseExportPodCommand<
    * @returns all notes in the workspace
    */
   private getPropsForWorkspaceScope(): DNodeProps[] | undefined {
-    const engine = ExtensionProvider.getEngine();
+    const engine = this.extension.getEngine();
     return Object.values(engine.notes).filter((notes) => notes.stub !== true);
   }
 
@@ -300,7 +373,7 @@ export abstract class BaseExportPodCommand<
    * @returns all notes in the vault
    */
   private getPropsForVaultScope(vault: DVault): DNodeProps[] | undefined {
-    const engine = ExtensionProvider.getEngine();
+    const engine = this.extension.getEngine();
     return Object.values(engine.notes).filter(
       (note) => note.stub !== true && VaultUtils.isEqualV2(note.vault, vault)
     );

--- a/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/GoogleDocsExportPodCommand.ts
@@ -37,11 +37,9 @@ export class GoogleDocsExportPodCommand extends BaseExportPodCommand<
   GoogleDocsExportReturnType
 > {
   public key = "dendron.googledocsexport";
-  private extension: IDendronExtension;
 
   public constructor(extension: IDendronExtension) {
-    super(new QuickPickHierarchySelector());
-    this.extension = extension;
+    super(new QuickPickHierarchySelector(), extension);
   }
 
   public createPod(

--- a/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
@@ -30,10 +30,8 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
   JSONExportReturnType
 > {
   public key = "dendron.jsonexportv2";
-  private extension: IDendronExtension;
   public constructor(extension: IDendronExtension) {
-    super(new QuickPickHierarchySelector());
-    this.extension = extension;
+    super(new QuickPickHierarchySelector(), extension);
   }
 
   public async gatherInputs(

--- a/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
@@ -30,11 +30,9 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
   MarkdownExportReturnType
 > {
   public key = "dendron.markdownexportv2";
-  private extension: IDendronExtension;
 
   public constructor(extension: IDendronExtension) {
-    super(new QuickPickHierarchySelector());
-    this.extension = extension;
+    super(new QuickPickHierarchySelector(), extension);
   }
 
   public async gatherInputs(

--- a/packages/plugin-core/src/commands/pods/NotionExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/NotionExportPodCommand.ts
@@ -38,10 +38,8 @@ export class NotionExportPodCommand extends BaseExportPodCommand<
   NotionExportReturnType
 > {
   public key = "dendron.notionexport";
-  private extension: IDendronExtension;
   public constructor(extension: IDendronExtension) {
-    super(new QuickPickHierarchySelector());
-    this.extension = extension;
+    super(new QuickPickHierarchySelector(), extension);
   }
 
   public createPod(

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -54,7 +54,7 @@ export class EngineAPIService
   implements DEngineClient, IEngineAPIService, EngineEventEmitter
 {
   private _internalEngine: DEngineClient;
-  private _engineEvents: EngineEventEmitter;
+  private _engineEventEmitter: EngineEventEmitter;
   private _trustedWorkspace: boolean = true;
 
   static createEngine({
@@ -103,14 +103,14 @@ export class EngineAPIService
     engineEvents: EngineEventEmitter;
   }) {
     this._internalEngine = engineClient;
-    this._engineEvents = engineEvents;
+    this._engineEventEmitter = engineEvents;
   }
   get onEngineNoteStateChanged(): Event<NoteChangeEntry[]> {
-    return this._engineEvents.onEngineNoteStateChanged;
+    return this._engineEventEmitter.onEngineNoteStateChanged;
   }
 
   dispose() {
-    this._engineEvents.dispose();
+    this._engineEventEmitter.dispose();
   }
 
   get trustedWorkspace(): boolean {
@@ -182,6 +182,10 @@ export class EngineAPIService
   }
   public set hooks(arg: DHookDict) {
     this._internalEngine.hooks = arg;
+  }
+
+  public get engineEventEmitter(): EngineEventEmitter {
+    return this._engineEventEmitter;
   }
 
   async refreshNotes(opts: RefreshNotesOpts) {
@@ -307,9 +311,5 @@ export class EngineAPIService
   }
   getAnchors(opts: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
     return this._internalEngine.getAnchors(opts);
-  }
-
-  getEngineEmitter(): EngineEventEmitter {
-    return this._engineEvents;
   }
 }

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -308,4 +308,8 @@ export class EngineAPIService
   getAnchors(opts: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
     return this._internalEngine.getAnchors(opts);
   }
+
+  getEngineEmitter(): EngineEventEmitter {
+    return this._engineEvents;
+  }
 }

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -51,6 +51,7 @@ export interface IEngineAPIService {
   configRoot: string;
   config: IntermediateDendronConfig;
   hooks: DHookDict;
+  engineEventEmitter: EngineEventEmitter;
 
   refreshNotes(opts: RefreshNotesOpts): Promise<RespV2<void>>;
 
@@ -121,6 +122,4 @@ export interface IEngineAPIService {
     opts: Optional<GetLinksRequest, "ws">
   ) => Promise<GetNoteLinksPayload>;
   getAnchors: (opts: GetAnchorsRequest) => Promise<GetNoteAnchorsPayload>;
-
-  getEngineEmitter(): EngineEventEmitter;
 }

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -38,6 +38,7 @@ import {
   SchemaModuleDict,
   SchemaModuleProps,
 } from "@dendronhq/common-all";
+import { EngineEventEmitter } from "@dendronhq/engine-server";
 
 export interface IEngineAPIService {
   trustedWorkspace: boolean;
@@ -120,4 +121,6 @@ export interface IEngineAPIService {
     opts: Optional<GetLinksRequest, "ws">
   ) => Promise<GetNoteLinksPayload>;
   getAnchors: (opts: GetAnchorsRequest) => Promise<GetNoteAnchorsPayload>;
+
+  getEngineEmitter(): EngineEventEmitter;
 }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -72,6 +72,7 @@ import {
   describeMultiWS,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
+  waitInMilliseconds,
   withConfig,
 } from "../testUtilsV3";
 
@@ -217,14 +218,6 @@ function getSplitTypeButtons(
     buttons
   ) as vscode.QuickInputButton[] & DendronBtn[];
   return { horizontalSplitBtn };
-}
-
-async function wait1Second(): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, 1000);
-  });
 }
 
 suite("NoteLookupCommand", function () {
@@ -1538,7 +1531,7 @@ suite("NoteLookupCommand", function () {
           };
 
           const scratch1Name = await createScratch();
-          await wait1Second();
+          await waitInMilliseconds(1000);
           const scratch2Name = await createScratch();
 
           expect(scratch1Name).toNotEqual(scratch2Name);

--- a/packages/plugin-core/src/test/suite-integ/TextDocumentService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/TextDocumentService.test.ts
@@ -1,6 +1,5 @@
 import {
   assert,
-  milliseconds,
   NoteChangeEntry,
   NoteChangeUpdateEntry,
 } from "@dendronhq/common-all";
@@ -23,24 +22,8 @@ import {
   describeSingleWS,
   describeMultiWS,
   subscribeToEngineStateChange,
+  waitInMilliseconds,
 } from "../testUtilsV3";
-
-async function wait1Millisecond(): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, 1);
-  });
-}
-
-/**
- * Returns current milliseconds and waits 1 millisecond to ensure
- * subsequent calls to this function will return different milliseconds. */
-async function millisNowAndWait1Milli(): Promise<number> {
-  const millis = milliseconds();
-  await wait1Millisecond();
-  return millis;
-}
 
 async function openAndEdit(fname: string) {
   const engine = ExtensionProvider.getEngine();
@@ -216,7 +199,7 @@ suite("TextDocumentService", function testSuite() {
               });
             });
           // Small sleep to ensure callback doesn't fire.
-          millisNowAndWait1Milli().then(() => done());
+          waitInMilliseconds(10).then(() => done());
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -3,20 +3,22 @@ import { PodExportScope } from "@dendronhq/pods-core";
 import { describe, after, beforeEach, afterEach } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
-import { getDWorkspace } from "../../../../workspace";
 import { expect } from "../../../testUtilsv2";
 import {
   describeMultiWS,
   describeSingleWS,
-  setupBeforeAfter,
+  waitInMilliseconds,
 } from "../../../testUtilsV3";
 import { VSCodeUtils } from "../../../../vsCodeUtils";
 import { TestExportPodCommand } from "./TestExportCommand";
-import { DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { assert, DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
 import sinon from "sinon";
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import { PodUIControls } from "../../../../components/pods/PodControls";
-import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import {
+  NoteTestUtilsV4,
+  testAssertsInsideCallback,
+} from "@dendronhq/common-test-utils";
 import { ExtensionProvider } from "../../../../ExtensionProvider";
 
 const stubQuickPick = (vault: DVault) => {
@@ -27,21 +29,18 @@ const stubQuickPick = (vault: DVault) => {
 };
 
 suite("BaseExportPodCommand", function () {
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
-    beforeHook: () => {},
-  });
-
   describe("GIVEN a BaseExportPodCommand implementation", () => {
     describeSingleWS(
       "WHEN exporting a note scope",
       {
-        ctx,
+        postSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand();
-
         test("THEN note prop should be in the export payload", async () => {
-          const { wsRoot, vaults } = getDWorkspace();
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
 
           const notePath = path.join(
             vault2Path({ vault: vaults[0], wsRoot }),
@@ -55,13 +54,71 @@ suite("BaseExportPodCommand", function () {
           expect((payload?.payload as NoteProps[])[0].fname).toEqual("root");
           expect((payload?.payload as NoteProps[]).length).toEqual(1);
         });
+
+        test("AND note is dirty, THEN a onDidSaveTextDocument should be fired", (done) => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
+          const engine = ExtensionProvider.getEngine();
+
+          const testNote = engine.notes["foo"];
+          const textToAppend = "BaseExportPodCommand testing";
+          // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
+          const disposable = vscode.workspace.onDidSaveTextDocument(
+            (textDocument) => {
+              testAssertsInsideCallback(() => {
+                expect(
+                  textDocument.getText().includes(textToAppend)
+                ).toBeTruthy();
+                expect(textDocument.fileName.endsWith("foo.md")).toBeTruthy();
+                disposable.dispose();
+                cmd.dispose();
+              }, done);
+            }
+          );
+
+          ExtensionProvider.getWSUtils()
+            .openNote(testNote)
+            .then(async (editor) => {
+              editor
+                .edit(async (editBuilder) => {
+                  const line = editor.document.getText().split("\n").length;
+                  editBuilder.insert(
+                    new vscode.Position(line, 0),
+                    textToAppend
+                  );
+                })
+                .then(async () => {
+                  cmd.run();
+                });
+            });
+        });
+
+        test("AND note is clean, THEN a onDidSaveTextDocument should not be fired", (done) => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
+          const engine = ExtensionProvider.getEngine();
+
+          const testNote = engine.notes["foo"];
+          vscode.workspace.onDidSaveTextDocument(() => {
+            assert(false, "Callback not expected");
+          });
+
+          ExtensionProvider.getWSUtils()
+            .openNote(testNote)
+            .then(async () => {
+              cmd.run();
+            });
+          // Small sleep to ensure callback doesn't fire.
+          waitInMilliseconds(10).then(() => done());
+        });
       }
     );
 
     describeMultiWS(
       "WHEN exporting a hierarchy scope",
       {
-        ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
           await ENGINE_HOOKS_MULTI.setupBasicMulti({ wsRoot, vaults });
           await NoteTestUtilsV4.createNote({
@@ -69,12 +126,13 @@ suite("BaseExportPodCommand", function () {
             vault: vaults[1],
             fname: "foo.test",
           });
-        }
+        },
       },
       () => {
-        const cmd = new TestExportPodCommand();
-
         test("THEN hierarchy note props should be in the export payload AND a note with a hierarchy match but in a different vault should not appear", async () => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
           const payload = await cmd.enrichInputs({
             exportScope: PodExportScope.Hierarchy,
           });
@@ -92,13 +150,13 @@ suite("BaseExportPodCommand", function () {
     describeMultiWS(
       "WHEN exporting a workspace scope",
       {
-        ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand();
-
         test("THEN workspace note props should be in the export payload", async () => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
           const payload = await cmd.enrichInputs({
             exportScope: PodExportScope.Workspace,
           });
@@ -111,7 +169,6 @@ suite("BaseExportPodCommand", function () {
     describeMultiWS(
       "WHEN exporting a lookup based scope",
       {
-        ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           await NoteTestUtilsV4.createNote({
@@ -127,7 +184,6 @@ suite("BaseExportPodCommand", function () {
         },
       },
       () => {
-        const cmd = new TestExportPodCommand();
         let sandbox: sinon.SinonSandbox;
 
         beforeEach(() => {
@@ -139,6 +195,9 @@ suite("BaseExportPodCommand", function () {
         });
 
         test("THEN lookup is prompted and lookup result should be the export payload", async () => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
           const engine = ExtensionProvider.getEngine();
           const { wsRoot, vaults } = engine;
           const testNote1 = NoteUtils.getNoteByFnameV5({
@@ -182,12 +241,13 @@ suite("BaseExportPodCommand", function () {
     describeMultiWS(
       "WHEN exporting a vault scope",
       {
-        ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
       },
       () => {
-        const cmd = new TestExportPodCommand();
         test("THEN quickpick is prompted and selected vault's notes shoul be export payload", async () => {
+          const cmd = new TestExportPodCommand(
+            ExtensionProvider.getExtension()
+          );
           const engine = ExtensionProvider.getEngine();
           const { vaults } = engine;
           stubQuickPick(vaults[0]);

--- a/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/TestExportCommand.ts
@@ -10,6 +10,7 @@ import {
 import { HierarchySelector } from "../../../../../src/components/lookup/HierarchySelector";
 import { BaseExportPodCommand } from "../../../../../src/commands/pods/BaseExportPodCommand";
 import { ExtensionProvider } from "../../../../ExtensionProvider";
+import { IDendronExtension } from "../../../../dendronExtensionInterface";
 
 /**
  * Test implementation of BaseExportPodCommand. For testing purposes only.
@@ -21,19 +22,21 @@ export class TestExportPodCommand extends BaseExportPodCommand<
   public key = "dendron.testexport";
 
   /**
-   * Hardcoded to return the 'foo' Hierarchy and vault[0] from ENGINE_HOOKS.setupBasic 
+   * Hardcoded to return the 'foo' Hierarchy and vault[0] from ENGINE_HOOKS.setupBasic
    */
   static mockedSelector: HierarchySelector = {
-    getHierarchy(): Promise<{hierarchy: string, vault: DVault} | undefined> {
-      return new Promise<{hierarchy: string, vault: DVault} | undefined>((resolve) => {
-        const { vaults } = ExtensionProvider.getDWorkspace();
-        resolve({hierarchy: "foo", vault: vaults[0] });
-      });
+    getHierarchy(): Promise<{ hierarchy: string; vault: DVault } | undefined> {
+      return new Promise<{ hierarchy: string; vault: DVault } | undefined>(
+        (resolve) => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          resolve({ hierarchy: "foo", vault: vaults[0] });
+        }
+      );
     },
   };
 
-  public constructor() {
-    super(TestExportPodCommand.mockedSelector);
+  public constructor(extension: IDendronExtension) {
+    super(TestExportPodCommand.mockedSelector, extension);
   }
 
   /**

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -662,3 +662,11 @@ export function subscribeToEngineStateChange(
 export function toDendronEngineClient(engine: IEngineAPIService) {
   return engine as unknown as DendronEngineClient;
 }
+
+export async function waitInMilliseconds(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, milliseconds);
+  });
+}


### PR DESCRIPTION
**Background**
Similar to https://github.com/dendronhq/dendron/pull/2631, this PR fixes the issue where user needs to save first before exporting to airtable.

**Changes**
1. Before exporting, we will first save the current document if it is dirty. After the save, listen to the engine for an `onEngineNoteStateChanged` event before continuing the command.
2. Expose EngineEmitter as part of EngineAPIService. This makes it easier to listen to events since the extension is readily available
3. Remove updating the engine as part of `onWillSaveNote`. 
- The TextDocument entering onDidSave for the TextDocumentService contains the proper updated timestamp
- `note.updated = now` actually updates the engine note for us so we can leave this in in case there's a bug that causes  onDidSave to never be triggered
- Ideally onWillSaveNote does not trigger an engine event. Otherwise every save action will cause 2 events to be fired which could be confusing

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)