### PR TITLE
chore: add blackbox testing for tree view (delete interaction)

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -886,7 +886,7 @@ suite("NativeTreeView tests", function () {
     );
   });
 
-  describe.only("Delete Note Command interactions", function () {
+  describe("Delete Note Command interactions", function () {
     describeMultiWS(
       "WHEN deleting note with top level hierarchy",
       {

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "../testUtilsv2";
-import { describe } from "mocha";
+import { describe, beforeEach } from "mocha";
 import { EngineNoteProvider } from "../../views/EngineNoteProvider";
 import { describeMultiWS } from "../testUtilsV3";
 import { MockEngineEvents } from "./MockEngineEvents";
@@ -12,6 +12,7 @@ import path from "path";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
+import { DeleteNodeCommand } from "../../commands/DeleteNodeCommand";
 
 function getNoteUri(opts: { note: NoteProps; wsRoot: string }) {
   const { note, wsRoot } = opts;
@@ -48,6 +49,21 @@ async function runRenameNote(opts: { noteId: string; newName: string }) {
     noModifyWatcher: true,
   };
   await renameCmd.execute(renameOpts);
+}
+
+async function runDeleteNote(opts: { noteId: string }) {
+  const engine = ExtensionProvider.getEngine();
+
+  const { wsRoot } = engine;
+  const { noteId } = opts;
+  const noteToDelete = engine.notes[noteId];
+  const _fsPath = getNoteUri({ note: noteToDelete, wsRoot }).fsPath;
+  const deleteCmd = new DeleteNodeCommand();
+  const deleteOpts = {
+    _fsPath,
+    noConfirm: true,
+  };
+  await deleteCmd.execute(deleteOpts);
 }
 
 async function getFullTree(opts: {
@@ -870,5 +886,909 @@ suite("NativeTreeView tests", function () {
     );
   });
 
+  describe.only("Delete Note Command interactions", function () {
+    describeMultiWS(
+      "WHEN deleting note with top level hierarchy",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [],
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN deleting note with stub parent",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.bar",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note and stub parent", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [],
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo.bar" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN deleting note with non-stub parent",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.bar",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo.bar" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [],
+              },
+            ],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN deleting note with stub children",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.bar.egg",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note and replaces it with a stub", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [
+                      {
+                        fname: "foo.bar.egg",
+                        childNodes: [],
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [
+                      {
+                        fname: "foo.bar.egg",
+                        childNodes: [],
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN deleting note with non-stub children",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.bar",
+          });
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo.baz",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note and replaces it with a stub", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [],
+                  },
+                  {
+                    fname: "foo.baz",
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [
+                  {
+                    fname: "foo.bar",
+                    childNodes: [],
+                  },
+                  {
+                    fname: "foo.baz",
+                    childNodes: [],
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+        });
+      }
+    );
+    describeMultiWS(
+      "WHEN deleting note with chain of ancestors that are only stubs",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "one.two.three.foo",
+          });
+        },
+      },
+      () => {
+        test("THEN tree view correctly removes deleted note and all its ancestor stubs", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                        stub: true,
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "one.two.three.foo" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [],
+          });
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN deleting note that was just created",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+        },
+      },
+      () => {
+        describe("AND created note is top hierarchy", () => {
+          test("THEN tree view correctly removes deleted note", async () => {
+            const mockEvents = new MockEngineEvents();
+            const provider = new EngineNoteProvider(mockEvents);
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
+            await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "bar",
+              engine,
+            });
+            const propsBefore = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsBefore = propsBefore[0];
+            const fullTreeBefore = await getFullTree({
+              root: vaultOneRootPropsBefore,
+              provider,
+              extra: { stub: true },
+            });
+
+            expect(fullTreeBefore).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "bar",
+                  childNodes: [],
+                },
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+              ],
+            });
+
+            await runDeleteNote({ noteId: "bar" });
+
+            const propsAfter = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsAfter = propsAfter[0];
+            const fullTreeAfter = await getFullTree({
+              root: vaultOneRootPropsAfter,
+              provider,
+            });
+            expect(fullTreeAfter).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+              ],
+            });
+          });
+        });
+
+        describe("AND created note also creates stub parent", () => {
+          test("THEN tree view correctly removes deleted note and stub parent", async () => {
+            const mockEvents = new MockEngineEvents();
+            const provider = new EngineNoteProvider(mockEvents);
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
+            await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "bar.egg",
+              engine,
+            });
+            const propsBefore = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsBefore = propsBefore[0];
+            const fullTreeBefore = await getFullTree({
+              root: vaultOneRootPropsBefore,
+              provider,
+              extra: { stub: true },
+            });
+
+            expect(fullTreeBefore).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "bar",
+                  childNodes: [
+                    {
+                      fname: "bar.egg",
+                      childNodes: [],
+                    },
+                  ],
+                  stub: true,
+                },
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+              ],
+            });
+
+            await runDeleteNote({ noteId: "bar.egg" });
+
+            const propsAfter = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsAfter = propsAfter[0];
+            const fullTreeAfter = await getFullTree({
+              root: vaultOneRootPropsAfter,
+              provider,
+              extra: { stub: true },
+            });
+            expect(fullTreeAfter).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+              ],
+            });
+          });
+        });
+
+        describe("AND created note has stub children", () => {
+          test("THEN tree view correctly removes deleted note and replaces it with a stub", async () => {
+            const mockEvents = new MockEngineEvents();
+            const provider = new EngineNoteProvider(mockEvents);
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
+            await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "one.two.three",
+              engine,
+            });
+
+            await NoteTestUtilsV4.createNoteWithEngine({
+              wsRoot,
+              vault: vaults[0],
+              fname: "one.two",
+              engine,
+            });
+            const propsBefore = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsBefore = propsBefore[0];
+            const fullTreeBefore = await getFullTree({
+              root: vaultOneRootPropsBefore,
+              provider,
+              extra: { stub: true },
+            });
+
+            expect(fullTreeBefore).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+                {
+                  fname: "one",
+                  childNodes: [
+                    {
+                      fname: "one.two",
+                      childNodes: [
+                        {
+                          fname: "one.two.three",
+                          childNodes: [],
+                        },
+                      ],
+                    },
+                  ],
+                  stub: true,
+                },
+              ],
+            });
+
+            await runDeleteNote({ noteId: "one.two" });
+
+            const propsAfter = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+            const vaultOneRootPropsAfter = propsAfter[0];
+            const fullTreeAfter = await getFullTree({
+              root: vaultOneRootPropsAfter,
+              provider,
+              extra: { stub: true },
+            });
+            expect(fullTreeAfter).toEqual({
+              fname: "root",
+              childNodes: [
+                {
+                  fname: "foo",
+                  childNodes: [],
+                },
+                {
+                  fname: "one",
+                  childNodes: [
+                    {
+                      fname: "one.two",
+                      childNodes: [
+                        {
+                          fname: "one.two.three",
+                          childNodes: [],
+                        },
+                      ],
+                      stub: true,
+                    },
+                  ],
+                  stub: true,
+                },
+              ],
+            });
+          });
+        });
+      }
+    );
+    describeMultiWS("WHEN deleting note that was just renamed", {}, () => {
+      beforeEach(async () => {
+        const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
+        await NoteTestUtilsV4.createNoteWithEngine({
+          wsRoot,
+          vault: vaults[0],
+          fname: "foo",
+          engine,
+        });
+      });
+      describe("AND renamed note is top hierarchy", () => {
+        test("THEN tree view correctly removes note that was just renamed and deleted", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          await runRenameNote({
+            noteId: "foo",
+            newName: "bar",
+          });
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "bar",
+                childNodes: [],
+              },
+            ],
+          });
+
+          await runDeleteNote({
+            noteId: "foo",
+          });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [],
+          });
+        });
+      });
+
+      describe("AND renamed note created a stub parent", () => {
+        test("THEN tree view correctly removes note that was just renamed and deleted as well as the stub parent", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          await runRenameNote({
+            noteId: "foo",
+            newName: "one.two.three.foo",
+          });
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                        stub: true,
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+
+          await runDeleteNote({
+            noteId: "foo",
+          });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [],
+          });
+        });
+      });
+
+      describe("AND renamed note has any children", () => {
+        test("THEN THEN tree view correctly removes note that was just renamed and deleted and replaces it with a stub", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
+          await NoteTestUtilsV4.createNoteWithEngine({
+            wsRoot,
+            vault: vaults[0],
+            fname: "one.two.three.foo",
+            engine,
+          });
+
+          await runRenameNote({
+            noteId: "foo",
+            newName: "one.two.three",
+          });
+
+          const propsBefore = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsBefore = propsBefore[0];
+          const fullTreeBefore = await getFullTree({
+            root: vaultOneRootPropsBefore,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeBefore).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+
+          await runDeleteNote({ noteId: "foo" });
+
+          const propsAfter = await (provider.getChildren() as Promise<
+            NoteProps[]
+          >);
+          const vaultOneRootPropsAfter = propsAfter[0];
+          const fullTreeAfter = await getFullTree({
+            root: vaultOneRootPropsAfter,
+            provider,
+            extra: { stub: true },
+          });
+
+          expect(fullTreeAfter).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "one",
+                childNodes: [
+                  {
+                    fname: "one.two",
+                    childNodes: [
+                      {
+                        fname: "one.two.three",
+                        childNodes: [
+                          {
+                            fname: "one.two.three.foo",
+                            childNodes: [],
+                          },
+                        ],
+                        stub: true,
+                      },
+                    ],
+                    stub: true,
+                  },
+                ],
+                stub: true,
+              },
+            ],
+          });
+        });
+      });
+    });
+  });
   describe("filesystem change interactions", function () {});
 });


### PR DESCRIPTION
# chore: add blackbox testing for tree view (delete interaction)

This PR:
- Adds a suite of tests in an attempt to find issues with the tree view given some delete operations.
- This PR is test only (does not fix any issues)
  - Fortunately, after the two passes of engine fixes, typical cases of delete operations are not breaking the tree view.
## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 

## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)