### PR TITLE
fix: malformed _trackCommon arguments

### DIFF
--- a/packages/plugin-core/src/utils/analytics.ts
+++ b/packages/plugin-core/src/utils/analytics.ts
@@ -125,7 +125,11 @@ export class AnalyticsUtils {
     segmentProps?: { timestamp?: Date }
   ) {
     return SegmentUtils.trackSync(
-      this._trackCommon({ event, ...customProps, ...segmentProps })
+      this._trackCommon({
+        event,
+        props: customProps,
+        timestamp: segmentProps?.timestamp,
+      })
     );
   }
 


### PR DESCRIPTION
# fix: malformed _trackCommon arguments

This PR:
- fixes a regression with `_trackCommon` not getting proper arguments from the track call, causing custom props to be dropped and not arriving at destinations.

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.