### PR TITLE
enhance(workspace): detect and warn for duplicate note IDs

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -130,6 +130,7 @@ export enum ContextualUIEvents {
 
 export enum WorkspaceEvents {
   AutoFix = "AutoFix",
+  DuplicateNoteFound = "DuplicateNoteFound",
 }
 
 export enum NativeWorkspaceEvents {

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -25,7 +25,7 @@ import {
   WriteNoteResp,
 } from ".";
 import { ThemeTarget, ThemeType } from "./constants";
-import { DendronError } from "./error";
+import { DendronError, IDendronError } from "./error";
 import {
   DEngineInitPayload,
   GetDecorationsPayload,
@@ -112,7 +112,7 @@ interface IDoRequestArgs {
  @deprecated - use RespV2 instead
   */
 type APIPayload<T = any> = {
-  error: DendronError | null;
+  error: IDendronError | null;
   data?: T;
 };
 

--- a/packages/common-all/src/types/errorTypes.ts
+++ b/packages/common-all/src/types/errorTypes.ts
@@ -1,0 +1,63 @@
+import { ERROR_SEVERITY } from "../constants";
+import { DendronError, DendronErrorProps, IDendronError } from "../error";
+import { VaultUtils } from "../vault";
+import { NoteProps } from "./foundation";
+import { DVault } from "./workspace";
+
+/** The error codes of errors that can occur during engine init. */
+export enum EngineInitErrorType {
+  DUPLICATE_NOTE_ID = "duplicate note id",
+}
+
+/** A duplicate note ID error.
+ *
+ * Note IDs must be unique, duplicate note IDs can cause issues in many parts of
+ * Dendron. This error occurs when a duplicate note ID is detected during engine
+ * init. It's non-fatal because most of Dendron will still function after this
+ * error.
+ */
+export class DuplicateNoteError extends DendronError<EngineInitErrorType.DUPLICATE_NOTE_ID> {
+  constructor(
+    opts: Omit<
+      DendronErrorProps<EngineInitErrorType.DUPLICATE_NOTE_ID>,
+      "name" | "message" | "severity"
+    > & {
+      noteA: NoteProps;
+      noteB: NoteProps;
+    }
+  ) {
+    super({
+      ...opts,
+      severity: ERROR_SEVERITY.MINOR,
+      message: `Notes ${opts.noteA.fname} in ${VaultUtils.getName(
+        opts.noteA.vault
+      )} and ${opts.noteB.fname} in ${VaultUtils.getName(
+        opts.noteB.vault
+      )} have duplicate IDs.`,
+      code: EngineInitErrorType.DUPLICATE_NOTE_ID,
+    });
+    this.noteA = {
+      fname: opts.noteA.fname,
+      vault: opts.noteA.vault,
+    };
+    this.noteB = {
+      fname: opts.noteB.fname,
+      vault: opts.noteB.vault,
+    };
+  }
+
+  public noteA: {
+    fname: string;
+    vault: DVault;
+  };
+  public noteB: {
+    fname: string;
+    vault: DVault;
+  };
+
+  static isDuplicateNoteError(
+    error: IDendronError<any>
+  ): error is DuplicateNoteError {
+    return error.code === EngineInitErrorType.DUPLICATE_NOTE_ID;
+  }
+}

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -18,6 +18,7 @@ export * from "./lookup";
 export * from "./unified";
 export * from "./events";
 export * from "./cacheData";
+export * from "./errorTypes";
 
 export type Stage = "dev" | "prod" | "test";
 export type DEngineQuery = {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -249,7 +249,7 @@ export type RespV3<T> =
 
 export type BooleanResp =
   | { data: true; error: null }
-  | { data: false; error: DendronError };
+  | { data: false; error: IDendronError };
 
 export function isDendronResp<T = any>(args: any): args is RespV2<T> {
   return args?.error instanceof DendronError;
@@ -263,7 +263,7 @@ export type RespRequired<T> =
       error: null | undefined;
       data: T;
     }
-  | { error: DendronError; data: undefined };
+  | { error: IDendronError; data: undefined };
 
 export interface QueryOptsV2 {
   /**

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -47,6 +47,9 @@ import {
   NoteChangeUpdateEntry,
   DNodeUtils,
   asyncLoopOneAtATime,
+  BaseDendronError,
+  StatusCodes,
+  DendronErrorProps,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -66,6 +69,60 @@ import { NoteParser } from "./noteParser";
 import { SchemaParser } from "./schemaParser";
 import { InMemoryNoteCache } from "../../util/inMemoryNoteCache";
 import { NotesFileSystemCache } from "../../cache";
+
+export enum EngineInitErrorType {
+  DUPLICATE_NOTE_ID = "duplicate note id",
+}
+
+export class DuplicateNoteError extends BaseDendronError<EngineInitErrorType.DUPLICATE_NOTE_ID> {
+  translateToHTTPErrorCode(): StatusCodes | undefined {
+    return StatusCodes.INTERNAL_SERVER_ERROR;
+  }
+
+  constructor(
+    opts: Omit<
+      DendronErrorProps<EngineInitErrorType.DUPLICATE_NOTE_ID>,
+      "name" | "message" | "severity"
+    > & {
+      noteA: NoteProps;
+      noteB: NoteProps;
+    }
+  ) {
+    super({
+      ...opts,
+      severity: ERROR_SEVERITY.MINOR,
+      message: `Notes ${opts.noteA.fname} in ${VaultUtils.getName(
+        opts.noteA.vault
+      )} and ${opts.noteB.fname} in ${VaultUtils.getName(
+        opts.noteB.vault
+      )} have duplicate IDs.`,
+      code: EngineInitErrorType.DUPLICATE_NOTE_ID,
+    });
+    this.noteA = {
+      fname: opts.noteA.fname,
+      vault: opts.noteA.vault,
+    };
+    this.noteB = {
+      fname: opts.noteB.fname,
+      vault: opts.noteB.vault,
+    };
+  }
+
+  public noteA: {
+    fname: string;
+    vault: DVault;
+  };
+  public noteB: {
+    fname: string;
+    vault: DVault;
+  };
+
+  static isDuplicateNoteError(
+    error: IDendronError<any>
+  ): error is DuplicateNoteError {
+    return Object.values(EngineInitErrorType).includes(error.code);
+  }
+}
 
 export class FileStorage implements DStore {
   public vaults: DVault[];
@@ -104,7 +161,7 @@ export class FileStorage implements DStore {
   }
 
   async init(): Promise<DEngineInitResp> {
-    let errors: DendronError[] = [];
+    let errors: IDendronError<any>[] = [];
     try {
       const resp = await this.initSchema();
       if (ResponseUtil.hasError(resp)) {
@@ -116,6 +173,16 @@ export class FileStorage implements DStore {
       const { notes: _notes, errors: initErrors } = await this.initNotes();
       errors = errors.concat(initErrors);
       _notes.map((ent) => {
+        // Check for duplicate IDs when adding notes to the map
+        if (this.notes[ent.id] !== undefined) {
+          const duplicate = this.notes[ent.id];
+          errors.push(
+            new DuplicateNoteError({
+              noteA: duplicate,
+              noteB: ent,
+            })
+          );
+        }
         this.notes[ent.id] = ent;
         this.noteFnames.add(ent);
       });

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -47,9 +47,7 @@ import {
   NoteChangeUpdateEntry,
   DNodeUtils,
   asyncLoopOneAtATime,
-  BaseDendronError,
-  StatusCodes,
-  DendronErrorProps,
+  DuplicateNoteError,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -69,60 +67,6 @@ import { NoteParser } from "./noteParser";
 import { SchemaParser } from "./schemaParser";
 import { InMemoryNoteCache } from "../../util/inMemoryNoteCache";
 import { NotesFileSystemCache } from "../../cache";
-
-export enum EngineInitErrorType {
-  DUPLICATE_NOTE_ID = "duplicate note id",
-}
-
-export class DuplicateNoteError extends BaseDendronError<EngineInitErrorType.DUPLICATE_NOTE_ID> {
-  translateToHTTPErrorCode(): StatusCodes | undefined {
-    return StatusCodes.INTERNAL_SERVER_ERROR;
-  }
-
-  constructor(
-    opts: Omit<
-      DendronErrorProps<EngineInitErrorType.DUPLICATE_NOTE_ID>,
-      "name" | "message" | "severity"
-    > & {
-      noteA: NoteProps;
-      noteB: NoteProps;
-    }
-  ) {
-    super({
-      ...opts,
-      severity: ERROR_SEVERITY.MINOR,
-      message: `Notes ${opts.noteA.fname} in ${VaultUtils.getName(
-        opts.noteA.vault
-      )} and ${opts.noteB.fname} in ${VaultUtils.getName(
-        opts.noteB.vault
-      )} have duplicate IDs.`,
-      code: EngineInitErrorType.DUPLICATE_NOTE_ID,
-    });
-    this.noteA = {
-      fname: opts.noteA.fname,
-      vault: opts.noteA.vault,
-    };
-    this.noteB = {
-      fname: opts.noteB.fname,
-      vault: opts.noteB.vault,
-    };
-  }
-
-  public noteA: {
-    fname: string;
-    vault: DVault;
-  };
-  public noteB: {
-    fname: string;
-    vault: DVault;
-  };
-
-  static isDuplicateNoteError(
-    error: IDendronError<any>
-  ): error is DuplicateNoteError {
-    return Object.values(EngineInitErrorType).includes(error.code);
-  }
-}
 
 export class FileStorage implements DStore {
   public vaults: DVault[];

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -16,6 +16,7 @@ import {
   VaultUtils,
   ConfigUtils,
   DEngineClient,
+  IDendronError,
 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
 import { RemarkUtils } from "../remark";
@@ -241,7 +242,7 @@ function convertNoteRef(opts: ConvertNoteRefOpts): {
   data: string | undefined;
 } {
   let data: string | undefined;
-  const errors: DendronError[] = [];
+  const errors: IDendronError[] = [];
   const { link, proc, compilerOpts } = opts;
   const procData = MDUtilsV5.getProcData(proc);
   const { noteRefLvl: refLvl, dest, config, fname } = procData;
@@ -478,7 +479,7 @@ export function convertNoteRefASTV2(
     }
   }
 
-  const errors: DendronError[] = [];
+  const errors: IDendronError[] = [];
   const { link, proc, compilerOpts, procOpts } = opts;
   const procData = MDUtilsV5.getProcData(proc);
   const { noteRefLvl: refLvl } = procData;

--- a/packages/plugin-core/src/commands/ReloadIndex.ts
+++ b/packages/plugin-core/src/commands/ReloadIndex.ts
@@ -1,6 +1,5 @@
 import {
   ConfigEvents,
-  DendronCompositeError,
   DEngineClient,
   DVault,
   ERROR_SEVERITY,
@@ -11,6 +10,8 @@ import {
   SchemaUtils,
   VaultUtils,
   WorkspaceEvents,
+  DuplicateNoteError,
+  errorsList,
 } from "@dendronhq/common-all";
 import {
   getDurationMilliseconds,
@@ -18,11 +19,7 @@ import {
   schemaModuleOpts2File,
   vault2Path,
 } from "@dendronhq/common-server";
-import {
-  DoctorActionsEnum,
-  DoctorService,
-  DuplicateNoteError,
-} from "@dendronhq/engine-server";
+import { DoctorActionsEnum, DoctorService } from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -240,8 +237,8 @@ export class ReloadIndexCommand extends BasicCommand<
       }
       if (error) {
         // There may be one or more errors,
-        const errorsList = DendronCompositeError.errorsList(error);
-        errorsList.forEach((error) => {
+        const errors = errorsList(error);
+        errors.forEach((error) => {
           if (DuplicateNoteError.isDuplicateNoteError(error) && error.code) {
             VSCodeUtils.showMessage(MessageSeverity.WARN, error.message, {});
             AnalyticsUtils.track(WorkspaceEvents.DuplicateNoteFound);
@@ -255,7 +252,7 @@ export class ReloadIndexCommand extends BasicCommand<
             });
           }
         });
-        if (errorsList.length === 0) {
+        if (errors.length === 0) {
           // For backwards compatibility, warn if there are warnings that are
           // non-fatal errors not covered by the new error architecture
           this.L.error({ ctx, error, msg: "init error" });

--- a/packages/plugin-core/src/logger.ts
+++ b/packages/plugin-core/src/logger.ts
@@ -1,4 +1,8 @@
-import { DendronError, error2PlainObject, setEnv } from "@dendronhq/common-all";
+import {
+  error2PlainObject,
+  IDendronError,
+  setEnv,
+} from "@dendronhq/common-all";
 import { createLogger } from "@dendronhq/common-server";
 import * as Sentry from "@sentry/node";
 import fs from "fs-extra";
@@ -19,7 +23,7 @@ export type TraceLevel = "debug" | "info" | "warn" | "error" | "fatal";
 const levels = ["debug", "info", "warn", "error", "fatal"];
 export type LogPayload = Partial<{
   ctx: string;
-  error: DendronError;
+  error: IDendronError;
   msg: string;
 }>;
 


### PR DESCRIPTION
Adds a warning when there are notes with duplicate IDs detected during initialization or reload.

![2022-05-04-17-17-54-532462625](https://user-images.githubusercontent.com/1008124/166827484-4e1c1cc5-4767-48a0-868f-0d84bf38f2af.png)

Also refactors error handling to match what was discussed in the previous PR.