### PR TITLE
fix(publishing): images without leading forward slashes are broken when published in some setups

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -118,12 +118,10 @@ class ImageNodeHandler extends DendronNodeHander {
       ? publishingConfig.assetsPrefix
       : cOpts?.assetsPrefix;
     const imageNode = node;
-    if (assetsPrefix) {
+
+    if (!isWebUri(imageNode.url)) {
       const imageUrl = _.trim(imageNode.url, "/");
-      // do not add assetPrefix for http/https url
-      imageNode.url = !isWebUri(imageUrl)
-        ? "/" + _.trim(assetsPrefix, "/") + "/" + imageUrl
-        : imageUrl;
+      imageNode.url = "/" + (assetsPrefix ? assetsPrefix + "/" : "") + imageUrl;
     }
     return { node: imageNode };
   }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -686,7 +686,7 @@ VFile {
 exports[`GIVEN dendronPub (old tests - need to be migrated) prefix imagePrefix 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
-<p><img src=\\"image-url.jpg\\" alt=\\"alt-text\\"></p>
+<p><img src=\\"/image-url.jpg\\" alt=\\"alt-text\\"></p>
 <hr>
 <strong>Children</strong>
 <ol>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -282,7 +282,7 @@ describe("GIVEN dendronPub (old tests - need to be migrated)", () => {
           assetsPrefix: "bond/",
         }
       ).processSync(`![alt-text](image-url.jpg)`);
-      await checkVFile(out, '<img src="image-url.jpg" alt="alt-text">');
+      await checkVFile(out, '<img src="/image-url.jpg" alt="alt-text">');
     });
 
     testWithEngine(

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utilsv5.spec.ts
@@ -74,7 +74,7 @@ describe("MDUtils.proc", () => {
           } = cleanVerifyOpts(opts);
           await checkString(
             resp.contents,
-            `<img src="assets/foo.jpg" alt="foo alt txt">`
+            `<img src="/assets/foo.jpg" alt="foo alt txt">`
           );
         },
         [ProcFlavor.PREVIEW]: ProcFlavor.REGULAR,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/image.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/image.spec.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GIVEN image link WHEN assetPrefix is NOT set "HTML: ASSET_PREFIX_SET: PUBLISHING" 1`] = `
+VFile {
+  "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
+<p><img src=\\"/some-image-link.png\\" alt=\\"some-image\\"></p>
+<hr>
+<strong>Children</strong>
+<ol>
+<li><a href=\\"/notes/foo.ch1\\">Ch1</a></li>
+</ol>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
 exports[`GIVEN image link WHEN assetPrefix is set and and image url is not local  "HTML: REMOTE_IMAGE: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
@@ -19,7 +35,7 @@ VFile {
 exports[`GIVEN image link WHEN assetPrefix set "HTML: ASSET_PREFIX_SET: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
-<p><img src=\\"/some-prefix/some-image-link.png\\" alt=\\"some-image\\"></p>
+<p><img src=\\"//some-prefix/some-image-link.png\\" alt=\\"some-image\\"></p>
 <hr>
 <strong>Children</strong>
 <ol>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
@@ -7,6 +7,31 @@ import { createProcCompileTests } from "../utils";
 import { getOpts, runTestCases } from "./utils";
 
 describe("GIVEN image link", () => {
+  describe("WHEN assetPrefix is NOT set", () => {
+    runTestCases(
+      createProcCompileTests({
+        name: "ASSET_PREFIX_SET",
+        setup: async (opts) => {
+          const { proc } = getOpts(opts);
+          const txt = `![some-image](some-image-link.png)`;
+          const resp = await proc.process(txt);
+          return { resp, proc };
+        },
+        verify: {
+          [DendronASTDest.HTML]: {
+            [ProcFlavor.PUBLISHING]: async ({ extra }) => {
+              const { resp } = extra;
+              expect(resp).toMatchSnapshot();
+              await checkString(resp.contents, "/some-image-link.png");
+            },
+          },
+        },
+        preSetupHook: async (opts) => {
+          await ENGINE_HOOKS.setupBasic({ ...opts, extra: { idv2: true } });
+        },
+      })
+    );
+  });
   describe("WHEN assetPrefix set", () => {
     runTestCases(
       createProcCompileTests({


### PR DESCRIPTION
Fixes a bug where images without leading slashes in the URL would be broken in publishing if there is no `assetsPrefix` set.

For example, `![](assets/image.jpg)` would be exported as `<img src="assets/image.jpg">` which is the wrong path.

Fixed existing tests which were checking for the wrong value, and added a new test to cover this case.

#2860

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)