### PR TITLE
chore(internal): Fix flaky CopyNoteLink and BacklinksTreeDataProvider test

### DIFF
--- a/packages/common-all/src/types/compat.ts
+++ b/packages/common-all/src/types/compat.ts
@@ -3,6 +3,10 @@ export type Disposable = {
   dispose: () => any;
 };
 
+export const isDisposable = (cmd: any): cmd is Disposable => {
+  return (cmd as Disposable).dispose !== undefined;
+};
+
 /** Simplified version of VSCode's `Point` class. */
 export type VSPosition = {
   line: number;

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -329,6 +329,7 @@ const getLinkCandidates = ({
       const possibleCandidates = NoteUtils.getNotesByFnameFromEngine({
         fname: word,
         engine,
+        vault: note.vault,
       }).filter((note) => note.stub !== true);
       linkCandidates.push(
         ...possibleCandidates.map((candidate): DLink => {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -53,7 +53,6 @@ import {
   UPGRADE_TOAST_WORDING_TEST,
 } from "./abTests";
 import { ALL_COMMANDS } from "./commands";
-import { CopyNoteLinkCommand } from "./commands/CopyNoteLink";
 import { DoctorCommand, PluginDoctorActionsEnum } from "./commands/Doctor";
 import { GoToSiblingCommand } from "./commands/GoToSiblingCommand";
 import { MoveNoteCommand } from "./commands/MoveNoteCommand";

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -71,6 +71,7 @@ import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { OpenBackupCommand } from "./OpenBackupCommand";
 import { CopyToClipboardCommand } from "./CopyToClipboardCommand";
+import { CopyNoteLinkCommand } from "./CopyNoteLink";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -87,6 +88,7 @@ const ALL_COMMANDS = [
   ConfigureExportPodV2,
   ConfigureGraphStylesCommand,
   ContributeCommand,
+  CopyNoteLinkCommand,
   CopyNoteRefCommand,
   CopyNoteURLCommand,
   CopyToClipboardCommand,

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -131,14 +131,6 @@ function assertAreEqual(actual: ProviderResult<Backlink>, expected: Backlink) {
 }
 
 suite("BacklinksTreeDataProvider", function () {
-  /*const ctx = setupBeforeAfter(this, {
-    beforeHook: () => {
-      VSCodeUtils.closeAllEditors();
-    },
-    afterHook: () => {
-      VSCodeUtils.closeAllEditors();
-    },
-  });*/
   // Set test timeout to 3 seconds
   this.timeout(3000);
 

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -23,13 +23,8 @@ import BacklinksTreeDataProvider from "../../features/BacklinksTreeDataProvider"
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Backlink } from "../../features/Backlink";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { expect, runMultiVaultTest } from "../testUtilsv2";
-import {
-  describeMultiWS,
-  describeSingleWS,
-  setupBeforeAfter,
-} from "../testUtilsV3";
-import { WSUtils } from "../../WSUtils";
+import { expect } from "../testUtilsv2";
+import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
 import { BacklinkSortOrder } from "../../types";
 import { MockEngineEvents } from "./MockEngineEvents";
 
@@ -453,56 +448,6 @@ suite("BacklinksTreeDataProvider", function () {
       });
     }
   );
-
-  test("link candidates should only work within a vault", (done) => {
-    let alpha: NoteProps;
-    let gamma: NoteProps;
-    const ctx2 = setupBeforeAfter(this, {
-      beforeHook: () => {
-        VSCodeUtils.closeAllEditors();
-      },
-      afterHook: () => {
-        VSCodeUtils.closeAllEditors();
-      },
-    });
-    runMultiVaultTest({
-      ctx: ctx2,
-      preSetupHook: async ({ wsRoot, vaults }) => {
-        alpha = await NoteTestUtilsV4.createNote({
-          fname: "alpha",
-          body: `gamma`,
-          vault: vaults[0],
-          wsRoot,
-        });
-        gamma = await NOTE_PRESETS_V4.NOTE_WITH_LINK_CANDIDATE_TARGET.create({
-          wsRoot,
-          vault: vaults[1],
-        });
-      },
-      onInit: async ({ wsRoot }) => {
-        TestConfigUtils.withConfig(
-          (config) => {
-            config.dev = {
-              enableLinkCandidates: true,
-            };
-            return config;
-          },
-          { wsRoot }
-        );
-
-        await WSUtils.openNote(alpha);
-        const alphaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
-        expect(alphaOut).toEqual([]);
-        expect(alpha.links).toEqual([]);
-
-        await WSUtils.openNote(gamma);
-        const gammaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
-        expect(gammaOut).toEqual([]);
-        expect(gamma.links).toEqual([]);
-        done();
-      },
-    });
-  });
 
   describeSingleWS(
     "GIVEN a single vault workspace with links and link candidates",

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -491,10 +491,6 @@ suite("BacklinksTreeDataProvider", function () {
         );
 
         await WSUtils.openNote(alpha);
-        const engine = ExtensionProvider.getEngine();
-        debugger;
-
-        //const alpha = engine.notes["alpha"];
         const alphaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
         expect(alphaOut).toEqual([]);
         expect(alpha.links).toEqual([]);

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -436,11 +436,10 @@ suite("BacklinksTreeDataProvider", function () {
       },
     },
     () => {
-      test.only("THEN link candidates should only work within a vault", async () => {
+      test("THEN link candidates should only work within a vault", async () => {
         const engine = ExtensionProvider.getEngine();
 
         const alpha = engine.notes["alpha"];
-        debugger;
         await ExtensionProvider.getWSUtils().openNote(alpha);
         const alphaOut = (await getRootChildrenBacklinksAsPlainObject()).out;
         expect(alphaOut).toEqual([]);

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -7,7 +7,7 @@ import {
   testAssertsInsideCallback,
 } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
-import { beforeEach, describe } from "mocha";
+import { describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
 import { CopyNoteLinkCommand } from "../../commands/CopyNoteLink";
@@ -33,13 +33,6 @@ suite("CopyNoteLink", function () {
       postSetupHook: ENGINE_HOOKS.setupBasic,
     },
     () => {
-      let copyNoteLinkCommand: CopyNoteLinkCommand;
-      beforeEach(() => {
-        copyNoteLinkCommand = new CopyNoteLinkCommand(
-          toDendronEngineClient(ExtensionProvider.getEngine())
-        );
-      });
-
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
@@ -47,7 +40,11 @@ suite("CopyNoteLink", function () {
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual("[[Foo|foo]]");
       });
 
@@ -81,7 +78,9 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                copyNoteLinkCommand.run();
+                new CopyNoteLinkCommand(
+                  toDendronEngineClient(ExtensionProvider.getEngine())
+                ).run();
               });
           });
       });
@@ -101,7 +100,11 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
       });
 
@@ -120,7 +123,11 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(
           `[[Lörem Foo：Bar🙂Baz Ipsum|testUnicode#lörem-foobarbaz-ipsum]]`
         );
@@ -146,13 +153,21 @@ suite("CopyNoteLink", function () {
           char: 12,
         });
         editor.selection = new vscode.Selection(pos, pos2);
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
         editor.selection = new vscode.Selection(
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
-        const link2 = (await copyNoteLinkCommand.run())?.link;
+        const link2 = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link2).toEqual(`[[H2|${noteWithTarget.fname}#h2]]`);
       });
 
@@ -170,7 +185,11 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
-        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).execute({})
+        )?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -198,7 +217,11 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition(),
           LocationTestUtils.getPresetWikiLinkPosition({ char: 10 })
         );
-        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).execute({})
+        )?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -227,7 +250,11 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 12, char: 12 })
         );
