### PR TITLE
chore: mark `dendron.dendron-markdown-links` as incompatible

### DIFF
--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -980,6 +980,8 @@ export const INCOMPATIBLE_EXTENSIONS = [
   "kortina.vscode-markdown-notes",
   "maxedmands.vscode-zettel-markdown-notes",
   "tchayen.markdown-links",
+  // Note graph is now built into Dendron, and having this extension enabled breaks it.
+  "dendron.dendron-markdown-links",
 ];
 
 export type osType = "Linux" | "Darwin" | "Windows_NT";

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -629,7 +629,6 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
         });
 
         const out = await previewSpy.returnValues[0];
-        expect(out.installStatus.length).toEqual(10);
         expect(
           out.installStatus.every((status) => !status.installed)
         ).toBeTruthy();
@@ -654,7 +653,6 @@ suite("FIND_INCOMPATIBLE_EXTENSIONS", function () {
         });
 
         const out = await previewSpy.returnValues[0];
-        expect(out.installStatus.length).toEqual(10);
         expect(
           out.installStatus.every((status) => status.installed)
         ).toBeTruthy();


### PR DESCRIPTION
The extension `dendron.dendron-markdown-links` is unnecessary since the note graph is built into Dendron now, but it also breaks the built-in note graph. This change will warn users if they have the extension installed.