### PR TITLE
enhance: detect misconfigured self contained vaults and offer to fix them

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -109,6 +109,8 @@ export enum ConfigEvents {
   EnabledExportPodV2 = "Enabled_Export_Pod_V2",
   ShowMissingDefaultConfigMessage = "Show_Missing_Default_Config_Message",
   MissingDefaultConfigMessageConfirm = "MissingDefaultConfigMessageConfirm",
+  MissingSelfContainedVaultsMessageShow = "MissingSelfContainedVaultsMessageShow",
+  MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",
 }
 
 export enum MigrationEvents {

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -6,7 +6,7 @@ import minimatch from "minimatch";
 import path from "path";
 import querystring from "querystring";
 import semver from "semver";
-import { DateTime, LruCache } from ".";
+import { DateTime, LruCache, VaultUtils } from ".";
 import { COLORS_LIST } from "./colors";
 import {
   CompatUtils,
@@ -1150,6 +1150,22 @@ export class ConfigUtils {
 
   static setVaults(config: IntermediateDendronConfig, value: DVault[]): void {
     ConfigUtils.setWorkspaceProp(config, "vaults", value);
+  }
+
+  /** Finds the matching vault in the config, and uses the callback to update it. */
+  static updateVault(
+    config: IntermediateDendronConfig,
+    vaultToUpdate: DVault,
+    updateCb: (vault: DVault) => DVault
+  ): void {
+    ConfigUtils.setVaults(
+      config,
+      ConfigUtils.getVaults(config).map((configVault) => {
+        if (!VaultUtils.isEqualV2(vaultToUpdate, configVault))
+          return configVault;
+        return updateCb(configVault);
+      })
+    );
   }
 
   static setNoteLookupProps<K extends keyof NoteLookupConfig>(

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -51,7 +51,6 @@ import {
   StrictConfigV5,
 } from "./types/intermediateConfigs";
 import { isWebUri } from "./util/regex";
-import { VaultUtils } from "./vault";
 
 /**
  * Dendron utilities

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -1,7 +1,9 @@
 import {
+  CONSTANTS,
   DendronError,
   DNodeUtils,
   DVault,
+  FOLDERS,
   isNotUndefined,
   NoteProps,
   NotesCache,
@@ -635,6 +637,16 @@ class FileUtils {
         });
     });
   };
+}
+
+/** Looks at the files at the given path to check if it's a self contained vault. */
+export async function isSelfContainedVaultFolder(dir: string) {
+  return _.every(
+    await Promise.all([
+      fs.pathExists(path.join(dir, CONSTANTS.DENDRON_CONFIG_FILE)),
+      fs.pathExists(path.join(dir, FOLDERS.NOTES)),
+    ])
+  );
 }
 
 export class ExtensionUtils {

--- a/packages/plugin-core/src/commands/ReloadIndex.ts
+++ b/packages/plugin-core/src/commands/ReloadIndex.ts
@@ -200,7 +200,7 @@ export class ReloadIndexCommand extends BasicCommand<
     const { wsRoot, engine } = ws;
 
     // Check if there are any misconfigured self contained vaults.
-    // Deliberately now awaiting this to avoid blocking the reload
+    // Deliberately not awaiting this to avoid blocking the reload
     ReloadIndexCommand.checkAndPromptForMisconfiguredSelfContainedVaults({
       engine: ExtensionProvider.getEngine(),
     });

--- a/packages/plugin-core/src/commands/ReloadIndex.ts
+++ b/packages/plugin-core/src/commands/ReloadIndex.ts
@@ -14,12 +14,15 @@ import {
   schemaModuleOpts2File,
   vault2Path,
 } from "@dendronhq/common-server";
+import { DoctorActionsEnum, DoctorService } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 import { ProgressLocation, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
+import { Logger } from "../logger";
+import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
 import { AnalyticsUtils } from "../utils/analytics";
 import { BasicCommand } from "./base";
 
@@ -103,6 +106,63 @@ export class ReloadIndexCommand extends BasicCommand<
     }
   }
 
+  /** Checks if there are any self contained vaults that aren't marked correctly, and prompts the user to fix the configuration. */
+  static async checkAndPromptForMisconfiguredSelfContainedVaults({
+    engine,
+  }: {
+    engine: IEngineAPIService;
+  }) {
+    const ctx = "checkAndPromptForMisconfiguredSelfContainedVaults";
+    const { wsRoot, vaults } = engine;
+
+    const doctor = new DoctorService();
+    const vaultsToFix = await doctor.findMisconfiguredSelfContainedVaults(
+      wsRoot,
+      vaults
+    );
+
+    const fixConfig = "Fix configuration";
+
+    if (vaultsToFix.length > 0) {
+      Logger.info({
+        ctx,
+        numVaultsToFix: vaultsToFix.length,
+      });
+
+      let message: string;
+      let detail: string | undefined;
+      if (vaultsToFix.length === 1) {
+        message = `Vault "${vaultsToFix[0]}" needs to be marked as a self contained vault in your configuration file.`;
+      } else {
+        message = `${vaultsToFix.length} vaults need to be marked as self contained vaults in your configuration file`;
+      }
+      const pick = await window.showWarningMessage(
+        message,
+        {
+          detail,
+        },
+        fixConfig,
+        "Ignore for now"
+      );
+      Logger.info({
+        ctx,
+        msg: "Used picked an option in the fix prompt",
+        pick,
+      });
+      if (pick === fixConfig) {
+        await doctor.executeDoctorActions({
+          action: DoctorActionsEnum.FIX_SELF_CONTAINED_VAULT_CONFIG,
+          engine,
+        });
+        Logger.info({
+          ctx,
+          msg: "Fixing vaults done!",
+        });
+      }
+    }
+    doctor.dispose();
+  }
+
   /**
    * Update index
    * @param opts
@@ -115,6 +175,12 @@ export class ReloadIndexCommand extends BasicCommand<
     const ws = ExtensionProvider.getDWorkspace();
     let initError: DendronError | undefined;
     const { wsRoot, engine } = ws;
+
+    // Check if there are any misconfigured self contained vaults.
+    // Deliberately now awaiting this to avoid blocking the reload
+    ReloadIndexCommand.checkAndPromptForMisconfiguredSelfContainedVaults({
+      engine: ExtensionProvider.getEngine(),
+    });
 
     // Fix up any broken vaults
     const reloadIndex = async () => {

--- a/packages/plugin-core/src/commands/ReloadIndex.ts
+++ b/packages/plugin-core/src/commands/ReloadIndex.ts
@@ -1,4 +1,5 @@
 import {
+  ConfigEvents,
   DendronError,
   DEngineClient,
   DVault,
@@ -150,6 +151,9 @@ export class ReloadIndexCommand extends BasicCommand<
       } else {
         message = `${vaultsToFix.length} vaults need to be marked as self contained vaults in your configuration file`;
       }
+      AnalyticsUtils.track(ConfigEvents.MissingSelfContainedVaultsMessageShow, {
+        vaultsToFix: vaultsToFix.length,
+      });
       const pick = await window.showWarningMessage(
         message,
         {
@@ -164,6 +168,9 @@ export class ReloadIndexCommand extends BasicCommand<
         pick,
       });
       if (pick === fixConfig) {
+        AnalyticsUtils.track(
+          ConfigEvents.MissingSelfContainedVaultsMessageAccept
+        );
         await doctor.executeDoctorActions({
           action: DoctorActionsEnum.FIX_SELF_CONTAINED_VAULT_CONFIG,
           engine,

--- a/packages/plugin-core/src/commands/ReloadIndex.ts
+++ b/packages/plugin-core/src/commands/ReloadIndex.ts
@@ -34,6 +34,8 @@ enum AutoFixAction {
   CREATE_ROOT_NOTE = "create root note",
 }
 
+export const FIX_CONFIG_SELF_CONTAINED = "Fix configuration";
+
 function categorizeActions(actions: (AutoFixAction | undefined)[]) {
   return {
     [AutoFixAction.CREATE_ROOT_NOTE]: actions.filter(
@@ -124,15 +126,14 @@ export class ReloadIndexCommand extends BasicCommand<
     engine: IEngineAPIService;
   }) {
     const ctx = "checkAndPromptForMisconfiguredSelfContainedVaults";
-    const { wsRoot, vaults } = engine;
-
+    const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
     const doctor = new DoctorService();
     const vaultsToFix = await doctor.findMisconfiguredSelfContainedVaults(
       wsRoot,
       vaults
     );
 
-    const fixConfig = "Fix configuration";
+    const fixConfig = FIX_CONFIG_SELF_CONTAINED;
 
     if (vaultsToFix.length > 0) {
       Logger.info({

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -2,7 +2,6 @@ import {
   ConfigEvents,
   ConfigUtils,
   ConfirmStatus,
-  DVault,
   ExtensionEvents,
   InstallStatus,
   SurveyEvents,
@@ -12,7 +11,6 @@ import {
 import {
   DConfig,
   DoctorActionsEnum,
-  DoctorService,
   InactvieUserMsgStatusEnum,
   MetadataService,
 } from "@dendronhq/engine-server";
@@ -26,11 +24,6 @@ import { StateService } from "../services/stateService";
 import { GLOBAL_STATE, INCOMPATIBLE_EXTENSIONS } from "../constants";
 import { SurveyUtils } from "../survey";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { isSelfContainedVaultFolder } from "@dendronhq/common-server";
-import path from "path";
-import { ExtensionProvider } from "../ExtensionProvider";
-import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
-import { Logger } from "../logger";
 
 export class StartupUtils {
   static showMissingDefaultConfigMessageIfNecessary(opts: {

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -2,6 +2,7 @@ import {
   ConfigEvents,
   ConfigUtils,
   ConfirmStatus,
+  DVault,
   ExtensionEvents,
   InstallStatus,
   SurveyEvents,
@@ -11,6 +12,7 @@ import {
 import {
   DConfig,
   DoctorActionsEnum,
+  DoctorService,
   InactvieUserMsgStatusEnum,
   MetadataService,
 } from "@dendronhq/engine-server";
@@ -24,6 +26,11 @@ import { StateService } from "../services/stateService";
 import { GLOBAL_STATE, INCOMPATIBLE_EXTENSIONS } from "../constants";
 import { SurveyUtils } from "../survey";
 import { VSCodeUtils } from "../vsCodeUtils";
+import { isSelfContainedVaultFolder } from "@dendronhq/common-server";
+import path from "path";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
+import { Logger } from "../logger";
 
 export class StartupUtils {
   static showMissingDefaultConfigMessageIfNecessary(opts: {


### PR DESCRIPTION
If the user has a self contained vault that was incorrectly configured as a self contained vault, then this PR will detect that issue and offer to fix it with a prompt. This PR also adds the doctor action that will fix the misconfigured vault.

![image](https://user-images.githubusercontent.com/1008124/163543027-8132ea89-9a36-4fd9-9f65-7f3c03c75ceb.png)

I also disabled the "create missing root note/schema" automatic fix for when it's a misconfigured self contained vault, as otherwise it would create a root note in the wrong folder. That means the initialization fails, but Dendron will unbreak itself once the user fixes the config or accepts out prompt.