### PR TITLE
chore: adding links telemetry to InitializeWorkspace event props

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -255,10 +255,39 @@ class ExtensionUtils {
       type: workspaceType,
       config: dendronConfig,
     } = workspace;
-    let numNotes = _.size(engine.notes);
-    if (numNotes > 10) {
-      numNotes = Math.round(numNotes / 10) * 10;
-    }
+    const numNotes = _.size(engine.notes);
+
+    let numNoteRefs = 0;
+    let numWikilinks = 0;
+    let numBacklinks = 0;
+    let numLinkCandidates = 0;
+    let numFrontmatterTags = 0;
+
+    // Takes about ~10 ms to compute in org-workspace
+    Object.values(engine.notes).forEach((val) => {
+      val.links.forEach((link) => {
+        switch (link.type) {
+          case "ref":
+            numNoteRefs += 1;
+            break;
+          case "wiki":
+            numWikilinks += 1;
+            break;
+          case "backlink":
+            numBacklinks += 1;
+            break;
+          case "linkCandidate":
+            numLinkCandidates += 1;
+            break;
+          case "frontmatterTag":
+            numFrontmatterTags += 1;
+            break;
+          default:
+            break;
+        }
+      });
+    });
+
     const numSchemas = _.size(engine.schemas);
     const codeWorkspacePresent = await fs.pathExists(
       path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME)
@@ -267,11 +296,15 @@ class ExtensionUtils {
     const siteUrl = publishigConfig.siteUrl;
     const enabledExportPodV2 = dendronConfig.dev?.enableExportPodV2;
     const { workspaceFile, workspaceFolders } = vscode.workspace;
-
     const trackProps = {
       duration: durationReloadWorkspace,
       noCaching: dendronConfig.noCaching || false,
       numNotes,
+      numNoteRefs,
+      numWikilinks,
+      numBacklinks,
+      numLinkCandidates,
+      numFrontmatterTags,
       numSchemas,
       numVaults: vaults.length,
       workspaceType,


### PR DESCRIPTION
## chore: adding links telemetry to InitializeWorkspace event props

- Adding Links telemetry to user properties
- Removing the 'round to the nearest 10' for numNotes.

I tested the calculations in org-workspace for the link information; it takes ~10 ms so no perf concerns around slowing down initialization.

Telemetry notes added to Airtable

---

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Instrumentation

### Basics

Pending v94 release.
- [n] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated
