### PR TITLE
chore: end the MEETING_NOTE_FEATURE_SHOWCASE_TEST a/b test

### DIFF
--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -11,6 +11,13 @@ export enum UpgradeToastWordingTestGroups {
   openChangelog = "openChangelog",
 }
 
+/**
+ * Section: Tests (Active or soon to be active)
+ *
+ * NOTE: please follow this convention for naming future tests:
+ * YYYY-MM-TEST_NAME.  For example, 2022-04-MEETING_NOTE_FEATURE_SHOWCASE
+ */
+
 /** Test if showing a web view on an upgrade is more successful than showing a toast notification. */
 export const UPGRADE_TOAST_WORDING_TEST = new ABTest(
   "UpgradeToastWordingTest",
@@ -110,7 +117,3 @@ export const CURRENT_AB_TESTS = [
   MEETING_NOTE_TUTORIAL_TEST,
   GRAPH_THEME_TEST,
 ];
-
-// Concluded Experiments (NOTE: make sure that you don't re-use these strings as
-// the name of a future AB Test to avoid conflicting strings):
-// - MeetingNoteFeatureShowcaseTest

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -15,7 +15,9 @@ export enum UpgradeToastWordingTestGroups {
  * Section: Tests (Active or soon to be active)
  *
  * NOTE: please follow this convention for naming future tests:
- * YYYY-MM-TEST_NAME.  For example, 2022-04-MEETING_NOTE_FEATURE_SHOWCASE
+ * YYYY-MM-TEST_NAME.  For example, 2022-04-MEETING_NOTE_FEATURE_SHOWCASE.
+ *
+ * See [[A/B Testing|dendron://dendron.docs/ref.ab-testing]] for more details.
  */
 
 /** Test if showing a web view on an upgrade is more successful than showing a toast notification. */

--- a/packages/plugin-core/src/abTests.ts
+++ b/packages/plugin-core/src/abTests.ts
@@ -70,20 +70,6 @@ export const MEETING_NOTE_TUTORIAL_TEST = new ABTest(
   ]
 );
 
-export const MEETING_NOTE_FEATURE_SHOWCASE_TEST = new ABTest(
-  "MeetingNoteFeatureShowcaseTest",
-  [
-    {
-      name: MeetingNoteTestGroups.show,
-      weight: 1,
-    },
-    {
-      name: MeetingNoteTestGroups.noShow,
-      weight: 1,
-    },
-  ]
-);
-
 export enum GraphThemeTestGroups {
   /**
    * New user will get Monokai graph theme by default
@@ -122,6 +108,9 @@ export const CURRENT_AB_TESTS = [
   UPGRADE_TOAST_WORDING_TEST,
   SELF_CONTAINED_VAULTS_TEST,
   MEETING_NOTE_TUTORIAL_TEST,
-  MEETING_NOTE_FEATURE_SHOWCASE_TEST,
   GRAPH_THEME_TEST,
 ];
+
+// Concluded Experiments (NOTE: make sure that you don't re-use these strings as
+// the name of a future AB Test to avoid conflicting strings):
+// - MeetingNoteFeatureShowcaseTest

--- a/packages/plugin-core/src/showcase/MeetingNotesTip.ts
+++ b/packages/plugin-core/src/showcase/MeetingNotesTip.ts
@@ -1,35 +1,14 @@
 import { assertUnreachable } from "@dendronhq/common-all";
-import { SegmentClient } from "@dendronhq/common-server";
 import { ShowcaseEntry } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
-import {
-  MeetingNoteTestGroups,
-  MEETING_NOTE_FEATURE_SHOWCASE_TEST,
-} from "../abTests";
-import { AnalyticsUtils } from "../utils/analytics";
 import {
   DisplayLocation,
   IFeatureShowcaseMessage,
 } from "./IFeatureShowcaseMessage";
 
 export class MeetingNotesTip implements IFeatureShowcaseMessage {
-  shouldShow(displayLocation: DisplayLocation): boolean {
-    switch (displayLocation) {
-      case DisplayLocation.InformationMessage: {
-        const ABUserGroup = MEETING_NOTE_FEATURE_SHOWCASE_TEST.getUserGroup(
-          SegmentClient.instance().anonymousId
-        );
-
-        return (
-          ABUserGroup === MeetingNoteTestGroups.show &&
-          !AnalyticsUtils.isFirstWeek()
-        );
-      }
-      case DisplayLocation.TipOfTheDayView:
-        return true;
-      default:
-        assertUnreachable(displayLocation);
-    }
+  shouldShow(_displayLocation: DisplayLocation): boolean {
+    return true;
   }
   get showcaseEntry(): ShowcaseEntry {
     return ShowcaseEntry.TryMeetingNotes;


### PR DESCRIPTION
## chore: end the MEETING_NOTE_FEATURE_SHOWCASE_TEST a/b test

We've collected enough data for this prompt test for Meeting Notes.  The effect of ending this test is that users in the B group will see the toast one time.  Users in the A group will not see the toast a second time.
