### PR TITLE
enhance(workspace): vault convert moves self contained vaults to the right location

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -50,6 +50,7 @@ import {
   StrictConfigV5,
 } from "./types/intermediateConfigs";
 import { isWebUri } from "./util/regex";
+import { VaultUtils } from "./vault";
 
 /**
  * Dendron utilities
@@ -1150,6 +1151,22 @@ export class ConfigUtils {
 
   static setVaults(config: IntermediateDendronConfig, value: DVault[]): void {
     ConfigUtils.setWorkspaceProp(config, "vaults", value);
+  }
+
+  /** Finds the matching vault in the config, and uses the callback to update it. */
+  static updateVault(
+    config: IntermediateDendronConfig,
+    vaultToUpdate: DVault,
+    updateCb: (vault: DVault) => DVault
+  ): void {
+    ConfigUtils.setVaults(
+      config,
+      ConfigUtils.getVaults(config).map((configVault) => {
+        if (!VaultUtils.isEqualV2(vaultToUpdate, configVault))
+          return configVault;
+        return updateCb(configVault);
+      })
+    );
   }
 
   static setNoteLookupProps<K extends keyof NoteLookupConfig>(

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -534,7 +534,7 @@ export class GitUtils {
       const contents = await fs.readFile(gitignore, { encoding: "utf-8" });
 
       const newContents = contents.replace(
-        new RegExp(`^${removePath}/?$`, "m"),
+        new RegExp(`^${_.escapeRegExp(removePath)}/?$`, "m"),
         ""
       );
       if (newContents !== contents) await fs.writeFile(gitignore, newContents);

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -208,6 +208,42 @@ export class GitUtils {
     return vaultName;
   }
 
+  /** If this vault had this remote, what path should it be stored under?
+   *
+   * If the remote is null, then you'll get the path should be if the vault was a local vault.
+   */
+  static getDependencyPathWithRemote({
+    vault,
+    remote,
+  }: {
+    remote: string | null;
+    vault: DVault;
+  }): string {
+    const vaultName =
+      vault.name ??
+      // if the vault has no name, compute one based on the path
+      _.findLast(vault.fsPath.split(/[/\\]/), (part) => part.length > 0) ??
+      // Fall back to fsPath directly if the calculation fails
+      vault.fsPath;
+
+    if (!remote) {
+      // local
+      return path.join(
+        FOLDERS.DEPENDENCIES,
+        FOLDERS.LOCAL_DEPENDENCY,
+        vaultName
+      );
+    } else {
+      return path.join(
+        FOLDERS.DEPENDENCIES,
+        GitUtils.remoteUrlToDependencyPath({
+          vaultName,
+          url: remote,
+        })
+      );
+    }
+  }
+
   static getVaultFromRepo(opts: {
     repoPath: string;
     repoUrl: string;

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -531,23 +531,11 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     let ignorePath: string = targetVault.fsPath;
     if (config.dev?.enableSelfContainedVaults) {
       // Move vault folder to the correct location
-      const vaultName =
-        targetVault.name ??
-        // if the vault has no name, compute one based on the path
-        _.findLast(
-          targetVault.fsPath.split(/[/\\]/),
-          (part) => part.length > 0
-        ) ??
-        // Fall back to fsPath directly if the calculation fails
-        targetVault.fsPath;
 
-      const newVaultPath = path.join(
-        FOLDERS.DEPENDENCIES,
-        GitUtils.remoteUrlToDependencyPath({
-          vaultName,
-          url: remoteUrl,
-        })
-      );
+      const newVaultPath = GitUtils.getDependencyPathWithRemote({
+        vault: targetVault,
+        remote: remoteUrl,
+      });
       await fs.move(
         path.join(wsRoot, targetVault.fsPath),
         path.join(wsRoot, newVaultPath)
@@ -605,20 +593,10 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
 
     if (config.dev?.enableSelfContainedVaults) {
       // Move vault folder to the correct location
-      const vaultName =
-        targetVault.name ??
-        // if the vault has no name, compute one based on the path
-        _.findLast(
-          targetVault.fsPath.split(/[/\\]/),
-          (part) => part.length > 0
-        ) ??
-        // Fall back to fsPath directly if the calculation fails
-        targetVault.fsPath;
-      const newVaultPath = path.join(
-        FOLDERS.DEPENDENCIES,
-        FOLDERS.LOCAL_DEPENDENCY,
-        vaultName
-      );
+      const newVaultPath = GitUtils.getDependencyPathWithRemote({
+        vault: targetVault,
+        remote: null,
+      });
       await fs.move(
         path.join(wsRoot, targetVault.fsPath),
         path.join(wsRoot, newVaultPath)

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -482,12 +482,6 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     vault: DVault;
     remoteUrl: string;
   }) {
-    // Add the vault to the gitignore of root, so that it doesn't show up as part of root anymore
-    await GitUtils.addToGitignore({
-      addPath: targetVault.fsPath,
-      root: wsRoot,
-    });
-
     // Now, initialize a repository in it
     const git = new Git({
       localUrl: path.join(wsRoot, targetVault.fsPath),
@@ -513,8 +507,6 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       if (!_.isNumber(err?.exitCode)) throw err;
     }
     await git.push({ remote, branch });
-    // Update `dendron.yml`, adding the remote to the converted vault
-    await this.markVaultAsRemoteInConfig(targetVault, remoteUrl);
     // Remove the vault folder from the tree of the root repository. Otherwise, the files will be there when
     // someone else pulls the root repo, which can break remote vault initialization. This doesn't delete the actual files.
     if (await fs.pathExists(path.join(wsRoot, ".git"))) {
@@ -527,10 +519,63 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       });
     }
 
+    const config = this.config;
+    ConfigUtils.updateVault(config, targetVault, (vault) => {
+      vault.remote = {
+        type: "git",
+        url: remoteUrl,
+      };
+      return vault;
+    });
+
+    let ignorePath: string = targetVault.fsPath;
+    if (config.dev?.enableSelfContainedVaults) {
+      // Move vault folder to the correct location
+      const vaultName =
+        targetVault.name ??
+        // if the vault has no name, compute one based on the path
+        _.findLast(
+          targetVault.fsPath.split(/[/\\]/),
+          (part) => part.length > 0
+        ) ??
+        // Fall back to fsPath directly if the calculation fails
+        targetVault.fsPath;
+
+      const newVaultPath = path.join(
+        FOLDERS.DEPENDENCIES,
+        GitUtils.remoteUrlToDependencyPath({
+          vaultName,
+          url: remoteUrl,
+        })
+      );
+      await fs.move(
+        path.join(wsRoot, targetVault.fsPath),
+        path.join(wsRoot, newVaultPath)
+      );
+
+      ConfigUtils.updateVault(config, targetVault, (vault) => {
+        vault.fsPath = newVaultPath;
+        return vault;
+      });
+      ignorePath = newVaultPath;
+    }
+
+    // Add the vault to the gitignore of root, so that it doesn't show up as part of root anymore
+    await GitUtils.addToGitignore({
+      addPath: ignorePath,
+      root: wsRoot,
+    });
+
+    await this.setConfig(config);
     return { remote, branch };
   }
 
-  /** Converts a remote vault to a local vault. */
+  /** Converts a remote vault to a local vault.
+   *
+   * If self contained vaults are enabled in the config, it will also move the
+   * vault folder to `dependencies/localhost/`. It will not convert the vault
+   * into a self contained vault however.
+   */
   async convertVaultLocal({
     wsRoot,
     vault: targetVault,
@@ -552,16 +597,39 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     });
     // Update `dendron.yml`, removing the remote from the converted vault
     const config = this.config;
-    const vaults = ConfigUtils.getVaults(config);
-    ConfigUtils.setVaults(
-      config,
-      vaults.map((vault) => {
-        if (VaultUtils.isEqualV2(vault, targetVault)) {
-          delete vault.remote;
-        }
+
+    ConfigUtils.updateVault(config, targetVault, (vault) => {
+      delete vault.remote;
+      return vault;
+    });
+
+    if (config.dev?.enableSelfContainedVaults) {
+      // Move vault folder to the correct location
+      const vaultName =
+        targetVault.name ??
+        // if the vault has no name, compute one based on the path
+        _.findLast(
+          targetVault.fsPath.split(/[/\\]/),
+          (part) => part.length > 0
+        ) ??
+        // Fall back to fsPath directly if the calculation fails
+        targetVault.fsPath;
+      const newVaultPath = path.join(
+        FOLDERS.DEPENDENCIES,
+        FOLDERS.LOCAL_DEPENDENCY,
+        vaultName
+      );
+      await fs.move(
+        path.join(wsRoot, targetVault.fsPath),
+        path.join(wsRoot, newVaultPath)
+      );
+
+      ConfigUtils.updateVault(config, targetVault, (vault) => {
+        vault.fsPath = newVaultPath;
         return vault;
-      })
-    );
+      });
+    }
+
     await this.setConfig(config);
   }
 

--- a/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
@@ -139,7 +139,12 @@ suite("GIVEN VaultConvert", function () {
         // Should have moved under dependencies
         expect(
           contents.match(
-            new RegExp(`^dependencies/${path.basename(remote)}`, "m")
+            new RegExp(
+              `^dependencies${_.escapeRegExp(path.sep)}${path.basename(
+                remote
+              )}`,
+              "m"
+            )
           )
         ).toBeTruthy();
       });

--- a/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
@@ -5,12 +5,17 @@ import _ from "lodash";
 import path from "path";
 import sinon from "sinon";
 import { VaultConvertCommand } from "../../commands/VaultConvert";
-import { getDWorkspace } from "../../workspace";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
 import fs from "fs-extra";
 import { before, after, describe } from "mocha";
-import { ConfigUtils, IntermediateDendronConfig } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  FOLDERS,
+  IntermediateDendronConfig,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import { ExtensionProvider } from "../../ExtensionProvider";
 
 suite("GIVEN VaultConvert", function () {
   describeMultiWS(
@@ -19,7 +24,7 @@ suite("GIVEN VaultConvert", function () {
     () => {
       let remote: string;
       before(async () => {
-        const { vaults } = getDWorkspace();
+        const { vaults } = ExtensionProvider.getDWorkspace();
         const cmd = new VaultConvertCommand();
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
@@ -36,7 +41,7 @@ suite("GIVEN VaultConvert", function () {
       });
 
       test("THEN updates .gitignore", async () => {
-        const { wsRoot } = getDWorkspace();
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
         const contents = await fs.readFile(path.join(wsRoot, ".gitignore"), {
           encoding: "utf-8",
         });
@@ -44,7 +49,7 @@ suite("GIVEN VaultConvert", function () {
       });
 
       test("THEN updates config", async () => {
-        const { wsRoot } = getDWorkspace();
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
         const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
         expect(ConfigUtils.getVaults(config)[0].remote).toEqual({
           type: "git",
@@ -53,7 +58,7 @@ suite("GIVEN VaultConvert", function () {
       });
 
       test("THEN the folder is a git repository", async () => {
-        const { wsRoot, vaults } = getDWorkspace();
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         const git = new Git({ localUrl: path.join(wsRoot, vaults[0].fsPath) });
         expect(await git.getRemote()).toEqual("origin");
         expect(await git.getCurrentBranch()).toBeTruthy();
@@ -61,7 +66,7 @@ suite("GIVEN VaultConvert", function () {
 
       describe("AND converting that back to a local vault", () => {
         before(async () => {
-          const { vaults } = getDWorkspace();
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const cmd = new VaultConvertCommand();
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
@@ -73,7 +78,7 @@ suite("GIVEN VaultConvert", function () {
         });
 
         test("THEN updates .gitignore", async () => {
-          const { wsRoot } = getDWorkspace();
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
           const contents = await fs.readFile(path.join(wsRoot, ".gitignore"), {
             encoding: "utf-8",
           });
@@ -81,13 +86,135 @@ suite("GIVEN VaultConvert", function () {
         });
 
         test("THEN updates config", async () => {
-          const { wsRoot } = getDWorkspace();
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
           const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
           expect(ConfigUtils.getVaults(config)[0].remote).toBeFalsy();
         });
 
         test("THEN the folder is NOT a git repository", async () => {
-          const { wsRoot, vaults } = getDWorkspace();
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const git = new Git({
+            localUrl: path.join(wsRoot, vaults[0].fsPath),
+          });
+          expect(await git.getRemote()).toBeFalsy();
+        });
+      });
+    }
+  );
+
+  describeMultiWS(
+    "WHEN converting a local vault to a remote vault with self contained vaults enabled",
+    {
+      preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
+      modConfigCb: (config) => {
+        config.dev = { enableSelfContainedVaults: true };
+        return config;
+      },
+    },
+    () => {
+      let remote: string;
+      before(async () => {
+        const { vaults } = ExtensionProvider.getDWorkspace();
+        const cmd = new VaultConvertCommand();
+        sinon.stub(cmd, "gatherType").resolves("remote");
+        sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
+
+        // Create a remote repository to be the upstream
+        remote = tmpDir().name;
+        await GitTestUtils.remoteCreate(remote);
+        sinon.stub(cmd, "gatherRemoteURL").resolves(remote);
+
+        await cmd.run();
+      });
+      after(async () => {
+        sinon.restore();
+      });
+
+      test("THEN updates .gitignore", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const contents = await fs.readFile(path.join(wsRoot, ".gitignore"), {
+          encoding: "utf-8",
+        });
+        // Should have moved under dependencies
+        expect(
+          contents.match(
+            new RegExp(`^dependencies/${path.basename(remote)}`, "m")
+          )
+        ).toBeTruthy();
+      });
+
+      test("THEN updates config", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+        expect(ConfigUtils.getVaults(config)[0].remote).toEqual({
+          type: "git",
+          url: remote,
+        });
+      });
+
+      test("THEN the vault is moved to the right folder", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = vaults[0];
+        expect(
+          await fs.pathExists(
+            path.join(wsRoot, VaultUtils.getRelPath(vault), "root.md")
+          )
+        ).toBeTruthy();
+        expect(vault.fsPath.startsWith(FOLDERS.DEPENDENCIES)).toBeTruthy();
+        expect(vault.fsPath.endsWith(path.basename(remote))).toBeTruthy();
+      });
+
+      test("THEN the folder is a git repository", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const git = new Git({ localUrl: path.join(wsRoot, vaults[0].fsPath) });
+        expect(await git.getRemote()).toEqual("origin");
+        expect(await git.getCurrentBranch()).toBeTruthy();
+      });
+
+      describe("AND converting that back to a local vault", () => {
+        before(async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          const cmd = new VaultConvertCommand();
+          sinon.stub(cmd, "gatherType").resolves("local");
+          sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
+
+          await cmd.run();
+        });
+        after(async () => {
+          sinon.restore();
+        });
+
+        test("THEN updates .gitignore", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const contents = await fs.readFile(path.join(wsRoot, ".gitignore"), {
+            encoding: "utf-8",
+          });
+          expect(contents.match(/^dependencies/m)).toBeFalsy();
+        });
+
+        test("THEN updates config", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+          expect(ConfigUtils.getVaults(config)[0].remote).toBeFalsy();
+        });
+
+        test("THEN the vault is moved to the right folder", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const vault = vaults[0];
+          expect(
+            await fs.pathExists(
+              path.join(wsRoot, VaultUtils.getRelPath(vault), "root.md")
+            )
+          ).toBeTruthy();
+          expect(
+            vault.fsPath.startsWith(
+              path.join(FOLDERS.DEPENDENCIES, FOLDERS.LOCAL_DEPENDENCY)
+            )
+          ).toBeTruthy();
+        });
+
+        test("THEN the folder is NOT a git repository", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
           const git = new Git({
             localUrl: path.join(wsRoot, vaults[0].fsPath),
           });
@@ -102,7 +229,7 @@ suite("GIVEN VaultConvert", function () {
     { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
     () => {
       before(async () => {
-        const { vaults } = getDWorkspace();
+        const { vaults } = ExtensionProvider.getDWorkspace();
         const cmd = new VaultConvertCommand();
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
@@ -119,14 +246,14 @@ suite("GIVEN VaultConvert", function () {
 
       test("THEN conversion fails mid-operation", async () => {
         // config is updated after the remote is fully set up, so if the config has been updated we know that we were able to set up and push to remote
-        const { wsRoot } = getDWorkspace();
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
         const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
         expect(ConfigUtils.getVaults(config)[0].remote).toBeFalsy();
       });
 
       describe("AND running the conversion command again", () => {
         before(async () => {
-          const { vaults } = getDWorkspace();
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const cmd = new VaultConvertCommand();
           sinon.stub(cmd, "gatherType").resolves("remote");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
@@ -144,7 +271,7 @@ suite("GIVEN VaultConvert", function () {
 
         test("THEN the conversion completes", async () => {
           // config is updated after the remote is fully set up, so if the config has been updated we know that we were able to set up and push to remote
-          const { wsRoot } = getDWorkspace();
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
           const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
           expect(ConfigUtils.getVaults(config)[0].remote).toBeTruthy();
         });

--- a/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
@@ -118,6 +118,7 @@ suite("GIVEN VaultConvert", function () {
         const cmd = new VaultConvertCommand();
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
+        sinon.stub(cmd, "promptForFolderMove").resolves(true);
 
         // Create a remote repository to be the upstream
         remote = tmpDir().name;
@@ -177,6 +178,7 @@ suite("GIVEN VaultConvert", function () {
           const cmd = new VaultConvertCommand();
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
+          sinon.stub(cmd, "promptForFolderMove").resolves(true);
 
           await cmd.run();
         });


### PR DESCRIPTION
If self contained vaults are enabled in the workspace, "Vault Convert" will now move them to the right folder under `dependencies` based on their remote. This doesn't convert the vault into a self contained vault, just puts it in the correct folder.

The prompt when the folder is going to be moved:

![image](https://user-images.githubusercontent.com/1008124/163332049-af1b3d4e-07b0-4c6f-b5f9-987da52855e9.png)


# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)