### PR TITLE
fix: metadata service respects initial installs from new vscode instances for improved metadata accuracy

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -3,6 +3,7 @@ export enum VSCodeEvents {
   ServerCrashed = "ServerCrashed",
   InitializeWorkspace = "InitializeWorkspace",
   Install = "Install",
+  NewInstanceInstall = "NewInstanceInstall",
   SchemaLookup_Show = "SchemaLookup_Show",
   NoteLookup_Gather = "NoteLookup_Gather",
   SchemaLookup_Gather = "SchemaLookup_Gather",

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -3,7 +3,6 @@ export enum VSCodeEvents {
   ServerCrashed = "ServerCrashed",
   InitializeWorkspace = "InitializeWorkspace",
   Install = "Install",
-  NewInstanceInstall = "NewInstanceInstall",
   SchemaLookup_Show = "SchemaLookup_Show",
   NoteLookup_Gather = "NoteLookup_Gather",
   SchemaLookup_Gather = "SchemaLookup_Gather",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -46,6 +46,7 @@ import { Duration } from "luxon";
 import path from "path";
 import semver from "semver";
 import * as vscode from "vscode";
+import os from "os";
 import {
   CURRENT_AB_TESTS,
   UpgradeToastWordingTestGroups,
@@ -367,6 +368,12 @@ export async function _activate(
     workspaceFolders: workspaceFolders?.map((fd) => fd.uri.fsPath),
   });
 
+  // At this point, the segment client has not been created yet.
+  // We need to check here if the uuid has been set for future references
+  // because the Segment client constructor will go ahead and create one if it doesn't exist.
+  const maybeUUIDPath = path.join(os.homedir(), CONSTANTS.DENDRON_ID);
+  const UUIDPathExists = await fs.pathExists(maybeUUIDPath);
+
   // If telemetry is not disabled, we enable telemetry and error reporting ^rw8l1w51hnjz
   // - NOTE: we do this outside of the try/catch block in case we run into an error with initialization
   if (!SegmentClient.instance().hasOptedOut && getStage() === "prod") {
@@ -416,19 +423,20 @@ export async function _activate(
     });
 
     // check if this is an install event, but a repeated one on a new instance.
-    let isNewInstanceInstall = false;
+    let isSecondaryInstall = false;
 
     // set initial install ^194e5bw7so9g
     if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
       // even if it's an initial install for this instance of vscode, it may not be for this machine.
       // in that case, we should skip setting the initial install time since it's already set.
+      // we also check if we already set uuid for this machine. If so, this is not a true initial install.
       const metadata = MetadataService.instance().getMeta();
-      if (metadata.firstInstall === undefined) {
+      if (metadata.firstInstall === undefined && !UUIDPathExists) {
         MetadataService.instance().setInitialInstall();
       } else {
         // we still want to proceed with InstallStatus.INITIAL_INSTALL because we want everything
         // tied to initial install to happen in this instance of VSCode once for the first time
-        isNewInstanceInstall = true;
+        isSecondaryInstall = true;
       }
     }
 
@@ -777,7 +785,7 @@ export async function _activate(
 
     await showWelcomeOrWhatsNew({
       extensionInstallStatus,
-      isNewInstanceInstall,
+      isSecondaryInstall,
       version: DendronExtension.version(),
       previousExtensionVersion: previousWorkspaceVersion,
       start: startActivate,
@@ -825,14 +833,14 @@ export function deactivate() {
 
 async function showWelcomeOrWhatsNew({
   extensionInstallStatus,
-  isNewInstanceInstall,
+  isSecondaryInstall,
   version,
   previousExtensionVersion,
   start,
   assetUri,
 }: {
   extensionInstallStatus: InstallStatus;
-  isNewInstanceInstall: boolean;
+  isSecondaryInstall: boolean;
   version: string;
   previousExtensionVersion: string;
   start: [number, number];
@@ -845,15 +853,15 @@ async function showWelcomeOrWhatsNew({
       Logger.info({
         ctx,
         msg: `extension, ${
-          isNewInstanceInstall
+          isSecondaryInstall
             ? "initial install"
-            : "install on new vscode instance"
+            : "secondary install on new vscode instance"
         }`,
       });
       // track how long install process took ^e8itkyfj2rn3
       AnalyticsUtils.track(VSCodeEvents.Install, {
         duration: getDurationMilliseconds(start),
-        isNewInstanceInstall,
+        isSecondaryInstall,
       });
 
       // set the global version of dendron ^oncxlt645b5r

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -851,11 +851,9 @@ async function showWelcomeOrWhatsNew({
         }`,
       });
       // track how long install process took ^e8itkyfj2rn3
-      const trackEvent = isNewInstanceInstall
-        ? VSCodeEvents.NewInstanceInstall
-        : VSCodeEvents.Install;
-      AnalyticsUtils.track(trackEvent, {
+      AnalyticsUtils.track(VSCodeEvents.Install, {
         duration: getDurationMilliseconds(start),
+        isNewInstanceInstall,
       });
 
       // set the global version of dendron ^oncxlt645b5r

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -976,6 +976,149 @@ suite("WHEN migrate config", function () {
   );
 });
 
+suite("GIVEN Dendron plugin activation", function () {
+  let setInitialInstallSpy: sinon.SinonSpy;
+  let showTelemetryNoticeSpy: sinon.SinonSpy;
+  const ctx: ExtensionContext = setupBeforeAfter(this);
+  let mockHomeDirStub: sinon.SinonStub;
+
+  function stubDendronWhenNotFirstInstall() {
+    MetadataService.instance().setInitialInstall();
+  }
+
+  function stubDendronGlobalVersionNotSet(ctx: ExtensionContext) {
+    ctx.globalState.update(GLOBAL_STATE.VERSION, undefined);
+  }
+
+  function setupSpies() {
+    setInitialInstallSpy = sinon.spy(
+      MetadataService.instance(),
+      "setInitialInstall"
+    );
+    showTelemetryNoticeSpy = sinon.spy(AnalyticsUtils, "showTelemetryNotice");
+  }
+
+  async function afterHook() {
+    mockHomeDirStub.restore();
+    sinon.restore();
+  }
+
+  describe("AND WHEN not first install", () => {
+    describeMultiWS(
+      "AND WHEN activate",
+      {
+        ctx,
+        preActivateHook: async () => {
+          mockHomeDirStub = TestEngineUtils.mockHomeDir();
+          stubDendronWhenNotFirstInstall();
+          setupSpies();
+        },
+        afterHook,
+        timeout: 1e4,
+      },
+      () => {
+        test("THEN set initial install not called", () => {
+          expect(setInitialInstallSpy.called).toBeFalsy();
+        });
+
+        test("THEN do not show telemetry notice", () => {
+          expect(showTelemetryNoticeSpy.called).toBeFalsy();
+        });
+      }
+    );
+    describeMultiWS(
+      "AND WHEN firstInstall not set for old user",
+      {
+        ctx,
+        preActivateHook: async () => {
+          mockHomeDirStub = TestEngineUtils.mockHomeDir();
+          stubDendronWhenNotFirstInstall();
+          setupSpies();
+          // when check for first install, should be empty
+          MetadataService.instance().deleteMeta("firstInstall");
+        },
+        afterHook,
+        timeout: 1e5,
+      },
+      () => {
+        test("THEN set initial install called", () => {
+          expect(
+            setInitialInstallSpy.calledWith(
+              Time.DateTime.fromISO("2021-06-22").toSeconds()
+            )
+          ).toBeTruthy();
+        });
+
+        test("THEN do not show telemetry notice", () => {
+          expect(showTelemetryNoticeSpy.called).toBeFalsy();
+        });
+      }
+    );
+  });
+
+  describe("AND WHEN first install", () => {
+    describeMultiWS(
+      "AND WHEN activate",
+      {
+        ctx,
+        preActivateHook: async ({ ctx }) => {
+          mockHomeDirStub = TestEngineUtils.mockHomeDir();
+          setupSpies();
+          stubDendronGlobalVersionNotSet(ctx);
+        },
+        afterHook,
+        timeout: 1e4,
+      },
+      () => {
+        test("THEN set initial install called", () => {
+          expect(setInitialInstallSpy.called).toBeTruthy();
+        });
+
+        test("THEN global version set", () => {
+          expect(ctx.globalState.get(GLOBAL_STATE.VERSION)).toNotEqual(
+            undefined
+          );
+        });
+        test("THEN show telemetry notice", () => {
+          expect(showTelemetryNoticeSpy.called).toBeTruthy();
+        });
+      }
+    );
+  });
+
+  describe.only("AND WHEN fresh install on new vscode instance", () => {
+    describeMultiWS(
+      "AND WHEN activate",
+      {
+        ctx,
+        preActivateHook: async ({ ctx }) => {
+          mockHomeDirStub = TestEngineUtils.mockHomeDir();
+          // new instance, so fresh user-data. global storage is clean slate.
+          stubDendronGlobalVersionNotSet(ctx);
+          // but we have first install already recorded in metadata.
+          stubDendronWhenNotFirstInstall();
+          setupSpies();
+        },
+        afterHook,
+        timeout: 1e4,
+      },
+      () => {
+        // we prevent this from happening in new vscode instances.
+        test("THEN set initial install is not called", () => {
+          expect(setInitialInstallSpy.called).toBeFalsy();
+        });
+
+        // but stil want to set this in the fresh globalStorage of the new vscode instance
+        test("THEN global version set", () => {
+          expect(ctx.globalState.get(GLOBAL_STATE.VERSION)).toNotEqual(
+            undefined
+          );
+        });
+      }
+    );
+  });
+});
+
 describe("shouldDisplayInactiveUserSurvey", () => {
   const ONE_WEEK = 604800;
   const NOW = Time.now().toSeconds();

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1086,7 +1086,7 @@ suite("GIVEN Dendron plugin activation", function () {
     );
   });
 
-  describe.only("AND WHEN fresh install on new vscode instance", () => {
+  describe("AND WHEN fresh install on new vscode instance", () => {
     describeMultiWS(
       "AND WHEN activate",
       {

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -979,7 +979,6 @@ suite("WHEN migrate config", function () {
 suite("GIVEN Dendron plugin activation", function () {
   let setInitialInstallSpy: sinon.SinonSpy;
   let showTelemetryNoticeSpy: sinon.SinonSpy;
-  const ctx: ExtensionContext = setupBeforeAfter(this);
   let mockHomeDirStub: sinon.SinonStub;
 
   function stubDendronWhenNotFirstInstall() {
@@ -1007,7 +1006,6 @@ suite("GIVEN Dendron plugin activation", function () {
     describeMultiWS(
       "AND WHEN activate",
       {
-        ctx,
         preActivateHook: async () => {
           mockHomeDirStub = TestEngineUtils.mockHomeDir();
           stubDendronWhenNotFirstInstall();
@@ -1029,7 +1027,6 @@ suite("GIVEN Dendron plugin activation", function () {
     describeMultiWS(
       "AND WHEN firstInstall not set for old user",
       {
-        ctx,
         preActivateHook: async () => {
           mockHomeDirStub = TestEngineUtils.mockHomeDir();
           stubDendronWhenNotFirstInstall();
@@ -1060,7 +1057,6 @@ suite("GIVEN Dendron plugin activation", function () {
     describeMultiWS(
       "AND WHEN activate",
       {
-        ctx,
         preActivateHook: async ({ ctx }) => {
           mockHomeDirStub = TestEngineUtils.mockHomeDir();
           setupSpies();
@@ -1068,8 +1064,9 @@ suite("GIVEN Dendron plugin activation", function () {
         },
         afterHook,
         timeout: 1e4,
+        noSetInstallStatus: true,
       },
-      () => {
+      (ctx) => {
         test("THEN set initial install called", () => {
           expect(setInitialInstallSpy.called).toBeTruthy();
         });
@@ -1086,11 +1083,10 @@ suite("GIVEN Dendron plugin activation", function () {
     );
   });
 
-  describe("AND WHEN fresh install on new vscode instance", () => {
+  describe("AND WHEN secondary install on a fresh vscode instance", () => {
     describeMultiWS(
       "AND WHEN activate",
       {
-        ctx,
         preActivateHook: async ({ ctx }) => {
           mockHomeDirStub = TestEngineUtils.mockHomeDir();
           // new instance, so fresh user-data. global storage is clean slate.
@@ -1101,8 +1097,9 @@ suite("GIVEN Dendron plugin activation", function () {
         },
         afterHook,
         timeout: 1e4,
+        noSetInstallStatus: true,
       },
-      () => {
+      (ctx) => {
         // we prevent this from happening in new vscode instances.
         test("THEN set initial install is not called", () => {
           expect(setInitialInstallSpy.called).toBeFalsy();


### PR DESCRIPTION
# fix: metadata service respects initial installs from new vscode instances for improved metadata accuracy

This PR:
- fixes an issue where an install event on a fresh vscode instance is recorded as an "initial install" globally.
  - this may have caused problems with prompt logic that rely on the integrity of the metadata service.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)