-        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).execute({})
+        )?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -255,7 +282,11 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(`#foo.bar`);
       });
     }
@@ -271,13 +302,6 @@ suite("CopyNoteLink", function () {
       postSetupHook: ENGINE_HOOKS.setupBasic,
     },
     () => {
-      let copyNoteLinkCommand: CopyNoteLinkCommand;
-      beforeEach(() => {
-        copyNoteLinkCommand = new CopyNoteLinkCommand(
-          toDendronEngineClient(ExtensionProvider.getEngine())
-        );
-      });
-
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
@@ -285,7 +309,11 @@ suite("CopyNoteLink", function () {
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual("[[Foo|dendron://vault1/foo]]");
       });
 
@@ -319,7 +347,9 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                copyNoteLinkCommand.run();
+                new CopyNoteLinkCommand(
+                  toDendronEngineClient(ExtensionProvider.getEngine())
+                ).run();
               });
           });
       });
@@ -345,7 +375,11 @@ suite("CopyNoteLink", function () {
           char: 12,
         });
         editor.selection = new vscode.Selection(pos, pos2);
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(
           `[[H1|dendron://vault1/${noteWithTarget.fname}#h1]]`
         );
@@ -353,13 +387,21 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
-        const link2 = (await copyNoteLinkCommand.run())?.link;
+        const link2 = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link2).toEqual(
           `[[H2|dendron://vault1/${noteWithTarget.fname}#h2]]`
         );
 
         await openNote(noteWithAnchor);
