### PR TITLE
chore: new engagement metrics

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -136,9 +136,7 @@ export enum NativeWorkspaceEvents {
 
 export enum EngagementEvents {
   NoteViewed = "NoteViewed",
-  NoteCreated = "NoteCreated",
-  NoteUpdated = "NoteUpdated",
-  NoteDeleted = "NoteDeleted",
+  EngineStateChanged = "EngineStateChanged",
 }
 
 export enum AppNames {

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -1,3 +1,6 @@
+// For all new additions to the telemetry events, follow UpperCamelCasing and
+// use noun+verb for the event name.
+
 /* eslint-disable camelcase */
 export enum VSCodeEvents {
   ServerCrashed = "ServerCrashed",
@@ -131,6 +134,13 @@ export enum NativeWorkspaceEvents {
   DetectedInNonDendronWS = "Native_Workspace_Detected_In_Non_Dendron_WS", // watcher has detected a Dendron workspace getting created inside a non-Dendron workspace
 }
 
+export enum EngagementEvents {
+  NoteViewed = "NoteViewed",
+  NoteCreated = "NoteCreated",
+  NoteUpdated = "NoteUpdated",
+  NoteDeleted = "NoteDeleted",
+}
+
 export enum AppNames {
   CODE = "vscode",
   CLI = "cli",
@@ -148,4 +158,5 @@ export const DendronEvents = {
   ContextualUIEvents,
   NativeWorkspaceEvents,
   WorkspaceEvents,
+  EngagementEvents,
 };

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -20,6 +20,7 @@ import {
   DVault,
   LegacyDuplicateNoteBehavior,
   LegacyHierarchyConfig,
+  NoteChangeEntry,
   NoteProps,
   NotePropsDict,
   SEOProps,
@@ -1346,4 +1347,18 @@ export function getJournalTitle(
   }
 
   return undefined;
+}
+
+/**
+ * Helper function to get a subset of NoteChangeEntry's matching a
+ * particular status from an array
+ * @param entries
+ * @param status
+ * @returns
+ */
+export function extractNoteChangeEntriesByType(
+  entries: NoteChangeEntry[],
+  status: "create" | "delete" | "update"
+): NoteChangeEntry[] {
+  return entries.filter((entry) => entry.status === status);
 }

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -591,7 +591,7 @@ export type VSCodeIdentifyProps = {
 export type CLIIdentifyProps = CLIProps;
 
 export class SegmentUtils {
-  static _trackCommon({
+  private static _trackCommon({
     event,
     context,
     platformProps,

--- a/packages/dendron-cli/src/commands/launchEngineServer.ts
+++ b/packages/dendron-cli/src/commands/launchEngineServer.ts
@@ -119,34 +119,23 @@ export class LaunchEngineServerCommand extends CLICommand<
           "create"
         ).length;
 
-        if (createCount > 0) {
-          CLIAnalyticsUtils.track(EngagementEvents.NoteCreated, {
-            count: createCount,
-          });
-        }
-
         const updateCount = extractNoteChangeEntriesByType(
           entries,
           "update"
         ).length;
-
-        if (updateCount > 0) {
-          CLIAnalyticsUtils.track(EngagementEvents.NoteUpdated, {
-            count: updateCount,
-          });
-        }
 
         const deleteCount = extractNoteChangeEntriesByType(
           entries,
           "delete"
         ).length;
 
-        if (deleteCount > 0) {
-          CLIAnalyticsUtils.track(EngagementEvents.NoteDeleted, {
-            count: deleteCount,
-          });
-        }
+        CLIAnalyticsUtils.track(EngagementEvents.EngineStateChanged, {
+          created: createCount,
+          updated: updateCount,
+          deleted: deleteCount,
+        });
       });
+
       if (out.error) {
         this.printError(out.error);
       }

--- a/packages/dendron-cli/src/commands/launchEngineServer.ts
+++ b/packages/dendron-cli/src/commands/launchEngineServer.ts
@@ -1,5 +1,9 @@
-import { ConfigUtils } from "@dendronhq/common-all";
 import { launchv2 } from "@dendronhq/api-server";
+import {
+  ConfigUtils,
+  EngagementEvents,
+  extractNoteChangeEntriesByType,
+} from "@dendronhq/common-all";
 import { LogLvl, resolvePath } from "@dendronhq/common-server";
 import {
   DendronEngineClient,
@@ -9,6 +13,7 @@ import {
 import _ from "lodash";
 import { Socket } from "net";
 import yargs from "yargs";
+import { CLIAnalyticsUtils } from "../utils/analytics";
 import { CLICommand, CommandCommonProps } from "./base";
 
 type CommandOutput = { port: number; server: any } & CommandCommonProps;
@@ -101,9 +106,47 @@ export class LaunchEngineServerCommand extends CLICommand<
       vaults,
       ws: wsRoot,
     });
+
     if (init) {
       this.L.info({ ctx, msg: "pre:engine.init" });
       const out = await engine.init();
+
+      // These events will only upload if the upload action completes before the
+      // CLI command completes. They are uploaded on a best effort basis.
+      engine.onEngineNoteStateChanged((entries) => {
+        const createCount = extractNoteChangeEntriesByType(
+          entries,
+          "create"
+        ).length;
+
+        if (createCount > 0) {
+          CLIAnalyticsUtils.track(EngagementEvents.NoteCreated, {
+            count: createCount,
+          });
+        }
+
+        const updateCount = extractNoteChangeEntriesByType(
+          entries,
+          "update"
+        ).length;
+
+        if (updateCount > 0) {
+          CLIAnalyticsUtils.track(EngagementEvents.NoteUpdated, {
+            count: updateCount,
+          });
+        }
+
+        const deleteCount = extractNoteChangeEntriesByType(
+          entries,
+          "delete"
+        ).length;
+
+        if (deleteCount > 0) {
+          CLIAnalyticsUtils.track(EngagementEvents.NoteDeleted, {
+            count: deleteCount,
+          });
+        }
+      });
       if (out.error) {
         this.printError(out.error);
       }

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -1,15 +1,14 @@
-import { NoteChangeEntry, NoteChangeUpdateEntry } from "@dendronhq/common-all";
+import {
+  NoteChangeEntry,
+  NoteChangeUpdateEntry,
+  extractNoteChangeEntriesByType,
+} from "@dendronhq/common-all";
 import {
   NoteTestUtilsV4,
   testAssertsInsideCallback,
 } from "@dendronhq/common-test-utils";
 import { DendronEngineClient } from "@dendronhq/engine-server";
-import {
-  createEngineFromServer,
-  ENGINE_HOOKS,
-  extractNoteChangeEntriesByType,
-  runEngineTestV5,
-} from "../..";
+import { createEngineFromServer, ENGINE_HOOKS, runEngineTestV5 } from "../..";
 
 /**
  * Tests that the EngineEvents interface of the client-side DendronEngineClient signals properly

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -10,7 +10,6 @@ import {
   WorkspaceSettings,
   ConfigUtils,
   NoteUtils,
-  NoteChangeEntry,
 } from "@dendronhq/common-all";
 import {
   getDurationMilliseconds,
@@ -443,18 +442,4 @@ export class TestEngineUtils {
     const vault = vaults[0];
     return NoteUtils.getNoteByFnameV5({ fname, notes, vault, wsRoot });
   }
-}
-
-/**
- * Test helper function to get a subset of NoteChangeEntry's matching a
- * particular status from an array
- * @param entries
- * @param status
- * @returns
- */
-export function extractNoteChangeEntriesByType(
-  entries: NoteChangeEntry[],
-  status: "create" | "delete" | "update"
-): NoteChangeEntry[] {
-  return entries.filter((entry) => entry.status === status);
 }

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -4,6 +4,7 @@ import {
   NoteProps,
   NoteUtils,
   SchemaUtils,
+  extractNoteChangeEntriesByType,
 } from "@dendronhq/common-all";
 import {
   FileTestUtils,
@@ -14,7 +15,6 @@ import {
 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
 import path from "path";
-import { extractNoteChangeEntriesByType } from "../..";
 import { setupBasic } from "./utils";
 
 const SCHEMAS = {

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -329,33 +329,21 @@ export class EngineAPIService
         "create"
       ).length;
 
-      if (createCount > 0) {
-        AnalyticsUtils.track(EngagementEvents.NoteCreated, {
-          count: createCount,
-        });
-      }
-
       const updateCount = extractNoteChangeEntriesByType(
         entries,
         "update"
       ).length;
-
-      if (updateCount > 0) {
-        AnalyticsUtils.track(EngagementEvents.NoteUpdated, {
-          count: updateCount,
-        });
-      }
 
       const deleteCount = extractNoteChangeEntriesByType(
         entries,
         "delete"
       ).length;
 
-      if (deleteCount > 0) {
-        AnalyticsUtils.track(EngagementEvents.NoteDeleted, {
-          count: deleteCount,
-        });
-      }
+      AnalyticsUtils.track(EngagementEvents.EngineStateChanged, {
+        created: createCount,
+        updated: updateCount,
+        deleted: deleteCount,
+      });
     });
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/TextDocumentService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/TextDocumentService.test.ts
@@ -2,6 +2,7 @@ import {
   assert,
   NoteChangeEntry,
   NoteChangeUpdateEntry,
+  extractNoteChangeEntriesByType,
 } from "@dendronhq/common-all";
 import { genHash } from "@dendronhq/common-server";
 import {
@@ -9,10 +10,7 @@ import {
   NOTE_PRESETS_V4,
   testAssertsInsideCallback,
 } from "@dendronhq/common-test-utils";
-import {
-  ENGINE_HOOKS,
-  extractNoteChangeEntriesByType,
-} from "@dendronhq/engine-test-utils";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { afterEach, describe } from "mocha";
 import * as vscode from "vscode";
 import { ExtensionProvider } from "../../ExtensionProvider";

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -1,19 +1,16 @@
+import { EngagementEvents } from "@dendronhq/common-all";
 import { WorkspaceUtils } from "@dendronhq/engine-server";
 import { TextEditor, TextEditorVisibleRangesChangeEvent, window } from "vscode";
 import { PreviewProxy } from "./components/views/PreviewProxy";
 import { IDendronExtension } from "./dendronExtensionInterface";
 import { debouncedUpdateDecorations } from "./features/windowDecorations";
 import { Logger } from "./logger";
-import { sentryReportingCallback } from "./utils/analytics";
+import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
 
 /**
  * See [[Window Watcher|dendron://dendron.docs/pkg.plugin-core.ref.window-watcher]] for docs
  */
 export class WindowWatcher {
-  private onDidChangeActiveTextEditorHandlers: ((
-    e: TextEditor | undefined
-  ) => void)[] = [];
-
   private _extension: IDendronExtension;
   private _preview: PreviewProxy;
 
@@ -59,12 +56,6 @@ export class WindowWatcher {
     );
   }
 
-  registerActiveTextEditorChangedHandler(
-    handler: (e: TextEditor | undefined) => void
-  ) {
-    this.onDidChangeActiveTextEditorHandlers.push(handler);
-  }
-
   private onDidChangeActiveTextEditor = sentryReportingCallback(
     async (editor: TextEditor | undefined) => {
       const ctx = "WindowWatcher:onDidChangeActiveTextEditor";
@@ -86,12 +77,6 @@ export class WindowWatcher {
         Logger.info({ ctx, editor: uri.fsPath });
         this.triggerUpdateDecorations(editor);
 
-        // other components can register handlers for window watcher
-        // those handlers get called here
-        this.onDidChangeActiveTextEditorHandlers.forEach((value) =>
-          value.call(this, editor)
-        );
-
         // If automatically show preview is enabled, then open the preview
         // whenever text editor changed, as long as it's not already opened:
         if (
@@ -102,8 +87,17 @@ export class WindowWatcher {
             await this._preview.show();
           }
         }
-      } else {
-        Logger.info({ ctx, editor: "undefined" });
+
+        // If the opened note is still the active text editor 5 seconds after
+        // opening, then count it as a valid 'viewed' event
+        setTimeout(() => {
+          if (
+            editor.document.uri.fsPath ===
+            window.activeTextEditor?.document.uri.fsPath
+          ) {
+            AnalyticsUtils.track(EngagementEvents.NoteViewed);
+          }
+        }, 5000);
       }
     }
   );


### PR DESCRIPTION
## chore: new engagement metrics

Adds new metrics for new KPI's around user engagement:
- Note Update / Delete / Create based off of EngineEvents
- Note View - if a user opens up a new Dendron Note and keeps it as the active text editor for at least 5 seconds.  I did some testing to see how 5 seconds 'feels', and to me it feels like a reasonable grace period, but I'm open to tweaking this as well.  The goal is to reasonably capture the effect of someone looking at a note and getting some info out of it while also filtering out any instances of a user opening a note inadvertently or opening the note they weren't looking for.

I also did some cleanup on the watcher class to remove the legacy `registerActiveTextEditorChangedHandler` pattern.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [N/A] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)