### PR TITLE
enhance: use better defaults for `Create Task Note`

### DIFF
--- a/packages/common-all/src/types/configs/workspace/task.ts
+++ b/packages/common-all/src/types/configs/workspace/task.ts
@@ -26,9 +26,9 @@ export type TaskConfig = Pick<
  */
 export function genDefaultTaskConfig(): TaskConfig {
   return {
-    name: "",
-    dateFormat: "",
-    addBehavior: NoteAddBehaviorEnum.childOfCurrent,
+    name: "task",
+    dateFormat: "y.MM.dd",
+    addBehavior: NoteAddBehaviorEnum.asOwnDomain,
     statusSymbols: {
       "": " ",
       wip: "w",

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -55,9 +55,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -204,9 +204,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -343,9 +343,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -449,9 +449,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -572,9 +572,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -49,9 +49,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -198,9 +198,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -337,9 +337,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -443,9 +443,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -566,9 +566,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -696,9 +696,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w
@@ -813,9 +813,9 @@ workspace:
         dateFormat: y.MM.dd.HHmmss
         addBehavior: asOwnDomain
     task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
+        name: task
+        dateFormat: y.MM.dd
+        addBehavior: asOwnDomain
         statusSymbols:
             '': ' '
             wip: w

--- a/packages/plugin-core/src/commands/CreateTask.ts
+++ b/packages/plugin-core/src/commands/CreateTask.ts
@@ -1,14 +1,21 @@
-import { ConfigUtils, LookupNoteTypeEnum } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  LookupNoteTypeEnum,
+  NoteAddBehaviorEnum,
+} from "@dendronhq/common-all";
 import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
-import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 import { CommandOutput as NoteLookupOutput } from "./NoteLookupCommand";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
+import { ExtensionProvider } from "../ExtensionProvider";
 
 type CommandOpts = {};
 
-type CommandOutput = NoteLookupOutput | undefined;
+type CommandOutput = {
+  lookup: Promise<NoteLookupOutput | undefined>;
+  addBehavior: NoteAddBehaviorEnum;
+};
 
 export { CommandOpts as CreateTaskOpts };
 
@@ -27,12 +34,22 @@ export class CreateTaskCommand extends BasicCommand<
     const ctx = "CreateTask";
 
     Logger.info({ ctx, msg: "enter", opts });
-    const { config } = getDWorkspace();
-    const { createTaskSelectionType } = ConfigUtils.getTask(config);
+    const { config } = ExtensionProvider.getDWorkspace();
+    const { createTaskSelectionType, addBehavior } =
+      ConfigUtils.getTask(config);
 
-    return AutoCompletableRegistrar.getNoteLookupCmd().run({
-      noteType: LookupNoteTypeEnum.task,
-      selectionType: createTaskSelectionType,
-    });
+    return {
+      lookup: AutoCompletableRegistrar.getNoteLookupCmd().run({
+        noteType: LookupNoteTypeEnum.task,
+        selectionType: createTaskSelectionType,
+      }),
+      addBehavior,
+    };
+  }
+
+  addAnalyticsPayload(_opts: CommandOpts, res: CommandOutput) {
+    return {
+      addBehavior: res.addBehavior,
+    };
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/Extension.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/Extension.test.ts
@@ -289,9 +289,9 @@ suite("GIVEN SetupWorkspace Command", function () {
               addBehavior: "asOwnDomain",
             },
             task: {
-              name: "",
-              dateFormat: "",
-              addBehavior: "childOfCurrent",
+              name: "task",
+              dateFormat: "y.MM.dd",
+              addBehavior: "asOwnDomain",
               statusSymbols: {
                 "": " ",
                 wip: "w",

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1594,7 +1594,7 @@ suite("NoteLookupCommand", function () {
             noConfirm: true,
           })) as CommandOutput;
 
-          expect(out.quickpick.value.startsWith(`foo`)).toBeTruthy();
+          expect(out.quickpick.value.startsWith(`task`)).toBeTruthy();
 
           cmd.cleanUp();
           done();
@@ -2275,7 +2275,7 @@ suite("NoteLookupCommand", function () {
             expect(selection2linkBtn.pressed).toBeTruthy();
 
             const quickpickValue = controller.quickPick.value;
-            expect(quickpickValue.startsWith(`foo.`)).toBeTruthy();
+            expect(quickpickValue.startsWith(`task.`)).toBeTruthy();
             expect(quickpickValue.endsWith(".foo-body")).toBeTruthy();
 
             controller.onHide();

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
@@ -140,7 +140,7 @@ describe(`GIVEN a LookupControllerV3`, () => {
       });
 
       describe(`WHEN task mode is toggled`, () => {
-        test(`THEN the contents of the quick pick update with 'foo.'`, async () => {
+        test(`THEN the contents of the quick pick update with 'task.'`, async () => {
           const engine = ExtensionProvider.getEngine();
 
           await WSUtilsV2.instance().openNote(engine.notes["foo"]);
@@ -162,7 +162,7 @@ describe(`GIVEN a LookupControllerV3`, () => {
           viewModel.nameModifierMode.value = LookupNoteTypeEnum.task;
 
           const qp = controller.quickPick;
-          expect(qp.value.startsWith("foo.")).toBeTruthy();
+          expect(qp.value.startsWith("task.")).toBeTruthy();
 
           // Now untoggle the button:
           viewModel.nameModifierMode.value = LookupNoteTypeEnum.none;


### PR DESCRIPTION
This PR sets the `Create Task Note` command's default configuration so that tasks will look like `task.2022.04.29.task-name`.
This format is what we've been using and it has worked well for us. We also had some feedback from a community member that this setup makes more sense.

This change will only affect new workspaces, as existing users might be already creating tasks with their existing config and we wouldn't want to break their setup.

I also added some telemetry for the `addBehavior` used when creating the task. The default changed from `childOfCurrent` to `asOwnDomain`, so we can use that to measure if people with the new default are stickier with tasks.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)