-        const link3 = (await copyNoteLinkCommand.run())?.link;
+        const link3 = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link3).toEqual(
           `[[Beta|dendron://vault2/${noteWithAnchor.fname}]]`
         );
@@ -379,7 +421,11 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
-        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).execute({})
+        )?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -409,7 +455,11 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 12 })
         );
-        const link = (await copyNoteLinkCommand.execute({}))?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).execute({})
+        )?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -428,13 +478,6 @@ suite("CopyNoteLink", function () {
   );
 
   describeSingleWS("WHEN in a non-note file", {}, () => {
-    let copyNoteLinkCommand: CopyNoteLinkCommand;
-    beforeEach(() => {
-      copyNoteLinkCommand = new CopyNoteLinkCommand(
-        toDendronEngineClient(ExtensionProvider.getEngine())
-      );
-    });
-
     test("THEN creates a link to that file", async () => {
       const { wsRoot } = ExtensionProvider.getDWorkspace();
       const fsPath = path.join(wsRoot, "test.js");
@@ -443,7 +486,11 @@ suite("CopyNoteLink", function () {
         "const x = 'Pariatur officiis voluptatem molestiae.'"
       );
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-      const link = (await copyNoteLinkCommand.run())?.link;
+      const link = (
+        await new CopyNoteLinkCommand(
+          toDendronEngineClient(ExtensionProvider.getEngine())
+        ).run()
+      )?.link;
       expect(link).toEqual("[[test.js]]");
     });
 
@@ -453,7 +500,11 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(wsRoot, ".config.yaml");
         await fs.writeFile(fsPath, "x: 1");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual("[[.config.yaml]]");
       });
     });
@@ -473,7 +524,11 @@ suite("CopyNoteLink", function () {
           "x = 'Pariatur officiis voluptatem molestiae.'"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(path.join("[[assets", "test.py]]"));
       });
     });
@@ -485,7 +540,11 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(path.join(wsRoot, vaultPath), "test.rs");
         await fs.writeFile(fsPath, "let x = 123;");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(path.join(`[[${vaultPath}`, "test.rs]]"));
       });
     });
@@ -498,7 +557,11 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(dirPath, "test.clj");
         await fs.writeFile(fsPath, "(set! x 1)");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(link).toEqual(path.join("[[src", "clj", "test.clj]]"));
       });
     });

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -34,16 +34,14 @@ suite("CopyNoteLink", function () {
     },
     () => {
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
           vault2Path({ vault: vaults[0], wsRoot }),
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual("[[Foo|foo]]");
       });
@@ -78,14 +76,12 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                new CopyNoteLinkCommand(
-                  toDendronEngineClient(ExtensionProvider.getEngine())
-                ).run();
+                new CopyNoteLinkCommand(toDendronEngineClient(engine)).run();
               });
           });
       });
 
