### PR TITLE
fix: highlighting misidentified capitalized header anchors on wikilinks as missing

### DIFF
--- a/packages/engine-server/src/markdown/decorations/wikilinks.ts
+++ b/packages/engine-server/src/markdown/decorations/wikilinks.ts
@@ -105,7 +105,7 @@ function checkIfAnchorIsValid({
   // wildcard header anchor or line anchor. These are hard to check, so let's just say they exist.
   if (anchor && /^[*L]/.test(anchor)) return true;
   // otherwise, check that the anchor actually exists inside the note
-  return allAnchors.includes(anchor);
+  return allAnchors.includes(anchor.toLowerCase());
 }
 
 export async function linkedNoteType({

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -104,6 +104,12 @@ suite("GIVEN a text document with decorations", function () {
       {
         preSetupHook: async ({ wsRoot, vaults }) => {
           await NoteTestUtilsV4.createNote({
+            fname: "withHeader",
+            vault: vaults[0],
+            wsRoot,
+            body: "## ipsam adipisci",
+          });
+          await NoteTestUtilsV4.createNote({
             fname: "tags.bar",
             vault: vaults[0],
             wsRoot,
@@ -128,6 +134,9 @@ suite("GIVEN a text document with decorations", function () {
               "[[with alias|root]]",
               "",
               "![[root.*#head]]",
+              "",
+              "[[withHeader#ipsam-adipisci]]",
+              "[[withHeader#does-not-exist]]",
               "",
               "[[does.not.exist]]",
               "",
@@ -177,7 +186,7 @@ suite("GIVEN a text document with decorations", function () {
             allDecorations,
             decorationType: EDITOR_DECORATION_TYPES.wikiLink,
           });
-          expect(wikilinkDecorations!.length).toEqual(7);
+          expect(wikilinkDecorations!.length).toEqual(8);
           expect(
             isTextDecorated("[[root]]", wikilinkDecorations!, document)
           ).toBeTruthy();
@@ -193,6 +202,13 @@ suite("GIVEN a text document with decorations", function () {
           ).toBeTruthy();
           expect(
             isTextDecorated("![[root.*#head]]", wikilinkDecorations!, document)
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "[[withHeader#ipsam-adipisci]]",
+              wikilinkDecorations!,
+              document
+            )
           ).toBeTruthy();
           expect(
             isTextDecorated("[[/test.txt]]", wikilinkDecorations!, document)
@@ -216,6 +232,13 @@ suite("GIVEN a text document with decorations", function () {
           expect(
             isTextDecorated(
               "[[does.not.exist]]",
+              brokenWikilinkDecorations!,
+              document
+            )
+          ).toBeTruthy();
+          expect(
+            isTextDecorated(
+              "[[withHeader#does-not-exist]]",
               brokenWikilinkDecorations!,
               document
             )

--- a/test-workspace/vault/dendron.ref.links.md
+++ b/test-workspace/vault/dendron.ref.links.md
@@ -2,7 +2,7 @@
 id: 73eb67ea-0291-45e7-8f2f-193fd6f00643
 title: Links
 desc: ""
-updated: 1650354689201
+updated: 1651563961085
 created: 1608518909864
 ---
 
@@ -52,6 +52,8 @@ Vault2
 ### Header
 
 ![[dendron.welcome#header1]]
+
+If the header is capitalized that also should work since they are case insensitive: ![[dendron.welcome#Header1]]
 
 ### With Special Characters
 


### PR DESCRIPTION
#2862

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)