### PR TITLE
fix: self contained vaults get cloned into the wrong directory

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -440,6 +440,13 @@ export function tmpDir(): DirResult {
   return dirPath;
 }
 
+/** Returns the path to where the notes are stored inside the vault.
+ *
+ * For self contained vaults, this is the `notes` folder inside of the vault.
+ * For other vault types, this is the root of the vault itself.
+ *
+ * If you always need the root of the vault, use {@link pathForVaultRoot} instead.
+ */
 export const vault2Path = ({
   vault,
   wsRoot,
@@ -449,6 +456,24 @@ export const vault2Path = ({
 }) => {
   return resolvePath(VaultUtils.getRelPath(vault), wsRoot);
 };
+
+/** Returns the root of the vault.
+ *
+ * This is similar to {@link vault2Path}, the only difference is that for self
+ * contained vaults `vault2Path` returns the `notes` folder inside the vault,
+ * while this returns the root of the vault.
+ */
+export function pathForVaultRoot({
+  vault,
+  wsRoot,
+}: {
+  vault: DVault;
+  wsRoot: string;
+}) {
+  if (VaultUtils.isSelfContained(vault))
+    return resolvePath(path.join(wsRoot, vault.fsPath));
+  return vault2Path({ vault, wsRoot });
+}
 
 export function writeJSONWithCommentsSync(fpath: string, data: any) {
   const payload = stringify(data, null, 4);

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -1101,13 +1101,13 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
         message: "Internal error: cloning non-git vault",
       });
     }
-    if (vault.workspace !== undefined || vault.seed !== undefined) {
-      throw new DendronError({
-        message:
-          "Internal error: can't clone workspace and seed vaults directly",
-      });
+    let repoPath: string;
+    if (vault.selfContained) {
+      // vault2Path gives the path to the `notes` folder for self contained vaults
+      repoPath = path.join(wsRoot, vault.fsPath);
+    } else {
+      repoPath = vault2Path({ vault, wsRoot });
     }
-    const repoPath = path.join(wsRoot, vault.fsPath);
     this.logger.info({ msg: "cloning", repoPath });
     const git = simpleGit({ baseDir: wsRoot });
     await git.clone(urlTransformer(vault.remote.url), repoPath);

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -32,6 +32,7 @@ import {
   DLogger,
   GitUtils,
   note2File,
+  pathForVaultRoot,
   readJSONWithComments,
   schemaModuleOpts2File,
   simpleGit,
@@ -1101,13 +1102,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
         message: "Internal error: cloning non-git vault",
       });
     }
-    let repoPath: string;
-    if (vault.selfContained) {
-      // vault2Path gives the path to the `notes` folder for self contained vaults
-      repoPath = path.join(wsRoot, vault.fsPath);
-    } else {
-      repoPath = vault2Path({ vault, wsRoot });
-    }
+    const repoPath = pathForVaultRoot({ vault, wsRoot });
     this.logger.info({ msg: "cloning", repoPath });
     const git = simpleGit({ baseDir: wsRoot });
     await git.clone(urlTransformer(vault.remote.url), repoPath);

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -1446,7 +1446,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       await Promise.all(
         _.map(workspaces, async (wsEntry, wsName) => {
           const wsPath = path.join(wsRoot, wsName);
-          if (!fs.existsSync(wsPath)) {
+          if (!(await fs.pathExists(wsPath))) {
             return {
               wsPath: await this.cloneWorkspace({
                 wsName,
@@ -1503,7 +1503,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     const emptyRemoteVaults = vaults.filter(
       (vault) =>
         !_.isUndefined(vault.remote) &&
-        !fs.existsSync(vault2Path({ vault, wsRoot }))
+        !fs.existsSync(path.join(wsRoot, vault.fsPath))
     );
     const didClone =
       !_.isEmpty(emptyRemoteVaults) ||

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -1097,9 +1097,17 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     });
     const wsRoot = this.wsRoot;
     if (!vault.remote || vault.remote.type !== "git") {
-      throw new DendronError({ message: "cloning non-git vault" });
+      throw new DendronError({
+        message: "Internal error: cloning non-git vault",
+      });
     }
-    const repoPath = vault2Path({ wsRoot, vault });
+    if (vault.workspace !== undefined || vault.seed !== undefined) {
+      throw new DendronError({
+        message:
+          "Internal error: can't clone workspace and seed vaults directly",
+      });
+    }
+    const repoPath = path.join(wsRoot, vault.fsPath);
     this.logger.info({ msg: "cloning", repoPath });
     const git = simpleGit({ baseDir: wsRoot });
     await git.clone(urlTransformer(vault.remote.url), repoPath);


### PR DESCRIPTION
Fixes a bug where self contained vaults would get cloned into the wrong directory at startup if they were missing.

