### PR TITLE
fix: upgrade `textextensions` version so links to `XAML` files in preview open in editor

### DIFF
--- a/packages/dendron-next-server/package.json
+++ b/packages/dendron-next-server/package.json
@@ -62,7 +62,7 @@
     "gulp-postcss": "^9.0.0",
     "less-plugin-npm-import": "^2.1.0",
     "lodash": "^4.17.20",
-    "next": "^11.1.2",
+    "next": "11.1.4",
     "postcss": "^8.2.13",
     "react": "^17.0.2",
     "react-css-theme-switcher": "^0.3.0",

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -32,7 +32,7 @@
     "html-react-parser": "^1.3.0",
     "lodash": "^4.17.21",
     "luxon": "^1.25.0",
-    "next": "^12.1.0",
+    "next": "12.1.0",
     "next-seo": "^4.27.0",
     "next-sitemap": "1.8.11",
     "react": "^17.0.2",

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1136,7 +1136,7 @@
     "replace-in-file": "^6.2.0",
     "semver": "^7.3.2",
     "string-similarity": "^4.0.4",
-    "textextensions": "^5.14.0",
+    "textextensions": "^5.15.0",
     "unist-util-visit": "2.0.3",
     "vscode-languageclient": "^6.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18111,30 +18111,7 @@ next-tick@~1.0.0:
   resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next@12:
-  version "12.1.0"
-  resolved "https://registry.npmjs.org/next/-/next-12.1.0.tgz#c33d753b644be92fc58e06e5a214f143da61dd5d"
-  integrity sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==
-  dependencies:
-    "@next/env" "12.1.0"
-    caniuse-lite "^1.0.30001283"
-    postcss "8.4.5"
-    styled-jsx "5.0.0"
-    use-subscription "1.5.1"
-  optionalDependencies:
-    "@next/swc-android-arm64" "12.1.0"
-    "@next/swc-darwin-arm64" "12.1.0"
-    "@next/swc-darwin-x64" "12.1.0"
-    "@next/swc-linux-arm-gnueabihf" "12.1.0"
-    "@next/swc-linux-arm64-gnu" "12.1.0"
-    "@next/swc-linux-arm64-musl" "12.1.0"
-    "@next/swc-linux-x64-gnu" "12.1.0"
-    "@next/swc-linux-x64-musl" "12.1.0"
-    "@next/swc-win32-arm64-msvc" "12.1.0"
-    "@next/swc-win32-ia32-msvc" "12.1.0"
-    "@next/swc-win32-x64-msvc" "12.1.0"
-
-next@^11.1.2:
+next@11.1.4:
   version "11.1.4"
   resolved "https://registry.npmjs.org/next/-/next-11.1.4.tgz#2381eeeffae80f58e6d80d8335ab56d2e157064e"
   integrity sha512-GWQJrWYkfAKP8vmrzJcCfRSKv955Khyjqd5jipTcVKDGg+SH+NfjDMWFtCwArcQlHPvzisGu1ERLY0+Eoj7G+g==
@@ -18194,6 +18171,29 @@ next@^11.1.2:
     "@next/swc-darwin-x64" "11.1.4"
     "@next/swc-linux-x64-gnu" "11.1.4"
     "@next/swc-win32-x64-msvc" "11.1.4"
+
+next@12.1.0:
+  version "12.1.0"
+  resolved "https://registry.npmjs.org/next/-/next-12.1.0.tgz#c33d753b644be92fc58e06e5a214f143da61dd5d"
+  integrity sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==
+  dependencies:
+    "@next/env" "12.1.0"
+    caniuse-lite "^1.0.30001283"
+    postcss "8.4.5"
+    styled-jsx "5.0.0"
+    use-subscription "1.5.1"
+  optionalDependencies:
+    "@next/swc-android-arm64" "12.1.0"
+    "@next/swc-darwin-arm64" "12.1.0"
+    "@next/swc-darwin-x64" "12.1.0"
+    "@next/swc-linux-arm-gnueabihf" "12.1.0"
+    "@next/swc-linux-arm64-gnu" "12.1.0"
+    "@next/swc-linux-arm64-musl" "12.1.0"
+    "@next/swc-linux-x64-gnu" "12.1.0"
+    "@next/swc-linux-x64-musl" "12.1.0"
+    "@next/swc-win32-arm64-msvc" "12.1.0"
+    "@next/swc-win32-ia32-msvc" "12.1.0"
+    "@next/swc-win32-x64-msvc" "12.1.0"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -24197,10 +24197,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-textextensions@^5.14.0:
-  version "5.14.0"
-  resolved "https://registry.npmjs.org/textextensions/-/textextensions-5.14.0.tgz#a6ff6aee5faaa751e6157d422c722a2bfd59eedf"
-  integrity sha512-4cAYwNFNYlIAHBUo7p6zw8POUvWbZor+/R0Tanv+rIhsauEyV9QSrEXL40pI+GfTQxKX8k6Tyw6CmdSDSmASrg==
+textextensions@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.npmjs.org/textextensions/-/textextensions-5.15.0.tgz#4bb3296ad6fc111cf4b39c589dd028d8aaaf7060"
+  integrity sha512-MeqZRHLuaGamUXGuVn2ivtU3LA3mLCCIO5kUGoohTCoGmCBg/+8yPhWVX9WSl9telvVd8erftjFk9Fwb2dD6rw==
 
 thenify-all@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
- DEPENDENCY_UPDATE: @dendronhq/plugin-core updated textextensions from 5.14.0 to 5.15.0

This change includes my contribution adding `XAML` as a text extension to the list, which will allow the Dendron preview to open XAML files when a linked to one is clicked in the preview.

The upgrade command also pulled in minor version upgrades to `nextjs`, but I left them in since they should be harmless.

#1695
