### PR TITLE
fix: second pass of treeview v1 sync issue

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -353,7 +353,7 @@ export function note2File({
 }) {
   const { fname } = note;
   const ext = ".md";
-  const payload = NoteUtils.serialize(note);
+  const payload = NoteUtils.serialize(note, { excludeStub: true });
   const vpath = vault2Path({ vault, wsRoot });
   return fs.writeFile(path.join(vpath, fname + ext), payload);
 }

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -1091,6 +1091,7 @@ export class FileStorage implements DStore {
     let noDelete = false;
     if (maybeNote?.stub || opts?.updateExisting) {
       note = { ...maybeNote, ...note };
+      note = _.omit(note, "stub");
       noDelete = true;
     } else {
       changedEntries = await this._writeNewNote({

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -1206,10 +1206,10 @@ export class FileStorage implements DStore {
         .map((ent) => this.updateNote(ent))
     );
 
-    changedEntries.push({ note, status: "create" });
     if (maybeNote && !noDelete) {
       changedEntries.push({ note: maybeNote, status: "delete" });
     }
+    changedEntries.push({ note, status: "create" });
     this.logger.info({
       ctx,
       msg: "exit",

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -707,6 +707,7 @@ export class DendronEngineV2 implements DEngine {
         const { id } = ent.note;
         if (ent.status === "delete") {
           delete this.notes[id];
+          this.noteFnames.delete(ent.note);
         } else {
           const note = await EngineUtils.refreshNoteLinksAndAnchors({
             note: ent.note,

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -81,7 +81,7 @@ const runRename = async ({
   return out.concat([
     {
       actual: changed.data!.length,
-      expected: numChanges || 4,
+      expected: numChanges || 5,
     },
     {
       actual: checkVault,
@@ -218,7 +218,7 @@ const NOTES = {
         wsRoot,
         vaults,
         engine,
-        numChanges: 3,
+        numChanges: 4,
         cb: ({ barChange }) => {
           return [
             {
@@ -591,7 +591,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 4,
+          expected: 5,
         },
         {
           actual: _.trim(findByName("alpha", changed.data!).note.body),
@@ -635,7 +635,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 7,
+          expected: 8,
         },
         {
           actual: changed.data!.map((ent) => [ent.note.fname, ent.status]),
@@ -648,6 +648,7 @@ const NOTES = {
             // from creation
             ["baz", "create"],
             ["baz.one", "create"],
+            ["root", "update"],
             ["baz.one.three", "create"],
           ],
         },
@@ -690,7 +691,7 @@ const NOTES = {
         // alpha deleted, gamma created
         {
           actual: changed.data?.length,
-          expected: 7,
+          expected: 8,
         },
         // 3 notes, gamma and 3 roots
         {
@@ -732,7 +733,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 4,
+          expected: 5,
         },
         {
           actual: createdChange?.note.title,
@@ -783,7 +784,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 3,
+          expected: 5,
         },
         {
           actual: await AssertUtils.assertInString({
@@ -840,13 +841,13 @@ const NOTES = {
         match: [fnameLink],
         nomatch: [fnameTarget, fnameNew],
       });
-
       return [
         {
           actual: updated,
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: fnameTarget },
+            { status: "update", fname: "root" },
             { status: "create", fname: fnameNew },
           ],
         },
@@ -896,19 +897,19 @@ const NOTES = {
         match: ["baz"],
         nomatch: ["foo"],
       });
-
       return [
         {
           actual: updated,
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
+            { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
             { status: "update", fname: "bar" },
           ],
         },
         {
-          actual: _.trim(changed![3].note.body),
+          actual: _.trim(changed![4].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[1])}/baz]]`,
         },
         {
@@ -1031,6 +1032,7 @@ const NOTES = {
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "alpha" },
+            { status: "update", fname: "root" },
             { status: "create", fname: "gamma" },
             { status: "update", fname: "beta" },
           ],
@@ -1092,6 +1094,7 @@ const NOTES = {
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "alpha" },
+            { status: "update", fname: "root" },
             { status: "create", fname: "gamma" },
           ],
         },
@@ -1590,7 +1593,7 @@ const NOTES = {
           expected: "foo1",
         },
         {
-          actual: changedEntries && changedEntries.length === 3,
+          actual: changedEntries && changedEntries.length === 5,
           expected: true,
         },
       ];

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -535,7 +535,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 4,
+          expected: 5,
         },
         {
           actual: _.trim(findByName("alpha", changed.data!).note.body),

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -502,6 +502,8 @@ export class NoteLookupCommand
     if (item.stub) {
       Logger.info({ ctx, msg: "create stub" });
       nodeNew = engine.notes[item.id];
+      // when we are accepting a new item that is a stub, it no longer is a stub
+      nodeNew = _.omit(nodeNew, "stub");
     } else {
       const vault = await this.getVaultForNewNote({ fname, picker });
       if (vault === undefined) {

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -153,7 +153,7 @@ suite("MoveNoteCommand", function () {
               },
             ],
           });
-          expect(resp?.changed?.length).toEqual(3);
+          expect(resp?.changed?.length).toEqual(5);
           active = VSCodeUtils.getActiveTextEditor() as vscode.TextEditor;
           expect(DNodeUtils.fname(active.document.uri.fsPath)).toEqual(
             "foobar"
@@ -587,13 +587,6 @@ suite("MoveNoteCommand", function () {
         expect(
           await EngineTestUtilsV4.checkVault({
             wsRoot,
-            vault: vault1,
-            nomatch: ["foo.md"],
-          })
-        ).toBeTruthy();
-        expect(
-          await EngineTestUtilsV4.checkVault({
-            wsRoot,
             vault: vault2,
             nomatch: ["bar.md"],
           })
@@ -709,14 +702,12 @@ suite("MoveNoteCommand", function () {
         ).toBeTruthy();
 
         expect(
-          _.isUndefined(
-            NoteUtils.getNoteByFnameV5({
-              fname: "foo",
-              notes,
-              vault: vault1,
-              wsRoot,
-            })
-          )
+          NoteUtils.getNoteByFnameV5({
+            fname: "foo",
+            notes,
+            vault: vault1,
+            wsRoot,
+          })?.stub
         ).toBeTruthy();
         expect(
           _.isUndefined(

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -49,11 +49,25 @@ async function runRenameNote(opts: { noteId: string; newName: string }) {
   await renameCmd.execute(renameOpts);
 }
 
+async function getFullTree(opts: {
+  root: NoteProps;
+  provider: EngineNoteProvider;
+}): Promise<{ fname: string; childNodes: any }> {
+  const { root, provider } = opts;
+  const children = await (provider.getChildren(root) as Promise<NoteProps[]>);
+  const childNodes = await Promise.all(
+    children.map(async (child) => {
+      const tree = await getFullTree({ root: child, provider });
+      return tree;
+    })
+  );
+  return { fname: root.fname, childNodes };
+}
+
 suite("NativeTreeView tests", function () {
   this.timeout(2000);
 
   describe("Rename Note Command interactions", function () {
-    // when renaming note with top level hierarchy
     describeMultiWS(
       "WHEN renaming note with top level hierarchy",
       {
@@ -95,7 +109,7 @@ suite("NativeTreeView tests", function () {
         });
       }
     );
-    // when renaming note with stub parent
+
     describeMultiWS(
       "WHEN renaming note with stub parent",
       {
@@ -154,7 +168,7 @@ suite("NativeTreeView tests", function () {
         });
       }
     );
-    // when renaming note with non-stub parent
+
     describeMultiWS(
       "WHEN renaming note with non-stub parent",
       {
@@ -219,7 +233,7 @@ suite("NativeTreeView tests", function () {
         });
       }
     );
-    // when renaming note stub children
+
     describeMultiWS(
       "WHEN renaming note with stub children",
       {
@@ -305,9 +319,333 @@ suite("NativeTreeView tests", function () {
         });
       }
     );
-    // when renaming note with non-stub children
-    // when renaming note with a chain of ancestors that are only stubs
-    // when renaming note to a file name of an existing stub note
+
+    describeMultiWS(
+      "WHEN renaming note with non-stub children",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+            genRandomId: true,
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.bar",
+            genRandomId: true,
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.baz",
+            genRandomId: true,
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly displays renamed note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const vaultOneRootId = propsBefore[0].id;
+
+          const childrenBefore = await (provider.getChildren(
+            vaultOneRootPropsBefore
+          ) as Promise<NoteProps[]>);
+          expect(childrenBefore.map((child) => child.fname)).toEqual(["foo"]);
+
+          const grandChildrenBefore = await (provider.getChildren(
+            childrenBefore[0]
+          ) as Promise<NoteProps[]>);
+          expect(grandChildrenBefore.map((gchild) => gchild.fname)).toEqual([
+            "foo.bar",
+            "foo.baz",
+          ]);
+
+          const engine = ExtensionProvider.getEngine();
+          await runRenameNote({
+            noteId: childrenBefore[0].id,
+            newName: "fooz",
+          });
+
+          const vault1RootPropsAfter = engine.notes[vaultOneRootId];
+          const childrenAfter = await (provider.getChildren(
+            vault1RootPropsAfter
+          ) as Promise<NoteProps[]>);
+          expect(
+            childrenAfter.map((child) => {
+              return { fname: child.fname, stub: child.stub };
+            })
+          ).toEqual([
+            { fname: "foo", stub: true },
+            { fname: "fooz", stub: undefined },
+          ]);
+
+          const grandChildrenAfter = await (provider.getChildren(
+            childrenAfter[0]
+          ) as Promise<NoteProps[]>);
+          expect(grandChildrenAfter.map((gchild) => gchild.fname)).toEqual([
+            "foo.bar",
+            "foo.baz",
+          ]);
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN renaming note with a chain of ancestors that are only stubs",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "one.two.three.foo",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly displays renamed note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const engine = ExtensionProvider.getEngine();
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const vaultOneRootId = propsBefore[0].id;
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+          });
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          await runRenameNote({
+            noteId: "one.two.three.foo",
+            newName: "zero",
+          });
+
+          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+          });
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "zero",
+                childNodes: [],
+              },
+            ],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN renaming note results in a chain of stub ancestors",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly displays renamed note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const engine = ExtensionProvider.getEngine();
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const vaultOneRootId = propsBefore[0].id;
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+          });
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [],
+              },
+            ],
+          });
+
+          await runRenameNote({
+            noteId: "foo",
+            newName: "one.two.three.foo",
+          });
+
+          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+          });
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN renaming note to replace an existing stub note",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "one.two.three",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly displays renamed note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const engine = ExtensionProvider.getEngine();
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const vaultOneRootId = propsBefore[0].id;
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+          });
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [],
+              },
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          await runRenameNote({
+            noteId: "foo",
+            newName: "one",
+          });
+
+          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+          });
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          expect(engine.notes["foo"].stub).toBeFalsy();
+        });
+      }
+    );
   });
 
   describe("filesystem change interactions", function () {});

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -209,7 +209,7 @@ suite("NativeTreeView tests", function () {
         },
       },
       () => {
-        test.only("THEN tree view correctly displays renamed note", async () => {
+        test("THEN tree view correctly displays renamed note", async () => {
           const mockEvents = new MockEngineEvents();
           const provider = new EngineNoteProvider(mockEvents);
 

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -723,7 +723,7 @@ suite("NoteLookupCommand", function () {
         },
       },
       () => {
-        test("THEN stub is created", async () => {
+        test.only("THEN a note is created and stub property is removed", async () => {
           const { vaults, engine, wsRoot } = ExtensionProvider.getDWorkspace();
           const cmd = new NoteLookupCommand();
           const vault = TestEngineUtils.vault1(vaults);
@@ -733,12 +733,13 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo",
           }))!;
           expect(_.first(opts.quickpick.selectedItems)?.fname).toEqual("foo");
-          NoteUtils.getNoteOrThrow({
+          const fooNote = NoteUtils.getNoteOrThrow({
             fname: "foo",
             notes: engine.notes,
             vault,
             wsRoot,
           });
+          expect(fooNote.stub).toBeFalsy();
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -403,7 +403,7 @@ suite("NoteLookupCommand", function () {
           });
           await NoteTestUtilsV4.createNote({
             wsRoot,
-            fname: "foo.ch2",
+            fname: "foo.ch2.gch1",
             vault: vaults[0],
             props: { stub: true },
           });
@@ -723,7 +723,7 @@ suite("NoteLookupCommand", function () {
         },
       },
       () => {
-        test.only("THEN a note is created and stub property is removed", async () => {
+        test("THEN a note is created and stub property is removed", async () => {
           const { vaults, engine, wsRoot } = ExtensionProvider.getDWorkspace();
           const cmd = new NoteLookupCommand();
           const vault = TestEngineUtils.vault1(vaults);

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -14,7 +14,6 @@ import sinon from "sinon";
 import { getEngine } from "../../workspace";
 import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
 import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
-import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 
 suite("RefactorHierarchy", function () {
   const ctx = setupBeforeAfter(this, {

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -321,36 +321,6 @@ suite("RefactorHierarchy", function () {
           },
         });
       });
-
-      test("THEN: stub note is captured if it exists in the file system.", (done) => {
-        runLegacyMultiWorkspaceTest({
-          ctx,
-          preSetupHook,
-          onInit: async () => {
-            const lookup = new NoteLookupCommand();
-            await lookup.run({
-              noConfirm: true,
-              initialValue: "dendron.ref.foo",
-            });
-
-            const cmd = new RefactorHierarchyCommandV2();
-            const engine = getEngine();
-            const capturedNotes = cmd.getCapturedNotes({
-              scope: undefined,
-              matchRE: new RegExp("dendron.ref"),
-              engine,
-            });
-
-            // only the note `dendron.ref.foo`, that is a stub note but has an actual file created
-            // should be part of the captured notes.
-            const capturedStubNotes = capturedNotes.filter((note) => note.stub);
-            expect(capturedStubNotes.length).toEqual(1);
-            expect(capturedStubNotes[0].fname).toEqual("dendron.ref.foo");
-
-            done();
-          },
-        });
-      });
     });
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
@@ -131,7 +131,7 @@ suite("RenameProvider", function () {
           done();
         });
         test("THEN references to target note is correctly updated", (done) => {
-          expect(executeOut?.changed.length).toEqual(6);
+          expect(executeOut?.changed.length).toEqual(7);
           const { vaults, engine, wsRoot } = getDWorkspace();
           const { notes } = engine;
           const noteWithLink = NoteUtils.getNoteByFnameV5({
@@ -266,7 +266,7 @@ suite("RenameProvider", function () {
           done();
         });
         test("THEN references to target note is correctly updated", (done) => {
-          expect(executeOut?.changed.length).toEqual(6);
+          expect(executeOut?.changed.length).toEqual(7);
           const { vaults, engine, wsRoot } = getDWorkspace();
           const { notes } = engine;
           const noteWithLink = NoteUtils.getNoteByFnameV5({
@@ -370,7 +370,7 @@ suite("RenameProvider", function () {
           done();
         });
         test("THEN references to target note is correctly updated", (done) => {
-          expect(executeOut?.changed.length).toEqual(7);
+          expect(executeOut?.changed.length).toEqual(8);
           const { vaults, engine, wsRoot } = getDWorkspace();
           const { notes } = engine;
           const noteWithLink = NoteUtils.getNoteByFnameV5({
@@ -461,7 +461,7 @@ suite("RenameProvider", function () {
           done();
         });
         test("THEN references to target note is correctly updated", (done) => {
-          expect(executeOut?.changed.length).toEqual(7);
+          expect(executeOut?.changed.length).toEqual(8);
           const { vaults, engine, wsRoot } = getDWorkspace();
           const { notes } = engine;
           const noteWithLink = NoteUtils.getNoteByFnameV5({
@@ -557,7 +557,7 @@ suite("RenameProvider", function () {
           done();
         });
         test("THEN references to target note is correctly updated", (done) => {
-          expect(executeOut?.changed.length).toEqual(7);
+          expect(executeOut?.changed.length).toEqual(8);
           const { vaults, engine, wsRoot } = getDWorkspace();
           const { notes } = engine;
           const noteWithLink = NoteUtils.getNoteByFnameV5({


### PR DESCRIPTION
# fix: second pass of treeview v1 sync issue
- This PR does a second pass of fixing engine / treeview state mismatch issues.
- Case: renaming a note into an already existing stub note
  - Doing this used to leave the + mark in the tree view because the parent / children were not properly updated
  - This used to leave `stub: true` in the renamed note's frontmatter, which caused a lot of problems
    - The resulted renamed note would appear in lookup twice. one would be a stub and one wouldn't.
      - depending on the accepted item, there was a possibility of losing the entire body of the note.
    - Now all notes will lose their `stub: true` property once they are persisted in the store.
      - this, however, doesn't _disallow_ the user from adding the property themselves.
        - a separate PR will be submitted for a doctor command that scrubs existing persisted notes with `stub: true`
        - a separate PR will be submitted for a code action provider that warns users if they have `stub: true` in the frontmatter of their active note.
- Case: renaming a note that has a stub parent and any children
  - This used to simply not work. Tree view would crash since the engine events emitted weren't right, and we ended up with the parent pointing to the renamed note, which is already registered in the tree view.
  - now explicitly handles updating of parent when a rename requires a stub replacement during `delete`.
- Since we are chaining multiple updates to possibly the same note, we don't clean up duplicate update events at the end of `rename`. We preserve them since they aren't truly duplicates. We need each of them to correctly end up with the desired engine state.
  - This change broke a lot of existing tests (particularly the ones that count emitted events). They are all fixed here.
 
## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)