### PR TITLE
enhance(workspace): Speed up workspace initialization

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -371,7 +371,7 @@ export class NoteUtils {
    * @param opts
    * @returns All notes that were changed including the parents
    */
-  static addOrUpdateParents(opts: {
+  static addOrUpdateParentsWithDict(opts: {
     note: NoteProps;
     notesDict: NotePropsDict;
     notesByFnameDict: NoteFNamesDict;
@@ -429,6 +429,22 @@ export class NoteUtils {
       });
     }
     return changed;
+  }
+
+  static addOrUpdateParents(opts: {
+    note: NoteProps;
+    notesDict: NotePropsDict;
+    createStubs: boolean;
+    wsRoot: string;
+  }): NoteChangeEntry[] {
+    const { note, notesDict, createStubs, wsRoot } = opts;
+    return NoteUtils.addOrUpdateParentsWithDict({
+      note,
+      notesDict,
+      notesByFnameDict: new NoteFNamesDict(_.values(notesDict)),
+      createStubs,
+      wsRoot,
+    });
   }
 
   static addSchema(opts: {

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -323,10 +323,16 @@ export class NoteFNamesDict {
     if (initialNotes) this.addAll(initialNotes);
   }
 
-  public get(notes: Readonly<NotePropsDict>, fname: string) {
+  public get(notes: Readonly<NotePropsDict>, fname: string, vault?: DVault) {
     const keys = this._internalMap.get(cleanName(fname));
     if (keys === undefined) return [];
-    return keys.map((key) => notes[key]).filter(isNotUndefined);
+    let matchedNotes = keys.map((key) => notes[key]).filter(isNotUndefined);
+    if (vault) {
+      matchedNotes = matchedNotes.filter((note) =>
+        VaultUtils.isEqualV2(note.vault, vault)
+      );
+    }
+    return matchedNotes;
   }
 
   /** Returns true if dict has `note` exactly with this fname and id. */

--- a/packages/engine-server/src/cache/dendronFileSystemCache.ts
+++ b/packages/engine-server/src/cache/dendronFileSystemCache.ts
@@ -31,7 +31,11 @@ export abstract class DendronFileSystemCache<T extends FileSystemCache, V>
    */
   private readFromFileSystem(): T {
     if (fs.existsSync(this._cachePath)) {
-      return fs.readJSONSync(this._cachePath) as T;
+      try {
+        return fs.readJSONSync(this._cachePath) as T;
+      } catch (_err: any) {
+        return this.createEmptyCacheContents();
+      }
     } else {
       return this.createEmptyCacheContents();
     }
@@ -57,6 +61,7 @@ export abstract class DendronFileSystemCache<T extends FileSystemCache, V>
    * Delete cache file if it exists
    */
   removeFromFileSystem(): void {
+    this.createEmptyCacheContents();
     if (fs.pathExistsSync(this._cachePath)) {
       return fs.removeSync(this._cachePath);
     }

--- a/packages/engine-server/src/drivers/file/noteParser.ts
+++ b/packages/engine-server/src/drivers/file/noteParser.ts
@@ -4,12 +4,15 @@ import {
   DEngineClient,
   DNodeUtils,
   DStore,
+  DuplicateNoteError,
   DVault,
   ErrorFactory,
   ErrorUtils,
   ERROR_SEVERITY,
   ERROR_STATUS,
+  IDendronError,
   isNotUndefined,
+  NoteFNamesDict,
   NoteProps,
   NotePropsDict,
   NotesCacheEntry,
@@ -84,20 +87,20 @@ export class NoteParser extends ParserBase {
     allPaths: string[],
     vault: DVault
   ): Promise<{
-    notes: NoteProps[];
+    notesById: NotePropsDict;
     cacheUpdates: NotesCacheEntryMap;
-    errors: DendronError[];
+    errors: IDendronError[];
   }> {
     const ctx = "parseFile";
     const fileMetaDict: FileMetaDict = getFileMeta(allPaths);
     const maxLvl = _.max(_.keys(fileMetaDict).map((e) => _.toInteger(e))) || 2;
-    const notesByFname: NotePropsDict = {};
+    const notesByFname: NoteFNamesDict = new NoteFNamesDict();
     const notesById: NotePropsDict = {};
     this.logger.info({ ctx, msg: "enter", vault });
     const cacheUpdates: { [key: string]: NotesCacheEntry } = {};
     // Keep track of which notes in cache no longer exist
     const unseenKeys = this.cache.getCacheEntryKeys();
-    const errors: DendronError[] = [];
+    const errors: IDendronError<any>[] = [];
 
     // get root note
     if (_.isUndefined(fileMetaDict[1])) {
@@ -127,7 +130,7 @@ export class NoteParser extends ParserBase {
         hash: rootProps.noteHash,
       });
     }
-    notesByFname[rootNote.fname] = rootNote;
+    notesByFname.add(rootNote);
     notesById[rootNote.id] = rootNote;
     unseenKeys.delete(rootNote.fname);
 
@@ -167,7 +170,18 @@ export class NoteParser extends ParserBase {
       .filter(isNotUndefined);
     prevNodes.forEach((ent) => {
       DNodeUtils.addChild(rootNote, ent);
-      notesByFname[ent.fname] = ent;
+
+      // Check for duplicate IDs when adding notes to the map
+      if (notesById[ent.id] !== undefined) {
+        const duplicate = notesById[ent.id];
+        errors.push(
+          new DuplicateNoteError({
+            noteA: duplicate,
+            noteB: ent,
+          })
+        );
+      }
+      notesByFname.add(ent);
       notesById[ent.id] = ent;
     });
     this.logger.info({ ctx, msg: "post:parseDomainNotes" });
@@ -183,7 +197,7 @@ export class NoteParser extends ParserBase {
           try {
             const resp = this.parseNoteProps({
               fileMeta: ent,
-              parents: prevNodes,
+              notesDict: notesById,
               notesByFname,
               addParent: true,
               vault,
@@ -203,7 +217,17 @@ export class NoteParser extends ParserBase {
             // need to be inside this loop
             // deal with `src/__tests__/enginev2.spec.ts`, with stubs/ test case
             notes.forEach((ent) => {
-              notesByFname[ent.fname] = ent;
+              // Check for duplicate IDs when adding notes to the map
+              if (notesById[ent.id] !== undefined) {
+                const duplicate = notesById[ent.id];
+                errors.push(
+                  new DuplicateNoteError({
+                    noteA: duplicate,
+                    noteB: ent,
+                  })
+                );
+              }
+              notesByFname.add(ent);
               notesById[ent.id] = ent;
             });
             return notes;
@@ -225,7 +249,6 @@ export class NoteParser extends ParserBase {
     this.logger.info({ ctx, msg: "post:parseAllNotes" });
 
     // add schemas
-    const out = _.values(notesByFname);
     const domains = rootNote.children.map(
       (ent) => notesById[ent]
     ) as NoteProps[];
@@ -242,13 +265,13 @@ export class NoteParser extends ParserBase {
 
     // OPT:make async and don't wait for return
     // Skip this if we found no notes, which means vault did not initialize
-    if (out.length > 0) {
+    if (_.size(notesById) > 0) {
       // TODO only write if there are changes
       this.cache.writeToFileSystem();
     }
 
     this.logger.info({ ctx, msg: "post:matchSchemas" });
-    return { notes: out, cacheUpdates, errors };
+    return { notesById, cacheUpdates, errors };
   }
 
   /**
@@ -258,20 +281,26 @@ export class NoteParser extends ParserBase {
    */
   parseNoteProps(opts: {
     fileMeta: FileMeta;
-    notesByFname?: NotePropsDict;
+    notesDict?: NotePropsDict;
+    notesByFname?: NoteFNamesDict;
     parents?: NoteProps[];
     addParent: boolean;
     createStubs?: boolean;
     vault: DVault;
-    errors: DendronError[];
-  }): { propsList: NoteProps[]; noteHash: string; matchHash: boolean } {
+    errors: IDendronError[];
+  }): {
+    propsList: NoteProps[];
+    noteHash: string;
+    matchHash: boolean;
+  } {
     const cleanOpts = _.defaults(opts, {
       addParent: true,
       createStubs: true,
+      notesDict: {},
       notesByFname: {},
       parents: [] as NoteProps[],
     });
-    const { fileMeta, parents, notesByFname, vault, errors } = cleanOpts;
+    const { fileMeta, notesDict, notesByFname, vault, errors } = cleanOpts;
     const ctx = "parseNoteProps";
     this.logger.debug({ ctx, msg: "enter", fileMeta });
     const wsRoot = this.opts.store.wsRoot;
@@ -311,13 +340,22 @@ export class NoteParser extends ParserBase {
     if (cleanOpts.addParent) {
       const stubs = NoteUtils.addOrUpdateParents({
         note: noteProps,
-        notesList: _.uniqBy(_.values(notesByFname).concat(parents), "id"),
+        notesDict,
+        notesByFnameDict: notesByFname,
         createStubs: cleanOpts.createStubs,
         wsRoot: this.opts.store.wsRoot,
       });
-      out = out.concat(stubs.map((noteChangeEntry) => noteChangeEntry.note));
+      out = out.concat(
+        stubs
+          .filter((noteChangeEntry) => noteChangeEntry.status === "create")
+          .map((noteChangeEntry) => noteChangeEntry.note)
+      );
     }
-    return { propsList: out, noteHash, matchHash };
+    return {
+      propsList: out,
+      noteHash,
+      matchHash,
+    };
   }
 
   private file2NoteWithCache({
@@ -329,7 +367,7 @@ export class NoteParser extends ParserBase {
     fpath: string;
     vault: DVault;
     toLowercase?: boolean;
-    errors: DendronError[];
+    errors: IDendronError[];
   }): {
     note: NoteProps;
     matchHash: boolean;

--- a/packages/engine-server/src/drivers/file/noteParser.ts
+++ b/packages/engine-server/src/drivers/file/noteParser.ts
@@ -338,7 +338,7 @@ export class NoteParser extends ParserBase {
 
     // add parent
     if (cleanOpts.addParent) {
-      const stubs = NoteUtils.addOrUpdateParents({
+      const stubs = NoteUtils.addOrUpdateParentsWithDict({
         note: noteProps,
         notesDict,
         notesByFnameDict: notesByFname,

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -962,7 +962,7 @@ export class FileStorage implements DStore {
       note = NoteUtils.hydrate({ noteRaw: note, noteHydrated: maybeNote });
     }
     if (opts?.newNode) {
-      NoteUtils.addOrUpdateParents({
+      NoteUtils.addOrUpdateParentsWithDict({
         note,
         notesDict: this.notes,
         notesByFnameDict: this.noteFnames,
@@ -1064,7 +1064,7 @@ export class FileStorage implements DStore {
     // this is the default behavior
     // only do this if we aren't writing to existing note. we never hit this case in that situation.
     if (!opts?.noAddParent && !existingNote) {
-      const out = NoteUtils.addOrUpdateParents({
+      const out = NoteUtils.addOrUpdateParentsWithDict({
         note,
         notesDict: this.notes,
         notesByFnameDict: this.noteFnames,

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -447,7 +447,8 @@ export class FileStorage implements DStore {
       })
     );
     this.notes = Object.assign({}, ...out);
-    this.noteFnames = new NoteFNamesDict(_.values(this.notes));
+    const allNotes = _.values(this.notes);
+    this.noteFnames = new NoteFNamesDict(allNotes);
     if (_.size(this.notes) === 0) {
       errors.push(
         new DendronError({
@@ -457,7 +458,7 @@ export class FileStorage implements DStore {
       );
     }
 
-    this._addBacklinks({ notesWithLinks, allNotes: _.values(this.notes) });
+    this._addBacklinks({ notesWithLinks, allNotes });
 
     return { errors };
   }
@@ -567,6 +568,7 @@ export class FileStorage implements DStore {
     const notesCache: NotesFileSystemCache = new NotesFileSystemCache({
       cachePath,
       noCaching: this.engine.config.noCaching,
+      logger: this.logger,
     });
     if (!out.data) {
       return {

--- a/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts
@@ -1,7 +1,10 @@
 import { CONSTANTS, DVault, VaultUtils } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import { FileTestUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
-import { NotesFileSystemCache } from "@dendronhq/engine-server";
+import {
+  DendronEngineClient,
+  NotesFileSystemCache,
+} from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -37,7 +40,7 @@ describe("engine, schemas/", () => {
 describe("engine, cache", () => {
   test("basic", async () => {
     await runEngineTestV5(
-      async ({ wsRoot, vaults }) => {
+      async ({ wsRoot, vaults, engine }) => {
         let cache = new Set();
         vaults.map((vault) => {
           const cachePath = path.join(
@@ -46,6 +49,7 @@ describe("engine, cache", () => {
           );
           const notesCache = new NotesFileSystemCache({
             cachePath,
+            logger: (engine as DendronEngineClient).logger,
           });
           cache = new Set([...cache, ...notesCache.getCacheEntryKeys()]);
         });
@@ -70,6 +74,7 @@ describe("engine, cache", () => {
         );
         const notesCache = new NotesFileSystemCache({
           cachePath,
+          logger: (engine as DendronEngineClient).logger,
         });
         const alpha = { ...engine.notes["alpha"] };
         const omitKeys = ["body", "links", "parent", "children"];

--- a/packages/engine-test-utils/src/presets/engine-server/delete.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/delete.ts
@@ -9,6 +9,7 @@ import {
 } from "@dendronhq/common-test-utils";
 import {
   createCacheEntry,
+  DendronEngineClient,
   NotesFileSystemCache,
 } from "@dendronhq/engine-server";
 import fs from "fs-extra";
@@ -44,11 +45,12 @@ const NOTES = {
   GRANDCHILD_WITH_ALL_STUB_PARENTS: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
       const resp = await engine.deleteNote(
         NoteUtils.getNoteByFnameFromEngine({
@@ -94,8 +96,10 @@ const NOTES = {
           expected: 2,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 1,
         },
       ];
@@ -114,12 +118,13 @@ const NOTES = {
   NOTE_NO_CHILDREN: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const notes = engine.notes;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
       const resp = await engine.deleteNote(
         NoteUtils.getNoteByFnameFromEngine({
@@ -144,8 +149,10 @@ const NOTES = {
           expected: 3,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 2,
         },
       ];
@@ -221,11 +228,12 @@ const NOTES = {
   DOMAIN_NO_CHILDREN: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
       const noteToDelete = NoteUtils.getNoteByFnameFromEngine({
         fname: "foo",
@@ -259,8 +267,10 @@ const NOTES = {
           expected: 2,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 1,
         },
       ];
@@ -278,11 +288,12 @@ const NOTES = {
   STALE_CACHE_ENTRY: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
 
       // Create random note and write to cache
       const staleNote = await NoteTestUtilsV4.createNote({
@@ -311,12 +322,14 @@ const NOTES = {
           expected: true,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 4,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath })
+          actual: new NotesFileSystemCache({ cachePath, logger })
             .getCacheEntryKeys()
             .has("my-new-note"),
           expected: false,
@@ -332,12 +345,13 @@ const NOTES = {
   MULTIPLE_DELETES: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const notes = engine.notes;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
       const resp = await engine.deleteNote(
         NoteUtils.getNoteByFnameFromEngine({
@@ -377,8 +391,10 @@ const NOTES = {
           expected: 3,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 1,
         },
       ];

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -18,7 +18,10 @@ import {
   TestPresetEntryV4,
   TestResult,
 } from "@dendronhq/common-test-utils";
-import { NotesFileSystemCache } from "@dendronhq/engine-server";
+import {
+  DendronEngineClient,
+  NotesFileSystemCache,
+} from "@dendronhq/engine-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -530,7 +533,10 @@ const NOTES = {
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({
+        cachePath,
+        logger: (engine as DendronEngineClient).logger,
+      });
       const keySet = notesCache.getCacheEntryKeys();
       return [
         {

--- a/packages/engine-test-utils/src/presets/engine-server/update.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/update.ts
@@ -4,7 +4,10 @@ import {
   TestPresetEntryV4,
   NOTE_PRESETS_V4,
 } from "@dendronhq/common-test-utils";
-import { NotesFileSystemCache } from "@dendronhq/engine-server";
+import {
+  DendronEngineClient,
+  NotesFileSystemCache,
+} from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
 
@@ -12,11 +15,12 @@ const NOTES = {
   NOTE_NO_CHILDREN: new TestPresetEntryV4(
     async ({ vaults, wsRoot, engine }) => {
       const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
-      const notesCache = new NotesFileSystemCache({ cachePath });
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
       const noteOld = NoteUtils.getNoteByFnameFromEngine({
         fname: "foo",
@@ -47,8 +51,10 @@ const NOTES = {
           expected: 2,
         },
         {
-          actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-            .size,
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
           expected: 2,
         },
       ];

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -15,7 +15,10 @@ import {
   SCHEMA_PRESETS_V4,
   TestPresetEntryV4,
 } from "@dendronhq/common-test-utils";
-import { NotesFileSystemCache } from "@dendronhq/engine-server";
+import {
+  DendronEngineClient,
+  NotesFileSystemCache,
+} from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
 import { setupBasic } from "./utils";
@@ -111,11 +114,12 @@ const SCHEMAS = {
 const NOTES = {
   CUSTOM_ATT: new TestPresetEntryV4(async ({ wsRoot, vaults, engine }) => {
     const vault = vaults[0];
+    const logger = (engine as DendronEngineClient).logger;
     const cachePath = path.join(
       vault2Path({ wsRoot, vault }),
       CONSTANTS.DENDRON_CACHE_FILE
     );
-    const notesCache = new NotesFileSystemCache({ cachePath });
+    const notesCache = new NotesFileSystemCache({ cachePath, logger });
     const keySet = notesCache.getCacheEntryKeys();
     const note = await NOTE_PRESETS_V4.NOTE_WITH_CUSTOM_ATT.create({
       wsRoot,
@@ -143,8 +147,10 @@ const NOTES = {
         expected: 1,
       },
       {
-        actual: new NotesFileSystemCache({ cachePath }).getCacheEntryKeys()
-          .size,
+        actual: new NotesFileSystemCache({
+          cachePath,
+          logger,
+        }).getCacheEntryKeys().size,
         expected: 2,
       },
     ];

--- a/packages/plugin-core/src/commands/GoUpCommand.ts
+++ b/packages/plugin-core/src/commands/GoUpCommand.ts
@@ -26,7 +26,8 @@ export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
     const engine = getDWorkspace().engine;
     const nparent = DNodeUtils.findClosestParent(
       path.basename(maybeTextEditor.document.uri.fsPath, ".md"),
-      _.values(engine.notes),
+      engine.notes,
+      engine.noteFnames,
       {
         noStubs: true,
         vault: PickerUtilsV2.getVaultForOpenEditor(),


### PR DESCRIPTION
**Background**
While timestamping the initialisation process, I found out that the bulk of the time was spent in `addOrUpdateParents`. This was due to the linear search component of using `_.find` with a noteprops array. By changing the signature to use a combination of `NotePropsDict` and `NoteFNamesDict`, I was able to make drastic improvements to init speed.

Before (org-workspace on local Macbook): ~50 sec
After: ~4 sec

**Changes**
1. Use `NotePropsDict` and `NoteFNamesDict` in place of `NoteProps[]` within noteParser.ts

**Future work**
Continue to scrub code for more usages of `_.find` with a noteprops array or `getNoteByFnameV5`


# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)