-      test("WHEN the editor is selecting a header, THEN CopyNoteLink should return a link with that header", async () => {
+      test.only("WHEN the editor is selecting a header, THEN CopyNoteLink should return a link with that header", async () => {
         const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const noteWithLink = await NoteTestUtilsV4.createNoteWithEngine({
           fname: "testHeader",
@@ -101,9 +97,7 @@ suite("CopyNoteLink", function () {
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
       });
@@ -124,9 +118,7 @@ suite("CopyNoteLink", function () {
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(
           `[[Lörem Foo：Bar🙂Baz Ipsum|testUnicode#lörem-foobarbaz-ipsum]]`
@@ -154,9 +146,7 @@ suite("CopyNoteLink", function () {
         });
         editor.selection = new vscode.Selection(pos, pos2);
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
         editor.selection = new vscode.Selection(
@@ -164,9 +154,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
         const link2 = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link2).toEqual(`[[H2|${noteWithTarget.fname}#h2]]`);
       });
@@ -186,9 +174,9 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).execute({})
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
+            {}
+          )
         )?.link;
         const body = editor.document.getText();
 
@@ -218,9 +206,9 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ char: 10 })
         );
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).execute({})
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
+            {}
+          )
         )?.link;
         const body = editor.document.getText();
 
@@ -251,9 +239,9 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 12, char: 12 })
         );
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).execute({})
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
+            {}
+          )
         )?.link;
         const body = editor.document.getText();
 
@@ -283,9 +271,7 @@ suite("CopyNoteLink", function () {
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(`#foo.bar`);
       });
@@ -303,16 +289,14 @@ suite("CopyNoteLink", function () {
     },
     () => {
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
           vault2Path({ vault: vaults[0], wsRoot }),
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual("[[Foo|dendron://vault1/foo]]");
       });
@@ -347,9 +331,7 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                new CopyNoteLinkCommand(
-                  toDendronEngineClient(ExtensionProvider.getEngine())
-                ).run();
+                new CopyNoteLinkCommand(toDendronEngineClient(engine)).run();
               });
           });
       });
@@ -376,9 +358,7 @@ suite("CopyNoteLink", function () {
         });
         editor.selection = new vscode.Selection(pos, pos2);
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(
           `[[H1|dendron://vault1/${noteWithTarget.fname}#h1]]`
@@ -388,9 +368,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
         const link2 = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link2).toEqual(
           `[[H2|dendron://vault1/${noteWithTarget.fname}#h2]]`
@@ -398,9 +376,7 @@ suite("CopyNoteLink", function () {
 
         await openNote(noteWithAnchor);
         const link3 = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link3).toEqual(
           `[[Beta|dendron://vault2/${noteWithAnchor.fname}]]`
@@ -422,9 +398,9 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).execute({})
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
+            {}
+          )
         )?.link;
         const body = editor.document.getText();
 
@@ -456,9 +432,9 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 12 })
         );
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).execute({})
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
+            {}
+          )
         )?.link;
         const body = editor.document.getText();
 
