### PR TITLE
chore: improve error message from API svc

### DIFF
--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -307,7 +307,10 @@ abstract class API {
       payload.error = resp.data.error;
     } catch (err: any) {
       this._log(payload.error, "error");
-      payload.error = err?.response?.data?.error || err;
+      // Log errors from express:
+      payload.error =
+        err?.response?.data || // Corresponds to an unexpected server error (HTTP 500) if a data payload was added
+        err; // Corresponds to an axios (HTTP request) thrown error
     }
     if (payload.error) {
       this._log(payload.error, "error");
@@ -349,155 +352,134 @@ export class DendronAPI extends API {
     return _DendronAPI_INSTANCE;
   }
 
-  async assetGet(req: AssetGetRequest): Promise<DendronError | Buffer> {
-    const resp = await this._makeRequestRaw({
+  assetGet(req: AssetGetRequest): Promise<DendronError | Buffer> {
+    return this._makeRequestRaw({
       path: "assets/",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async assetGetTheme(
-    req: AssetGetThemeRequest
-  ): Promise<DendronError | Buffer> {
-    const resp = await this._makeRequestRaw({
+  assetGetTheme(req: AssetGetThemeRequest): Promise<DendronError | Buffer> {
+    return this._makeRequestRaw({
       path: "assets/theme",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async configGet(
-    req: WorkspaceRequest
-  ): Promise<APIPayload<ConfigGetPayload>> {
-    const resp = await this._makeRequest({
+  configGet(req: WorkspaceRequest): Promise<APIPayload<ConfigGetPayload>> {
+    return this._makeRequest({
       path: "config/get",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async configWrite(
-    req: ConfigWriteOpts & WorkspaceRequest
-  ): Promise<RespV2<void>> {
-    const resp = await this._makeRequest({
+  configWrite(req: ConfigWriteOpts & WorkspaceRequest): Promise<RespV2<void>> {
+    return this._makeRequest({
       path: "config/write",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async workspaceInit(req: WorkspaceInitRequest): Promise<InitializePayload> {
-    const resp = await this._makeRequest({
+  workspaceInit(req: WorkspaceInitRequest): Promise<InitializePayload> {
+    return this._makeRequest({
       path: "workspace/initialize",
       method: "post",
       body: {
         ...req,
       },
     });
-    return resp;
   }
 
-  async workspaceList(): Promise<WorkspaceListPayload> {
-    const resp = await this._makeRequest({
+  workspaceList(): Promise<WorkspaceListPayload> {
+    return this._makeRequest({
       path: "workspace/all",
       method: "get",
     });
-    return resp;
   }
 
-  async workspaceSync(req: WorkspaceSyncRequest): Promise<InitializePayload> {
-    const resp = await this._makeRequest({
+  workspaceSync(req: WorkspaceSyncRequest): Promise<InitializePayload> {
+    return this._makeRequest({
       path: "workspace/sync",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineBulkAdd(req: EngineBulkAddRequest): Promise<WriteNoteResp> {
-    const resp = await this._makeRequest({
+  engineBulkAdd(req: EngineBulkAddRequest): Promise<WriteNoteResp> {
+    return this._makeRequest({
       path: "note/bulkAdd",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineDelete(req: EngineDeleteRequest): Promise<EngineDeletePayload> {
-    const resp = await this._makeRequest({
+  engineDelete(req: EngineDeleteRequest): Promise<EngineDeletePayload> {
+    return this._makeRequest({
       path: "note/delete",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineGetNoteByPath(
+  engineGetNoteByPath(
     req: EngineGetNoteByPathRequest
   ): Promise<EngineGetNoteByPathPayload> {
-    const resp = await this._makeRequest({
+    return this._makeRequest({
       path: "note/getByPath",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineInfo(): Promise<RespRequired<EngineInfoResp>> {
-    const resp = await this._makeRequest({
+  engineInfo(): Promise<RespRequired<EngineInfoResp>> {
+    return this._makeRequest({
       path: "note/info",
       method: "get",
     });
-    return resp;
   }
 
-  async engineRenameNote(
+  engineRenameNote(
     req: EngineRenameNoteRequest
   ): Promise<EngineRenameNotePayload> {
-    const resp = await this._makeRequest({
+    return this._makeRequest({
       path: "note/rename",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineUpdateNote(
+  engineUpdateNote(
     req: EngineUpdateNoteRequest
   ): Promise<EngineUpdateNotePayload> {
-    const resp = await this._makeRequest({
+    return this._makeRequest({
       path: "note/update",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async engineWrite(req: EngineWriteRequest): Promise<WriteNoteResp> {
-    const resp = await this._makeRequest({
+  engineWrite(req: EngineWriteRequest): Promise<WriteNoteResp> {
+    return this._makeRequest({
       path: "note/write",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async noteQuery(req: NoteQueryRequest): Promise<NoteQueryResp> {
-    const resp = await this._makeRequest({
+  noteQuery(req: NoteQueryRequest): Promise<NoteQueryResp> {
+    return this._makeRequest({
       path: "note/query",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async noteRender(req: APIRequest<RenderNoteOpts>) {
-    const resp = await this._makeRequest<{
+  noteRender(req: APIRequest<RenderNoteOpts>) {
+    return this._makeRequest<{
       data: RenderNotePayload;
       error: null | DendronError;
     }>({
@@ -505,92 +487,78 @@ export class DendronAPI extends API {
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async getNoteBlocks(
-    req: GetNoteBlocksRequest
-  ): Promise<GetNoteBlocksPayload> {
-    const resp = await this._makeRequest({
+  getNoteBlocks(req: GetNoteBlocksRequest): Promise<GetNoteBlocksPayload> {
+    return this._makeRequest({
       path: "note/blocks",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async getDecorations(
-    req: GetDecorationsRequest
-  ): Promise<GetDecorationsPayload> {
-    const resp = await this._makeRequest({
+  getDecorations(req: GetDecorationsRequest): Promise<GetDecorationsPayload> {
+    return this._makeRequest({
       path: "note/decorations",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async getLinks(req: GetLinksRequest): Promise<GetNoteLinksPayload> {
-    const resp = await this._makeRequest({
+  getLinks(req: GetLinksRequest): Promise<GetNoteLinksPayload> {
+    return this._makeRequest({
       path: "note/links",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async getAnchors(req: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
-    const resp = await this._makeRequest({
+  getAnchors(req: GetAnchorsRequest): Promise<GetNoteAnchorsPayload> {
+    return this._makeRequest({
       path: "note/anchors",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async schemaDelete(req: SchemaDeleteRequest): Promise<SchemaDeletePayload> {
-    const resp = await this._makeRequest({
+  schemaDelete(req: SchemaDeleteRequest): Promise<SchemaDeletePayload> {
+    return this._makeRequest({
       path: "schema/delete",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async schemaRead(req: SchemaReadRequest): Promise<SchemaReadPayload> {
-    const resp = await this._makeRequest({
+  schemaRead(req: SchemaReadRequest): Promise<SchemaReadPayload> {
+    return this._makeRequest({
       path: "schema/get",
       method: "get",
       qs: req,
     });
-    return resp;
   }
 
-  async schemaQuery(req: SchemaQueryRequest): Promise<SchemaQueryPayload> {
-    const resp = await this._makeRequest({
+  schemaQuery(req: SchemaQueryRequest): Promise<SchemaQueryPayload> {
+    return this._makeRequest({
       path: "schema/query",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async schemaWrite(req: SchemaWriteRequest): Promise<SchemaWritePayload> {
-    const resp = await this._makeRequest({
+  schemaWrite(req: SchemaWriteRequest): Promise<SchemaWritePayload> {
+    return this._makeRequest({
       path: "schema/write",
       method: "post",
       body: req,
     });
-    return resp;
   }
 
-  async schemaUpdate(req: SchemaUpdateRequest): Promise<SchemaUpdatePayload> {
-    const resp = await this._makeRequest({
+  schemaUpdate(req: SchemaUpdateRequest): Promise<SchemaUpdatePayload> {
+    return this._makeRequest({
       path: "schema/update",
       method: "post",
       body: req,
     });
-    return resp;
   }
 }
 


### PR DESCRIPTION
## chore: improve error message from API svc

While debugging an issue with @hikchoi - we noticed that if express returns a 500, the client side logs an Axios wrapper error as opposed to our original 500 error data from the server, resulting in a useless callstack.  This change fixes that.  I also made a change to remove an unnecessary layer of promises in the API layer.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)