### PR TITLE
fix(pods): export markdown links with `.md` extension

### DIFF
--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -1130,7 +1130,8 @@ export class RemarkUtils {
             dirty = true;
           }
 
-          linkNode.value = newValue;
+          // NOTE: important to add this at the end so that we don't convert `.md` to `/md`
+          linkNode.value = newValue + ".md";
         });
         //TODO: Add support for Ref Notes and Block Links
 

--- a/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/MarkdownPod.spec.ts
@@ -847,7 +847,7 @@ describe("markdown export pod", () => {
           }
         );
         expect(foo).toMatchSnapshot("note link reference");
-        await checkString(foo, "[One](/simple-wikilink/one)");
+        await checkString(foo, "[One](/simple-wikilink/one.md)");
 
         // Now do a comparison for a note reference at the top level hierarchy
         // check contents
@@ -860,7 +860,7 @@ describe("markdown export pod", () => {
         expect(foo).toMatchSnapshot("top hierarchy note link reference");
         await checkString(
           foo,
-          "[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target)"
+          "[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target.md)"
         );
       },
       {

--- a/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/MarkdownPod.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/MarkdownPod.spec.ts.snap
@@ -11,13 +11,13 @@ foo.ch1 body"
 exports[`markdown export pod test wikilink conversion: note link reference 1`] = `
 "# Simple Wikilink
 
-[One](/simple-wikilink/one)"
+[One](/simple-wikilink/one.md)"
 `;
 
 exports[`markdown export pod test wikilink conversion: top hierarchy note link reference 1`] = `
 "# Wikilink Top Hierarchy
 
-[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target)"
+[Wikilink Top Hierarchy Target](/wikilink-top-hierarchy-target.md)"
 `;
 
 exports[`markdown publish pod basic 1`] = `

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
@@ -253,7 +253,7 @@ describe("GIVEN a Markdown Export Pod with a particular config", () => {
             expect(_.isString(data)).toBeTruthy();
             if (_.isString(data)) {
               expect(
-                data?.includes("[One](/simple-wikilink/one)")
+                data?.includes("[One](/simple-wikilink/one.md)")
               ).toBeTruthy();
             }
           },

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -157,7 +157,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
    * @param items
    * @returns
    */
-  async _prepareItems(items: DItem[]) {
+  async buildFileDirAssetDicts(items: DItem[]) {
     const engineFileDict: { [k: string]: DItem } = {};
     const assetFileDict: { [k: string]: DItem } = {};
     // create map of files
@@ -453,7 +453,7 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
     // get all items
     const { items, errors } = await this._collectItems(src.fsPath);
     this.L.info({ ctx, wsRoot, numItems: _.size(items), msg: "collectItems" });
-    const { engineFileDict } = await this._prepareItems(items);
+    const { engineFileDict } = await this.buildFileDirAssetDicts(items);
     const { hDict, assetMap } = await this.collectNotesCopyAssets({
       files: _.values(engineFileDict),
       src: src.fsPath,


### PR DESCRIPTION
fix(pods): export markdown links with `.md` extension

Prior to this fix we were not exporting markdown notes with the `.md` extension

***

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

NA
## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended
NA
## Docs

### Basics

NA

## 


### Basics

NA

## 



## Close the Loop

### Basics

### Extended
NA