@@ -479,7 +455,7 @@ suite("CopyNoteLink", function () {
 
   describeSingleWS("WHEN in a non-note file", {}, () => {
     test("THEN creates a link to that file", async () => {
-      const { wsRoot } = ExtensionProvider.getDWorkspace();
+      const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
       const fsPath = path.join(wsRoot, "test.js");
       await fs.writeFile(
         fsPath,
@@ -487,23 +463,19 @@ suite("CopyNoteLink", function () {
       );
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
       const link = (
-        await new CopyNoteLinkCommand(
-          toDendronEngineClient(ExtensionProvider.getEngine())
-        ).run()
+        await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
       )?.link;
       expect(link).toEqual("[[test.js]]");
     });
 
     describe("AND the file name starts with a dot", async () => {
       test("THEN creates a link to that file", async () => {
-        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
         const fsPath = path.join(wsRoot, ".config.yaml");
         await fs.writeFile(fsPath, "x: 1");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual("[[.config.yaml]]");
       });
@@ -511,7 +483,7 @@ suite("CopyNoteLink", function () {
 
     describe("AND the file is in assets", () => {
       test("THEN creates a link using assets", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const dirPath = path.join(
           wsRoot,
           VaultUtils.getRelPath(vaults[0]),
@@ -525,9 +497,7 @@ suite("CopyNoteLink", function () {
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(path.join("[[assets", "test.py]]"));
       });
@@ -535,15 +505,13 @@ suite("CopyNoteLink", function () {
 
     describe("AND the file is in a vault, but not in assets", () => {
       test("THEN creates a link from root", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const vaultPath = VaultUtils.getRelPath(vaults[0]);
         const fsPath = path.join(path.join(wsRoot, vaultPath), "test.rs");
         await fs.writeFile(fsPath, "let x = 123;");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(path.join(`[[${vaultPath}`, "test.rs]]"));
       });
@@ -551,16 +519,14 @@ suite("CopyNoteLink", function () {
 
     describe("AND the file is in a nested folder", () => {
       test("THEN creates a link to that file", async () => {
-        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
         const dirPath = path.join(wsRoot, "src", "clj");
         await fs.ensureDir(dirPath);
         const fsPath = path.join(dirPath, "test.clj");
         await fs.writeFile(fsPath, "(set! x 1)");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
         const link = (
-          await new CopyNoteLinkCommand(
-            toDendronEngineClient(ExtensionProvider.getEngine())
-          ).run()
+          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
         )?.link;
         expect(link).toEqual(path.join("[[src", "clj", "test.clj]]"));
       });

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -27,6 +27,13 @@ function openNote(note: NoteProps) {
 }
 
 suite("CopyNoteLink", function () {
+  let copyNoteLinkCommand: CopyNoteLinkCommand;
+  beforeEach(() => {
+    copyNoteLinkCommand = new CopyNoteLinkCommand(
+      ExtensionProvider.getExtension()
+    );
+  });
+
   describeSingleWS(
     "GIVEN a basic setup on a single vault workspace",
     {
@@ -34,15 +41,13 @@ suite("CopyNoteLink", function () {
     },
     () => {
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
-        const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
           vault2Path({ vault: vaults[0], wsRoot }),
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual("[[Foo|foo]]");
       });
 
@@ -76,7 +81,7 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                new CopyNoteLinkCommand(toDendronEngineClient(engine)).run();
+                copyNoteLinkCommand.run();
               });
           });
       });
@@ -96,9 +101,7 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(`[[Foo Bar|${noteWithLink.fname}#foo-bar]]`);
       });
 
@@ -117,9 +120,7 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(
           `[[Lörem Foo：Bar🙂Baz Ipsum|testUnicode#lörem-foobarbaz-ipsum]]`
         );
@@ -145,17 +146,13 @@ suite("CopyNoteLink", function () {
           char: 12,
         });
         editor.selection = new vscode.Selection(pos, pos2);
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
         editor.selection = new vscode.Selection(
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
-        const link2 = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link2 = (await copyNoteLinkCommand.run())?.link;
         expect(link2).toEqual(`[[H2|${noteWithTarget.fname}#h2]]`);
       });
 
@@ -173,11 +170,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
-            {}
-          )
-        )?.link;
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -205,11 +198,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition(),
           LocationTestUtils.getPresetWikiLinkPosition({ char: 10 })
         );
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
-            {}
-          )
-        )?.link;
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -238,11 +227,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 12, char: 12 })
         );
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
-            {}
-          )
-        )?.link;
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -270,9 +255,7 @@ suite("CopyNoteLink", function () {
         const end = LocationTestUtils.getPresetWikiLinkPosition({ char: 10 });
         editor.selection = new vscode.Selection(start, end);
         // generate a wikilink for it
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(`#foo.bar`);
       });
     }
@@ -295,9 +278,7 @@ suite("CopyNoteLink", function () {
           "foo.md"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual("[[Foo|dendron://vault1/foo]]");
       });
 
@@ -331,7 +312,7 @@ suite("CopyNoteLink", function () {
                 );
               })
               .then(async () => {
-                new CopyNoteLinkCommand(toDendronEngineClient(engine)).run();
+                copyNoteLinkCommand.run();
               });
           });
       });
