### PR TITLE
chore: remove upgrade view A/B test, add upgrade toast button wording test

### DIFF
--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -1,27 +1,36 @@
 // ^xi5t1r2j51ot
 import { ABTest } from "@dendronhq/common-server";
 
-export enum UpgradeToastOrViewTestGroups {
-  /** Users who get a toast notification in the corner of VSCode. */
-  upgradeToast = "upgradeToast",
-  /** Users who get a upgrade webview pop up.  */
-  upgradeView = "upgradeView",
+export enum UpgradeToastWordingTestGroups {
+  /** The button on the upgrade toast will say "see what changed" */
+  seeWhatChanged = "seeWhatChanged",
+  /** The button on the upgrade toast will say "see what's new" */
+  seeWhatsNew = "seeWhatsNew",
+  /** The button on the upgrade toast will say "open the changelog" */
+  openChangelog = "openChangelog",
 }
 
 /** Test if showing a web view on an upgrade is more successful than showing a toast notification. */
-export const UPGRADE_TOAST_OR_VIEW_TEST = new ABTest("UpgradeToastOrViewTest", [
-  {
-    name: UpgradeToastOrViewTestGroups.upgradeToast,
-    weight: 1,
-  },
-  {
-    name: UpgradeToastOrViewTestGroups.upgradeView,
-    weight: 1,
-  },
-]);
+export const UPGRADE_TOAST_WORDING_TEST = new ABTest(
+  "UpgradeToastWordingTest",
+  [
+    {
+      name: UpgradeToastWordingTestGroups.seeWhatChanged,
+      weight: 1,
+    },
+    {
+      name: UpgradeToastWordingTestGroups.seeWhatsNew,
+      weight: 1,
+    },
+    {
+      name: UpgradeToastWordingTestGroups.openChangelog,
+      weight: 1,
+    },
+  ]
+);
 
 /** All A/B tests that are currently running.
  *
  * ^tkqhy45hflfd
  */
-export const CURRENT_AB_TESTS = [UPGRADE_TOAST_OR_VIEW_TEST];
+export const CURRENT_AB_TESTS = [UPGRADE_TOAST_WORDING_TEST];

--- a/packages/plugin-core/src/views/UpgradeView.ts
+++ b/packages/plugin-core/src/views/UpgradeView.ts
@@ -26,6 +26,23 @@ const UPGRADE_VIEW_HTML = `<!DOCTYPE html>
 
 </html>`;
 
+/**
+ * This was an attempt at a webview that displays the changelog.
+ *
+ * There are a few known issues with this view:
+ * - It displays the entire changelog page, which includes the entire history
+ *   and not just what was changed
+ * - It's hard to collect any telemetry from the view because of VSCode/iframe
+ *   security policies
+ * - The displayed page doesn't function properly because VSCode disables
+ *   javascript inside of it
+ * - Clicking any link inside the view opens that page inside the view as well,
+ *   rather than opening it with the default browser
+ *
+ * As a result, we decided to not roll out this view. If we ever decide to
+ * reintroduce this, consider the bugs above.
+ *
+ * */
 export function showUpgradeView() {
   const panel = vscode.window.createWebviewPanel(
     "releaseNotes",


### PR DESCRIPTION
I removed the test, but kept the view in with the issues documented in case we decide to go back to it at some point.

For the upgrade toast, I introduced a test that tests out 3 different wordings:
- See what changed (existing)
- See what's new
- Open the changelog

