### PR TITLE
fix(view): support custom styles for Note Graph

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -766,6 +766,7 @@ export enum GraphViewMessageEnum {
   "onGetActiveEditor" = "onGetActiveEditor",
   "onReady" = "onReady",
   "onRequestGraphStyle" = "onRequestGraphStyle",
+  "onGraphStyleLoad" = "onGraphStyleLoad",
 }
 
 export enum CalendarViewMessageType {

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -1,6 +1,7 @@
 import {
   DMessageEnum,
   DMessageSource,
+  GraphViewMessageEnum,
   LookupViewMessageEnum,
   NoteUtils,
   OnDidChangeActiveTextEditorMsg,
@@ -96,6 +97,13 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ideDispatch(ideSlice.actions.refreshLookup(msg.data.payload));
         logger.info({ ctx, msg: "refreshLookup:post" });
         break;
+      case GraphViewMessageEnum.onGraphStyleLoad: {
+        const cmsg = msg;
+        const { styles } = cmsg.data;
+        logger.info({ ctx, styles, msg: "styles" });
+        ideDispatch(ideSlice.actions.setGraphStyles(styles));
+        break;
+      }
       default:
         logger.error({ ctx, msg: "unknown message", payload: msg });
         break;

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -93,6 +93,8 @@ import { DendronExtension, getDWorkspace, getExtension } from "./workspace";
 import { WorkspaceActivator } from "./workspace/workspaceActivater";
 import { WorkspaceInitFactory } from "./workspace/WorkspaceInitFactory";
 import { WSUtils } from "./WSUtils";
+import { ShowNoteGraphCommand } from "./commands/ShowNoteGraph";
+import { NoteGraphPanelFactory } from "./components/views/NoteGraphViewFactory";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -1036,6 +1038,19 @@ async function _setupCommands({
           sentryReportingCallback(async () => {
             await new ShowSchemaGraphCommand(
               SchemaGraphViewFactory.create(ws)
+            ).run();
+          })
+        )
+      );
+    }
+
+    if (!existingCommands.includes(DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key)) {
+      context.subscriptions.push(
+        vscode.commands.registerCommand(
+          DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key,
+          sentryReportingCallback(async () => {
+            await new ShowNoteGraphCommand(
+              NoteGraphPanelFactory.create(ws, ws.getEngine())
             ).run();
           })
         )

--- a/packages/plugin-core/src/commands/ShowNoteGraph.ts
+++ b/packages/plugin-core/src/commands/ShowNoteGraph.ts
@@ -16,6 +16,8 @@ export class ShowNoteGraphCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
+  static requireActiveWorkspace: boolean = true;
+
   key = DENDRON_COMMANDS.SHOW_NOTE_GRAPH.key;
 
   private _panel;

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -98,7 +98,7 @@ export class NoteGraphPanelFactory {
             const styles = GraphStyleService.getParsedStyles();
             if (styles) {
               this._panel!.webview.postMessage({
-                type: "onGraphStyleLoad",
+                type: GraphViewMessageEnum.onGraphStyleLoad,
                 data: {
                   styles,
                 },


### PR DESCRIPTION
This Pr aims to 
- fix the regression of Graph migration to `dendron-plugin-views` which broke the application of graph's custom CSS.
- It also adds back Show Note Graph in `_extension.ts`.

![image](https://user-images.githubusercontent.com/84971366/163435284-7a1cba6a-226d-4627-a92d-cdfcee3e269b.png)

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)