### PR TITLE
chore: self contained vaults rollout AB test

### DIFF
--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -45,7 +45,7 @@ export const SELF_CONTAINED_VAULTS_TEST = new ABTest(
     },
     {
       name: SelfContainedVaultsTestGroups.selfContained,
-      weight: 0,
+      weight: 1,
     },
   ]
 );
@@ -89,6 +89,7 @@ export const MEETING_NOTE_FEATURE_SHOWCASE_TEST = new ABTest(
  */
 export const CURRENT_AB_TESTS = [
   UPGRADE_TOAST_WORDING_TEST,
+  SELF_CONTAINED_VAULTS_TEST,
   MEETING_NOTE_TUTORIAL_TEST,
   MEETING_NOTE_FEATURE_SHOWCASE_TEST,
 ];


### PR DESCRIPTION
This PR re-adds the self contained vaults AB test, split 90/10.