### PR TITLE
fix: insert note index `#undefined` in case missing tags

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1,17 +1,12 @@
 /* eslint-disable no-throw-literal */
 // @ts-ignore
-import title from "title";
 import matter from "gray-matter";
 import _ from "lodash";
 import minimatch from "minimatch";
 import path from "path";
+import title from "title";
 import { URI } from "vscode-uri";
-import {
-  CONSTANTS,
-  ERROR_STATUS,
-  TAGS_HIERARCHY,
-  TAGS_HIERARCHY_BASE,
-} from "./constants";
+import { CONSTANTS, ERROR_STATUS, TAGS_HIERARCHY } from "./constants";
 import { DendronError } from "./error";
 import { Time } from "./time";
 import {
@@ -573,7 +568,7 @@ export class NoteUtils {
     const { fname, vault } = note;
     let title = note.title;
 
-    if (note.fname.startsWith(TAGS_HIERARCHY_BASE)) {
+    if (note.fname.startsWith(TAGS_HIERARCHY)) {
       const tag = note.fname.split(TAGS_HIERARCHY)[1];
       return `#${tag}`;
     }

--- a/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
@@ -1,13 +1,13 @@
+import { ConfigUtils } from "@dendronhq/common-all";
+import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestConfigUtils } from "@dendronhq/engine-test-utils";
-import { AssertUtils } from "@dendronhq/common-test-utils";
-import * as vscode from "vscode";
 import { describe } from "mocha";
+import * as vscode from "vscode";
 import { InsertNoteIndexCommand } from "../../commands/InsertNoteIndexCommand";
 import { VSCodeUtils } from "../../vsCodeUtils";
+import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-import { ConfigUtils } from "@dendronhq/common-all";
-import { WSUtils } from "../../WSUtils";
 
 suite("InsertNoteIndex", function () {
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this);
@@ -32,6 +32,90 @@ suite("InsertNoteIndex", function () {
             await AssertUtils.assertInString({
               body,
               match: [["## Index", "- [[Ch1|foo.ch1]]"].join("\n")],
+            })
+          );
+          done();
+        },
+      });
+    });
+
+    test("tags.foo without tags note", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          //await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "root",
+            body: "this is root",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo",
+            body: "this is tag foo",
+          });
+        },
+        onInit: async ({ engine }) => {
+          const notes = engine.notes;
+          const cmd = new InsertNoteIndexCommand();
+
+          await WSUtils.openNote(notes["root"]);
+
+          const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+          editor.selection = new vscode.Selection(9, 0, 9, 0);
+          await cmd.execute({});
+          const body = editor.document.getText();
+          expect(
+            await AssertUtils.assertInString({
+              body,
+              match: [["## Index", "- [[Tags|tags]]"].join("\n")],
+            })
+          );
+          done();
+        },
+      });
+    });
+
+    test("tags.foo with tags note", (done) => {
+      runLegacyMultiWorkspaceTest({
+        ctx,
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          //await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "root",
+            body: "this is root",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags",
+            body: "this is tag",
+          });
+          await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "tags.foo",
+            body: "this is tag foo",
+          });
+        },
+        onInit: async ({ engine }) => {
+          const notes = engine.notes;
+          const cmd = new InsertNoteIndexCommand();
+
+          await WSUtils.openNote(notes["root"]);
+
+          const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+          editor.selection = new vscode.Selection(9, 0, 9, 0);
+          await cmd.execute({});
+          const body = editor.document.getText();
+          expect(
+            await AssertUtils.assertInString({
+              body,
+              match: [["## Index", "- [[Tags|tags]]"].join("\n")],
             })
           );
           done();


### PR DESCRIPTION
# Community PR Review Checklist

## Problem description

- When insert note index command runs it collects the active note's child notes. 
- These notes will be checked with the condition which was modified. 
- The condition checked if the note's name startsWith "tags". 
- If it was true, the next line splits the note's name at "tags." and returns the 1st element (without checking the result of the split).

## First Time Specifics

- [x] if its your first pull request to Dendron, watch out for the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) bot that will ask you to agree to Dendron's CLA
- [x] if its your first pull request and you're on our Discord, make sure that Kevin gives you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) role by adding your discord as part of the description  👨‍🌾👩‍🌾
- [ ] (optional) ping `@Dendron Team` in the `#dev` channel of our discord - we usually respond to PRs within 24h

## Commit

- [x] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#branch-style)
- [x] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style)
- [x] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
  Related to: https://github.com/dendronhq/dendron/issues/2314

## Code

- [x] code should follow [Code Conventions](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#branch-style)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e.html#commit-style).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

## Tests

- [x] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#writing-tests) 
- [x] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#executing-tests)
- [x] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#manual-testing) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html#updating-test-snapshots)

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://docs.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://docs.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)