@@ -357,9 +338,7 @@ suite("CopyNoteLink", function () {
           char: 12,
         });
         editor.selection = new vscode.Selection(pos, pos2);
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(
           `[[H1|dendron://vault1/${noteWithTarget.fname}#h1]]`
         );
@@ -367,17 +346,13 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })
         );
-        const link2 = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link2 = (await copyNoteLinkCommand.run())?.link;
         expect(link2).toEqual(
           `[[H2|dendron://vault1/${noteWithTarget.fname}#h2]]`
         );
 
         await openNote(noteWithAnchor);
-        const link3 = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link3 = (await copyNoteLinkCommand.run())?.link;
         expect(link3).toEqual(
           `[[Beta|dendron://vault2/${noteWithAnchor.fname}]]`
         );
@@ -397,11 +372,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 10 })
         );
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
-            {}
-          )
-        )?.link;
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -431,11 +402,7 @@ suite("CopyNoteLink", function () {
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 10, char: 12 })
         );
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).execute(
-            {}
-          )
-        )?.link;
+        const link = (await copyNoteLinkCommand.execute({}))?.link;
         const body = editor.document.getText();
 
         // check that the link looks like what we expect
@@ -462,9 +429,7 @@ suite("CopyNoteLink", function () {
         "const x = 'Pariatur officiis voluptatem molestiae.'"
       );
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-      const link = (
-        await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-      )?.link;
+      const link = (await copyNoteLinkCommand.run())?.link;
       expect(link).toEqual("[[test.js]]");
     });
 
@@ -474,9 +439,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(wsRoot, ".config.yaml");
         await fs.writeFile(fsPath, "x: 1");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual("[[.config.yaml]]");
       });
     });
@@ -496,9 +459,7 @@ suite("CopyNoteLink", function () {
           "x = 'Pariatur officiis voluptatem molestiae.'"
         );
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join("[[assets", "test.py]]"));
       });
     });
@@ -510,9 +471,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(path.join(wsRoot, vaultPath), "test.rs");
         await fs.writeFile(fsPath, "let x = 123;");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join(`[[${vaultPath}`, "test.rs]]"));
       });
     });
