### PR TITLE
fix(workspace): webview already registered problem with lookup panel

### DIFF
--- a/packages/plugin-core/src/commands/CreateJournalNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateJournalNoteCommand.ts
@@ -47,7 +47,6 @@ export class CreateJournalNoteCommand extends BasicCommand<
         CopyNoteLinkBtn.create(false),
         HorizontalSplitBtn.create(false),
       ],
-      disableLookupView: true,
       title: "Create Journal Note",
     };
     const controller = this.extension.lookupControllerFactory.create(opts);

--- a/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
@@ -49,7 +49,6 @@ export class CreateScratchNoteCommand extends BasicCommand<
         CopyNoteLinkBtn.create(false),
         HorizontalSplitBtn.create(false),
       ],
-      disableLookupView: true,
       title: "Create Scratch Note",
     };
     const controller = this.extension.lookupControllerFactory.create(opts);

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -256,6 +256,7 @@ export class NoteLookupCommand
             copts.splitType === LookupSplitTypeEnum.horizontal
           ),
         ],
+        enableLookupView: true,
       });
     }
     this._provider = extension.noteLookupProviderFactory.create("lookup", {

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -64,7 +64,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     nodeType: DNodeType;
     buttons: DendronBtn[];
     fuzzThreshold?: number;
-    disableLookupView?: boolean;
+    enableLookupView?: boolean;
     title?: string;
     viewModel: ILookupViewModel;
   }) {
@@ -79,7 +79,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     this._title = opts.title;
 
     this._viewModel = opts.viewModel;
-    if (!opts.disableLookupView) {
+    if (opts.enableLookupView) {
       this._disposables.push(new LookupPanelView(this._viewModel));
     }
   }

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3Factory.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3Factory.ts
@@ -67,7 +67,7 @@ export class LookupControllerV3Factory implements ILookupControllerV3Factory {
       nodeType: opts?.nodeType as DNodeType,
       fuzzThreshold: opts?.fuzzThreshold,
       buttons: buttons.concat(extraButtons),
-      disableLookupView: opts?.disableLookupView,
+      enableLookupView: opts?.enableLookupView,
       title: opts?.title,
       viewModel,
     });

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3Interface.ts
@@ -120,9 +120,9 @@ export type LookupControllerV3CreateOpts = {
    */
   fuzzThreshold?: number;
   /**
-   * disable lookup view
+   * enable lookup view - false by default or if undefined
    */
-  disableLookupView?: boolean;
+  enableLookupView?: boolean;
   /**
    * optional custom title of quickpic
    */

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
@@ -73,7 +73,6 @@ describe(`GIVEN a LookupControllerV3`, () => {
       const controller = new LookupControllerV3({
         nodeType: "note",
         buttons,
-        disableLookupView: true,
         title: "Test Quick Pick",
         viewModel,
       });
@@ -202,7 +201,6 @@ describe(`GIVEN a LookupControllerV3`, () => {
       const controller = new LookupControllerV3({
         nodeType: "note",
         buttons,
-        disableLookupView: true,
         title: "Test Quick Pick",
         viewModel,
       });


### PR DESCRIPTION
## fix(workspace): webview already registered problem with lookup panel

Fixing the issue introduced with the lookup refactoring where a handful of views that required lookup wouldn't work because of a "webview with this name has already been registered" error from vscode.

There are two parts to this problem- this review only addresses one of them, but it should be sufficient to resolve this issue.  They are:
1. We weren't properly disabling lookup Panel view via the LookupV3Controller factory options for all views that didn't want the panel (which right now is all lookup instances besides the "main" lookup . Thus, a `LookupPanelView` would still get constructed, which would in turn do the vscode webview registration. I've flipped the opt from being a 'disablePanelView' to 'enablePanelView', and made the default `false` instead of true. This code change implements this change.
2. Everyone constructing `LookupControllerV3` needs to properly dispose it.  Right now, this only happens in `NoteLookupCommand`.  This change doesn't address this because it's actually quite tricky with how the controllers rely on HistoryService and split their lifecycle potentially across `GatherInputs` and `Execute` portions of the command execution lifecycle.  I've decided to defer this change until a later refactoring of `ILookupController` / `ILookupProvider`. Functionally, this should be ok as-is for now- the only other thing that gets disposed right now is the view model subscriptions, which should get cleaned up eventually anyway once the controller goes out of scope. 

---

## Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [N/A] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)