### PR TITLE
chore: log anonymous id at startup

### DIFF
--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -256,6 +256,7 @@ export class SegmentClient {
       this._anonymousId = genUUID();
       fs.writeFileSync(uuidPath, this._anonymousId);
     }
+    this.logger.info({ msg: "anonymous id", anonymousId: this._anonymousId });
   }
 
   identifyAnonymous(props?: { [key: string]: any }, opts?: SegmentExtraArg) {


### PR DESCRIPTION
Logs the user anonymous id at startup, which may be helpful in debugging when a user sends us extension logs.