@@ -525,9 +484,7 @@ suite("CopyNoteLink", function () {
         const fsPath = path.join(dirPath, "test.clj");
         await fs.writeFile(fsPath, "(set! x 1)");
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fsPath));
-        const link = (
-          await new CopyNoteLinkCommand(toDendronEngineClient(engine)).run()
-        )?.link;
+        const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(path.join("[[src", "clj", "test.clj]]"));
       });
     });

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -27,19 +27,19 @@ function openNote(note: NoteProps) {
 }
 
 suite("CopyNoteLink", function () {
-  let copyNoteLinkCommand: CopyNoteLinkCommand;
-  beforeEach(() => {
-    copyNoteLinkCommand = new CopyNoteLinkCommand(
-      toDendronEngineClient(ExtensionProvider.getEngine())
-    );
-  });
-
   describeSingleWS(
     "GIVEN a basic setup on a single vault workspace",
     {
       postSetupHook: ENGINE_HOOKS.setupBasic,
     },
     () => {
+      let copyNoteLinkCommand: CopyNoteLinkCommand;
+      beforeEach(() => {
+        copyNoteLinkCommand = new CopyNoteLinkCommand(
+          toDendronEngineClient(ExtensionProvider.getEngine())
+        );
+      });
+
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
@@ -271,6 +271,13 @@ suite("CopyNoteLink", function () {
       postSetupHook: ENGINE_HOOKS.setupBasic,
     },
     () => {
+      let copyNoteLinkCommand: CopyNoteLinkCommand;
+      beforeEach(() => {
+        copyNoteLinkCommand = new CopyNoteLinkCommand(
+          toDendronEngineClient(ExtensionProvider.getEngine())
+        );
+      });
+
       test("WHEN the editor is on a saved file, THEN CopyNoteLink should return link with title and fname of engine note", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const notePath = path.join(
@@ -421,6 +428,13 @@ suite("CopyNoteLink", function () {
   );
 
   describeSingleWS("WHEN in a non-note file", {}, () => {
+    let copyNoteLinkCommand: CopyNoteLinkCommand;
+    beforeEach(() => {
+      copyNoteLinkCommand = new CopyNoteLinkCommand(
+        toDendronEngineClient(ExtensionProvider.getEngine())
+      );
+    });
+
     test("THEN creates a link to that file", async () => {
       const { wsRoot } = ExtensionProvider.getDWorkspace();
       const fsPath = path.join(wsRoot, "test.js");
@@ -502,7 +516,11 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a block anchor", async () => {
           await prepFileAndSelection(" ^my-block-anchor");
-          const link = (await copyNoteLinkCommand.run())?.link;
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
           expect(
             await linkHasAnchor(
               "block",
@@ -526,7 +544,11 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a line anchor", async () => {
           await prepFileAndSelection();
-          const link = (await copyNoteLinkCommand.run())?.link;
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
           // Link should contain an anchor
           expect(
             await linkHasAnchor("line", ["src", "test.hs"], link)
@@ -546,7 +568,11 @@ suite("CopyNoteLink", function () {
       () => {
         test("THEN creates a link to that file with a block anchor", async () => {
           await prepFileAndSelection();
-          const link = (await copyNoteLinkCommand.run())?.link;
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
           expect(
             await linkHasAnchor("block", ["src", "test.hs"], link)
           ).toBeTruthy();
@@ -557,83 +583,97 @@ suite("CopyNoteLink", function () {
     describeSingleWS("AND config is set unset", {}, () => {
       test("THEN creates a link to that file with a block anchor", async () => {
         await prepFileAndSelection();
-        const link = (await copyNoteLinkCommand.run())?.link;
+        const link = (
+          await new CopyNoteLinkCommand(
+            toDendronEngineClient(ExtensionProvider.getEngine())
+          ).run()
+        )?.link;
         expect(
           await linkHasAnchor("block", ["src", "test.hs"], link)
         ).toBeTruthy();
       });
     });
 
-    describe("AND config is set to prompt", () => {
-      describeSingleWS(
-        "AND user picks line in the prompt",
-        {
-          modConfigCb: (config) => {
-            ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
-            return config;
-          },
+    describeSingleWS(
+      "GIVEN a workspace where config is set to prompt",
+      {
+        modConfigCb: (config) => {
+          ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
+          return config;
         },
-        () => {
-          test("THEN generates a link anchor ", async () => {
-            await prepFileAndSelection();
-            const pick = sinon
-              .stub(vscode.window, "showQuickPick")
-              .resolves({ label: "line" });
-            const link = (await copyNoteLinkCommand.run())?.link;
-            expect(pick.calledOnce).toBeTruthy();
-            expect(
-              await linkHasAnchor("line", ["src", "test.hs"], link)
-            ).toBeTruthy();
-          });
-        }
-      );
+      },
+      () => {
+        test("WHEN user picks line in the prompt, THEN CopyNoteLinkCommand generates a link anchor ", async () => {
+          await prepFileAndSelection();
+          const pick = sinon
+            .stub(vscode.window, "showQuickPick")
+            .resolves({ label: "line" });
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
+          expect(pick.calledOnce).toBeTruthy();
+          expect(
+            await linkHasAnchor("line", ["src", "test.hs"], link)
+          ).toBeTruthy();
+        });
+      }
+    );
 
-      describeSingleWS(
-        "AND user picks block in the prompt",
-        {
-          modConfigCb: (config) => {
-            ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
-            return config;
-          },
+    describeSingleWS(
+      "GIVEN a workspace where config is set to prompt",
+      {
+        modConfigCb: (config) => {
+          ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
+          return config;
         },
-        () => {
-          test("THEN generates a block anchor ", async () => {
-            await prepFileAndSelection();
-            const pick = sinon
-              .stub(vscode.window, "showQuickPick")
-              .resolves({ label: "block" });
-            const link = (await copyNoteLinkCommand.run())?.link;
-            expect(pick.calledOnce).toBeTruthy();
-            expect(
-              await linkHasAnchor("block", ["src", "test.hs"], link)
-            ).toBeTruthy();
-          });
-        }
-      );
+      },
+      () => {
+        test("WHEN user picks block in the prompt, THEN CopyNoteLinkCommand generates a block anchor ", async () => {
+          await prepFileAndSelection();
+          const pick = sinon
+            .stub(vscode.window, "showQuickPick")
+            .resolves({ label: "block" });
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
+          expect(pick.calledOnce).toBeTruthy();
+          expect(
+            await linkHasAnchor("block", ["src", "test.hs"], link)
+          ).toBeTruthy();
+        });
+      }
+    );
 
-      describeSingleWS(
-        "AND user cancels the prompt",
-        {
-          modConfigCb: (config) => {
-            ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
-            return config;
-          },
+    describeSingleWS(
+      "GIVEN a workspace where config is set to prompt",
+      {
+        modConfigCb: (config) => {
+          ConfigUtils.setNonNoteLinkAnchorType(config, "prompt");
+          return config;
         },
-        () => {
-          test("THEN generates a line anchor ", async () => {
-            await prepFileAndSelection();
-            const pick = sinon
-              .stub(vscode.window, "showQuickPick")
-              .resolves(undefined);
-            const link = (await copyNoteLinkCommand.run())?.link;
-            expect(pick.calledOnce).toBeTruthy();
-            expect(
-              await linkHasAnchor("line", ["src", "test.hs"], link)
-            ).toBeTruthy();
-          });
-        }
-      );
-    });
+      },
+      () => {
+        test("WHEN user cancels the prompt, THEN CopyNoteLinkCommand generates a line anchor ", async () => {
+          await prepFileAndSelection();
+          const pick = sinon
+            .stub(vscode.window, "showQuickPick")
+            .resolves(undefined);
+          const link = (
+            await new CopyNoteLinkCommand(
+              toDendronEngineClient(ExtensionProvider.getEngine())
+            ).run()
+          )?.link;
+          expect(pick.calledOnce).toBeTruthy();
+          expect(
+            await linkHasAnchor("line", ["src", "test.hs"], link)
+          ).toBeTruthy();
+        });
+      }
+    );
   });
 });
 

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -72,7 +72,6 @@ import {
   stubWorkspaceFile,
   stubWorkspaceFolders,
 } from "./testUtilsv2";
-import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
 
 const TIMEOUT = 60 * 1000 * 5;
 
@@ -671,8 +670,8 @@ export function subscribeToEngineStateChange(
   return engineClient.onEngineNoteStateChanged(callback);
 }
 
-export function toDendronEngineClient(engine: IEngineAPIService) {
-  return engine as unknown as DendronEngineClient;
+export function toDendronEngineClient(engine: DEngineClient) {
+  return engine as DendronEngineClient;
 }
 
 export async function waitInMilliseconds(milliseconds: number): Promise<void> {


### PR DESCRIPTION
**Changes**
1. One reason `CopyNoteLink` test keeps failing is that its trying to access the engine before its setup. Add requirement in class to need active workspace
2. Fixed bug in BackLinksDataProvider (with help from hikchoi) where linkCandidates wasn't respecting the same vault only requirement
3. Refactored BackLinksDataProvider test to newest test harness
4. Add `await` to setupCommands. Noticed some tests ran into "this command is already registered command". I believe its caused by running `setupCommands` twice w/o waiting for the first to finish.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)