### PR TITLE
enhance: quick fix to make dendron side bar visible when dendron not …

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -101,8 +101,7 @@
         },
         {
           "id": "dendron.help-and-feedback",
-          "name": "Help and Feedback",
-          "when": "dendron:pluginActive"
+          "name": "Help and Feedback"
         }
       ]
     },


### PR DESCRIPTION
## enhance: quick fix to make dendron side bar visible when dendron not active

Quick cheap fix to make Dendron Icon not disappear during reload workspace (this can make user's visible side panel switch upon reload index).  This will make the 'help and feedback' section always active, and hence keep the Dendron container group non-empty and keep the Dendron icon around.  

Next step is to add the 'recent vaults/workspaces' panel and show that as well.