### PR TITLE
chore: removing more instances of getNoteByFnameV5

### DIFF
--- a/packages/engine-server/src/markdown/utils.ts
+++ b/packages/engine-server/src/markdown/utils.ts
@@ -1,18 +1,16 @@
 import {
-  IntermediateDendronConfig,
+  ConfigUtils,
   DendronError,
   DEngineClient,
   DNoteLoc,
   DVault,
-  GetNoteOpts,
+  FIFOQueue,
   getSlugger,
   getStage,
-  NotePropsDict,
+  IntermediateDendronConfig,
   NoteProps,
   NoteUtils,
   VaultUtils,
-  ConfigUtils,
-  FIFOQueue,
 } from "@dendronhq/common-all";
 // @ts-ignore
 import mermaid from "@dendronhq/remark-mermaid";
@@ -45,21 +43,21 @@ import { default as unified, default as Unified, Processor } from "unified";
 import { Node, Parent } from "unist";
 import { hierarchies, RemarkUtils } from "./remark";
 import { backlinks } from "./remark/backlinks";
+import { BlockAnchorOpts, blockAnchors } from "./remark/blockAnchors";
 import { dendronPub, DendronPubOpts } from "./remark/dendronPub";
+import { extendedImage } from "./remark/extendedImage";
+import { hashtags } from "./remark/hashtag";
 import { NoteRefsOptsV2, noteRefsV2 } from "./remark/noteRefsV2";
 import { publishSite } from "./remark/publishSite";
 import { transformLinks } from "./remark/transformLinks";
+import { userTags } from "./remark/userTags";
 import { wikiLinks, WikiLinksOpts } from "./remark/wikiLinks";
-import { BlockAnchorOpts, blockAnchors } from "./remark/blockAnchors";
 import {
   DendronASTData,
   DendronASTDest,
-  VaultMissingBehavior,
   DendronASTTypes,
+  VaultMissingBehavior,
 } from "./types";
-import { hashtags } from "./remark/hashtag";
-import { userTags } from "./remark/userTags";
-import { extendedImage } from "./remark/extendedImage";
 
 const toString = require("mdast-util-to-string");
 
@@ -103,16 +101,6 @@ enum DendronProcDataKeys {
   NOTE_REF_LVL = "noteRefLvl",
   ENGINE = "engine",
 }
