### PR TITLE
fix: correctly handle previous global and workspace version

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -490,6 +490,7 @@ export async function _activate(
   const { workspaceFile, workspaceFolders } = vscode.workspace;
   const logLevel = process.env["LOG_LEVEL"];
   const { extensionPath, extensionUri, logUri } = context;
+  const metadataService = MetadataService.instance();
   const stateService = new StateService({
     globalState: context.globalState,
     workspaceState: context.workspaceState,
@@ -553,8 +554,24 @@ export async function _activate(
     ws.workspaceImpl = undefined;
 
     const currentVersion = DendronExtension.version();
-    const previousWorkspaceVersion = stateService.getWorkspaceVersion();
-    const previousGlobalVersion = stateService.getGlobalVersion();
+    // const previousWorkspaceVersion = stateService.getWorkspaceVersion();
+    // const previousGlobalVersion = stateService.getGlobalVersion();
+
+    // this used to be handled by StateService (if undefined, 0.0.0).
+    // this will be reassigned if we are in a dendron workspace.
+    let previousWorkspaceVersion = "0.0.0";
+
+    const previousGlobalVersionFromState = stateService.getGlobalVersion();
+
+    // temporarily here to backfill globalState into metadata
+    // this should be removed once we determine that
+    // we have sufficiently backfilled out user.
+    if (previousGlobalVersionFromState) {
+      metadataService.setGlobalVersion(previousGlobalVersionFromState);
+    }
+
+    const previousGlobalVersion = metadataService.getGlobalVersion();
+
     const { extensionInstallStatus, isSecondaryInstall } =
       ExtensionUtils.getAndTrackInstallStatus({
         UUIDPathExists,
@@ -605,6 +622,8 @@ export async function _activate(
       // --- Get Version State
       const wsRoot = wsImpl.wsRoot;
       const wsService = new WorkspaceService({ wsRoot });
+      const wsMeta = wsService.getMeta();
+      previousWorkspaceVersion = wsMeta.version;
 
       // initialize Segment client
       AnalyticsUtils.setupSegmentWithCacheFlush({ context, ws: wsImpl });

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -554,8 +554,6 @@ export async function _activate(
     ws.workspaceImpl = undefined;
 
     const currentVersion = DendronExtension.version();
-    // const previousWorkspaceVersion = stateService.getWorkspaceVersion();
-    // const previousGlobalVersion = stateService.getGlobalVersion();
 
     // this used to be handled by StateService (if undefined, 0.0.0).
     // this will be reassigned if we are in a dendron workspace.


### PR DESCRIPTION
# fix: correctly handle previous global and workspace version
This PR:
- fixes a regression introduced in the initialization logic where previous global and workspace version was not properly handled
  - With the recent clean-up of the initialization logic the following changes were omitted
    - previousGlobalVersion from state service was not getting backfilled to the corresponding metadata, and was not read from metadata for subsequent use
    - previousWorkspaceVersion from state service was not getting backfilled to the corresponding workspace metadata, and was not read from workspace metadata for subsequent use
  - This resulted in an `InstallStatus.UPGRADED` for every initialization

NOTE: to manually test that this fixes the issue, you may need to reload once after dendron is initialized since that we need the first pass of initialization for the metadata to sync up

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.