### PR TITLE
fix(views): optimize graph view graph calculation speed

### DIFF
--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -6,6 +6,7 @@ import {
   stringifyError,
   NoteUtils,
   ConfigGetPayload,
+  NoteFNamesDict,
 } from "@dendronhq/common-all";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import _ from "lodash";
@@ -143,6 +144,7 @@ const initialState: InitialState = {
   currentRequestId: undefined,
   vaults: [],
   notes: {},
+  noteFName: new NoteFNamesDict([]),
   schemas: {},
   notesRendered: {},
   error: null,
@@ -160,6 +162,7 @@ export const engineSlice = createSlice({
       state.schemas = schemas;
       state.vaults = vaults;
       state.config = config;
+      state.noteFName = new NoteFNamesDict(_.values(notes));
     },
     setConfig: (state, action: PayloadAction<ConfigGetPayload>) => {
       state.config = action.payload;

--- a/packages/common-frontend/src/types.ts
+++ b/packages/common-frontend/src/types.ts
@@ -1,4 +1,4 @@
-import { DEngineInitPayload } from "@dendronhq/common-all";
+import { DEngineInitPayload, NoteFNamesDict } from "@dendronhq/common-all";
 import _ from "lodash";
 
 export enum LoadingStatus {
@@ -11,6 +11,7 @@ export type EngineSliceState = {
   error: any;
   loading: LoadingStatus;
   currentRequestId: string | undefined;
+  noteFName: NoteFNamesDict;
 } & Partial<DEngineInitPayload> &
   Pick<DEngineInitPayload, "notes" | "schemas" | "vaults">;
 


### PR DESCRIPTION
## fix(views): optimize graph view graph calculation speed

This change makes an optimization in the calculation of nodes/edges from engine state in the graph view.  The cause of slowdown is that we were still using `getNoteByFnameV5`.  Switching to use the dictionary based `getNoteByFnameFromEngine` isn't straightforward though, as the engine isn't available in the webviews (at least, it's not a `DEngineClient`) - furthermore, the `NoteFNameDict` class can't be serialized and consequently cannot be sent over the API, so I opted to reconstruct the FName Dict in the engine slice, which seems fast enough.

Results - for org-workspace, which is currently at ~ 
- 24000 nodes
- 24322 hierarchical edges
- 53250 link edges

The computation time is down from ~5 minutes to less than 1 second.  Cytoscape will still take about 10 additional seconds to do its rendering though.

---

## Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation
N/A
### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)