-
-export const renderFromNoteProps = (
-  opts: { notes: NotePropsDict } & GetNoteOpts
-) => {
-  const note = NoteUtils.getNoteByFnameV5(opts);
-  if (!note) {
-    throw Error("no note found");
-  }
-  return renderFromNote({ note });
-};
 
 export const renderFromNote = (opts: { note: NoteProps }) => {
   const { note } = opts;

--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -123,7 +123,7 @@ export class WSUtils {
     @deprecated. Use same method in {@link WSUtilsV2}
   **/
   static getNoteFromPath(fsPath: string) {
-    const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
+    const { engine } = ExtensionProvider.getDWorkspace();
     const fname = path.basename(fsPath, ".md");
     let vault: DVault;
     try {
@@ -132,11 +132,10 @@ export class WSUtils {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameV5({
+    return NoteUtils.getNoteByFnameFromEngine({
       fname,
       vault,
-      wsRoot,
-      notes: engine.notes,
+      engine,
     });
   }
 

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -41,7 +41,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
   }
 
   getNoteFromPath(fsPath: string): NoteProps | undefined {
-    const { engine, wsRoot } = this.extension.getDWorkspace();
+    const { engine } = this.extension.getDWorkspace();
     const fname = path.basename(fsPath, ".md");
     let vault: DVault;
     try {
@@ -50,11 +50,10 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameV5({
+    return NoteUtils.getNoteByFnameFromEngine({
       fname,
       vault,
-      wsRoot,
-      notes: engine.notes,
+      engine,
     });
   }
 
@@ -83,7 +82,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
   }
 
   getNoteFromDocument(document: vscode.TextDocument) {
-    const { engine, wsRoot } = this.extension.getDWorkspace();
+    const { engine } = this.extension.getDWorkspace();
     const txtPath = document.uri.fsPath;
     const fname = path.basename(txtPath, ".md");
     let vault: DVault;
@@ -93,11 +92,10 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameV5({
+    return NoteUtils.getNoteByFnameFromEngine({
       fname,
       vault,
-      wsRoot,
-      notes: engine.notes,
+      engine,
     });
   }
 

--- a/packages/plugin-core/src/clientUtils.ts
+++ b/packages/plugin-core/src/clientUtils.ts
@@ -49,11 +49,10 @@ export class DendronClientUtilsV2 {
         // const domain: NoteProps | undefined = undefined;
         out = DNodeUtils.domainName(fname);
         const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
-        const domain = NoteUtils.getNoteByFnameV5({
+        const domain = NoteUtils.getNoteByFnameFromEngine({
           fname,
-          notes: opts.engine.notes,
+          engine: opts.engine,
           vault,
-          wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
         });
         if (domain && domain.schema) {
           const smod = opts.engine.schemas[domain.schema.moduleId];

--- a/packages/plugin-core/src/commands/ConvertLink.ts
+++ b/packages/plugin-core/src/commands/ConvertLink.ts
@@ -1,11 +1,3 @@
-import { QuickPickItem, Range, TextEditor } from "vscode";
-import { DENDRON_COMMANDS } from "../constants";
-import { VSCodeUtils } from "../vsCodeUtils";
-import { BasicCommand } from "./base";
-import {
-  getReferenceAtPosition,
-  getReferenceAtPositionResp,
-} from "../utils/md";
 import {
   assertUnreachable,
   DendronError,
@@ -13,18 +5,25 @@ import {
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
-import { getDWorkspace } from "../workspace";
-import { WSUtils } from "../WSUtils";
 import {
   HistoryEvent,
   LinkUtils,
   ParseLinkV2Resp,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
+import { QuickPickItem, Range, TextEditor } from "vscode";
 import { LookupControllerV3CreateOpts } from "../components/lookup/LookupControllerV3Interface";
-import { NoteLookupProviderUtils } from "../components/lookup/NoteLookupProviderUtils";
-import { ExtensionProvider } from "../ExtensionProvider";
 import { NoteLookupProviderSuccessResp } from "../components/lookup/LookupProviderV3Interface";
+import { NoteLookupProviderUtils } from "../components/lookup/NoteLookupProviderUtils";
+import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
+import {
+  getReferenceAtPosition,
+  getReferenceAtPositionResp,
+} from "../utils/md";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { WSUtils } from "../WSUtils";
+import { BasicCommand } from "./base";
 
 type CommandOpts = {
   range: Range;
@@ -303,8 +302,8 @@ export class ConvertLinkCommand extends BasicCommand<
   }
 
   async gatherInputs(): Promise<CommandOpts> {
-    const { engine } = getDWorkspace();
-    const { vaults, wsRoot, notes } = engine;
+    const engine = ExtensionProvider.getEngine();
+    const { vaults, wsRoot } = engine;
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
     const { document, selection } = editor;
     const reference = await getReferenceAtPosition({
@@ -332,11 +331,10 @@ export class ConvertLinkCommand extends BasicCommand<
     if (targetVault === undefined) {
       throw ConvertLinkCommand.noVaultError();
     } else {
-      const targetNote = NoteUtils.getNoteByFnameV5({
+      const targetNote = NoteUtils.getNoteByFnameFromEngine({
         fname: ref,
-        notes,
+        engine: ExtensionProvider.getEngine(),
         vault: targetVault,
-        wsRoot,
       });
 
       if (targetNote === undefined) {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -237,18 +237,17 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       `## The following files have broken links`,
     ];
 
-    const { notes, vaults, wsRoot } = engine;
+    const { vaults, wsRoot } = engine;
     _.forEach(_.sortBy(brokenLinks, ["file"]), (ent) => {
       content = content.concat(`${ent.file}\n`);
       const vault = VaultUtils.getVaultByName({
         vaults,
         vname: ent.vault,
       }) as DVault;
-      const note = NoteUtils.getNoteByFnameV5({
+      const note = NoteUtils.getNoteByFnameFromEngine({
         fname: ent.file,
-        notes,
+        engine,
         vault,
-        wsRoot,
       }) as NoteProps;
       const fsPath = NoteUtils.getFullPath({
         note,

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -350,11 +350,10 @@ export abstract class BaseExportPodCommand<
 
     const fname = path.basename(fsPath, ".md");
 
-    const maybeNote = NoteUtils.getNoteByFnameV5({
+    const maybeNote = NoteUtils.getNoteByFnameFromEngine({
       fname,
       vault,
-      notes: engine.notes,
-      wsRoot,
+      engine,
     }) as NoteProps;
 
     if (!maybeNote) {

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -153,8 +153,7 @@ export class ProviderAcceptHooks {
     // setup vars
     const oldVault = PickerUtilsV2.getVaultForOpenEditor();
     const newVault = quickpick.vault ? quickpick.vault : oldVault;
-    const { wsRoot, engine } = ExtensionProvider.getDWorkspace();
-    const notes = engine.notes;
+    const engine = ExtensionProvider.getEngine();
 
     // get old note
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
@@ -167,11 +166,10 @@ export class ProviderAcceptHooks {
       : selectedItem.fname;
 
     // get new note
-    const newNote = NoteUtils.getNoteByFnameV5({
+    const newNote = NoteUtils.getNoteByFnameFromEngine({
       fname,
-      notes,
+      engine,
       vault: newVault,
-      wsRoot,
     });
     const isStub = newNote?.stub;
     if (newNote && !isStub) {

--- a/packages/plugin-core/src/features/RenameProvider.ts
+++ b/packages/plugin-core/src/features/RenameProvider.ts
@@ -6,18 +6,17 @@ import {
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
-import _ from "lodash";
 import { vault2Path } from "@dendronhq/common-server";
+import _ from "lodash";
 import vscode from "vscode";
 import { RenameNoteV2aCommand } from "../commands/RenameNoteV2a";
+import { ExtensionProvider } from "../ExtensionProvider";
 import {
   getReferenceAtPosition,
   getReferenceAtPositionResp,
 } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { WSUtils } from "../WSUtils";
-import { ExtensionProvider } from "../ExtensionProvider";
 
 export default class RenameProvider implements vscode.RenameProvider {
   private _targetNote: NoteProps | undefined;
@@ -32,8 +31,8 @@ export default class RenameProvider implements vscode.RenameProvider {
     document: vscode.TextDocument;
   }) {
     const { reference, document } = opts;
-    const { engine } = getDWorkspace();
-    const { notes, vaults, wsRoot } = engine;
+    const engine = ExtensionProvider.getEngine();
+    const { vaults } = engine;
     const { label, vaultName, range, ref, refType, refText } = reference;
     const targetVault = vaultName
       ? VaultUtils.getVaultByName({ vaults, vname: vaultName })
@@ -44,11 +43,10 @@ export default class RenameProvider implements vscode.RenameProvider {
       });
     } else {
       const fname = ref;
-      const targetNote = NoteUtils.getNoteByFnameV5({
+      const targetNote = NoteUtils.getNoteByFnameFromEngine({
         fname,
-        notes,
+        engine,
         vault: targetVault,
-        wsRoot,
       });
       if (targetNote === undefined) {
         throw new DendronError({
@@ -123,7 +121,7 @@ export default class RenameProvider implements vscode.RenameProvider {
   > {
     const { newName } = opts;
     if (this._targetNote !== undefined) {
-      const { engine } = getDWorkspace();
+      const engine = ExtensionProvider.getEngine();
       const { wsRoot } = engine;
       const renameCmd = new RenameNoteV2aCommand();
       const targetVault = this._targetNote.vault;

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -36,6 +36,7 @@ import {
   TextDocument,
   TextEdit,
 } from "vscode";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { sentryReportingCallback } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
@@ -237,19 +238,20 @@ export const resolveCompletionItem = sentryReportingCallback(
     )
       return;
 
-    const engine = getDWorkspace().engine;
-    const { vaults, notes, wsRoot } = engine;
+    const engine = ExtensionProvider.getEngine();
+    const { vaults, wsRoot } = engine;
     const vault = VaultUtils.getVaultByName({ vname, vaults });
     if (_.isUndefined(vault)) {
       Logger.info({ ctx, msg: "vault not found", fname, vault, wsRoot });
       return;
     }
-    const note = NoteUtils.getNoteByFnameV5({
+
+    const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
       vault,
-      notes,
-      wsRoot,
+      engine,
     });
+
     if (_.isUndefined(note)) {
       Logger.info({ ctx, msg: "note not found", fname, vault, wsRoot });
       return;

--- a/packages/pods-core/src/basev3.ts
+++ b/packages/pods-core/src/basev3.ts
@@ -82,11 +82,10 @@ export abstract class PublishPod<
       vaults: engine.vaults,
       vname: vaultName,
     });
-    const note = NoteUtils.getNoteByFnameV5({
+    const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
-      notes: engine.notes,
+      engine,
       vault: vault!,
-      wsRoot: engine.wsRoot,
     });
     if (!note) {
       throw Error("no note found");

--- a/packages/pods-core/src/builtin/GDocPod.ts
+++ b/packages/pods-core/src/builtin/GDocPod.ts
@@ -336,20 +336,12 @@ export class GDocImportPod extends ImportPod<GDocImportPodConfig> {
     onPrompt?: (arg0?: PROMPT) => Promise<{ title: string } | undefined>;
     importComments?: ImportComments;
   }) => {
-    const {
-      note,
-      engine,
-      wsRoot,
-      vault,
-      confirmOverwrite,
-      onPrompt,
-      importComments,
-    } = opts;
-    const existingNote = NoteUtils.getNoteByFnameV5({
+    const { note, engine, vault, confirmOverwrite, onPrompt, importComments } =
+      opts;
+    const existingNote = NoteUtils.getNoteByFnameFromEngine({
       fname: note.fname,
-      notes: engine.notes,
+      engine,
       vault,
-      wsRoot,
     });
     if (!_.isUndefined(existingNote)) {
       if (

--- a/packages/pods-core/src/builtin/GithubIssuePod.ts
+++ b/packages/pods-core/src/builtin/GithubIssuePod.ts
@@ -254,18 +254,12 @@ export class GithubIssueImportPod extends ImportPod<GithubIssueImportPodConfig> 
   /**
    * method to get notes that are not already present in the vault
    */
-  getNewNotes(
-    notes: NoteProps[],
-    engine: DEngineClient,
-    wsRoot: string,
-    vault: DVault
-  ) {
+  getNewNotes(notes: NoteProps[], engine: DEngineClient, vault: DVault) {
     return notes.filter((note) => {
-      const n = NoteUtils.getNoteByFnameV5({
+      const n = NoteUtils.getNoteByFnameFromEngine({
         fname: note.fname,
-        notes: engine.notes,
+        engine,
         vault,
-        wsRoot,
       });
       return _.isUndefined(n);
     });
@@ -277,17 +271,15 @@ export class GithubIssueImportPod extends ImportPod<GithubIssueImportPodConfig> 
   private async getUpdatedNotes(
     notes: NoteProps[],
     engine: DEngineClient,
-    wsRoot: string,
     vault: DVault
   ) {
     let updatedNotes: NoteProps[] = [];
 
     asyncLoopOneAtATime(notes, async (note) => {
-      const n = NoteUtils.getNoteByFnameV5({
+      const n = NoteUtils.getNoteByFnameFromEngine({
         fname: note.fname,
-        notes: engine.notes,
+        engine,
         vault,
-        wsRoot,
       });
       if (
         !_.isUndefined(n) &&
@@ -359,13 +351,8 @@ export class GithubIssueImportPod extends ImportPod<GithubIssueImportPodConfig> 
       concatenate,
       fnameAsId,
     });
-    const newNotes = this.getNewNotes(notes, engine, wsRoot, vault);
-    const updatedNotes = await this.getUpdatedNotes(
-      notes,
-      engine,
-      wsRoot,
-      vault
-    );
+    const newNotes = this.getNewNotes(notes, engine, vault);
+    const updatedNotes = await this.getUpdatedNotes(notes, engine, vault);
 
     await engine.bulkAddNotes({ notes: newNotes });
 

--- a/packages/pods-core/src/builtin/OrbitPod.ts
+++ b/packages/pods-core/src/builtin/OrbitPod.ts
@@ -142,7 +142,7 @@ export class OrbitImportPod extends ImportPod<OrbitImportPodConfig> {
     wsRoot: string;
     config: ImportPodConfig;
   }) {
-    const { vault, members, engine, wsRoot, config } = opts;
+    const { vault, members, engine, config } = opts;
     const conflicts: Conflict[] = [];
     const create: NoteProps[] = [];
     const notesToUpdate: UpdateNotesOpts[] = [];
@@ -162,11 +162,10 @@ export class OrbitImportPod extends ImportPod<OrbitImportPodConfig> {
         noteName = DNodeUtils.cleanFname(noteName);
         this.L.debug({ ctx: "membersToNotes", msg: "enter", member });
         let fname;
-        const note = NoteUtils.getNoteByFnameV5({
+        const note = NoteUtils.getNoteByFnameFromEngine({
           fname: `people.${noteName}`,
-          notes: engine.notes,
+          engine,
           vault,
-          wsRoot,
         });
 
         if (!_.isUndefined(note)) {


### PR DESCRIPTION
## chore: removing more instances of getNoteByFnameV5

Encountered another perf issue with Note Graph view around usage of `getNoteByFnameV5`, so I decided to do another scrub and remove more instances.  This change may result in some perf benefits across Dendron.

Remaining references:
- tests
- a few tricky ones within `storev2`, where we don't have an engine ref and hence can't use the new function.

---

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)