### PR TITLE
fix(workspace): hovering an asset link while holding `ctrl` opens it

### DIFF
--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -5,7 +5,7 @@ import {
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { ExtensionUtils, findNonNoteFile } from "@dendronhq/common-server";
+import { findNonNoteFile } from "@dendronhq/common-server";
 import * as Sentry from "@sentry/node";
 import vscode, { Location, Position, Uri } from "vscode";
 import { findAnchorPos, GotoNoteCommand } from "../commands/GotoNote";
@@ -32,22 +32,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
   }
 
   private async provideForNonNoteFile(nonNoteFile: string) {
-    if (!ExtensionUtils.isTextFileExtension(nonNoteFile)) {
-      // If we provide a definition for asset files, it will also trigger on hover.
-      // Which means it will launch the deafult app when the user hovers over an asset link.
-      return;
-    }
-    // Otherwise it's a text file, in which case `GotoNoteCommand` will open it in the editor.
-    // In that case it should be safe to use it.
-    const out = await new GotoNoteCommand(
-      ExtensionProvider.getExtension()
-    ).execute({
-      qs: nonNoteFile,
-      kind: TargetKind.NON_NOTE,
-    });
-    // Wasn't able to create
-    if (out?.kind !== TargetKind.NON_NOTE) return;
-    return new Location(Uri.file(out.fullPath), new Position(0, 0));
+    return new Location(Uri.file(nonNoteFile), new Position(0, 0));
   }
 
   private async provideForNewNote(

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1645254233145
+updated: 1650354689201
 created: 1608518909864
 ---
 
@@ -152,6 +152,8 @@ const x = 1;
 [[/vault/root.schema.yml]]
 
 And a link to line 6 in that file: [[/vault/root.schema.yml#L6]]
+
+And to an asset file: [[/assets/images/logo.png]]
 
 ## Link to a file outside any vault
 


### PR DESCRIPTION
This PR fixes Dendron opening asset files when hovering over them while holding `ctrl`.

This would cause asset links to text files (`[[/example.txt]]`) to open inside VSCode when hovered (rather than offering the file location), and binary files to launch the default app for them when hovered.

With this PR, `ctrl+hover` over a link to a text file will show the definition as expected, and for binary files it will do nothing (this is VSCode behavior, if VSCode adds support later it may display it as a definition).