### PR TITLE
feat: add goto command

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -69,7 +69,7 @@ export async function createFileWatcher(
   });
   const didCreate = false;
 
-  return new Promise(async (resolve, _reject) => {
+  return new Promise((resolve, _reject) => {
     if (!fs.existsSync(fpath)) {
       return setTimeout(() => {
         resolve(

--- a/packages/common-test-utils/src/presets/plugin-core/lookup-single.ts
+++ b/packages/common-test-utils/src/presets/plugin-core/lookup-single.ts
@@ -7,7 +7,7 @@ import { TestPresetEntry } from "../../utils";
 const UPDATE_ITEMS = {
   SCHEMA_SUGGESTION: new TestPresetEntry({
     label: "schema suggestion",
-    before: async ({ vault }: { vault: DVault }) => {
+    beforeTestResults: async ({ vault }: { vault: DVault }) => {
       fs.removeSync(path.join(vault.fsPath, "foo.ch1.md"));
     },
     results: async ({ items }: { items: NoteProps }) => {

--- a/packages/common-test-utils/src/utils.ts
+++ b/packages/common-test-utils/src/utils.ts
@@ -89,10 +89,20 @@ export class AssertUtils {
   }
 }
 
-export class TestPresetEntry<TBeforeOpts, TAfterOpts, TResultsOpts> {
+export class TestPresetEntry<
+  TBeforeOpts,
+  TAfterOpts = any,
+  TResultsOpts = any
+> {
   public label: string;
-  public before: (_opts: TBeforeOpts) => Promise<any>;
+  public beforeTestResults: (_opts: TBeforeOpts) => Promise<any>;
+  /**
+   * Run this before setting up workspace
+   */
   public preSetupHook: SetupHookFunction;
+  /**
+   * Run this before setting up hooks
+   */
   public postSetupHook: SetupHookFunction;
   public after: (_opts: TAfterOpts) => Promise<any>;
   public results: (_opts: TResultsOpts) => Promise<TestResult[]>;
@@ -102,7 +112,7 @@ export class TestPresetEntry<TBeforeOpts, TAfterOpts, TResultsOpts> {
   constructor({
     label,
     results,
-    before,
+    beforeTestResults,
     after,
     preSetupHook,
     postSetupHook,
@@ -111,13 +121,13 @@ export class TestPresetEntry<TBeforeOpts, TAfterOpts, TResultsOpts> {
     preSetupHook?: SetupHookFunction;
     postSetupHook?: SetupHookFunction;
     beforeSetup?: (_opts: TBeforeOpts) => Promise<any>;
-    before?: (_opts: TBeforeOpts) => Promise<any>;
+    beforeTestResults?: (_opts: TBeforeOpts) => Promise<any>;
     after?: (_opts: TAfterOpts) => Promise<any>;
     results: (_opts: TResultsOpts) => Promise<TestResult[]>;
   }) {
     this.label = label;
     this.results = results;
-    this.before = before || (async () => {});
+    this.beforeTestResults = beforeTestResults || (async () => {});
     this.preSetupHook = preSetupHook || (async () => {});
     this.postSetupHook = postSetupHook || (async () => {});
     this.after = after || (async () => {});

--- a/packages/common-test-utils/src/utils.ts
+++ b/packages/common-test-utils/src/utils.ts
@@ -1,6 +1,7 @@
 import {
   DEngineClient,
   DEngineInitResp,
+  NotePropsDict,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import assert from "assert";
@@ -96,6 +97,7 @@ export class TestPresetEntry<TBeforeOpts, TAfterOpts, TResultsOpts> {
   public after: (_opts: TAfterOpts) => Promise<any>;
   public results: (_opts: TResultsOpts) => Promise<TestResult[]>;
   public init: () => Promise<void>;
+  public notes: NotePropsDict = {};
 
   constructor({
     label,
@@ -115,11 +117,12 @@ export class TestPresetEntry<TBeforeOpts, TAfterOpts, TResultsOpts> {
   }) {
     this.label = label;
     this.results = results;
-    this.before = before ? before : async () => {};
-    this.preSetupHook = preSetupHook ? preSetupHook : async () => {};
-    this.postSetupHook = postSetupHook ? postSetupHook : async () => {};
-    this.after = after ? after : async () => {};
+    this.before = before || (async () => {});
+    this.preSetupHook = preSetupHook || (async () => {});
+    this.postSetupHook = postSetupHook || (async () => {});
+    this.after = after || (async () => {});
     this.init = async () => {};
+    this.preSetupHook = _.bind(this.preSetupHook, this);
   }
 }
 

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -1,16 +1,16 @@
 import { Server } from "@dendronhq/api-server";
 import {
   CleanDendronSiteConfig,
+  ConfigUtils,
   CONSTANTS,
-  IntermediateDendronConfig,
   DEngineClient,
   DVault,
   DWorkspace,
+  IntermediateDendronConfig,
+  NoteUtils,
   WorkspaceFolderRaw,
   WorkspaceOpts,
   WorkspaceSettings,
-  ConfigUtils,
-  NoteUtils,
 } from "@dendronhq/common-all";
 import {
   getDurationMilliseconds,
@@ -18,23 +18,19 @@ import {
   vault2Path,
 } from "@dendronhq/common-server";
 import {
-  GenTestResults,
   NoteTestUtilsV4,
-  PostSetupHookFunction,
-  PreSetupHookFunction,
   RunEngineTestFunctionOpts,
   RunEngineTestFunctionV4,
   runJestHarnessV2,
   SetupHookFunction,
-  SetupTestFunctionV4,
   TestResult,
 } from "@dendronhq/common-test-utils";
 import { LaunchEngineServerCommand } from "@dendronhq/dendron-cli";
 import {
   createEngine as engineServerCreateEngine,
   DConfig,
-  WorkspaceService,
   WorkspaceConfig,
+  WorkspaceService,
 } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
@@ -105,7 +101,8 @@ export async function createServer(opts: WorkspaceOpts & { port?: number }) {
  */
 export async function createEngineFromServer(
   opts: WorkspaceOpts
-): Promise<any> {  const { engine, port, server } = await createServer(opts);
+): Promise<any> {
+  const { engine, port, server } = await createServer(opts);
   return { engine, port, server };
 }
 
@@ -217,55 +214,6 @@ export type RunEngineTestFunctionV5<T = any> = (
     port?: number;
   }
 ) => Promise<TestResult[] | void | T>;
-
-export class TestPresetEntryV5 {
-  public preSetupHook: PreSetupHookFunction;
-  public postSetupHook: PostSetupHookFunction;
-  public testFunc: RunEngineTestFunctionV4;
-  public extraOpts: any;
-  public setupTest?: SetupTestFunctionV4;
-  public genTestResults?: GenTestResults;
-  public vaults: DVault[];
-  public workspaces: DWorkspace[];
-
-  constructor(
-    func: RunEngineTestFunctionV5,
-    opts?: {
-      preSetupHook?: PreSetupHookFunction;
-      postSetupHook?: PostSetupHookFunction;
-      extraOpts?: any;
-      setupTest?: SetupTestFunctionV4;
-      genTestResults?: GenTestResults;
-      vaults?: DVault[];
-    }
-  ) {
-    const {
-      preSetupHook,
-      postSetupHook,
-      extraOpts,
-      setupTest,
-      genTestResults,
-      workspaces,
-    } = _.defaults(opts, {
-      workspaces: [],
-    });
-    this.preSetupHook = preSetupHook || (async () => {});
-    this.postSetupHook = postSetupHook || (async () => {});
-    this.testFunc = _.bind(func, this);
-    this.extraOpts = extraOpts;
-    this.setupTest = setupTest;
-    this.genTestResults = _.bind(genTestResults || (async () => []), this);
-    this.workspaces = workspaces;
-    this.vaults = opts?.vaults || [
-      { fsPath: "vault1" },
-      { fsPath: "vault2" },
-      {
-        name: "vaultThree",
-        fsPath: "vault3",
-      },
-    ];
-  }
-}
 
 /**
  *

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -106,6 +106,10 @@
         "title": "Dendron: Contribute"
       },
       {
+        "command": "dendron.goto",
+        "title": "Dendron: Go to"
+      },
+      {
         "command": "dendron.gotoNote",
         "title": "Dendron: Go to Note"
       },
@@ -442,6 +446,10 @@
       "commandPalette": [
         {
           "command": "dendron.browseNote",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.goto",
           "when": "dendron:pluginActive"
         },
         {
@@ -933,6 +941,10 @@
       }
     },
     "keybindings": [
+      {
+        "command": "dendron.goto",
+        "when": "editorFocus"
+      },
       {
         "command": "dendron.gotoNote",
         "key": "ctrl+enter",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -490,7 +490,6 @@ export async function _activate(
   const { workspaceFile, workspaceFolders } = vscode.workspace;
   const logLevel = process.env["LOG_LEVEL"];
   const { extensionPath, extensionUri, logUri } = context;
-  const metadataService = MetadataService.instance();
   const stateService = new StateService({
     globalState: context.globalState,
     workspaceState: context.workspaceState,

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -490,6 +490,7 @@ export async function _activate(
   const { workspaceFile, workspaceFolders } = vscode.workspace;
   const logLevel = process.env["LOG_LEVEL"];
   const { extensionPath, extensionUri, logUri } = context;
+  const metadataService = MetadataService.instance();
   const stateService = new StateService({
     globalState: context.globalState,
     workspaceState: context.workspaceState,

--- a/packages/plugin-core/src/commands/GoToNoteInterface.ts
+++ b/packages/plugin-core/src/commands/GoToNoteInterface.ts
@@ -4,6 +4,7 @@ import { Position, ViewColumn } from "vscode";
 export enum TargetKind {
   NOTE = "note",
   NON_NOTE = "nonNote",
+  LINK = "link",
 }
 
 export type GoToNoteCommandOpts = {
@@ -31,4 +32,5 @@ export type GoToNoteCommandOutput =
   | { kind: TargetKind.NOTE; note: NoteProps; pos?: Position; source?: string }
   // When opening a non-note file
   | { kind: TargetKind.NON_NOTE; fullPath: string; type: GotoFileType }
+  | { kind: TargetKind.LINK; fullPath: string }
   | undefined;

--- a/packages/plugin-core/src/commands/GoToNoteInterface.ts
+++ b/packages/plugin-core/src/commands/GoToNoteInterface.ts
@@ -32,5 +32,6 @@ export type GoToNoteCommandOutput =
   | { kind: TargetKind.NOTE; note: NoteProps; pos?: Position; source?: string }
   // When opening a non-note file
   | { kind: TargetKind.NON_NOTE; fullPath: string; type: GotoFileType }
-  | { kind: TargetKind.LINK; fullPath: string }
+  // When opening a link to a non txt-file like resource (eg. pdf, website, etc)
+  | { kind: TargetKind.LINK; fullPath: string; fromProxy: boolean }
   | undefined;

--- a/packages/plugin-core/src/commands/Goto.ts
+++ b/packages/plugin-core/src/commands/Goto.ts
@@ -23,6 +23,10 @@ type CommandOutput = RespV3<GoToNoteCommandOutput>;
 
 const GOTO_KEY = "uri";
 
+/**
+ * Go to the current link under cursor. This command will exhibit different behavior depending on the type of the link.
+ * See [[dendron.ref.commands.goto]] for more details
+ */
 export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.GOTO.key;
 

--- a/packages/plugin-core/src/commands/Goto.ts
+++ b/packages/plugin-core/src/commands/Goto.ts
@@ -34,6 +34,21 @@ export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
     super();
   }
 
+  addAnalyticsPayload?(_opts?: CommandOpts, out?: CommandOutput) {
+    if (!out?.data) {
+      return {};
+    }
+    const kind = out.data.kind;
+    // non-note file has file type
+    if (out.data.kind === TargetKind.NON_NOTE) {
+      return {
+        kind,
+        type: out.data.type,
+      };
+    }
+    return { kind };
+  }
+
   async gatherInputs(): Promise<CommandInput | undefined> {
     return {};
   }
@@ -88,6 +103,7 @@ export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
       data: {
         kind: TargetKind.LINK,
         fullPath: note.custom[GOTO_KEY],
+        fromProxy: true,
       },
     };
   }

--- a/packages/plugin-core/src/commands/Goto.ts
+++ b/packages/plugin-core/src/commands/Goto.ts
@@ -1,0 +1,88 @@
+import {
+  DendronError,
+  DVault,
+  NoteUtils,
+  RespV3,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { getLinkFromSelectionWithWorkspace } from "../utils/editor";
+import { DendronExtension } from "../workspace";
+import { BasicCommand } from "./base";
+import { GotoNoteCommand } from "./GotoNote";
+import { GoToNoteCommandOutput, TargetKind } from "./GoToNoteInterface";
+import { OpenLinkCommand } from "./OpenLink";
+
+type CommandOpts = {};
+
+type CommandInput = {};
+
+type CommandOutput = RespV3<GoToNoteCommandOutput>;
+
+export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
+  key = DENDRON_COMMANDS.GOTO.key;
+
+  constructor(private _ext: DendronExtension) {
+    super();
+  }
+
+  async gatherInputs(): Promise<CommandInput | undefined> {
+    return {};
+  }
+  async execute(): Promise<CommandOutput> {
+    const { vaults, engine } = ExtensionProvider.getDWorkspace();
+
+    const link = await getLinkFromSelectionWithWorkspace();
+    if (!link) {
+      return {
+        error: new DendronError({ message: "selection is not a valid link" }),
+      };
+    }
+
+    // get vault
+    let vault: DVault | undefined;
+    const { anchorHeader, value: fname, vaultName } = link;
+    if (vaultName) {
+      vault = VaultUtils.getVaultByNameOrThrow({
+        vaults,
+        vname: vaultName,
+      });
+    }
+
+    // get note
+    const notes = NoteUtils.getNotesByFnameFromEngine({
+      fname,
+      engine,
+      vault,
+    });
+    if (notes.length === 0) {
+      return {
+        error: new DendronError({ message: "selection is not a note" }),
+      };
+    }
+
+    // TODO: for now, get first note, in the future, show prompt
+    const note = notes[0];
+
+    // if note doesn't have url, run goto note command
+    if (_.isUndefined(note.custom.url)) {
+      const resp = await new GotoNoteCommand(this._ext).execute({
+        qs: note.fname,
+        vault: note.vault,
+        anchor: anchorHeader,
+      });
+      return { data: resp };
+    }
+
+    // we found a link
+    await new OpenLinkCommand().execute({ url: note.custom.url });
+    return {
+      data: {
+        kind: TargetKind.LINK,
+        fullPath: note.custom.url,
+      },
+    };
+  }
+}

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -17,6 +17,7 @@ import { DENDRON_COMMANDS } from "../constants";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { getAnalyticsPayload } from "../utils/analytics";
+import { getLinkFromSelectionWithWorkspace } from "../utils/editor";
 import { PluginFileUtils } from "../utils/files";
 import { getReferenceAtPosition } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
@@ -204,7 +205,7 @@ export class GotoNoteCommand extends BasicCommand<
       return opts;
     }
 
-    const link = await this.getLinkFromSelection();
+    const link = await getLinkFromSelectionWithWorkspace();
     if (!link) {
       window.showErrorMessage("selection is not a valid link");
       return null;

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -15,11 +15,9 @@ import { VaultSelectionMode } from "../components/lookup/types";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
 import { IDendronExtension } from "../dendronExtensionInterface";
-import { ExtensionProvider } from "../ExtensionProvider";
 import { getAnalyticsPayload } from "../utils/analytics";
 import { getLinkFromSelectionWithWorkspace } from "../utils/editor";
 import { PluginFileUtils } from "../utils/files";
-import { getReferenceAtPosition } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { IWSUtilsV2 } from "../WSUtilsV2Interface";
 import { BasicCommand } from "./base";
@@ -56,7 +54,7 @@ export const findAnchorPos = (opts: {
 };
 
 type FoundLinkSelection = NonNullable<
-  Awaited<ReturnType<GotoNoteCommand["getLinkFromSelection"]>>
+  Awaited<ReturnType<typeof getLinkFromSelectionWithWorkspace>>
 >;
 
 /**
@@ -74,34 +72,6 @@ export class GotoNoteCommand extends BasicCommand<
     super();
     this.extension = extension;
     this.wsUtils = extension.wsUtils;
-  }
-
-  async getLinkFromSelection() {
-    const { selection, editor } = VSCodeUtils.getSelection();
-    if (
-      _.isEmpty(selection) ||
-      _.isUndefined(selection) ||
-      _.isUndefined(selection.start) ||
-      !editor
-    )
-      return;
-    const currentLine = editor.document.lineAt(selection.start.line).text;
-    if (!currentLine) return;
-    const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-    const reference = await getReferenceAtPosition({
-      document: editor.document,
-      position: selection.start,
-      opts: { allowInCodeBlocks: true },
-      wsRoot,
-      vaults,
-    });
-    if (!reference) return;
-    return {
-      alias: reference?.label,
-      value: reference?.ref,
-      vaultName: reference?.vaultName,
-      anchorHeader: reference.anchorStart,
-    };
   }
 
   private getQs(

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -23,13 +23,13 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   async gatherInputs(): Promise<CommandInput | undefined> {
     return {};
   }
-  async execute({ url }: { url?: string }) {
+  async execute(opts?: { url?: string }) {
     const ctx = DENDRON_COMMANDS.OPEN_LINK;
     this.L.info({ ctx });
 
     let text = "";
 
-    text = url ?? getURLAt(VSCodeUtils.getActiveTextEditor());
+    text = opts?.url ?? getURLAt(VSCodeUtils.getActiveTextEditor());
 
     if (_.isUndefined(text) || text === "") {
       const error = DendronError.createFromStatus({

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -23,13 +23,13 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   async gatherInputs(): Promise<CommandInput | undefined> {
     return {};
   }
-  async execute(opts?: { url?: string }) {
+  async execute(opts?: { uri?: string }) {
     const ctx = DENDRON_COMMANDS.OPEN_LINK;
     this.L.info({ ctx });
 
     let text = "";
 
-    text = opts?.url ?? getURLAt(VSCodeUtils.getActiveTextEditor());
+    text = opts?.uri ?? getURLAt(VSCodeUtils.getActiveTextEditor());
 
     if (_.isUndefined(text) || text === "") {
       const error = DendronError.createFromStatus({

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -23,13 +23,13 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
   async gatherInputs(): Promise<CommandInput | undefined> {
     return {};
   }
-  async execute() {
+  async execute({ url }: { url?: string }) {
     const ctx = DENDRON_COMMANDS.OPEN_LINK;
     this.L.info({ ctx });
 
     let text = "";
 
-    text = getURLAt(VSCodeUtils.getActiveTextEditor());
+    text = url ?? getURLAt(VSCodeUtils.getActiveTextEditor());
 
     if (_.isUndefined(text) || text === "") {
       const error = DendronError.createFromStatus({

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -73,6 +73,7 @@ import { OpenBackupCommand } from "./OpenBackupCommand";
 import { CopyToClipboardCommand } from "./CopyToClipboardCommand";
 import { CopyNoteLinkCommand } from "./CopyNoteLink";
 import { CreateMeetingNoteCommand } from "./CreateMeetingNoteCommand";
+import { GotoCommand } from "./Goto";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -108,6 +109,7 @@ const ALL_COMMANDS = [
   ExportPodV2Command,
   GoDownCommand,
   GoUpCommand,
+  GotoCommand,
   GotoNoteCommand,
   ImportPodCommand,
   InsertNoteCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -246,6 +246,15 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     // no prefix, we don't want to show this command
     title: `${CMD_PREFIX} Contribute`,
   },
+  GOTO: {
+    key: "dendron.goto",
+    // no prefix, we don't want to show this command
+    title: `${CMD_PREFIX} Go to`,
+    when: DendronContext.PLUGIN_ACTIVE,
+    keybindings: {
+      when: "editorFocus",
+    },
+  },
   GOTO_NOTE: {
     key: "dendron.gotoNote",
     // no prefix, we don't want to show this command

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -237,18 +237,15 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   // --- Notes
   BROWSE_NOTE: {
     key: "dendron.browseNote",
-    // no prefix, we don't want to show this command
     title: `${CMD_PREFIX} Browse Note`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
   CONTRIBUTE: {
     key: "dendron.contributeToCause",
-    // no prefix, we don't want to show this command
     title: `${CMD_PREFIX} Contribute`,
   },
   GOTO: {
     key: "dendron.goto",
-    // no prefix, we don't want to show this command
     title: `${CMD_PREFIX} Go to`,
     when: DendronContext.PLUGIN_ACTIVE,
     keybindings: {
@@ -257,7 +254,6 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   },
   GOTO_NOTE: {
     key: "dendron.gotoNote",
-    // no prefix, we don't want to show this command
     title: `${CMD_PREFIX} Go to Note`,
     when: DendronContext.PLUGIN_ACTIVE,
     keybindings: {

--- a/packages/plugin-core/src/test/presets/GotoNotePreset.ts
+++ b/packages/plugin-core/src/test/presets/GotoNotePreset.ts
@@ -1,6 +1,9 @@
 import { NoteTestUtilsV4, TestPresetEntry } from "@dendronhq/common-test-utils";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 import { getActiveEditorBasename } from "../testUtils";
+import { LocationTestUtils } from "../testUtilsv2";
 
 const ANCHOR = new TestPresetEntry({
   label: "anchor",
@@ -70,7 +73,9 @@ const ANCHOR_WITH_SPECIAL_CHARS = new TestPresetEntry({
   },
 });
 
-const CODE_BLOCK_PRESET = new TestPresetEntry({
+const CODE_BLOCK_PRESET = new TestPresetEntry<{
+  ext: IDendronExtension;
+}>({
   label: "link in code block",
 
   preSetupHook: async ({ wsRoot, vaults }) => {
@@ -93,6 +98,17 @@ const CODE_BLOCK_PRESET = new TestPresetEntry({
       ].join("\n"),
     });
   },
+
+  beforeTestResults: async ({ ext }) => {
+    const { engine } = ext.getDWorkspace();
+    const note = engine.notes["test.note"];
+    const editor = await new WSUtilsV2(ext).openNote(note);
+    editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
+      line: 9,
+      char: 23,
+    });
+  },
+
   results: async () => {
     return [
       {

--- a/packages/plugin-core/src/test/presets/GotoNotePreset.ts
+++ b/packages/plugin-core/src/test/presets/GotoNotePreset.ts
@@ -70,7 +70,41 @@ const ANCHOR_WITH_SPECIAL_CHARS = new TestPresetEntry({
   },
 });
 
+const CODE_BLOCK_PRESET = new TestPresetEntry({
+  label: "link in code block",
+
+  preSetupHook: async ({ wsRoot, vaults }) => {
+    await NoteTestUtilsV4.createNote({
+      fname: "test.target",
+      vault: vaults[0],
+      wsRoot,
+      body: "In aut veritatis odit tempora aut ipsa quo.",
+    });
+    await NoteTestUtilsV4.createNote({
+      fname: "test.note",
+      vault: vaults[0],
+      wsRoot,
+      body: [
+        "```tsx",
+        "const x = 1;",
+        "// see [[test target|test.target]]",
+        "const y = x + 1;",
+        "```",
+      ].join("\n"),
+    });
+  },
+  results: async () => {
+    return [
+      {
+        actual: getActiveEditorBasename(),
+        expected: "test.target.md",
+      },
+    ];
+  },
+});
+
 export const GOTO_NOTE_PRESETS = {
   ANCHOR,
   ANCHOR_WITH_SPECIAL_CHARS,
+  CODE_BLOCK_PRESET,
 };

--- a/packages/plugin-core/src/test/suite-integ/Goto.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Goto.test.ts
@@ -2,9 +2,7 @@ import { runMochaHarness } from "@dendronhq/common-test-utils";
 import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../../constants";
 import { ExtensionProvider } from "../../ExtensionProvider";
-import { WSUtilsV2 } from "../../WSUtilsV2";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
-import { LocationTestUtils } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
 
 const executeGotoCmd = () => {
@@ -19,14 +17,8 @@ suite("GotoNote", function () {
     },
     () => {
       test("THEN goto note", async () => {
-        const { engine } = ExtensionProvider.getDWorkspace();
-        const note = engine.notes["test.note"];
         const ext = ExtensionProvider.getExtension();
-        const editor = await new WSUtilsV2(ext).openNote(note);
-        editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
-          line: 9,
-          char: 23,
-        });
+        await GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.beforeTestResults({ ext });
         await executeGotoCmd();
         await runMochaHarness(GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.results);
       });

--- a/packages/plugin-core/src/test/suite-integ/Goto.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Goto.test.ts
@@ -1,8 +1,11 @@
 import { runMochaHarness } from "@dendronhq/common-test-utils";
+import sinon from "sinon";
 import * as vscode from "vscode";
+import { GotoCommand } from "../../commands/Goto";
 import { DENDRON_COMMANDS } from "../../constants";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
+import { expect } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
 
 const executeGotoCmd = () => {
@@ -11,16 +14,54 @@ const executeGotoCmd = () => {
 
 suite("GotoNote", function () {
   describeMultiWS(
-    "WHEN pass in note",
+    GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.label,
     {
-      preSetupHook: GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.preSetupHook,
+      preSetupHook: GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.preSetupHook,
     },
     () => {
       test("THEN goto note", async () => {
         const ext = ExtensionProvider.getExtension();
-        await GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.beforeTestResults({ ext });
+        await GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.beforeTestResults({ ext });
         await executeGotoCmd();
-        await runMochaHarness(GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.results);
+        await runMochaHarness(GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.results);
+      });
+    }
+  );
+
+  describeMultiWS(
+    GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.label,
+    {
+      preSetupHook: GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.preSetupHook,
+    },
+    () => {
+      test("THEN goto note", async () => {
+        const ext = ExtensionProvider.getExtension();
+        await GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.beforeTestResults({
+          ext,
+        });
+        await executeGotoCmd();
+        await runMochaHarness(
+          GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.results
+        );
+      });
+    }
+  );
+
+  describeMultiWS(
+    "WHEN link to note with uri http",
+    {
+      preSetupHook: GOTO_NOTE_PRESETS.LINK_TO_NOTE_WITH_URI_HTTP.preSetupHook,
+    },
+    () => {
+      test("THEN goto note", async () => {
+        const ext = ExtensionProvider.getExtension();
+        await GOTO_NOTE_PRESETS.LINK_TO_NOTE_WITH_URI_HTTP.beforeTestResults({
+          ext,
+        });
+        const cmd = new GotoCommand(ext);
+        const openLinkMethod = sinon.stub(cmd, "openLink" as keyof GotoCommand);
+        await cmd.execute();
+        expect(openLinkMethod.calledOnce).toBeTruthy();
       });
     }
   );

--- a/packages/plugin-core/src/test/suite-integ/Goto.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Goto.test.ts
@@ -1,0 +1,35 @@
+import { runMochaHarness } from "@dendronhq/common-test-utils";
+import * as vscode from "vscode";
+import { DENDRON_COMMANDS } from "../../constants";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { WSUtilsV2 } from "../../WSUtilsV2";
+import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
+import { LocationTestUtils } from "../testUtilsv2";
+import { describeMultiWS } from "../testUtilsV3";
+
+const executeGotoCmd = () => {
+  return vscode.commands.executeCommand(DENDRON_COMMANDS.GOTO.key);
+};
+
+suite("GotoNote", function () {
+  describeMultiWS(
+    "WHEN pass in note",
+    {
+      preSetupHook: GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.preSetupHook,
+    },
+    () => {
+      test("THEN goto note", async () => {
+        const { engine } = ExtensionProvider.getDWorkspace();
+        const note = engine.notes["test.note"];
+        const ext = ExtensionProvider.getExtension();
+        const editor = await new WSUtilsV2(ext).openNote(note);
+        editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
+          line: 9,
+          char: 23,
+        });
+        await executeGotoCmd();
+        await runMochaHarness(GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.results);
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -8,7 +8,7 @@ import {
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
 import _ from "lodash";
-import { describe, before } from "mocha";
+import { before, describe } from "mocha";
 import path from "path";
 import sinon from "sinon";
 import * as vscode from "vscode";
@@ -35,14 +35,17 @@ function createGoToNoteCmd() {
 }
 
 suite("GotoNote", function () {
-  const ctx = setupBeforeAfter(this, {});
+  describe("new style tests", () => {
+    const preSetupHook = ENGINE_HOOKS.setupBasic;
 
-  describe("using args", () => {
-    test("basic", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic,
-        onInit: async ({ vaults, engine }) => {
+    describeMultiWS(
+      "WHEN pass in note",
+      {
+        preSetupHook,
+      },
+      () => {
+        test("THEN goto note", async () => {
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           const note = engine.notes["foo"];
           const { note: out } = (await createGoToNoteCmd().run({
@@ -51,21 +54,23 @@ suite("GotoNote", function () {
           })) as { note: NoteProps };
           expect(out).toEqual(note);
           expect(getActiveEditorBasename()).toEqual("foo.md");
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
-    test("go to a stub ", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
+    describeMultiWS(
+      "WHEN goto stub",
+      {
         preSetupHook: async ({ wsRoot, vaults }) => {
           const vault = vaults[0];
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           const vpath = vault2Path({ vault, wsRoot });
           fs.removeSync(path.join(vpath, "foo.md"));
         },
-        onInit: async ({ vaults, engine }) => {
+      },
+      () => {
+        test("THEN get note", async () => {
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           const note = NoteUtils.getNoteByFnameV5({
             fname: "foo",
@@ -87,16 +92,18 @@ suite("GotoNote", function () {
             id: note.id,
           });
           expect(getActiveEditorBasename()).toEqual("foo.md");
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
-    test("go to new note", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic,
-        onInit: async ({ vaults }) => {
+    describeMultiWS(
+      "WHEN goto new note",
+      {
+        preSetupHook,
+      },
+      () => {
+        test("THEN note created", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           const { note: out } = (await createGoToNoteCmd().run({
             qs: "foo.ch2",
@@ -106,19 +113,21 @@ suite("GotoNote", function () {
             fname: "foo.ch2",
           });
           expect(getActiveEditorBasename()).toEqual("foo.ch2.md");
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
-    test("go to new note with template", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
-        preSetupHook: ENGINE_HOOKS.setupBasic,
+    describeMultiWS(
+      "WHEN goto note with template",
+      {
+        preSetupHook,
         postSetupHook: async ({ wsRoot, vaults }) => {
           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
         },
-        onInit: async ({ vaults }) => {
+      },
+      () => {
+        test("THEN apply template", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           await createGoToNoteCmd().run({
             qs: "bar.ch1",
@@ -128,15 +137,13 @@ suite("GotoNote", function () {
           const content =
             VSCodeUtils.getActiveTextEditor()?.document.getText() as string;
           expect(content.indexOf("ch1 template") >= 0).toBeTruthy();
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
     describeMultiWS(
       "GIVEN a new note and a template in different vaults",
       {
-        ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         postSetupHook: async ({ wsRoot, vaults }) => {
           await ENGINE_HOOKS.setupSchemaPreseet({ wsRoot, vaults });
@@ -162,7 +169,6 @@ suite("GotoNote", function () {
     describeMultiWS(
       "GIVEN a new note and multiple templates in different vaults with the same name",
       {
-        ctx,
         preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         postSetupHook: async ({ wsRoot, vaults }) => {
           // Template is in vault 1 and 3
@@ -195,13 +201,16 @@ suite("GotoNote", function () {
       }
     );
 
-    test("go to note with anchor", (done) => {
-      runLegacyMultiWorkspaceTest({
-        ctx,
+    describeMultiWS(
+      "WHEN goto note with anchor",
+      {
         preSetupHook: async (opts) => {
           await ANCHOR.preSetupHook(opts);
         },
-        onInit: async ({ vaults }) => {
+      },
+      () => {
+        test("THEN goto anchor", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           await createGoToNoteCmd().run({
             qs: "alpha",
@@ -215,15 +224,13 @@ suite("GotoNote", function () {
           const selection = VSCodeUtils.getActiveTextEditor()?.selection;
           expect(selection?.start.line).toEqual(9);
           expect(selection?.start.character).toEqual(0);
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
-    test("go to note header with wikilink and unicode characters", (done) => {
-      // ## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum
-      runLegacyMultiWorkspaceTest({
-        ctx,
+    describeMultiWS(
+      "WHEN go to note header with wikilink and unicode characters",
+      {
         preSetupHook: async ({ vaults, wsRoot }) => {
           await NoteTestUtilsV4.createNote({
             wsRoot,
@@ -232,7 +239,10 @@ suite("GotoNote", function () {
             body: "\n\n## Lörem [[Foo：Bar🙂Baz|foo：bar🙂baz]] Ipsum\n\nlorem ipsum",
           });
         },
-        onInit: async ({ vaults }) => {
+      },
+      () => {
+        test("THEN goto ehader", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           await createGoToNoteCmd().run({
             qs: "target-note",
@@ -246,20 +256,22 @@ suite("GotoNote", function () {
           const selection = VSCodeUtils.getActiveTextEditor()?.selection;
           expect(selection?.start.line).toEqual(9);
           expect(selection?.start.character).toEqual(0);
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
-    test("anchor with special chars", (done) => {
-      let specialCharsHeader: string;
-      runLegacyMultiWorkspaceTest({
-        ctx,
+    let specialCharsHeader: string;
+    describeMultiWS(
+      "WHEN anchor with special chars",
+      {
         preSetupHook: async (opts) => {
           ({ specialCharsHeader } =
             await ANCHOR_WITH_SPECIAL_CHARS.preSetupHook(opts));
         },
-        onInit: async ({ vaults }) => {
+      },
+      () => {
+        test("THEN goto anchor", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
           await createGoToNoteCmd().run({
             qs: "alpha",
@@ -273,11 +285,13 @@ suite("GotoNote", function () {
           const selection = VSCodeUtils.getActiveTextEditor()?.selection;
           expect(selection?.start.line).toEqual(9);
           expect(selection?.start.character).toEqual(0);
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
+  });
 
+  const ctx = setupBeforeAfter(this, {});
+  describe("using args", () => {
     test("block anchor", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
@@ -465,7 +479,6 @@ suite("GotoNote", function () {
     describeMultiWS(
       "WHEN in a code block",
       {
-        ctx,
         preSetupHook: async ({ wsRoot, vaults }) => {
           await NoteTestUtilsV4.createNote({
             fname: "test.target",

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -477,21 +477,16 @@ suite("GotoNote", function () {
 
   describe("using selection", () => {
     describeMultiWS(
-      "WHEN in a code block",
+      "WHEN link in code block",
       {
-        preSetupHook: GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.preSetupHook,
+        preSetupHook: GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.preSetupHook,
       },
       () => {
         test("THEN opens the note", async () => {
-          const { engine } = ExtensionProvider.getDWorkspace();
-          const note = engine.notes["test.note"];
-          const editor = await WSUtils.openNote(note);
-          editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
-            line: 9,
-            char: 23,
-          });
+          const ext = ExtensionProvider.getExtension();
+          await GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.beforeTestResults({ ext });
           await createGoToNoteCmd().run();
-          await runMochaHarness(GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.results);
+          await runMochaHarness(GOTO_NOTE_PRESETS.LINK_IN_CODE_BLOCK.results);
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -4,6 +4,7 @@ import {
   AssertUtils,
   NoteTestUtilsV4,
   NOTE_PRESETS_V4,
+  runMochaHarness,
 } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import fs from "fs-extra";
@@ -475,40 +476,22 @@ suite("GotoNote", function () {
   });
 
   describe("using selection", () => {
-    let note: NoteProps;
     describeMultiWS(
       "WHEN in a code block",
       {
-        preSetupHook: async ({ wsRoot, vaults }) => {
-          await NoteTestUtilsV4.createNote({
-            fname: "test.target",
-            vault: vaults[0],
-            wsRoot,
-            body: "In aut veritatis odit tempora aut ipsa quo.",
-          });
-          note = await NoteTestUtilsV4.createNote({
-            fname: "test.note",
-            vault: vaults[0],
-            wsRoot,
-            body: [
-              "```tsx",
-              "const x = 1;",
-              "// see [[test target|test.target]]",
-              "const y = x + 1;",
-              "```",
-            ].join("\n"),
-          });
-        },
+        preSetupHook: GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.preSetupHook,
       },
       () => {
         test("THEN opens the note", async () => {
+          const { engine } = ExtensionProvider.getDWorkspace();
+          const note = engine.notes["test.note"];
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
             line: 9,
             char: 23,
           });
           await createGoToNoteCmd().run();
-          expect(getActiveEditorBasename()).toEqual("test.target.md");
+          await runMochaHarness(GOTO_NOTE_PRESETS.CODE_BLOCK_PRESET.results);
         });
       }
     );

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -33,7 +33,6 @@ import vscode, {
 import { TargetKind } from "../commands/GoToNoteInterface";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { WSUtils } from "../WSUtils";
 import { getReferenceAtPosition } from "./md";
 
 export function isAnythingSelected(): boolean {
@@ -205,12 +204,17 @@ export async function getSelectionAnchors(opts: {
 /**
  * Utility method to check if the selected text is a broken wikilink
  */
-export async function isBrokenWikilink(): Promise<boolean> {
-  const { editor, selection } = VSCodeUtils.getSelection();
-  if (!editor || !selection) return false;
-  const note = WSUtils.getNoteFromDocument(editor.document);
-  const { engine } = ExtensionProvider.getDWorkspace();
-  if (!note) return false;
+export async function isBrokenWikilink({
+  editor,
+  selection,
+  note,
+  engine,
+}: {
+  editor: TextEditor;
+  selection: vscode.Selection;
+  note: NoteProps;
+  engine: DEngineClient;
+}): Promise<boolean> {
   const line = editor.document.lineAt(selection.start.line).text;
   const proc = MDUtilsV5.procRemarkParse(
     { mode: ProcMode.FULL },

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -285,9 +285,9 @@ export async function getLinkFromSelectionWithWorkspace() {
   });
   if (!reference) return;
   return {
-    alias: reference?.label,
-    value: reference?.ref,
-    vaultName: reference?.vaultName,
+    alias: reference.label,
+    value: reference.ref,
+    vaultName: reference.vaultName,
     anchorHeader: reference.anchorStart,
   };
 }

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -261,6 +261,9 @@ export type ProcessSelectionOpts = {
   source?: string;
 };
 
+/**
+ * NOTE: this method requires that `ExtensionProvider` be available and can provide a workspace
+ */
 export async function getLinkFromSelectionWithWorkspace() {
   const { selection, editor } = VSCodeUtils.getSelection();
   if (

--- a/packages/plugin-core/src/utils/editor.ts
+++ b/packages/plugin-core/src/utils/editor.ts
@@ -266,6 +266,8 @@ export type ProcessSelectionOpts = {
  */
 export async function getLinkFromSelectionWithWorkspace() {
   const { selection, editor } = VSCodeUtils.getSelection();
+  // can't just collapse to `selection?.start !== undefined`
+  // because typescript compiler complains that selection might be undefined otherwise inside of the if block
   if (
     _.isEmpty(selection) ||
     _.isUndefined(selection) ||

--- a/packages/plugin-core/src/utils/index.ts
+++ b/packages/plugin-core/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./editor";


### PR DESCRIPTION
feat: add goto command

This adds a new command `Go to` which supports navigating the `uri` parameter of [[Proxy Notes|dendron://dendron.docs/rfc.38-links-to-non-note-files#proxy-notes]].

See docs in https://github.com/dendronhq/dendron-site/pull/489

In addition to implementing this feature, the following sections were cleaned up: 
- refactor codeActionProvider (to avoid introducing a new circular dependency)
- fix some tests in GotoNote
- add presents for GotoNote
- extract some utilities as common utilities


# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 

## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

NA

## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)
