### PR TITLE
fix: Lookup creates a bad wikilink if `selection2link` is enabled and the selection is multiline

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -731,7 +731,10 @@ export class LookupControllerV3 implements ILookupControllerV3 {
             await editor.edit((builder) => {
               const link = note.fname;
               if (!_.isUndefined(selection) && !selection.isEmpty) {
-                builder.replace(selection, `[[${text}|${link}]]`);
+                builder.replace(
+                  selection,
+                  `[[${text?.replace(/\n/g, "")}|${link}]]`
+                );
               }
             });
           }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -70,6 +70,7 @@ import { createMockQuickPick, getActiveEditorBasename } from "../testUtils";
 import { expect, resetCodeWorkspace } from "../testUtilsv2";
 import {
   describeMultiWS,
+  describeSingleWS,
   runLegacyMultiWorkspaceTest,
   setupBeforeAfter,
   waitInMilliseconds,
@@ -1849,6 +1850,55 @@ suite("NoteLookupCommand", function () {
         },
       });
     });
+
+    describeSingleWS(
+      "WHEN selection2link is used with a multi-line string",
+      {
+        ctx,
+        postSetupHook: async ({ vaults, wsRoot }) => {
+          NoteTestUtilsV4.createNote({
+            fname: "multi-line",
+            vault: vaults[0],
+            wsRoot,
+            body: "test\ning\n",
+          });
+        },
+      },
+      () => {
+        test("THEN it produces a valid string", async () => {
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+          const fooNoteEditor = await ExtensionProvider.getWSUtils().openNote(
+            engine.notes["multi-line"]
+          );
+
+          // selects "test \n ing \n"
+          fooNoteEditor.selection = new vscode.Selection(7, 0, 9, 0);
+          const { text } = VSCodeUtils.getSelection();
+          expect(text).toEqual("test\ning\n");
+
+          await cmd.run({
+            selectionType: "selection2link",
+            noConfirm: true,
+          });
+
+          // should create foo.foo-body.md with an empty body.
+          expect(getActiveEditorBasename().endsWith("multi-line.testing.md"));
+          const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
+          const newNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+            newNoteEditor.document
+          );
+          expect(newNote?.body).toEqual("");
+
+          // should change selection to link with alais.
+          const changedText = fooNoteEditor.document.getText();
+          expect(changedText.endsWith("[[testing|multi-line.testing]]\n"));
+
+          cmd.cleanUp();
+        });
+      }
+    );
 
     test("selection2link modifier toggle", (done) => {
       runLegacyMultiWorkspaceTest({


### PR DESCRIPTION

#2854

# Dendron Extended PR Checklist

## Code

### Basics

- [ ] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [ ] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)