### PR TITLE
fix(pod): pod export fails when destination is at the root of drive in windows

### DIFF
--- a/packages/dendron-cli/src/commands/exportPodV2.ts
+++ b/packages/dendron-cli/src/commands/exportPodV2.ts
@@ -81,6 +81,7 @@ export class ExportPodV2CLICommand extends CLICommand<
       case PodV2Types.JSONExportV2:
         return new JSONExportPodV2({
           podConfig: config,
+          wsRoot: engine.wsRoot,
         });
       case PodV2Types.AirtableExportV2:
         return new AirtableExportPodV2({

--- a/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
@@ -501,6 +501,7 @@ describe("GIVEN a JSON Export Pod with a particular config", () => {
           };
           const pod = new JSONExportPodV2({
             podConfig,
+            wsRoot: opts.wsRoot,
           });
           const props = NoteUtils.getNoteByFnameFromEngine({
             fname: "bar",
@@ -539,6 +540,7 @@ describe("GIVEN a JSON Export Pod with a particular config", () => {
             };
             const pod = new JSONExportPodV2({
               podConfig,
+              wsRoot: opts.wsRoot,
             });
 
             const props = NoteUtils.getNoteByFnameFromEngine({

--- a/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
@@ -59,10 +59,11 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
       canSelectFiles: true,
       canSelectFolders: false,
     };
-    const destination = await PodUIControls.promptUserForDestination(
-      exportScope,
-      options
-    );
+    const destination =
+      opts && opts.destination
+        ? opts.destination
+        : await PodUIControls.promptUserForDestination(exportScope, options);
+
     if (!destination) {
       return;
     }
@@ -129,6 +130,7 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
   ): ExportPodV2<JSONExportReturnType> {
     return new JSONExportPodV2({
       podConfig: config,
+      wsRoot: this.extension.getDWorkspace().wsRoot,
     });
   }
 

--- a/packages/pods-core/src/utils.ts
+++ b/packages/pods-core/src/utils.ts
@@ -573,4 +573,14 @@ export class PodUtils {
       `svcconfig.${connectionId}.yml`
     );
   };
+
+  /**
+   * @param dest
+   * @returns true if parent of filepath is root
+   */
+  static isParentRoot = (dest: string) => {
+    const parent = path.dirname(dest);
+    const parsedPath = path.parse(parent);
+    return parsedPath.root === parent;
+  };
 }


### PR DESCRIPTION
This PR aims to resolve the issue with pod export when the destination is at the root of the drive.
- If export destination was selected `E:\export`, it returned the below error. This PR attempts to successfully complete the export for such scenarios.
```log
{"errno":-4048,"syscall":"mkdir","code":"EPERM","path":"e:\\"}
``` 
[[Fix Error When Parent of Destination Is Root in Exportv2|task.2022.04.05.fix-error-when-parent-of-destination-is-root-in-exportv2]]

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)