### PR TITLE
chore: fixing release names for sentry source map uploads

### DIFF
--- a/packages/plugin-core/webpack.common.js
+++ b/packages/plugin-core/webpack.common.js
@@ -62,14 +62,25 @@ const config = {
     ...(process.env.SKIP_SENTRY
       ? []
       : [
+          // Upload one set of source maps to associate it with the vscode@ prefixed client release:
           // @ts-ignore
           new SentryWebpackPlugin({
             authToken: process.env.SENTRY_AUTH_TOKEN,
             org: "dendron",
             project: "dendron",
-            release: process.env.DENDRON_RELEASE_VERSION,
+            release: "vscode@" + process.env.DENDRON_RELEASE_VERSION,
 
             // other SentryWebpackPlugin configuration
+            include: ".",
+            ignore: ["node_modules", "webpack.*.js"],
+          }),
+          // Upload a second set of source maps to associate it with the express@ prefixed client release:
+          // @ts-ignore
+          new SentryWebpackPlugin({
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            org: "dendron",
+            project: "dendron",
+            release: "express@" + process.env.DENDRON_RELEASE_VERSION,
             include: ".",
             ignore: ["node_modules", "webpack.*.js"],
           }),


### PR DESCRIPTION
## chore: fixing release names for sentry source map uploads

Fixing a regression from https://github.com/dendronhq/dendron/pull/2563 where we changed release names in Sentry to have to flavors, @vscode prefixed and @express prefixed. 

Symbols are not properly being associated with the releases anymore.  This change does a dual upload to add artifacts to the changed release names.

Testing: difficult to test locally - we can test via nightly builds.
