### PR TITLE
chore: enhancing meeting note telemetry

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -143,6 +143,7 @@ export enum NativeWorkspaceEvents {
 export enum EngagementEvents {
   NoteViewed = "NoteViewed",
   EngineStateChanged = "EngineStateChanged",
+  AdditionalNoteFromMeetingNoteCreated = "AdditionalNoteFromMeetingNoteCreated",
 }
 
 export enum AppNames {

--- a/packages/plugin-core/src/commands/CreateTask.ts
+++ b/packages/plugin-core/src/commands/CreateTask.ts
@@ -9,6 +9,7 @@ import { BasicCommand } from "./base";
 import { CommandOutput as NoteLookupOutput } from "./NoteLookupCommand";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 import { ExtensionProvider } from "../ExtensionProvider";
+import { maybeSendMeetingNoteTelemetry } from "../utils/MeetingTelemHelper";
 
 type CommandOpts = {};
 
@@ -37,6 +38,8 @@ export class CreateTaskCommand extends BasicCommand<
     const { config } = ExtensionProvider.getDWorkspace();
     const { createTaskSelectionType, addBehavior } =
       ConfigUtils.getTask(config);
+
+    maybeSendMeetingNoteTelemetry("task");
 
     return {
       lookup: AutoCompletableRegistrar.getNoteLookupCmd().run({

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -275,7 +275,9 @@ export class GotoNoteCommand extends BasicCommand<
     let pos: undefined | Position;
     const out = await this.extension.pauseWatchers<GoToNoteCommandOutput>(
       async () => {
-        const existing = await client.getNoteByPath({
+        // First query to see if the note exists to determine if we will send
+        // telemetry, createIfNew set to false
+        const respFromExistenceCheck = await client.getNoteByPath({
           npath: qs,
           createIfNew: false,
           vault,
@@ -292,7 +294,7 @@ export class GotoNoteCommand extends BasicCommand<
 
         // If a new note is going to be created, check if we should send meeting
         // note telemetry.
-        if (!existing.data?.note) {
+        if (!respFromExistenceCheck.data?.note) {
           let type = "general";
 
           if (qs.startsWith("user.")) {

--- a/packages/plugin-core/src/utils/MeetingTelemHelper.ts
+++ b/packages/plugin-core/src/utils/MeetingTelemHelper.ts
@@ -1,0 +1,42 @@
+import { NoteProps, EngagementEvents } from "@dendronhq/common-all";
+import _ from "lodash";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { AnalyticsUtils } from "./analytics";
+
+/**
+ * Send a special telemetry marker if a note is being created from a Meeting
+ * Note. If the current active editor isn't a meeting note, nothing is sent.
+ *
+ * This functionality can be removed after enough data is collected.
+ *
+ * @param type - will be attached to the telemetry data payload
+ * @returns
+ */
+export function maybeSendMeetingNoteTelemetry(type: string) {
+  const maybeEditor = VSCodeUtils.getActiveTextEditor()!;
+  if (_.isUndefined(maybeEditor)) {
+    return;
+  }
+
+  const activeNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+    maybeEditor.document
+  ) as NoteProps & { traitIds?: string[] };
+
+  if (_.isUndefined(activeNote)) {
+    return;
+  }
+
+  if (
+    activeNote &&
+    activeNote.traitIds &&
+    activeNote.traitIds.includes("meetingNote")
+  ) {
+    AnalyticsUtils.track(
+      EngagementEvents.AdditionalNoteFromMeetingNoteCreated,
+      {
+        type,
+      }
+    );
+  }
+}


### PR DESCRIPTION
## chore: enhancing meeting note telemetry #2888

Adding telemetry to let us know when a user is creating a note from a Meeting Note. This is meant to test the hypothesis that Meeting Notes will lead to users creating more notes.
