### PR TITLE
fix(view): apply current theme when vscode reduce motion setting is on

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -84,6 +84,13 @@ export class WebViewCommonUtils {
         if (newTheme === 'high-contrast') {
             newTheme = 'dark'; // the high-contrast theme seems to be an extreme case of the dark theme
         }
+        // this class is introduced with new vscode setting reduce motion  to reduce the amount of motion
+        // in the window.
+        var reduceMotionClassName = "vscode-reduce-motion"
+        if(newTheme.includes(reduceMotionClassName)) {
+          newTheme = newTheme.replace(reduceMotionClassName,"").trim()
+        }
+
         // be bale to get current theme using JS;
         window.currentTheme = newTheme;
 

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -17,7 +17,7 @@ import {
   setLogLevel,
 } from "@dendronhq/common-frontend";
 import _ from "lodash";
-import React from "react";
+import React, { useEffect } from "react";
 import { useWorkspaceProps } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage, useVSCodeMessage } from "../utils/vscode";
@@ -115,6 +115,14 @@ function DendronApp(props: DendronAppProps) {
   const opts = _.defaults(props.opts, {
     padding: props.Component.name === "DendronGraphPanel" ? "0px" : "33px",
   });
+
+  useEffect(() => {
+    // this class is introduced with new reduced Motion feature of vscode and is resulting
+    // in a bug where webviews are updated to light theme.
+    //More info about this class here: https://code.visualstudio.com/api/extension-guides/webview#accessibility
+    document.body.classList.remove("vscode-reduce-motion");
+  }, []);
+
   return (
     <Provider store={combinedStore}>
       <Layout style={{ padding: opts.padding }}>

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -17,7 +17,7 @@ import {
   setLogLevel,
 } from "@dendronhq/common-frontend";
 import _ from "lodash";
-import React, { useEffect } from "react";
+import React from "react";
 import { useWorkspaceProps } from "../hooks";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage, useVSCodeMessage } from "../utils/vscode";
@@ -115,14 +115,6 @@ function DendronApp(props: DendronAppProps) {
   const opts = _.defaults(props.opts, {
     padding: props.Component.name === "DendronGraphPanel" ? "0px" : "33px",
   });
-
-  useEffect(() => {
-    // this class is introduced with new reduced Motion feature of vscode and is resulting
-    // in a bug where webviews are updated to light theme.
-    //More info about this class here: https://code.visualstudio.com/api/extension-guides/webview#accessibility
-    document.body.classList.remove("vscode-reduce-motion");
-  }, []);
-
   return (
     <Provider store={combinedStore}>
       <Layout style={{ padding: opts.padding }}>

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -201,6 +201,12 @@ export class WebViewUtils {
       function getTheme() {
           // get theme
           let vsTheme = document.body.className;
+          
+          var reduceMotionClassName = "vscode-reduce-motion"
+          if(vsTheme.includes(reduceMotionClassName)) {
+            vsTheme = vsTheme.replace(reduceMotionClassName,"").trim()
+          }
+
           let dendronTheme;
           if (vsTheme.endsWith("dark")) {
               dendronTheme = "dark";


### PR DESCRIPTION
This is an attempt to quickly fix the issue: https://github.com/dendronhq/dendron/issues/2738.
More info about the class `vscode-reduce-motion` [here](https://code.visualstudio.com/api/extension-guides/webview#accessibility). 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)