### PR TITLE
fix(view): views don't update for new notes with self contained vaults

### DIFF
--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -92,7 +92,11 @@ export const syncNote = createAsyncThunk(
       return resp;
     }
     const data = resp.data!;
-    logger.info({ state: "pre:setNotes", notes: data.map(NoteUtils.toLogObj) });
+    logger.debug({
+      state: "pre:setNotes",
+      // Logging notes, but avoiding it if there's too many notes to avoid any performance impact
+      notes: data.length < 10 ? data.map(NoteUtils.toLogObj) : null,
+    });
     if (data?.length) {
       dispatch(updateNote(data[0]));
       dispatch(setError(undefined));

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -92,7 +92,7 @@ export const syncNote = createAsyncThunk(
       return resp;
     }
     const data = resp.data!;
-    logger.info({ state: "pre:setNotes" });
+    logger.info({ state: "pre:setNotes", notes: data.map(NoteUtils.toLogObj) });
     if (data?.length) {
       dispatch(updateNote(data[0]));
       dispatch(setError(undefined));

--- a/packages/dendron-plugin-views/src/components/DendronCalendarPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronCalendarPanel.tsx
@@ -5,6 +5,7 @@ import {
   DMessageSource,
   NoteProps,
   Time,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { createLogger, engineHooks } from "@dendronhq/common-frontend";
 import {
@@ -107,7 +108,7 @@ export default function DendronCalendarPanel({ ide, engine }: DendronProps) {
   const groupedDailyNotes = useMemo(() => {
     const vaultNotes = _.values(notes).filter((notes) => {
       if (currentVault) {
-        return notes.vault.fsPath === currentVault?.fsPath;
+        return VaultUtils.isEqualV2(notes.vault, currentVault);
       }
       return true;
     });

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -504,6 +504,11 @@ export class DendronEngineV2 implements DEngine {
     const ctx = "Engine:queryNotes";
     const { qs, vault, createIfNew, onlyDirectChildren, originalQS } = opts;
 
+    // Need to ignore this because the engine stringifies this property, so the types are incorrect.
+    // @ts-ignore
+    if (vault?.selfContained === "true" || vault?.selfContained === "false")
+      vault.selfContained = vault.selfContained === "true";
+
     const items = await this.fuseEngine.queryNote({
       qs,
       onlyDirectChildren,
@@ -535,9 +540,9 @@ export class DendronEngineV2 implements DEngine {
     this.logger.info({ ctx, msg: "exit" });
     let notes = items.map((ent) => this.notes[ent.id]);
     if (!_.isUndefined(vault)) {
-      notes = notes.filter((ent) =>
-        VaultUtils.isEqual(vault, ent.vault, this.wsRoot)
-      );
+      notes = notes.filter((ent) => {
+        return VaultUtils.isEqualV2(vault, ent.vault);
+      });
     }
     return {
       error: null,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -541,7 +541,7 @@ export class DendronEngineV2 implements DEngine {
     let notes = items.map((ent) => this.notes[ent.id]);
     if (!_.isUndefined(vault)) {
       notes = notes.filter((ent) => {
-        return VaultUtils.isEqualV2(vault, ent.vault);
+        return VaultUtils.isEqual(vault, ent.vault, this.wsRoot);
       });
     }
     return {


### PR DESCRIPTION
The issue was caused by the API stringifying properties passed to it. This meant selfContained: true would become selfContained: "true", and the engine would think that these are different vaults.

This issue was first discovered for the calendar view, but likely affected other views.

This fix solves the problem by parsing the stringified property. Also included are a few small refactors to use VaultUtils.isEqualV2.

This is the same as #2783, but there were a lot of conflicts when rebasing that PR so I opted to cherry pick it into a new PR.