### PR TITLE
chore: ab testing framework

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -13,6 +13,7 @@ export enum VSCodeEvents {
   /** @deprecated: treeview v2 is deprecated. */
   TreeView_Ready = "TreeView_Ready",
   Upgrade = "Upgrade",
+  UpgradeSeeWhatsChangedClicked = "UpgradeSeeWhatsChangedClicked",
   DisableTelemetry = "DisableTelemetry",
   EnableTelemetry = "EnableTelemetry",
   Uninstall = "Uninstall",

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -14,6 +14,7 @@ export enum VSCodeEvents {
   TreeView_Ready = "TreeView_Ready",
   Upgrade = "Upgrade",
   UpgradeSeeWhatsChangedClicked = "UpgradeSeeWhatsChangedClicked",
+  UpgradeViewClosed = "UpgradeViewClosed",
   DisableTelemetry = "DisableTelemetry",
   EnableTelemetry = "EnableTelemetry",
   Uninstall = "Uninstall",

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -54,6 +54,7 @@
     "pino": "^6.3.2",
     "pino-pretty": "^4.3.0",
     "simple-git": "^3.3.0",
+    "spark-md5": "^3.0.2",
     "tmp": "^0.2.1",
     "vscode-uri": "^2.1.2",
     "yaml-unist-parser": "^1.3.1"

--- a/packages/common-server/src/abTesting.ts
+++ b/packages/common-server/src/abTesting.ts
@@ -1,0 +1,69 @@
+import _ from "lodash";
+import SparkMD5 from "spark-md5";
+
+/** One group in an A/B test. Describes one group of users. */
+type ABTestGroup<GroupNames> = {
+  /** Name for the group. */
+  name: GroupNames;
+  /** The likelihood of a user to be in this group. The number should be
+   * positive and nonzero. The weight is calculated in relation to the weight of other groups
+   * in the A/B test. */
+  weight: number;
+};
+
+const MAX_B16_INT = 0xffffffff;
+
+/** One A/B test.
+ *
+ * Warning! Test names **must** stay consistent between Dendron releases, or
+ * users will see the tests flip/flop.
+ *
+ * Can test two or more groups.
+ *
+ * ```ts
+ * const EXAMPLE_TEST = new ABTest("example", [
+ *   {
+ *     name: "user with example",
+ *     weight: 2,
+ *   },
+ *   {
+ *     name: "users without example",
+ *     weight: 1,
+ *   },
+ * ]);
+ *
+ * EXAMPLE_TEST.getUserGroup("anonymous user UUID");
+ * ```
+ */
+export class ABTest<GroupNames> {
+  public name: string;
+  private groups: ABTestGroup<GroupNames>[];
+
+  constructor(name: string, groups: ABTestGroup<GroupNames>[]) {
+    this.name = name;
+
+    const sumWeights = _.sumBy(groups, (group) => group.weight);
+    this.groups = groups.map((group) => {
+      return { ...group, weight: group.weight / sumWeights };
+    });
+  }
+
+  /** Given the user ID, find which group of the AB test the user belongs to. */
+  public getUserGroup(userId: string) {
+    const hash = SparkMD5.hash(`${this.name}:${userId}`);
+    const hashedInt = parseInt(`0x${hash.slice(0, 8)}`, 16);
+    const userRandom = hashedInt / MAX_B16_INT;
+
+    // add up group weights until we hit the user random
+    let accum = 0;
+    for (const group of this.groups) {
+      accum += group.weight;
+
+      // once we're above the user's random threshold, the user is in this group
+      if (userRandom <= accum) {
+        return group.name;
+      }
+    }
+    return this.groups[this.groups.length - 1].name;
+  }
+}

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -536,6 +536,10 @@ type UserProfileProps = {
    */
   numNotes?: number;
   /**
+   * The current A/B test groups the user is participating in
+   */
+  splitTests?: string[];
+  /**
    * The role of user. Retrieved from initial survey.
    */
   role?: string;

--- a/packages/common-server/src/index.ts
+++ b/packages/common-server/src/index.ts
@@ -10,3 +10,4 @@ export * from "./errorReporting";
 export * from "./types";
 export * from "./server";
 export * from "./yaml";
+export * from "./abTesting";

--- a/packages/engine-test-utils/src/__tests__/common-server/abTesting.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/abTesting.spec.ts
@@ -1,0 +1,123 @@
+import { ABTest } from "@dendronhq/common-server";
+import { DefaultMap, genUUID } from "@dendronhq/common-all";
+import _ from "lodash";
+
+// To make checks more accurate, make FLOAT_SAME smaller and LOOP much larger.
+// The tests to pass when the accuracy is higher, they just take longer.
+const FLOAT_SAME = 0.01; // accurate to 1 percent
+const LOOP = 20000;
+
+function estimateABTestOutcomes<Out>(test: ABTest<Out>): Map<Out, number> {
+  const foundCount = new DefaultMap<Out, number>(() => 0);
+
+  let i = 0;
+  // eslint-disable-next-line no-plusplus
+  for (; i < LOOP; i++) {
+    const group = test.getUserGroup(genUUID());
+    foundCount.set(group, foundCount.get(group) + 1);
+  }
+
+  const sum = _.sum([...foundCount.values()]);
+  return new Map(
+    [...foundCount.entries()].map(([group, count]) => [group, count / sum])
+  );
+}
+
+/** Returns true if both floats are approximately equal. */
+export function checkFloatEquals(
+  left: number,
+  right: number,
+  accept: number = FLOAT_SAME
+) {
+  return Math.abs(left - right) < accept;
+}
+
+describe("GIVEN ABTest", () => {
+  describe("WHEN the same user is checked for the same test multiple times", () => {
+    test("THEN they get the same group every time", () => {
+      const userId = genUUID();
+      const abTest = new ABTest("abtest", [
+        {
+          name: "left",
+          weight: 1,
+        },
+        {
+          name: "right",
+          weight: 1,
+        },
+      ]);
+      const first = abTest.getUserGroup(userId);
+      // Repeating this a few times to make sure we always get the same outcome
+      expect(abTest.getUserGroup(userId)).toEqual(first);
+      expect(abTest.getUserGroup(userId)).toEqual(first);
+      expect(abTest.getUserGroup(userId)).toEqual(first);
+      expect(abTest.getUserGroup(userId)).toEqual(first);
+      expect(abTest.getUserGroup(userId)).toEqual(first);
+    });
+  });
+
+  describe("WHEN there are 2 groups of equal weight", () => {
+    test("THEN the groups will appear approximately equally", () => {
+      const estimates = estimateABTestOutcomes(
+        new ABTest("abtest", [
+          {
+            name: "left",
+            weight: 1,
+          },
+          {
+            name: "right",
+            weight: 1,
+          },
+        ])
+      );
+
+      expect(checkFloatEquals(estimates.get("left")!, 0.5)).toBeTruthy();
+      expect(checkFloatEquals(estimates.get("right")!, 0.5)).toBeTruthy();
+    });
+  });
+
+  describe("WHEN there are 2 groups of differing weights", () => {
+    test("THEN that group will appear more often", () => {
+      const estimates = estimateABTestOutcomes(
+        new ABTest("abtest", [
+          {
+            name: "left",
+            weight: 3,
+          },
+          {
+            name: "right",
+            weight: 1,
+          },
+        ])
+      );
+
+      expect(checkFloatEquals(estimates.get("left")!, 0.75)).toBeTruthy();
+      expect(checkFloatEquals(estimates.get("right")!, 0.25)).toBeTruthy();
+    });
+  });
+
+  describe("WHEN there are 3 groups of equal weight", () => {
+    test("THEN the groups will appear approximately equally", () => {
+      const estimates = estimateABTestOutcomes(
+        new ABTest("abtest", [
+          {
+            name: "left",
+            weight: 1,
+          },
+          {
+            name: "middle",
+            weight: 1,
+          },
+          {
+            name: "right",
+            weight: 1,
+          },
+        ])
+      );
+
+      expect(checkFloatEquals(estimates.get("left")!, 0.333)).toBeTruthy();
+      expect(checkFloatEquals(estimates.get("middle")!, 0.333)).toBeTruthy();
+      expect(checkFloatEquals(estimates.get("right")!, 0.333)).toBeTruthy();
+    });
+  });
+});

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -46,7 +46,7 @@ import semver from "semver";
 import * as vscode from "vscode";
 import {
   CURRENT_AB_TESTS,
-  UpgradeToastOrViewTestEnum,
+  UpgradeToastOrViewTestGroups,
   UPGRADE_TOAST_OR_VIEW_TEST,
 } from "./abTests";
 import { ALL_COMMANDS } from "./commands";
@@ -826,7 +826,7 @@ async function showWelcomeOrWhatsNew({
       });
 
       switch (toastOrView) {
-        case UpgradeToastOrViewTestEnum.upgradeToast: {
+        case UpgradeToastOrViewTestGroups.upgradeToast: {
           vscode.window
             .showInformationMessage(
               `Dendron has been upgraded to ${version} from ${previousExtensionVersion}`,
@@ -851,7 +851,7 @@ async function showWelcomeOrWhatsNew({
             });
           break;
         }
-        case UpgradeToastOrViewTestEnum.upgradeView: {
+        case UpgradeToastOrViewTestGroups.upgradeView: {
           showUpgradeView();
           break;
         }

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -1,0 +1,17 @@
+import { ABTest } from "@dendronhq/common-server";
+
+export enum UpgradeToastOrViewTestEnum {
+  upgradeToast = "upgradeToast",
+  upgradeView = "upgradeView",
+}
+
+export const UPGRADE_TOAST_OR_VIEW_TEST = new ABTest("UpgradeToastOrViewTest", [
+  {
+    name: UpgradeToastOrViewTestEnum.upgradeToast,
+    weight: 1,
+  },
+  {
+    name: UpgradeToastOrViewTestEnum.upgradeView,
+    weight: 1,
+  },
+]);

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -1,5 +1,7 @@
 import { ABTest } from "@dendronhq/common-server";
 
+// ^xi5t1r2j51ot
+
 export enum UpgradeToastOrViewTestEnum {
   upgradeToast = "upgradeToast",
   upgradeView = "upgradeView",
@@ -15,3 +17,9 @@ export const UPGRADE_TOAST_OR_VIEW_TEST = new ABTest("UpgradeToastOrViewTest", [
     weight: 1,
   },
 ]);
+
+/** All A/B tests that are currently running.
+ *
+ * ^tkqhy45hflfd
+ */
+export const CURRENT_AB_TESTS = [UPGRADE_TOAST_OR_VIEW_TEST];

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -1,19 +1,21 @@
+// ^xi5t1r2j51ot
 import { ABTest } from "@dendronhq/common-server";
 
-// ^xi5t1r2j51ot
-
-export enum UpgradeToastOrViewTestEnum {
+export enum UpgradeToastOrViewTestGroups {
+  /** Users who get a toast notification in the corner of VSCode. */
   upgradeToast = "upgradeToast",
+  /** Users who get a upgrade webview pop up.  */
   upgradeView = "upgradeView",
 }
 
+/** Test if showing a web view on an upgrade is more successful than showing a toast notification. */
 export const UPGRADE_TOAST_OR_VIEW_TEST = new ABTest("UpgradeToastOrViewTest", [
   {
-    name: UpgradeToastOrViewTestEnum.upgradeToast,
+    name: UpgradeToastOrViewTestGroups.upgradeToast,
     weight: 1,
   },
   {
-    name: UpgradeToastOrViewTestEnum.upgradeView,
+    name: UpgradeToastOrViewTestGroups.upgradeView,
     weight: 1,
   },
 ]);

--- a/packages/plugin-core/src/views/UpgradeView.ts
+++ b/packages/plugin-core/src/views/UpgradeView.ts
@@ -1,0 +1,36 @@
+import vscode from "vscode";
+
+const UPGRADE_VIEW_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>"Release Notes"</title>
+  <style>
+    html, body, iframe {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      height: 100vh;
+      width: 100vw;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <iframe id="iframeView" src="https://wiki.dendron.so/notes/9bc92432-a24c-492b-b831-4d5378c1692b/"></iframe>
+</body>
+
+</html>`;
+
+export function showUpgradeView() {
+  const panel = vscode.window.createWebviewPanel(
+    "releaseNotes",
+    "Release Notes",
+    vscode.ViewColumn.One,
+    {}
+  );
+
+  panel.webview.html = UPGRADE_VIEW_HTML;
+  panel.reveal();
+}

--- a/packages/plugin-core/src/views/UpgradeView.ts
+++ b/packages/plugin-core/src/views/UpgradeView.ts
@@ -1,4 +1,7 @@
+import { VSCodeEvents } from "@dendronhq/common-all";
 import vscode from "vscode";
+import { AnalyticsUtils } from "../utils/analytics";
+import { WebViewUtils } from "./utils";
 
 const UPGRADE_VIEW_HTML = `<!DOCTYPE html>
 <html lang="en">
@@ -32,5 +35,10 @@ export function showUpgradeView() {
   );
 
   panel.webview.html = UPGRADE_VIEW_HTML;
-  panel.reveal();
+
+  WebViewUtils.openWebviewAndMeasureTimeOpen(panel, (duration) => {
+    AnalyticsUtils.track(VSCodeEvents.UpgradeViewClosed, {
+      timeOpen: duration,
+    });
+  });
 }

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -6,7 +6,11 @@ import {
   getStage,
   getWebTreeViewEntry,
 } from "@dendronhq/common-all";
-import { findUpTo, WebViewCommonUtils } from "@dendronhq/common-server";
+import {
+  findUpTo,
+  getDurationMilliseconds,
+  WebViewCommonUtils,
+} from "@dendronhq/common-server";
 import path from "path";
 import * as vscode from "vscode";
 import { IDendronExtension } from "../dendronExtensionInterface";
@@ -272,4 +276,42 @@ export class WebViewUtils {
      */
     return WebViewUtils.genHTMLForView({ title, view });
   };
+
+  /** Opens the given panel, and measures how long it stays open.
+   *
+   * Call this function **before** you open the panel with `panel.reveal()`.
+   * This function will open the panel for you.
+   *
+   * @param panel The panel, must not have been opened yet.
+   * @param onClose A callback that will run once the webview is closed. The duration given is in milliseconds.
+   */
+  static openWebviewAndMeasureTimeOpen(
+    panel: vscode.WebviewPanel,
+    onClose: (duration: number) => void
+  ) {
+    let visibleTimeTotal = 0;
+    // We don't get an initial view state change event, so we have to start the timer now
+    let visibleStart: [number, number] | undefined = process.hrtime();
+
+    panel.onDidChangeViewState((event) => {
+      if (event.webviewPanel.visible) {
+        // When the user switches back into the view, we start measuring
+        visibleStart = process.hrtime();
+      } else {
+        // When the user switches away from the view, we stop measuring
+        if (visibleStart)
+          visibleTimeTotal += getDurationMilliseconds(visibleStart);
+        visibleStart = undefined;
+      }
+    });
+
+    panel.onDidDispose(() => {
+      // If the user closes the webview while it's open, the view state change
+      // event is skipped and it immediately calls the dispose event.
+      if (visibleStart)
+        visibleTimeTotal += getDurationMilliseconds(visibleStart);
+
+      onClose(visibleTimeTotal);
+    });
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23250,7 +23250,7 @@ space-separated-tokens@^1.0.0:
   resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
-spark-md5@^3.0.1:
+spark-md5@^3.0.1, spark-md5@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==


### PR DESCRIPTION
Adds an A/B testing framework to Dendron. To demonstrate this framework, also adds an A/B test for displaying a toast with a link to the changelog, versus displaying the changelog page in a webview.

Docs: https://github.com/dendronhq/dendron-docs/pull/25

The webview looks like this: 
![image](https://user-images.githubusercontent.com/1008124/162163595-312f3cd5-7fe1-44e0-bea8-d63448bbef40.png)

Co-authored-by: jonathanyeung <jonathanyeung@users.noreply.github.com>

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)
