### PR TITLE
chore: fixing all instances of foreach => asyncs

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/LookupUtils.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  asyncLoopOneAtATime,
   DendronError,
   DVault,
   RespV2,
@@ -46,7 +47,7 @@ function setupNotesForTest({
   vault3?: string[];
 }) {
   if (vault1) {
-    vault1.forEach(async (str) => {
+    asyncLoopOneAtATime(vault1, async (str) => {
       await NoteTestUtilsV4.createNote({
         vault: TestEngineUtils.vault1(vaults),
         wsRoot,
@@ -58,7 +59,7 @@ function setupNotesForTest({
   }
 
   if (vault2) {
-    vault2.forEach(async (str) => {
+    asyncLoopOneAtATime(vault2, async (str) => {
       await NoteTestUtilsV4.createNote({
         vault: TestEngineUtils.vault2(vaults),
         wsRoot,
@@ -70,7 +71,7 @@ function setupNotesForTest({
   }
 
   if (vault3) {
-    vault3.forEach(async (str) => {
+    asyncLoopOneAtATime(vault3, async (str) => {
       await NoteTestUtilsV4.createNote({
         vault: TestEngineUtils.vault3(vaults),
         wsRoot,

--- a/packages/pods-core/src/builtin/NotionPod.ts
+++ b/packages/pods-core/src/builtin/NotionPod.ts
@@ -1,4 +1,9 @@
-import { DendronError, ERROR_SEVERITY, NoteProps } from "@dendronhq/common-all";
+import {
+  asyncLoop,
+  DendronError,
+  ERROR_SEVERITY,
+  NoteProps,
+} from "@dendronhq/common-all";
 import { markdownToBlocks } from "@instantish/martian";
 import type {
   Page,
@@ -47,9 +52,11 @@ export class NotionExportPod extends ExportPod<NotionExportConfig> {
   /**
    * Method to create pages in Notion
    */
-  createPagesInNotion = async (blockPagesArray: any, notion: Client) => {
-    blockPagesArray.forEach(async (block: any) => {
-      // @ts-ignore
+  createPagesInNotion = (
+    blockPagesArray: any,
+    notion: Client
+  ): Promise<any[]> => {
+    return asyncLoop(blockPagesArray, async (block: any) => {
       await limiter.removeTokens(1);
       try {
         await notion.pages.create(block);


### PR DESCRIPTION
## chore: fixing all instances of foreach => asyncs

From an earlier debugging session, there was an issue caused by a `iterable.foreach(async () => {})` construct.  Because these issues are hard to detect, I went ahead and scrubbed through the code base for other instances and fixed them.

--- 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)