### PR TITLE
fix(publish): add luxon as dev dependency

### DIFF
--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -47,6 +47,7 @@
     "@next/bundle-analyzer": "^11.1.2",
     "@playwright/test": "^1.18.1",
     "@types/fs-extra": "^9.0.12",
+    "@types/luxon": "^2.3.1",
     "@types/react": "^17.0.21",
     "eslint": "^7.32.0",
     "eslint-config-next": "^11.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5542,6 +5542,11 @@
   resolved "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz#aceeb2d5be8fccf541237e184e37ecff5faa9096"
   integrity sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==
 
+"@types/luxon@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@types/luxon/-/luxon-2.3.1.tgz#e34763178b46232e4c5f079f1706e18692415519"
+  integrity sha512-nAPUltOT28fal2eDZz8yyzNhBjHw1NEymFBP7Q9iCShqpflWPybxHbD7pw/46jQmT+HXOy1QN5hNTms8MOTlOQ==
+
 "@types/markdown-it@^10.0.2":
   version "10.0.3"
   resolved "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-10.0.3.tgz#a9800d14b112c17f1de76ec33eff864a4815eec7"


### PR DESCRIPTION
fix(publish): add luxon as dev dependency

Required for clean build of nextjs-template