### PR TITLE
chore: add tests for vault remove with self contained vaults

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -3,6 +3,7 @@ import {
   DVault,
   WorkspaceSettings,
   ConfigUtils,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { readYAML } from "@dendronhq/common-server";
 import { FileTestUtils } from "@dendronhq/common-test-utils";
@@ -16,22 +17,23 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { VaultAddCommand } from "../../commands/VaultAddCommand";
 import { VaultRemoveCommand } from "../../commands/VaultRemoveCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { DendronExtension, getDWorkspace } from "../../workspace";
-import { expect, runMultiVaultTest, runSingleVaultTest } from "../testUtilsv2";
+import { DendronExtension } from "../../workspace";
+import { expect } from "../testUtilsv2";
 import {
-  runLegacyMultiWorkspaceTest,
-  setupBeforeAfter,
+  describeMultiWS,
+  describeSingleWS,
   stubVaultInput,
 } from "../testUtilsV3";
 
-const addWorkspaceVault = async ({
+async function addWorkspaceVault({
   vaults,
   wsName,
 }: {
   vaults: DVault[];
   wsName: string;
-}) => {
+}) {
   const { wsRoot } = await setupWS({
     vaults,
     asRemote: true,
@@ -47,246 +49,287 @@ const addWorkspaceVault = async ({
   });
   await cmd.run();
   return { wsRoot, vaults };
-};
+}
 
-const stubQuickPick = (vault: DVault) => {
+function stubQuickPick(vault: DVault) {
   // @ts-ignore
   VSCodeUtils.showQuickPick = () => {
     return { data: vault };
   };
-};
+}
 
-const getConfig = () => {
-  const configPath = DConfig.configPath(getDWorkspace().wsRoot as string);
-  const config = readYAML(configPath) as IntermediateDendronConfig;
-  return config;
-};
+function getConfig() {
+  return DConfig.getRaw(
+    ExtensionProvider.getDWorkspace().wsRoot
+  ) as IntermediateDendronConfig;
+}
 
-const getWorkspaceFile = () => {
+function getWorkspaceFile() {
   const settings = fs.readJSONSync(
     DendronExtension.workspaceFile().fsPath
   ) as WorkspaceSettings;
   return settings;
-};
+}
 
-suite("VaultRemoveCommand", function () {
-  const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
-    beforeHook: () => {
-      sinon
-        .stub(vscode.commands, "executeCommand")
-        .returns(Promise.resolve({}));
-    },
+suite("GIVEN VaultRemoveCommand", function () {
+  this.beforeEach(() => {
+    sinon.stub(vscode.commands, "executeCommand").resolves({});
   });
 
-  describe("workspace", () => {
-    test("basic", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        onInit: async ({ vaults }) => {
-          const remoteVaultName = "remoteVault";
-          const remoteWsName = "remoteWs";
-          const vaultsRemote = [{ fsPath: remoteVaultName }];
-          await addWorkspaceVault({
-            vaults: vaultsRemote,
-            wsName: remoteWsName,
-          });
-          stubQuickPick({ fsPath: remoteVaultName, workspace: remoteWsName });
-          await new VaultRemoveCommand().run();
-          const config = getConfig();
-          expect(ConfigUtils.getVaults(config)).toEqual(vaults);
-          expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
-          expect(
-            _.find(getWorkspaceFile().folders, {
-              path: path.join(remoteWsName, remoteVaultName),
-            })
-          ).toEqual(undefined);
-          done();
-        },
+  describeMultiWS("WHEN removing a workspace vault", {}, () => {
+    test("THEN the vault is removed", async () => {
+      const { vaults } = ExtensionProvider.getDWorkspace();
+      const remoteVaultName = "remoteVault";
+      const remoteWsName = "remoteWs";
+      const vaultsRemote = [{ fsPath: remoteVaultName }];
+      await addWorkspaceVault({
+        vaults: vaultsRemote,
+        wsName: remoteWsName,
       });
+      stubQuickPick({ fsPath: remoteVaultName, workspace: remoteWsName });
+      await new VaultRemoveCommand().run();
+      const config = getConfig();
+      expect(ConfigUtils.getVaults(config)).toEqual(vaults);
+      expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
+      expect(
+        _.find(getWorkspaceFile().folders, {
+          path: path.join(remoteWsName, remoteVaultName),
+        })
+      ).toEqual(undefined);
     });
   });
 
-  describe("single vault", () => {
-    test("basic", (done) => {
-      runMultiVaultTest({
-        ctx,
-        onInit: async ({ wsRoot, vaults }) => {
-          // @ts-ignore
-          VSCodeUtils.showQuickPick = () => {
-            return { data: vaults[1] };
-          };
-          await new VaultRemoveCommand().run();
-
-          expect(
-            FileTestUtils.cmpFilesV2(path.join(wsRoot, vaults[1].fsPath), [
-              "bar.ch1.md",
-              "bar.md",
-              "bar.schema.yml",
-              "root.md",
-              "root.schema.yml",
-            ])
-          ).toBeTruthy();
-
-          // check config updated
-          const configPath = DConfig.configPath(
-            getDWorkspace().wsRoot as string
-          );
-          const config = readYAML(configPath) as IntermediateDendronConfig;
-          expect(
-            ConfigUtils.getVaults(config).map((ent) => ent.fsPath)
-          ).toEqual([vaults[0].fsPath]);
-
-          // check vscode settings updated
-          const settings = fs.readJSONSync(
-            DendronExtension.workspaceFile().fsPath
-          ) as WorkspaceSettings;
-          expect(settings.folders).toEqual([{ path: vaults[0].fsPath }]);
-          done();
-        },
+  describeMultiWS("WHEN removing a regular vault", {}, () => {
+    test("THEN the vault is removed", async () => {
+      const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+      const vaultToRemove = vaults[1];
+      sinon.stub(VSCodeUtils, "showQuickPick").resolves({
+        // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+        // @ts-ignore
+        data: vaultToRemove,
       });
-    });
+      await new VaultRemoveCommand().run();
 
-    test("omit duplicateNoteBehavior when only one vault left", (done) => {
-      runSingleVaultTest({
-        ctx,
-        onInit: async ({ wsRoot }) => {
-          const configPath = DConfig.configPath(
-            getDWorkspace().wsRoot as string
-          );
+      // Shouldn't delete the actual files
+      expect(
+        FileTestUtils.cmpFilesV2(path.join(wsRoot, vaultToRemove.fsPath), [
+          "root.md",
+          "root.schema.yml",
+        ])
+      ).toBeTruthy();
 
-          // add a second vault
-          const vpath2 = path.join(wsRoot, "vault2");
+      // check that the config updated
+      const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+      expect(ConfigUtils.getVaults(config).map((ent) => ent.fsPath)).toEqual([
+        vaults[0].fsPath,
+        vaults[2].fsPath,
+      ]);
 
-          stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
-          await new VaultAddCommand().run();
-
-          const config = readYAML(configPath) as IntermediateDendronConfig;
-          // confirm that duplicateNoteBehavior option exists
-          const publishingConfig = ConfigUtils.getPublishingConfig(config);
-          expect(publishingConfig.duplicateNoteBehavior).toBeTruthy();
-
-          const { vaults } = getDWorkspace();
-
-          // @ts-ignore
-          VSCodeUtils.showQuickPick = () => {
-            return { data: vaults[1] };
-          };
-          await new VaultRemoveCommand().run();
-
-          const configNew = readYAML(configPath) as IntermediateDendronConfig;
-          // confirm that duplicateNoteBehavior setting is gone
-          const publishingConfigNew =
-            ConfigUtils.getPublishingConfig(configNew);
-          expect(publishingConfigNew.duplicateNoteBehavior).toBeFalsy();
-
-          done();
-        },
-      });
-    });
-
-    test("pull removed vault from duplicateNoteBehavior payload", (done) => {
-      runSingleVaultTest({
-        ctx,
-        onInit: async ({ wsRoot, vault }) => {
-          // add two more vaults
-
-          const vpath2 = path.join(wsRoot, "vault2");
-          const vpath3 = path.join(wsRoot, "vault3");
-
-          stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
-          await new VaultAddCommand().run();
-
-          stubVaultInput({ sourceType: "local", sourcePath: vpath3 });
-          await new VaultAddCommand().run();
-
-          const { vaults } = getDWorkspace();
-
-          const configPathOrig = DConfig.configPath(
-            getDWorkspace().wsRoot as string
-          );
-          const configOrig = readYAML(
-            configPathOrig
-          ) as IntermediateDendronConfig;
-          // check what we are starting from.
-          const origVaults = ConfigUtils.getVaults(configOrig);
-          expect(origVaults.map((ent) => ent.fsPath)).toEqual([
-            vaults[0].fsPath,
-            vaults[1].fsPath,
-            vaults[2].fsPath,
-          ]);
-
-          // @ts-ignore
-          VSCodeUtils.showQuickPick = () => {
-            return { data: vaults[1] };
-          };
-          await new VaultRemoveCommand().run();
-
-          const configPath = DConfig.configPath(
-            getDWorkspace().wsRoot as string
-          );
-          const config = readYAML(configPath) as IntermediateDendronConfig;
-
-          // check that "vault2" is gone from payload
-          const publishingConfig = ConfigUtils.getPublishingConfig(config);
-          expect(publishingConfig.duplicateNoteBehavior!.payload).toEqual([
-            path.parse(vault.fsPath).base,
-            "vault3",
-          ]);
-          done();
-        },
-      });
+      // check vscode settings updated
+      const settings = (await fs.readJSON(
+        DendronExtension.workspaceFile().fsPath
+      )) as WorkspaceSettings;
+      expect(settings.folders).toEqual([
+        { path: vaults[0].fsPath },
+        { path: vaults[2].fsPath },
+      ]);
     });
   });
 
-  describe("Contextual-UI", () => {
-    describe("WHEN Dendron: Vault Remove is clicked for local vault `vault1` from the context menu", () => {
-      test("THEN vault1 should be removed from workspace and config", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          onInit: async ({ vaults, wsRoot }) => {
-            const args = {
-              fsPath: path.join(wsRoot, vaults[1].fsPath),
-            };
-            await new VaultRemoveCommand().run(args);
-            const config = getConfig();
-            expect(ConfigUtils.getVaults(config)).toNotEqual(vaults);
-            expect(
-              _.find(getWorkspaceFile().folders, {
-                path: path.join(vaults[1].fsPath),
-              })
-            ).toEqual(undefined);
-            done();
-          },
+  describeMultiWS(
+    "WHEN removing a self contained vault",
+    { selfContained: true },
+    () => {
+      test("THEN the vault is removed", async () => {
+        const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultToRemove = vaults[1];
+        sinon.stub(VSCodeUtils, "showQuickPick").resolves({
+          // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+          // @ts-ignore
+          data: vaultToRemove,
         });
+        await new VaultRemoveCommand().run();
+
+        // Shouldn't delete the actual files
+        expect(
+          FileTestUtils.cmpFilesV2(
+            path.join(wsRoot, VaultUtils.getRelPath(vaultToRemove)),
+            ["root.md", "root.schema.yml"]
+          )
+        ).toBeTruthy();
+
+        // check that the config updated
+        const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+        expect(ConfigUtils.getVaults(config).map((ent) => ent.fsPath)).toEqual([
+          vaults[0].fsPath,
+          vaults[2].fsPath,
+        ]);
+
+        // check vscode settings updated
+        const settings = (await fs.readJSON(
+          DendronExtension.workspaceFile().fsPath
+        )) as WorkspaceSettings;
+        expect(settings.folders).toEqual([
+          { path: VaultUtils.getRelPath(vaults[0]) },
+          { path: VaultUtils.getRelPath(vaults[2]) },
+        ]);
+      });
+    }
+  );
+
+  describeMultiWS(
+    "WHEN removing the top level self contained vault",
+    { selfContained: true },
+    () => {
+      test("THEN the vault is removed", async () => {
+        const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultToRemove = vaults[0];
+        sinon.stub(VSCodeUtils, "showQuickPick").resolves({
+          // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+          // @ts-ignore
+          data: vaultToRemove,
+        });
+        await new VaultRemoveCommand().run();
+
+        // Shouldn't delete the actual files
+        expect(
+          FileTestUtils.cmpFilesV2(
+            path.join(wsRoot, VaultUtils.getRelPath(vaultToRemove)),
+            ["root.md", "root.schema.yml"]
+          )
+        ).toBeTruthy();
+
+        // check that the config updated
+        const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+        expect(ConfigUtils.getVaults(config).map((ent) => ent.fsPath)).toEqual([
+          vaults[1].fsPath,
+          vaults[2].fsPath,
+        ]);
+
+        // check vscode settings updated
+        const settings = (await fs.readJSON(
+          DendronExtension.workspaceFile().fsPath
+        )) as WorkspaceSettings;
+        expect(settings.folders).toEqual([
+          { path: VaultUtils.getRelPath(vaults[1]) },
+          { path: VaultUtils.getRelPath(vaults[2]) },
+        ]);
+      });
+    }
+  );
+
+  describeSingleWS("WHEN there's only one vault left after remove", {}, () => {
+    test("THEN duplicateNoteBehavior is omitted", async () => {
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
+      const configPath = DConfig.configPath(wsRoot as string);
+
+      // add a second vault
+      const vault2 = "vault2";
+      const vpath2 = path.join(wsRoot, vault2);
+
+      stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
+      await new VaultAddCommand().run();
+
+      const config = readYAML(configPath) as IntermediateDendronConfig;
+      // confirm that duplicateNoteBehavior option exists
+      const publishingConfig = ConfigUtils.getPublishingConfig(config);
+      expect(publishingConfig.duplicateNoteBehavior).toBeTruthy();
+
+      // @ts-ignore
+      VSCodeUtils.showQuickPick = () => {
+        return { data: { fsPath: vault2 } };
+      };
+      await new VaultRemoveCommand().run();
+
+      const configNew = readYAML(configPath) as IntermediateDendronConfig;
+      // confirm that duplicateNoteBehavior setting is gone
+      const publishingConfigNew = ConfigUtils.getPublishingConfig(configNew);
+      expect(publishingConfigNew.duplicateNoteBehavior).toBeFalsy();
+    });
+  });
+
+  describeSingleWS("WHEN a published vault is removed", {}, () => {
+    test("THEN the vault is removed from duplicateNoteBehavior payload", async () => {
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
+      const firstVault = ExtensionProvider.getDWorkspace().vaults[0];
+      // add two more vaults
+
+      const vpath2 = path.join(wsRoot, "vault2");
+      const vpath3 = path.join(wsRoot, "vault3");
+
+      stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
+      await new VaultAddCommand().run();
+
+      stubVaultInput({ sourceType: "local", sourcePath: vpath3 });
+      await new VaultAddCommand().run();
+
+      const { vaults } = ExtensionProvider.getDWorkspace();
+
+      const configOrig = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+      // check what we are starting from.
+      const origVaults = ConfigUtils.getVaults(configOrig);
+      expect(origVaults.map((ent) => ent.fsPath)).toEqual([
+        vaults[0].fsPath,
+        vaults[1].fsPath,
+        vaults[2].fsPath,
+      ]);
+
+      // @ts-ignore
+      VSCodeUtils.showQuickPick = () => {
+        return { data: vaults[1] };
+      };
+      await new VaultRemoveCommand().run();
+
+      const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+
+      // check that "vault2" is gone from payload
+      const publishingConfig = ConfigUtils.getPublishingConfig(config);
+      expect(publishingConfig.duplicateNoteBehavior!.payload).toEqual([
+        path.parse(firstVault.fsPath).base,
+        "vault3",
+      ]);
+    });
+  });
+
+  describe("WHEN it's used from the Contextual-UI", () => {
+    describeMultiWS("AND it removes a regular vault vault1", {}, () => {
+      test("THEN vault1 should be removed from workspace and config", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const args = {
+          fsPath: path.join(wsRoot, vaults[1].fsPath),
+        };
+        await new VaultRemoveCommand().run(args);
+        const config = getConfig();
+        expect(ConfigUtils.getVaults(config)).toNotEqual(vaults);
+        expect(
+          _.find(getWorkspaceFile().folders, {
+            path: path.join(vaults[1].fsPath),
+          })
+        ).toEqual(undefined);
       });
     });
-    describe("WHEN Dendron: Vault Remove is clicked for remote vault `remoteWs` from the context menu", () => {
-      test("THEN vault `remoteWs` should be removed from workspace and config", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          onInit: async ({ vaults, wsRoot }) => {
-            const remoteVaultName = "remoteVault";
-            const remoteWsName = "remoteWs";
-            const vaultsRemote = [{ fsPath: remoteVaultName }];
-            await addWorkspaceVault({
-              vaults: vaultsRemote,
-              wsName: remoteWsName,
-            });
-            const args = {
-              fsPath: path.join(wsRoot, remoteWsName, remoteVaultName),
-            };
-            await new VaultRemoveCommand().run(args);
-            const config = getConfig();
-            expect(ConfigUtils.getVaults(config)).toEqual(vaults);
-            expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
-            expect(
-              _.find(getWorkspaceFile().folders, {
-                path: path.join(remoteWsName, remoteVaultName),
-              })
-            ).toEqual(undefined);
-            done();
-          },
+    describe("AND it removes a remote workspace vault remoteWs", () => {
+      test("THEN remoteWs should be removed from workspace and config", async () => {
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const remoteVaultName = "remoteVault";
+        const remoteWsName = "remoteWs";
+        const vaultsRemote = [{ fsPath: remoteVaultName }];
+        await addWorkspaceVault({
+          vaults: vaultsRemote,
+          wsName: remoteWsName,
         });
+        const args = {
+          fsPath: path.join(wsRoot, remoteWsName, remoteVaultName),
+        };
+        await new VaultRemoveCommand().run(args);
+        const config = getConfig();
+        expect(ConfigUtils.getVaults(config)).toEqual(vaults);
+        expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
+        expect(
+          _.find(getWorkspaceFile().folders, {
+            path: path.join(remoteWsName, remoteVaultName),
+          })
+        ).toEqual(undefined);
       });
     });
   });


### PR DESCRIPTION
- This PR refactors the tests in the `VaultRemoveCommand.test.ts` to use the new harness.
- This PR also adds tests for self contained vaults being removed with VaultRemoveCommand. 