### PR TITLE
enhance: starting general release of self contained vaults for some new users

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -9,6 +9,7 @@ import {
   ConfigUtils,
   CONSTANTS,
   DendronError,
+  DENDRON_VSCODE_CONFIG_KEYS,
   getStage,
   GitEvents,
   InstallStatus,
@@ -46,6 +47,8 @@ import * as vscode from "vscode";
 import os from "os";
 import {
   CURRENT_AB_TESTS,
+  SelfContainedVaultsTestGroups,
+  SELF_CONTAINED_VAULTS_TEST,
   UpgradeToastWordingTestGroups,
   UPGRADE_TOAST_WORDING_TEST,
 } from "./abTests";
@@ -425,6 +428,23 @@ export async function _activate(
         // we still want to proceed with InstallStatus.INITIAL_INSTALL because we want everything
         // tied to initial install to happen in this instance of VSCode once for the first time
         isSecondaryInstall = true;
+      }
+
+      if (!isSecondaryInstall) {
+        // For new users, we want to roll out self contained vaults to some of
+        // them. We'll do that by setting the global config, so all workspace
+        // they create from now on will be self contained, and they can turn off
+        // the config if there are problems.
+        const split = SELF_CONTAINED_VAULTS_TEST.getUserGroup(
+          SegmentClient.instance().anonymousId
+        );
+        if (split === SelfContainedVaultsTestGroups.selfContained) {
+          VSCodeUtils.setWorkspaceConfig(
+            DENDRON_VSCODE_CONFIG_KEYS.ENABLE_SELF_CONTAINED_VAULTS_WORKSPACE,
+            true,
+            vscode.ConfigurationTarget.Global
+          );
+        }
       }
     }
 

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -29,6 +29,27 @@ export const UPGRADE_TOAST_WORDING_TEST = new ABTest(
   ]
 );
 
+export enum SelfContainedVaultsTestGroups {
+  /** User will get a regular workspace and vaults set up, like before. */
+  regular = "regularVaults",
+  /** User will get a self contained vault as a workspace. */
+  selfContained = "selfContainedVaults",
+}
+
+export const SELF_CONTAINED_VAULTS_TEST = new ABTest(
+  "SelfContainedVaultsTest",
+  [
+    {
+      name: SelfContainedVaultsTestGroups.regular,
+      weight: 9,
+    },
+    {
+      name: SelfContainedVaultsTestGroups.selfContained,
+      weight: 1,
+    },
+  ]
+);
+
 /** All A/B tests that are currently running.
  *
  * ^tkqhy45hflfd

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -587,6 +587,14 @@ export class VSCodeUtils {
   }
 
   static getWorkspaceConfig = vscode.workspace.getConfiguration;
+  static setWorkspaceConfig(
+    section: string,
+    value: any,
+    configurationTarget?: vscode.ConfigurationTarget | boolean | null
+  ) {
+    const config = vscode.workspace.getConfiguration();
+    config.update(section, value, configurationTarget);
+  }
 
   static isExtensionInstalled(extensionId: string) {
     return !_.isUndefined(vscode.extensions.getExtension(extensionId));


### PR DESCRIPTION
This PR adds an A/B test for self contained vaults, split 10% to 90%. For new users in the self contained vaults group, we'll set the default for new workspaces as self contained. Any new workspaces created by these users will be self contained vaults.

I did some manual testing, the "Get started" button will create a self contained vault.