### PR TITLE
fix: typo "hierarchy", "should"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24920,7 +24920,7 @@ The changelog below lists changes that follow the [conventional commits](https:/
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## [0.20.1-alpha.13](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.12...v0.20.1-alpha.13) (2020-12-21)
 
@@ -24945,7 +24945,7 @@ The changelog below lists changes that follow the [conventional commits](https:/
 
 ### Bug Fixes
 
-- refactor hiearchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
+- refactor hierarchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
 
 ## [0.20.1-alpha.9](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.8...v0.20.1-alpha.9) (2020-12-19)
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Dendron has hundreds of features. The following is a list of highlights.
 
 - export your knowledge base as a static (nextjs) site
 - lookup locally and share globally with generated links
-- manage what you publish using fine grained permissions on a per vault, per hiearchy and per note basis
+- manage what you publish using fine grained permissions on a per vault, per hierarchy and per note basis
 
 <a href="https://www.loom.com/share/727537e0fd49481cac2accc2b3362fa3">
     <img style="" src="https://org-dendron-public-assets.s3.amazonaws.com/images/727537e0fd49481cac2accc2b3362fa3.gif">

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shoud show hierarchy"
+          "description": "Shouldd show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shouldd show hierarchy"
+          "description": "Should show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shoud show hiearchy"
+          "description": "Shoud show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -1,8 +1,8 @@
-import { DEngineClient } from "./typesv2";
-import { DHookDict } from "./hooks";
-import { IntermediateDendronConfig } from "./intermediateConfigs";
-import { SeedSite } from "./seed";
 import { URI } from "vscode-uri";
+import { DHookDict } from "./hooks";
+import { SeedSite } from "./seed";
+import { DEngineClient } from "./typesv2";
+import { IntermediateDendronConfig } from "./intermediateConfigs";
 
 // === Primitives
 export type DPermission = {

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -1,8 +1,8 @@
-import { URI } from "vscode-uri";
-import { DHookDict } from "./hooks";
-import { SeedSite } from "./seed";
 import { DEngineClient } from "./typesv2";
+import { DHookDict } from "./hooks";
 import { IntermediateDendronConfig } from "./intermediateConfigs";
+import { SeedSite } from "./seed";
+import { URI } from "vscode-uri";
 
 // === Primitives
 export type DPermission = {
@@ -276,7 +276,7 @@ export type DendronConfig = {
   useKatex?: boolean;
 
   /**
-   * Shoud show hiearchy
+   * Shoud show hierarchy
    */
   hierarchyDisplay?: boolean;
 

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -276,7 +276,7 @@ export type DendronConfig = {
   useKatex?: boolean;
 
   /**
-   * Shoud show hierarchy
+   * Shouldd show hierarchy
    */
   hierarchyDisplay?: boolean;
 

--- a/packages/common-all/src/types/workspace.ts
+++ b/packages/common-all/src/types/workspace.ts
@@ -276,7 +276,7 @@ export type DendronConfig = {
   useKatex?: boolean;
 
   /**
-   * Shouldd show hierarchy
+   * Should show hierarchy
    */
   hierarchyDisplay?: boolean;
 

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -1,25 +1,24 @@
 import {
   CONSTANTS,
-  ConfigUtils,
+  IntermediateDendronConfig,
+  DendronError,
   DVault,
   DWorkspace,
-  DendronError,
-  FOLDERS,
-  IntermediateDendronConfig,
   NoteProps,
   RESERVED_KEYS,
   VaultUtils,
+  ConfigUtils,
+  FOLDERS,
 } from "@dendronhq/common-all";
+import execa from "execa";
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
 import simpleGit, {
   SimpleGit,
   ResetMode as SimpleGitResetMode,
 } from "simple-git";
-
-import _ from "lodash";
-import execa from "execa";
-import fs from "fs-extra";
 import { parse } from "url";
-import path from "path";
 import { readYAMLAsync } from ".";
 import { vault2Path } from "./filesv2";
 

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -1,24 +1,25 @@
 import {
   CONSTANTS,
-  IntermediateDendronConfig,
-  DendronError,
+  ConfigUtils,
   DVault,
   DWorkspace,
+  DendronError,
+  FOLDERS,
+  IntermediateDendronConfig,
   NoteProps,
   RESERVED_KEYS,
   VaultUtils,
-  ConfigUtils,
-  FOLDERS,
 } from "@dendronhq/common-all";
-import execa from "execa";
-import fs from "fs-extra";
-import _ from "lodash";
-import path from "path";
 import simpleGit, {
   SimpleGit,
   ResetMode as SimpleGitResetMode,
 } from "simple-git";
+
+import _ from "lodash";
+import execa from "execa";
+import fs from "fs-extra";
 import { parse } from "url";
+import path from "path";
 import { readYAMLAsync } from ".";
 import { vault2Path } from "./filesv2";
 
@@ -27,8 +28,8 @@ export { simpleGit, SimpleGit, SimpleGitResetMode };
 const formatString = (opts: { txt: string; note: NoteProps }) => {
   const { txt, note } = opts;
   _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
-  const noteHiearchy = note.fname.replace(/\./g, "/");
-  return _.template(txt)({ noteHiearchy });
+  const noteHierarchy = note.fname.replace(/\./g, "/");
+  return _.template(txt)({ noteHierarchy });
 };
 
 /**

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shoud show hierarchy"
+          "description": "Shouldd show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shouldd show hierarchy"
+          "description": "Should show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -39,7 +39,7 @@
         },
         "hierarchyDisplay": {
           "type": "boolean",
-          "description": "Shoud show hiearchy"
+          "description": "Shoud show hierarchy"
         },
         "hierarchyDisplayTitle": {
           "type": "string",

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -13793,7 +13793,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## 0.20.1-alpha.13 (2020-12-21)
 
@@ -13805,7 +13805,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- refactor hiearchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
+- refactor hierarchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
 
 ## 0.20.1-alpha.7 (2020-12-19)
 
@@ -14874,7 +14874,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## [0.20.1-alpha.13](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.12...v0.20.1-alpha.13) (2020-12-21)
 
@@ -14898,7 +14898,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- refactor hiearchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
+- refactor hierarchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
 
 ## [0.20.1-alpha.7](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.6...v0.20.1-alpha.7) (2020-12-19)
 

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -1,24 +1,25 @@
+import { BackupKeyEnum, BackupService } from "./backup";
 import {
-  CleanDendronSiteConfig,
   CONSTANTS,
-  IntermediateDendronConfig,
+  CleanDendronPublishingConfig,
+  CleanDendronSiteConfig,
+  ConfigUtils,
+  DeepPartial,
   DendronError,
+  DendronPublishingConfig,
   DendronSiteConfig,
   ERROR_STATUS,
-  getStage,
-  ConfigUtils,
-  DendronPublishingConfig,
   GithubEditViewModeEnum,
-  CleanDendronPublishingConfig,
-  configIsV4,
+  IntermediateDendronConfig,
   StrictConfigV5,
-  DeepPartial,
+  configIsV4,
+  getStage,
 } from "@dendronhq/common-all";
 import { readYAML, writeYAML, writeYAMLAsync } from "@dendronhq/common-server";
-import fs from "fs-extra";
+
 import _ from "lodash";
+import fs from "fs-extra";
 import path from "path";
-import { BackupKeyEnum, BackupService } from "./backup";
 
 export class DConfig {
   static configPath(configRoot: string): string {
@@ -103,7 +104,7 @@ export class DConfig {
     if (_.size(siteHierarchies) < 1) {
       throw DendronError.createFromStatus({
         status: ERROR_STATUS.INVALID_CONFIG,
-        message: `siteHiearchies must have at least one hiearchy`,
+        message: `siteHiearchies must have at least one hierarchy`,
       });
     }
     siteIndex = this.getSiteIndex(config);
@@ -154,7 +155,7 @@ export class DConfig {
     if (_.size(siteHierarchies) < 1) {
       throw DendronError.createFromStatus({
         status: ERROR_STATUS.INVALID_CONFIG,
-        message: `siteHiearchies must have at least one hiearchy`,
+        message: `siteHiearchies must have at least one hierarchy`,
       });
     }
     siteIndex = this.getSiteIndex(config);

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -1,25 +1,24 @@
-import { BackupKeyEnum, BackupService } from "./backup";
 import {
-  CONSTANTS,
-  CleanDendronPublishingConfig,
   CleanDendronSiteConfig,
-  ConfigUtils,
-  DeepPartial,
+  CONSTANTS,
+  IntermediateDendronConfig,
   DendronError,
-  DendronPublishingConfig,
   DendronSiteConfig,
   ERROR_STATUS,
-  GithubEditViewModeEnum,
-  IntermediateDendronConfig,
-  StrictConfigV5,
-  configIsV4,
   getStage,
+  ConfigUtils,
+  DendronPublishingConfig,
+  GithubEditViewModeEnum,
+  CleanDendronPublishingConfig,
+  configIsV4,
+  StrictConfigV5,
+  DeepPartial,
 } from "@dendronhq/common-all";
 import { readYAML, writeYAML, writeYAMLAsync } from "@dendronhq/common-server";
-
-import _ from "lodash";
 import fs from "fs-extra";
+import _ from "lodash";
 import path from "path";
+import { BackupKeyEnum, BackupService } from "./backup";
 
 export class DConfig {
   static configPath(configRoot: string): string {

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -1,38 +1,39 @@
 import {
-  assert,
-  IntermediateDendronConfig,
-  DendronError,
-  DendronSiteConfig,
-  DendronSiteFM,
+  BooleanResp,
+  ConfigUtils,
   DNodeUtils,
-  DuplicateNoteActionEnum,
-  DuplicateNoteBehavior,
   DVault,
   DVaultVisibility,
+  DendronError,
+  DendronPublishingConfig,
+  DendronSiteConfig,
+  DendronSiteFM,
+  DuplicateNoteActionEnum,
+  DuplicateNoteBehavior,
   HierarchyConfig,
-  NotePropsDict,
+  IntermediateDendronConfig,
   NoteProps,
+  NotePropsDict,
   NoteUtils,
   UseVaultBehavior,
   VaultUtils,
-  BooleanResp,
-  ConfigUtils,
-  DendronPublishingConfig,
+  assert,
   configIsV4,
-  isBlockAnchor,
   getSlugger,
+  isBlockAnchor,
 } from "@dendronhq/common-all";
+import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
 import {
   createLogger,
   resolvePath,
   vault2Path,
 } from "@dendronhq/common-server";
-import fs from "fs-extra";
-import _ from "lodash";
-import path from "path";
+
 import { DConfig } from "../config";
 import { DEngineClient } from "../types";
-import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
+import _ from "lodash";
+import fs from "fs-extra";
+import path from "path";
 
 const LOGGER_NAME = "SiteUtils";
 
@@ -181,7 +182,7 @@ export class SiteUtils {
     // async pass to process all notes
     const domainsAndhiearchiesToPublish = await Promise.all(
       siteHierarchies.map(async (domain, idx) => {
-        const out = await SiteUtils.filterByHiearchy({
+        const out = await SiteUtils.filterByHierarchy({
           domain,
           config,
           engine,
@@ -203,7 +204,7 @@ export class SiteUtils {
       domains.push(domain);
       hiearchiesToPublish.push(notes);
     });
-    // if single hiearchy, domain includes all immediate children
+    // if single hierarchy, domain includes all immediate children
     if (
       !opts.noExpandSingleDomain &&
       siteHierarchies.length === 1 &&
@@ -233,9 +234,9 @@ export class SiteUtils {
   }
 
   /**
-   * Filter notes to be published using hiearchy
+   * Filter notes to be published using hierarchy
    */
-  static async filterByHiearchy(opts: {
+  static async filterByHierarchy(opts: {
     domain: string;
     config: IntermediateDendronConfig;
     engine: DEngineClient;
@@ -243,12 +244,12 @@ export class SiteUtils {
   }): Promise<{ notes: NotePropsDict; domain: NoteProps } | undefined> {
     const { domain, engine, navOrder, config } = opts;
     const logger = createLogger(LOGGER_NAME);
-    logger.info({ ctx: "filterByHiearchy:enter", domain, config });
+    logger.info({ ctx: "filterByHierarchy:enter", domain, config });
     const hConfig = this.getConfigForHierarchy({
       config,
       noteOrName: domain,
     });
-    const notesForHiearchy = _.clone(engine.notes);
+    const notesForHierarchy = _.clone(engine.notes);
 
     // get the domain note
     const notes = NoteUtils.getNotesByFnameFromEngine({
@@ -256,7 +257,7 @@ export class SiteUtils {
       engine,
     });
     logger.info({
-      ctx: "filterByHiearchy:candidates",
+      ctx: "filterByHierarchy:candidates",
       domain,
       hConfig,
       notes: notes.map((ent) => ent.id),
@@ -274,12 +275,12 @@ export class SiteUtils {
         config,
         fname: domain,
         noteCandidates: notes,
-        noteDict: notesForHiearchy,
+        noteDict: notesForHierarchy,
       });
       // no note found
     } else if (notes.length < 1) {
       logger.error({
-        ctx: "filterByHiearchy",
+        ctx: "filterByHierarchy",
         msg: "note not found",
         domain,
       });
@@ -313,7 +314,7 @@ export class SiteUtils {
     }
 
     logger.info({
-      ctx: "filterByHiearchy",
+      ctx: "filterByHierarchy",
       domainNote: NoteUtils.toNoteLoc(domainNote),
     });
 
@@ -326,7 +327,7 @@ export class SiteUtils {
       let note = processQ.pop() as NoteProps;
 
       logger.debug({
-        ctx: "filterByHiearchy",
+        ctx: "filterByHierarchy",
         maybeNote: NoteUtils.toNoteLoc(note),
       });
 
@@ -346,7 +347,7 @@ export class SiteUtils {
       let children = HierarchyUtils.getChildren({
         skipLevels: siteFM.skipLevels || 0,
         note,
-        notes: notesForHiearchy,
+        notes: notesForHierarchy,
       });
       if (siteFM.skipLevels && siteFM.skipLevels > 0) {
         note.children = children.map((ent) => ent.id);
@@ -364,7 +365,7 @@ export class SiteUtils {
         })
       );
       logger.debug({
-        ctx: "filterByHiearchy:post-filter-children",
+        ctx: "filterByHierarchy:post-filter-children",
         note: NoteUtils.toNoteLoc(note),
         children: children.map((ent) => ent.id),
       });
@@ -577,7 +578,7 @@ export class SiteUtils {
       const logger = createLogger(LOGGER_NAME);
       if (maybeDomainNotes.length < 1) {
         logger.error({
-          ctx: "filterByHiearchy",
+          ctx: "filterByHierarchy",
           msg: "dup-resolution: no note found",
           vault,
         });
@@ -606,7 +607,7 @@ export class SiteUtils {
     });
     const logger = createLogger(LOGGER_NAME);
     logger.info({
-      ctx: "filterByHiearchy",
+      ctx: "filterByHierarchy",
       msg: "dup-resolution: resolving dup",
       parent: domainNote.id,
       children: domainNote.children,

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -1,39 +1,38 @@
 import {
-  BooleanResp,
-  ConfigUtils,
-  DNodeUtils,
-  DVault,
-  DVaultVisibility,
+  assert,
+  IntermediateDendronConfig,
   DendronError,
-  DendronPublishingConfig,
   DendronSiteConfig,
   DendronSiteFM,
+  DNodeUtils,
   DuplicateNoteActionEnum,
   DuplicateNoteBehavior,
+  DVault,
+  DVaultVisibility,
   HierarchyConfig,
-  IntermediateDendronConfig,
-  NoteProps,
   NotePropsDict,
+  NoteProps,
   NoteUtils,
   UseVaultBehavior,
   VaultUtils,
-  assert,
+  BooleanResp,
+  ConfigUtils,
+  DendronPublishingConfig,
   configIsV4,
-  getSlugger,
   isBlockAnchor,
+  getSlugger,
 } from "@dendronhq/common-all";
-import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
 import {
   createLogger,
   resolvePath,
   vault2Path,
 } from "@dendronhq/common-server";
-
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
 import { DConfig } from "../config";
 import { DEngineClient } from "../types";
-import _ from "lodash";
-import fs from "fs-extra";
-import path from "path";
+import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
 
 const LOGGER_NAME = "SiteUtils";
 

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -12243,7 +12243,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## 0.20.1-alpha.13 (2020-12-21)
 
@@ -12553,7 +12553,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## [0.20.1-alpha.13](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.12...v0.20.1-alpha.13) (2020-12-21)
 

--- a/packages/engine-test-utils/src/__tests__/common-server/git.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/git.spec.ts
@@ -1,15 +1,14 @@
 import {
   ConfigUtils,
-  GithubEditViewModeEnum,
   RESERVED_KEYS,
   VaultUtils,
+  GithubEditViewModeEnum,
 } from "@dendronhq/common-all";
-import { runEngineTestV5, testWithEngine } from "../../engine";
-
-import { ENGINE_HOOKS } from "../../presets";
 import { GitUtils } from "@dendronhq/common-server";
 import _ from "lodash";
 import path from "path";
+import { runEngineTestV5, testWithEngine } from "../../engine";
+import { ENGINE_HOOKS } from "../../presets";
 
 describe("GitUtils", () => {
   describe("getGithubEditUrl", () => {

--- a/packages/engine-test-utils/src/__tests__/common-server/git.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/git.spec.ts
@@ -1,14 +1,15 @@
 import {
   ConfigUtils,
+  GithubEditViewModeEnum,
   RESERVED_KEYS,
   VaultUtils,
-  GithubEditViewModeEnum,
 } from "@dendronhq/common-all";
+import { runEngineTestV5, testWithEngine } from "../../engine";
+
+import { ENGINE_HOOKS } from "../../presets";
 import { GitUtils } from "@dendronhq/common-server";
 import _ from "lodash";
 import path from "path";
-import { runEngineTestV5, testWithEngine } from "../../engine";
-import { ENGINE_HOOKS } from "../../presets";
 
 describe("GitUtils", () => {
   describe("getGithubEditUrl", () => {
@@ -60,7 +61,7 @@ describe("GitUtils", () => {
       ConfigUtils.setGithubProp(config, "editBranch", "main");
       ConfigUtils.setGithubProp(config, "editRepository", gitUrl);
       const note = engine.notes["foo.ch1"];
-      note.custom[RESERVED_KEYS.GIT_NOTE_PATH] = "{{ noteHiearchy }}.md";
+      note.custom[RESERVED_KEYS.GIT_NOTE_PATH] = "{{ noteHierarchy }}.md";
       expect(GitUtils.getGithubEditUrl({ note, config, wsRoot })).toEqual(
         "https://github.com/dendronhq/dendron-site/edit/main/foo/ch1.md"
       );

--- a/packages/engine-test-utils/src/__tests__/site.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/site.spec.ts
@@ -1,32 +1,31 @@
 import {
-  AssertUtils,
-  NoteTestUtilsV4,
-  SetupHookFunction,
-} from "@dendronhq/common-test-utils";
-import {
   ConfigUtils,
-  DVault,
-  DVaultVisibility,
   DendronSiteFM,
   DuplicateNoteActionEnum,
+  DVault,
+  DVaultVisibility,
   NoteProps,
   NotePropsDict,
   NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
-import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../presets";
+import { tmpDir, vault2Path } from "@dendronhq/common-server";
+import {
+  AssertUtils,
+  NoteTestUtilsV4,
+  SetupHookFunction,
+} from "@dendronhq/common-test-utils";
+import { SiteUtils } from "@dendronhq/engine-server";
+import fs from "fs-extra";
+import _ from "lodash";
+import { TestConfigUtils } from "../config";
 import {
   createEngineFromEngine,
   createEngineFromServer,
   createSiteConfig,
   runEngineTestV5,
 } from "../engine";
-import { tmpDir, vault2Path } from "@dendronhq/common-server";
-
-import { SiteUtils } from "@dendronhq/engine-server";
-import { TestConfigUtils } from "../config";
-import _ from "lodash";
-import fs from "fs-extra";
+import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../presets";
 
 const basicSetup = (preSetupHook?: SetupHookFunction) => ({
   createEngine: createEngineFromEngine,

--- a/packages/engine-test-utils/src/__tests__/site.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/site.spec.ts
@@ -1,31 +1,32 @@
 import {
+  AssertUtils,
+  NoteTestUtilsV4,
+  SetupHookFunction,
+} from "@dendronhq/common-test-utils";
+import {
   ConfigUtils,
-  DendronSiteFM,
-  DuplicateNoteActionEnum,
   DVault,
   DVaultVisibility,
+  DendronSiteFM,
+  DuplicateNoteActionEnum,
   NoteProps,
   NotePropsDict,
   NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
-import { tmpDir, vault2Path } from "@dendronhq/common-server";
-import {
-  AssertUtils,
-  NoteTestUtilsV4,
-  SetupHookFunction,
-} from "@dendronhq/common-test-utils";
-import { SiteUtils } from "@dendronhq/engine-server";
-import fs from "fs-extra";
-import _ from "lodash";
-import { TestConfigUtils } from "../config";
+import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../presets";
 import {
   createEngineFromEngine,
   createEngineFromServer,
   createSiteConfig,
   runEngineTestV5,
 } from "../engine";
-import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../presets";
+import { tmpDir, vault2Path } from "@dendronhq/common-server";
+
+import { SiteUtils } from "@dendronhq/engine-server";
+import { TestConfigUtils } from "../config";
+import _ from "lodash";
+import fs from "fs-extra";
 
 const basicSetup = (preSetupHook?: SetupHookFunction) => ({
   createEngine: createEngineFromEngine,
@@ -453,7 +454,7 @@ describe("SiteUtils", () => {
       );
     });
 
-    test("one hiearchy", async () => {
+    test("one hierarchy", async () => {
       await runEngineTestV5(
         async ({ engine, wsRoot }) => {
           const config = TestConfigUtils.withConfig(
@@ -497,7 +498,7 @@ describe("SiteUtils", () => {
     });
 
     // TODO
-    test.skip("one hiearchy, dups with list override", async () => {
+    test.skip("one hierarchy, dups with list override", async () => {
       await runEngineTestV5(
         async ({ engine, wsRoot }) => {
           const config = TestConfigUtils.withConfig(
@@ -559,7 +560,7 @@ describe("SiteUtils", () => {
       );
     });
 
-    test("mult hiearchy", async () => {
+    test("mult hierarchy", async () => {
       await runEngineTestV5(
         async ({ engine, wsRoot }) => {
           const config = TestConfigUtils.withConfig(
@@ -603,7 +604,7 @@ describe("SiteUtils", () => {
     });
 
     // TODO: fix
-    test.skip("mult hiearchy, diff publishByDefault", async () => {
+    test.skip("mult hierarchy, diff publishByDefault", async () => {
       await runEngineTestV5(
         async ({ engine, wsRoot, vaults }) => {
           const config = TestConfigUtils.withConfig(

--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -1,3 +1,4 @@
+import { Col, Row, Typography } from "antd";
 /* eslint-disable */
 import {
   ConfigUtils,
@@ -8,12 +9,12 @@ import {
   Time,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { Row, Col, Typography } from "antd";
+import { useDendronRouter, useNoteActive } from "../utils/hooks";
+
+import React from "react";
 import _ from "lodash";
 import path from "path";
-import React from "react";
 import { useEngineAppSelector } from "../features/engine/hooks";
-import { useDendronRouter, useNoteActive } from "../utils/hooks";
 
 const { Text, Link } = Typography;
 
@@ -25,8 +26,8 @@ const ms2ShortDate = (ts: number) => {
 const formatString = (opts: { txt: string; note: NoteProps }) => {
   const { txt, note } = opts;
   _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
-  const noteHiearchy = note.fname.replace(/\./g, "/");
-  return _.template(txt)({ noteHiearchy });
+  const noteHierarchy = note.fname.replace(/\./g, "/");
+  return _.template(txt)({ noteHierarchy });
 };
 
 class GitUtils {

--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -1,4 +1,3 @@
-import { Col, Row, Typography } from "antd";
 /* eslint-disable */
 import {
   ConfigUtils,
@@ -9,12 +8,12 @@ import {
   Time,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { useDendronRouter, useNoteActive } from "../utils/hooks";
-
-import React from "react";
+import { Row, Col, Typography } from "antd";
 import _ from "lodash";
 import path from "path";
+import React from "react";
 import { useEngineAppSelector } from "../features/engine/hooks";
+import { useDendronRouter, useNoteActive } from "../utils/hooks";
 
 const { Text, Link } = Typography;
 

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -18133,7 +18133,7 @@ The changelog below lists changes that follow the [conventional commits](https:/
 
 ### Bug Fixes
 
-- handle single hiearchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
+- handle single hierarchy properly ([3e822a6](https://github.com/dendronhq/dendron/commit/3e822a6d659c5f4da6bd3ddad9bf1d93a5c353e3))
 
 ## [0.20.1-alpha.13](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.12...v0.20.1-alpha.13) (2020-12-21)
 
@@ -18158,7 +18158,7 @@ The changelog below lists changes that follow the [conventional commits](https:/
 
 ### Bug Fixes
 
-- refactor hiearchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
+- refactor hierarchy miss self referential links ([00b385d](https://github.com/dendronhq/dendron/commit/00b385dd0d13e5809da012bbc88388886012b837))
 
 ## [0.20.1-alpha.9](https://github.com/dendronhq/dendron/compare/v0.20.1-alpha.8...v0.20.1-alpha.9) (2020-12-19)
 

--- a/packages/plugin-core/README.md
+++ b/packages/plugin-core/README.md
@@ -130,7 +130,7 @@ Dendron has hundreds of features. The following is a list of highlights.
 
 - export your knowledge base as a static (nextjs) site
 - lookup locally and share globally with generated links
-- manage what you publish using fine grained permissions on a per vault, per hiearchy and per note basis
+- manage what you publish using fine grained permissions on a per vault, per hierarchy and per note basis
 
 <a href="https://www.loom.com/share/727537e0fd49481cac2accc2b3362fa3">
     <img style="" src="https://org-dendron-public-assets.s3.amazonaws.com/images/727537e0fd49481cac2accc2b3362fa3.gif">

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -1,21 +1,20 @@
+import { vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
   NoteTestUtilsV4,
   PreSetupHookFunction,
 } from "@dendronhq/common-test-utils";
-import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
+import fs from "fs-extra";
 import { afterEach, beforeEach, describe } from "mocha";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-
-import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
-import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
+import path from "path";
 import { RefactorHierarchyCommandV2 } from "../../commands/RefactorHierarchyV2";
 import { expect } from "../testUtilsv2";
-import fs from "fs-extra";
-import { getEngine } from "../../workspace";
-import path from "path";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import sinon from "sinon";
-import { vault2Path } from "@dendronhq/common-server";
+import { getEngine } from "../../workspace";
+import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
+import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 
 suite("RefactorHierarchy", function () {
   const ctx = setupBeforeAfter(this, {

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -1,22 +1,23 @@
-import { vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
   NoteTestUtilsV4,
   PreSetupHookFunction,
 } from "@dendronhq/common-test-utils";
-import fs from "fs-extra";
+import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
 import { afterEach, beforeEach, describe } from "mocha";
-import path from "path";
+import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+
+import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
 import { RefactorHierarchyCommandV2 } from "../../commands/RefactorHierarchyV2";
 import { expect } from "../testUtilsv2";
-import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-import sinon from "sinon";
+import fs from "fs-extra";
 import { getEngine } from "../../workspace";
-import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
-import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
-import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
+import path from "path";
+import sinon from "sinon";
+import { vault2Path } from "@dendronhq/common-server";
 
-suite("RefactorHiearchy", function () {
+suite("RefactorHierarchy", function () {
   const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });

--- a/templates/dendron.md.j2
+++ b/templates/dendron.md.j2
@@ -102,7 +102,7 @@ Below is the schema for the cli hierarchy.
 - id: cli 
   # human readable description of hierarchy
   desc: reference to cli programs
-  # the root of the hiearchy has a parent of root
+  # the root of the hierarchy has a parent of root
   parent: root
   # regex that is used to match nodes of the schema
   data.pattern: "^l"
@@ -114,7 +114,7 @@ Here is schema for the programming language hierarchy
 
 ```yml
 - id: programming_language
-  # an alias is the shorthand representation of a hiearchy
+  # an alias is the shorthand representation of a hierarchy
   alias: l
   parent: root
   namespace: true


### PR DESCRIPTION
This only changes the typo of `Hiearchy` to `Hierarchy` and `hiearchy` to `hierarchy`
More typos: "shoud" -> "should"

# Community PR Review Checklist


## First Time Specifics

- [x] if its your first pull request to Dendron, watch out for the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) bot that will ask you to agree to Dendron's CLA
- [x] if its your first pull request and you're on our Discord, make sure that Kevin gives you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) role by adding your discord as part of the description  👨‍🌾👩‍🌾

## Commit

- [x] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#branch-style)

## Code

- [x] code should follow [Code Conventions](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#branch-style)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

## Tests

- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
