### PR TITLE
chore: bumping Node to v14+16 in ci

### DIFF
--- a/.github/workflows/ci-windows-test.yml
+++ b/.github/workflows/ci-windows-test.yml
@@ -13,8 +13,8 @@ jobs:
         os:
           - windows-latest
         node-version:
-          - 12.x
           - 14.x
+          - 16.x
         suite:
           - cli
           - plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 12.x
           - 14.x
+          - 16.x
         suite:
           - cli
           - plugin


### PR DESCRIPTION
## chore: bumping Node to v14+16 in ci

node 12 is now unsupported.