### PR TITLE
chore: make full graph view as default

### DIFF
--- a/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
+++ b/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
@@ -33,6 +33,7 @@ type FilterProps = {
   updateConfigField: (key: string, value: string | number | boolean) => void;
   isGraphReady: boolean;
   customCSS?: string;
+  type?: "note" | "schema";
 };
 
 const GraphFilterView = ({
@@ -40,6 +41,7 @@ const GraphFilterView = ({
   updateConfigField,
   isGraphReady,
   customCSS,
+  type,
 }: FilterProps) => {
   const [showView, setShowView] = useState(false);
   const { currentTheme } = useCurrentTheme();
@@ -115,14 +117,16 @@ const GraphFilterView = ({
             updateConfigField={updateConfigField}
           />
         </Panel>
-        <Panel header="Graph Theme" key="graphTheme">
-          <FilterViewSection
-            section="graphTheme"
-            config={config}
-            updateConfigField={updateConfigField}
-            customCSS={customCSS}
-          />
-        </Panel>
+        {type === "note" && (
+          <Panel header="Graph Theme" key="graphTheme">
+            <FilterViewSection
+              section="graphTheme"
+              config={config}
+              updateConfigField={updateConfigField}
+              customCSS={customCSS}
+            />
+          </Panel>
+        )}
       </Collapse>
     </Space>
   );

--- a/packages/dendron-plugin-views/src/components/graph.tsx
+++ b/packages/dendron-plugin-views/src/components/graph.tsx
@@ -346,6 +346,7 @@ export default function Graph({
           isGraphReady={isReady}
           updateConfigField={updateConfigField}
           customCSS={ide.graphStyles}
+          type={type}
         />
         {type === "note" && (
           <div
@@ -376,6 +377,7 @@ export default function Graph({
             width: "100%",
             height: "100%",
             zIndex: 1,
+            display: showNoteGraphMessage ? "none" : "block",
           }}
         />
       </div>

--- a/packages/dendron-plugin-views/src/hooks/useApplyGraphConfig.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useApplyGraphConfig.tsx
@@ -15,7 +15,7 @@ const useApplyGraphConfig = ({
 }) => {
   const { nodes, edges } = elements;
   const isLargeGraph = nodes.length + Object.values(edges).flat().length > 1000;
-  const [wasLocalGraph, setWasLocalGraph] = useState(true);
+  const [wasLocalGraph, setWasLocalGraph] = useState(false);
 
   const applyDisplayConfig = (allowRelayout: boolean) => {
     if (!graph || graph.$("*").length === 0) return;

--- a/packages/dendron-plugin-views/src/hooks/useSyncGraphWithIDE.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useSyncGraphWithIDE.tsx
@@ -47,10 +47,6 @@ const useSyncGraphWithIDE = ({ graph, ide, engine, config }: Props) => {
       ) {
         graphActiveNode.select();
         graph.center(graphActiveNode);
-        graph.zoom({
-          level: 1.5, // the zoom level
-          renderedPosition: graphActiveNode.position(),
-        });
 
         setLastSelectedID(graphActiveNode.id());
       }

--- a/packages/dendron-plugin-views/src/utils/graph.ts
+++ b/packages/dendron-plugin-views/src/utils/graph.ts
@@ -93,7 +93,7 @@ const coreGraphConfig: CoreGraphConfig = {
 
 const noteGraphConfig: NoteGraphConfig = {
   "connections.links": {
-    value: true,
+    value: false,
     mutable: true,
   },
   "information.edges-links": {
@@ -105,7 +105,7 @@ const noteGraphConfig: NoteGraphConfig = {
     mutable: true,
   },
   "options.show-local-graph": {
-    value: true,
+    value: false,
     mutable: true,
   },
 };


### PR DESCRIPTION
This PR aims to:
- Make Full Graph view as default view when you first open the graph.
- Hides Graph Theme for Schema graph view
- fixes the following bug with display of [Note Graph Message](https://github.com/dendronhq/dendron/blob/chore/make-full-graph-view-as-default/packages/dendron-plugin-views/src/components/graph.tsx#L406:L406) overlaps with full note graph in background

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)