### PR TITLE
enhance: display workspace information in full graph view

### DIFF
--- a/packages/dendron-next-server/styles/scss/main.scss
+++ b/packages/dendron-next-server/styles/scss/main.scss
@@ -50,4 +50,8 @@ $text-color: #111 !default;
 		border: 1px solid white; padding:10px; // required for tables in preview
 	}
 }
+.ant-message {
+  bottom: 5vh;
+  top: initial !important; // by-default top is 8
+}
 // TODO_END

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -11,6 +11,7 @@ import {
   milliseconds,
 } from "@dendronhq/common-all";
 import { createLogger, engineSlice } from "@dendronhq/common-frontend";
+import { message } from "antd";
 import { EdgeDefinition } from "cytoscape";
 import _ from "lodash";
 import { useEffect, useState } from "react";
@@ -21,6 +22,7 @@ import {
   GraphElements,
   GraphNodes,
 } from "../utils/graph";
+import { RiseOutlined } from "@ant-design/icons";
 
 const getVaultClass = (vault: DVault) => {
   const vaultName = VaultUtils.getName(vault);
@@ -576,7 +578,7 @@ const useGraphElements = ({
   logger.log({ msg: "enter", activeNoteId: noteActive?.id });
   const [noteCount, setNoteCount] = useState(0);
   const [schemaCount, setSchemaCount] = useState(0);
-
+  const [fullGraphVisited, setFullGraphVisited] = useState(false);
   const isLocalGraph = GraphUtils.isLocalGraph(config);
 
   // Prevent unnecessary parsing if no notes have been added/deleted and toggle Full NoteGraph on config change
@@ -621,6 +623,18 @@ const useGraphElements = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [noteActive, engine.notes, isLocalGraph]);
+
+  useEffect(() => {
+    if (type === "note" && !isLocalGraph && !fullGraphVisited) {
+      message.info({
+        content: `Your second brain is evolving... You have ${noteCount} notes connected internally with ${elements.edges.links?.length} links.`,
+        duration: 5,
+        icon: <RiseOutlined />,
+      });
+      setFullGraphVisited(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elements]);
 
   // Prevent unnecessary parsing if no schemas have been added/deleted
   useEffect(() => {

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -625,9 +625,18 @@ const useGraphElements = ({
   }, [noteActive, engine.notes, isLocalGraph]);
 
   useEffect(() => {
-    if (type === "note" && !isLocalGraph && !fullGraphVisited) {
+    if (
+      type === "note" &&
+      !isLocalGraph &&
+      !fullGraphVisited &&
+      noteCount > 0
+    ) {
       message.info({
-        content: `Your second brain is evolving... You have ${noteCount} notes connected internally with ${elements.edges.links?.length} links.`,
+        content: `Your second brain is evolving... You have ${noteCount} notes ${
+          elements.edges.links
+            ? `connected internally with ${elements.edges.links?.length} links`
+            : "."
+        }`,
         duration: 5,
         icon: <RiseOutlined />,
       });


### PR DESCRIPTION
This PR aims to highlight workspace information when `Full Graph View` is open for the first time. The message is autoclosable in 5s.
<img src="https://user-images.githubusercontent.com/84971366/167094601-107c81c9-a7c6-4ef4-911c-ba06085c9d09.png" width="500" height="500">

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [~] check whether code be simplified
  - [~] check if similar function already exist in the codebase. if so, can it be re-used?
  - [~] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
NA