### PR TITLE
fix(views): add margin back into note preview

### DIFF
--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -17,14 +17,12 @@ import {
   Provider,
   setLogLevel,
 } from "@dendronhq/common-frontend";
-import _ from "lodash";
+import { Layout } from "antd";
 import React from "react";
 import { useWorkspaceProps } from "../hooks";
+import "../styles/scss/main.scss";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage, useVSCodeMessage } from "../utils/vscode";
-import "../styles/scss/main.scss";
-import { Layout } from "antd";
-import DendronNotePreview from "./DendronNotePreview";
 const { Content } = Layout;
 
 const { useEngineAppSelector } = engineHooks;
@@ -115,21 +113,14 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
 }
 
 export type DendronAppProps = {
-  opts: { padding?: "inherit" };
+  opts: { padding: "inherit" | number | string };
   Component: DendronComponent;
 };
 
 function DendronApp(props: DendronAppProps) {
-  // fix regression for scroll in graph view
-  const opts = _.defaults(props.opts, {
-    padding:
-      props.Component.name && props.Component.name === DendronNotePreview.name
-        ? "33px"
-        : props.opts.padding,
-  });
   return (
     <Provider store={combinedStore}>
-      <Layout style={{ padding: opts.padding }}>
+      <Layout style={{ padding: props.opts.padding }}>
         <Content>
           <DendronVSCodeApp {...props} />
         </Content>

--- a/packages/dendron-plugin-views/src/index.tsx
+++ b/packages/dendron-plugin-views/src/index.tsx
@@ -16,10 +16,11 @@ const VIEW_NAME = elem.getAttribute("data-name")!;
 if (VALID_NAMES.includes(VIEW_NAME)) {
   console.log("NAME VALID: ", VIEW_NAME);
   const View = require(`./components/${VIEW_NAME}`).default;
-  let props = {};
-  console.log(View);
-  if (VIEW_NAME === "DendronTreeExplorerPanel") {
-    props = { padding: "inherit" };
+  let props = {
+    padding: "inherit",
+  };
+  if (VIEW_NAME === "DendronNotePreview") {
+    props = { padding: "33px" };
   }
   renderOnDOM(View, props);
 } else {


### PR DESCRIPTION
fix(views): add margin back into note preview

bundling changes made the 33px margin dissapear on preview. this adds it back in and consolidates setting the margin in `index.ts` 

manual test across all webviews to make sure that margin looks good