### PR TITLE
chore: fixing messageType prop in tip of day telem

### DIFF
--- a/packages/plugin-core/src/features/TipOfTheDayWebview.ts
+++ b/packages/plugin-core/src/features/TipOfTheDayWebview.ts
@@ -61,18 +61,18 @@ export default class TipOfTheDayWebview implements vscode.WebviewViewProvider {
     webviewView.webview.html = this.getContent(this._currentTip);
 
     webviewView.webview.onDidReceiveMessage(
-      async (message) => {
-        switch (message.command) {
+      async (messageFromWebview) => {
+        switch (messageFromWebview.command) {
           case this.TIP_SHOWN_MSG:
             AnalyticsUtils.track(VSCodeEvents.FeatureShowcaseDisplayed, {
-              messageType: message.showcaseEntry,
+              messageType: this._currentTip.showcaseEntry,
               displayLocation: DisplayLocation.TipOfTheDayView,
             });
             return;
 
           case this.BUTTON_CLICKED_MSG: {
             AnalyticsUtils.track(VSCodeEvents.FeatureShowcaseResponded, {
-              messageType: message.showcaseEntry,
+              messageType: this._currentTip.showcaseEntry,
               displayLocation: DisplayLocation.TipOfTheDayView,
               userResponse: FeatureShowcaseUserResponse.confirmed,
             });


### PR DESCRIPTION
## chore: fixing messageType prop in tip of day telem

Fixing the `messageType` property of the `FeatureShowcaseDisplayed` event for the 'Tip of the Day' view. It's currently reporting blank.

Verified the behavior under the debugger.  Updated Airtable record.