### PR TITLE
feat: Add doctor command to remove deprecated config and prompt on upgrade

### DIFF
--- a/docs/dendron.yml
+++ b/docs/dendron.yml
@@ -84,6 +84,7 @@ workspace:
         todoIntegration: false
         createTaskSelectionType: selection2link
     enableEditorDecorations: true
+    enableFullHierarchyNoteTitle: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -111,6 +111,8 @@ export enum ConfigEvents {
   ConfigNotMigrated = "Config_Not_Migrated",
   EnabledExportPodV2 = "Enabled_Export_Pod_V2",
   ShowMissingDefaultConfigMessage = "Show_Missing_Default_Config_Message",
+  DeprecatedConfigMessageConfirm = "DeprecatedConfigMessageConfirm",
+  ShowDeprecatedConfigMessage = "ShowDeprecatedConfigMessage",
   MissingDefaultConfigMessageConfirm = "MissingDefaultConfigMessageConfirm",
   MissingSelfContainedVaultsMessageShow = "MissingSelfContainedVaultsMessageShow",
   MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -112,7 +112,7 @@ export enum ConfigEvents {
   EnabledExportPodV2 = "Enabled_Export_Pod_V2",
   ShowMissingDefaultConfigMessage = "Show_Missing_Default_Config_Message",
   DeprecatedConfigMessageConfirm = "DeprecatedConfigMessageConfirm",
-  ShowDeprecatedConfigMessage = "ShowDeprecatedConfigMessage",
+  DeprecatedConfigMessageShow = "ShowDeprecatedConfigMessage",
   MissingDefaultConfigMessageConfirm = "MissingDefaultConfigMessageConfirm",
   MissingSelfContainedVaultsMessageShow = "MissingSelfContainedVaultsMessageShow",
   MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -1304,6 +1304,34 @@ export class ConfigUtils {
       backfilledConfig,
     };
   }
+
+  static detectDeprecatedConfigs(opts: {
+    config: Partial<IntermediateDendronConfig>;
+    deprecatedPaths: string[];
+  }):
+    | {
+        needToDelete: false;
+      }
+    | {
+        needToDelete: true;
+        pathsToDelete: string[];
+      } {
+    const { config, deprecatedPaths } = opts;
+    const foundDeprecatedPaths = deprecatedPaths.filter((path) =>
+      _.has(config, path)
+    );
+
+    if (foundDeprecatedPaths.length === 0) {
+      return {
+        needToDelete: false,
+      };
+    }
+
+    return {
+      needToDelete: true,
+      pathsToDelete: foundDeprecatedPaths,
+    };
+  }
 }
 
 /**

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -1308,29 +1308,16 @@ export class ConfigUtils {
   static detectDeprecatedConfigs(opts: {
     config: Partial<IntermediateDendronConfig>;
     deprecatedPaths: string[];
-  }):
-    | {
-        needToDelete: false;
-      }
-    | {
-        needToDelete: true;
-        pathsToDelete: string[];
-      } {
+  }): string[] {
     const { config, deprecatedPaths } = opts;
     const foundDeprecatedPaths = deprecatedPaths.filter((path) =>
       _.has(config, path)
     );
 
     if (foundDeprecatedPaths.length === 0) {
-      return {
-        needToDelete: false,
-      };
+      return [];
     }
-
-    return {
-      needToDelete: true,
-      pathsToDelete: foundDeprecatedPaths,
-    };
+    return foundDeprecatedPaths;
   }
 }
 

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -22,7 +22,7 @@ import {
 import throttle from "@jcoreio/async-throttle";
 import _ from "lodash";
 import path from "path";
-import { Git, WorkspaceService } from "..";
+import { DEPRECATED_PATHS, Git, WorkspaceService } from "..";
 import { LinkUtils, RemarkUtils } from "../markdown/remark/utils";
 import { DendronASTDest } from "../markdown/types";
 import { MDUtilsV4 } from "../markdown/utils";
@@ -40,6 +40,7 @@ export enum DoctorActionsEnum {
   FIX_REMOTE_VAULTS = "fixRemoteVaults",
   FIX_AIRTABLE_METADATA = "fixAirtableMetadata",
   ADD_MISSING_DEFAULT_CONFIGS = "addMissingDefaultConfigs",
+  REMOVE_DEPRECATED_CONFIGS = "removeDeprecatedConfigs",
   FIX_SELF_CONTAINED_VAULT_CONFIG = "fixSelfContainedVaultsInConfig",
 }
 
@@ -213,6 +214,43 @@ export class DoctorService implements Disposable {
 
     let doctorAction: ((note: NoteProps) => Promise<any>) | undefined;
     switch (action) {
+      case DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS: {
+        const { wsRoot, config } = engine;
+        const rawConfig = DConfig.getRaw(wsRoot);
+        const detectOut = ConfigUtils.detectDeprecatedConfigs({
+          config: rawConfig,
+          deprecatedPaths: DEPRECATED_PATHS,
+        });
+        if (detectOut.needToDelete) {
+          const { pathsToDelete } = detectOut;
+          const backupPath = await this.createBackup(
+            wsRoot,
+            DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS
+          );
+          if (backupPath instanceof DendronError) {
+            return {
+              exit: true,
+              error: backupPath,
+            };
+          }
+
+          const configDeepCopy = _.cloneDeep(config);
+          pathsToDelete.forEach((path) => {
+            _.unset(configDeepCopy, path);
+          });
+
+          await DConfig.writeConfig({ wsRoot, config: configDeepCopy });
+
+          return {
+            exit: true,
+            resp: {
+              backupPath,
+            },
+          };
+        }
+
+        return { exit: true };
+      }
       case DoctorActionsEnum.ADD_MISSING_DEFAULT_CONFIGS: {
         const { wsRoot } = engine;
         const rawConfig = DConfig.getRaw(wsRoot);

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -217,12 +217,11 @@ export class DoctorService implements Disposable {
       case DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS: {
         const { wsRoot, config } = engine;
         const rawConfig = DConfig.getRaw(wsRoot);
-        const detectOut = ConfigUtils.detectDeprecatedConfigs({
+        const pathsToDelete = ConfigUtils.detectDeprecatedConfigs({
           config: rawConfig,
           deprecatedPaths: DEPRECATED_PATHS,
         });
-        if (detectOut.needToDelete) {
-          const { pathsToDelete } = detectOut;
+        if (pathsToDelete.length > 0) {
           const backupPath = await this.createBackup(
             wsRoot,
             DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS

--- a/packages/engine-server/src/migrations/utils.ts
+++ b/packages/engine-server/src/migrations/utils.ts
@@ -234,7 +234,7 @@ export const PATH_MAP = new Map<string, mappedConfigPath>([
   ["publishing.enablePrettyLinks", { target: "site.usePrettyLinks" }],
 ]);
 
-/**
+/** ^2hgqigv11pvy
  * List of config paths that are deprecated
  * and should be checked for existence
  * and deleted from `dendron.yml`

--- a/packages/engine-server/src/migrations/utils.ts
+++ b/packages/engine-server/src/migrations/utils.ts
@@ -247,6 +247,7 @@ export const DEPRECATED_PATHS = [
   "site.previewPort",
   "site.useContainers",
   "site.generateChangelog",
+  "dev.enableWebUI",
 ];
 
 export class MigrationUtils {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -655,6 +655,12 @@ export async function _activate(
         extensionInstallStatus,
       });
 
+      // check for deprecated config keys and prompt for removal.
+      StartupUtils.showDeprecatedConfigMessageIfNecessary({
+        ext: ws,
+        extensionInstallStatus,
+      });
+
       // Re-use the id for error reporting too:
       Sentry.setUser({ id: SegmentClient.instance().anonymousId });
 

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -501,6 +501,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         });
         break;
       }
+      case DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS:
       case DoctorActionsEnum.ADD_MISSING_DEFAULT_CONFIGS: {
         const ds = new DoctorService();
         const out = await ds.executeDoctorActions({
@@ -514,11 +515,12 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
 
         if (out.resp) {
           const OPEN_CONFIG = "Open dendron.yml and Backup";
+          const message =
+            opts.action === DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS
+              ? `Deprecated configs removed. Backup of dendron.yml created in ${out.resp.backupPath}`
+              : `Missing defaults added. Backup of dendron.yml created in ${out.resp.backupPath}`;
           window
-            .showInformationMessage(
-              `Missing defaults added. Backup of dendron.yml created in ${out.resp.backupPath}`,
-              OPEN_CONFIG
-            )
+            .showInformationMessage(message, OPEN_CONFIG)
             .then(async (resp) => {
               if (resp === OPEN_CONFIG) {
                 const configPath = DConfig.configPath(wsRoot);
@@ -534,9 +536,11 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
           break;
         } else {
           // nothing happened.
-          window.showInformationMessage(
-            "There are no missing defaults. Exiting."
-          );
+          const message =
+            opts.action === DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS
+              ? "There are no deprecated configs. Exiting."
+              : "There are no missing defaults. Exiting";
+          window.showInformationMessage(message);
         }
 
         ds.dispose();

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1192,9 +1192,7 @@ suite("deprecated config detection", () => {
           config,
           deprecatedPaths: DEPRECATED_PATHS,
         });
-        expect(
-          out.needToDelete && _.isEqual(out.pathsToDelete, ["dev.enableWebUI"])
-        ).toBeTruthy();
+        expect(out).toEqual(["dev.enableWebUI"]);
       });
     }
   );

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -10,6 +10,7 @@ import {
 import { readYAMLAsync, tmpDir, writeYAML } from "@dendronhq/common-server";
 import {
   DConfig,
+  DEPRECATED_PATHS,
   EngineUtils,
   getWSMetaFilePath,
   MetadataService,
@@ -1160,6 +1161,112 @@ suite("missing default config detection", () => {
         [InstallStatus.NO_CHANGE, InstallStatus.INITIAL_INSTALL].forEach(
           (extensionInstallStatus) => {
             const out = StartupUtils.shouldDisplayMissingDefaultConfigMessage({
+              ext,
+              extensionInstallStatus,
+            });
+            expect(out).toBeFalsy();
+          }
+        );
+      });
+    });
+  });
+});
+
+suite("deprecated config detection", () => {
+  describeMultiWS(
+    "GIVEN dendron.yml with deprecated key",
+    {
+      modConfigCb: (config) => {
+        // @ts-ignore
+        config.dev = { enableWebUI: true };
+        return config;
+      },
+      timeout: 1e5,
+    },
+    () => {
+      test.only("THEN deprecated key is detected", () => {
+        const ws = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getRaw(ws.wsRoot);
+        expect((config.dev as any).enableWebUI).toBeTruthy();
+        const out = ConfigUtils.detectDeprecatedConfigs({
+          config,
+          deprecatedPaths: DEPRECATED_PATHS,
+        });
+        expect(
+          out.needToDelete && _.isEqual(out.pathsToDelete, ["dev.enableWebUI"])
+        ).toBeTruthy();
+      });
+    }
+  );
+
+  describe("GIVEN upgraded", () => {
+    describeMultiWS(
+      "AND deprecated key exists",
+      {
+        modConfigCb: (config) => {
+          // @ts-ignore
+          config.dev = { enableWebUI: true };
+          return config;
+        },
+        timeout: 1e5,
+      },
+      () => {
+        test("THEN prompted to remove deprecated config", () => {
+          const ext = ExtensionProvider.getExtension();
+          const out = StartupUtils.shouldDisplayDeprecatedConfigMessage({
+            ext,
+            extensionInstallStatus: InstallStatus.UPGRADED,
+          });
+          expect(out).toBeTruthy();
+        });
+      }
+    );
+
+    describeMultiWS("AND deprecated key doesn't exist", {}, () => {
+      test("THEN not prompted to remove deprecated config", () => {
+        const ext = ExtensionProvider.getExtension();
+        const out = StartupUtils.shouldDisplayDeprecatedConfigMessage({
+          ext,
+          extensionInstallStatus: InstallStatus.UPGRADED,
+        });
+        expect(out).toBeFalsy();
+      });
+    });
+  });
+
+  describe("GIVEN not upgraded", () => {
+    describeMultiWS(
+      "AND deprecated key exists",
+      {
+        modConfigCb: (config) => {
+          // @ts-ignore
+          config.dev = { enableWebUI: true };
+          return config;
+        },
+        timeout: 1e5,
+      },
+      () => {
+        test("THEN not prompted to remove deprecated config", () => {
+          const ext = ExtensionProvider.getExtension();
+          [InstallStatus.NO_CHANGE, InstallStatus.INITIAL_INSTALL].forEach(
+            (extensionInstallStatus) => {
+              const out = StartupUtils.shouldDisplayDeprecatedConfigMessage({
+                ext,
+                extensionInstallStatus,
+              });
+              expect(out).toBeFalsy();
+            }
+          );
+        });
+      }
+    );
+
+    describeMultiWS("AND deprecated key doesn't exist", {}, () => {
+      test("THEN not prompted to remove deprecated config", () => {
+        const ext = ExtensionProvider.getExtension();
+        [InstallStatus.NO_CHANGE, InstallStatus.INITIAL_INSTALL].forEach(
+          (extensionInstallStatus) => {
+            const out = StartupUtils.shouldDisplayDeprecatedConfigMessage({
               ext,
               extensionInstallStatus,
             });

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -1184,7 +1184,7 @@ suite("deprecated config detection", () => {
       timeout: 1e5,
     },
     () => {
-      test.only("THEN deprecated key is detected", () => {
+      test("THEN deprecated key is detected", () => {
         const ws = ExtensionProvider.getDWorkspace();
         const config = DConfig.getRaw(ws.wsRoot);
         expect((config.dev as any).enableWebUI).toBeTruthy();

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -13,6 +13,7 @@ import {
 } from "@dendronhq/common-all";
 import {
   DConfig,
+  DEPRECATED_PATHS,
   DoctorActionsEnum,
   InactvieUserMsgStatusEnum,
   LapsedUserSurveyStatusEnum,
@@ -87,6 +88,58 @@ export class StartupUtils {
         currentVersion,
       });
     }
+  }
+
+  static showDeprecatedConfigMessageIfNecessary(opts: {
+    ext: IDendronExtension;
+    extensionInstallStatus: InstallStatus;
+  }) {
+    if (StartupUtils.shouldDisplayDeprecatedConfigMessage(opts)) {
+      StartupUtils.showDeprecatedConfigMessage({ ext: opts.ext });
+    }
+  }
+
+  static shouldDisplayDeprecatedConfigMessage(opts: {
+    ext: IDendronExtension;
+    extensionInstallStatus: InstallStatus;
+  }): boolean {
+    if (opts.extensionInstallStatus === InstallStatus.UPGRADED) {
+      const wsRoot = opts.ext.getDWorkspace().wsRoot;
+      const rawConfig = DConfig.getRaw(wsRoot);
+      const out = ConfigUtils.detectDeprecatedConfigs({
+        config: rawConfig,
+        deprecatedPaths: DEPRECATED_PATHS,
+      });
+      const { needToDelete } = out;
+      return needToDelete;
+    } else {
+      return false;
+    }
+  }
+
+  static showDeprecatedConfigMessage(opts: { ext: IDendronExtension }) {
+    AnalyticsUtils.track(ConfigEvents.ShowDeprecatedConfigMessage);
+    const REMOVE_CONFIG = "Remove Deprecated Configuration";
+    const MESSAGE =
+      "We have detected some deprecated configurations. Would you like to remove them from dendron.yml?";
+    vscode.window
+      .showInformationMessage(MESSAGE, REMOVE_CONFIG)
+      .then(async (resp) => {
+        if (resp === REMOVE_CONFIG) {
+          AnalyticsUtils.track(ConfigEvents.DeprecatedConfigMessageConfirm, {
+            status: ConfirmStatus.accepted,
+          });
+          const cmd = new DoctorCommand(opts.ext);
+          await cmd.execute({
+            action: DoctorActionsEnum.REMOVE_DEPRECATED_CONFIGS,
+            scope: "workspace",
+          });
+        } else {
+          AnalyticsUtils.track(ConfigEvents.DeprecatedConfigMessageConfirm, {
+            status: ConfirmStatus.rejected,
+          });
+        }
+      });
   }
 
   static showMissingDefaultConfigMessageIfNecessary(opts: {

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -106,12 +106,11 @@ export class StartupUtils {
     if (opts.extensionInstallStatus === InstallStatus.UPGRADED) {
       const wsRoot = opts.ext.getDWorkspace().wsRoot;
       const rawConfig = DConfig.getRaw(wsRoot);
-      const out = ConfigUtils.detectDeprecatedConfigs({
+      const pathsToDelete = ConfigUtils.detectDeprecatedConfigs({
         config: rawConfig,
         deprecatedPaths: DEPRECATED_PATHS,
       });
-      const { needToDelete } = out;
-      return needToDelete;
+      return pathsToDelete.length > 0;
     } else {
       return false;
     }

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -118,7 +118,7 @@ export class StartupUtils {
   }
 
   static showDeprecatedConfigMessage(opts: { ext: IDendronExtension }) {
-    AnalyticsUtils.track(ConfigEvents.ShowDeprecatedConfigMessage);
+    AnalyticsUtils.track(ConfigEvents.DeprecatedConfigMessageShow);
     const REMOVE_CONFIG = "Remove Deprecated Configuration";
     const MESSAGE =
       "We have detected some deprecated configurations. Would you like to remove them from dendron.yml?";


### PR DESCRIPTION
# feat: Add doctor command to remove deprecated config and prompt on upgrade
This PR:
- Adds doctor action `removeDeprecatedConfigs` that detects and removes deprecated config keys marked in `DEPRECATED_PATHS`
  - This also creates a backup.
  - User is given a follow-up prompt to optionally open and inspect `dendron.yml` and the backup file side by side.
- Adds `dev.enableWebUI` to `DEPRECATED_PATHS`
- Adds prompt on upgrade letting users know that there is a deprecated key in `dendron.yml`, and a button that triggers the doctor command.
- This addition removes the need to explicitly write migration code that scrubs config keys that are no longer used.

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

https://github.com/dendronhq/dendron-site/pull/483

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)