### PR TITLE
chore: end the upgrade toast wording AB test

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -2,15 +2,6 @@
 import { ABTest } from "./abTesting";
 import { GraphThemeEnum } from "./types/typesv2";
 
-export enum UpgradeToastWordingTestGroups {
-  /** The button on the upgrade toast will say "see what changed" */
-  seeWhatChanged = "seeWhatChanged",
-  /** The button on the upgrade toast will say "see what's new" */
-  seeWhatsNew = "seeWhatsNew",
-  /** The button on the upgrade toast will say "open the changelog" */
-  openChangelog = "openChangelog",
-}
-
 /**
  * Section: Tests (Active or soon to be active)
  *
@@ -19,25 +10,6 @@ export enum UpgradeToastWordingTestGroups {
  *
  * See [[A/B Testing|dendron://dendron.docs/ref.ab-testing]] for more details.
  */
-
-/** Test if showing a web view on an upgrade is more successful than showing a toast notification. */
-export const UPGRADE_TOAST_WORDING_TEST = new ABTest(
-  "UpgradeToastWordingTest",
-  [
-    {
-      name: UpgradeToastWordingTestGroups.seeWhatChanged,
-      weight: 1,
-    },
-    {
-      name: UpgradeToastWordingTestGroups.seeWhatsNew,
-      weight: 1,
-    },
-    {
-      name: UpgradeToastWordingTestGroups.openChangelog,
-      weight: 1,
-    },
-  ]
-);
 
 export enum SelfContainedVaultsTestGroups {
   /** User will get a regular workspace and vaults set up, like before. */
@@ -163,7 +135,6 @@ export const AB_TUTORIAL_TEST = new ABTest("AB_TUTORIAL_TEST", [
  * ^tkqhy45hflfd
  */
 export const CURRENT_AB_TESTS = [
-  UPGRADE_TOAST_WORDING_TEST,
   SELF_CONTAINED_VAULTS_TEST,
   GRAPH_THEME_TEST,
   GRAPH_THEME_FEATURE_SHOWCASE_TEST,

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -4,7 +4,6 @@ import {
   SubProcessExitType,
 } from "@dendronhq/api-server";
 import {
-  assertUnreachable,
   ConfigEvents,
   ConfigUtils,
   CONSTANTS,
@@ -23,8 +22,6 @@ import {
   SelfContainedVaultsTestGroups,
   SELF_CONTAINED_VAULTS_TEST,
   Time,
-  UpgradeToastWordingTestGroups,
-  UPGRADE_TOAST_WORDING_TEST,
   VaultUtils,
   VSCodeEvents,
   WorkspaceType,
@@ -996,31 +993,12 @@ async function showWelcomeOrWhatsNew({
 
       metadataService.setGlobalVersion(version);
 
-      // ^t6dxodie048o
-      const toastWording = UPGRADE_TOAST_WORDING_TEST.getUserGroup(
-        SegmentClient.instance().anonymousId
-      );
-
       AnalyticsUtils.track(VSCodeEvents.Upgrade, {
         previousVersion: previousExtensionVersion,
         duration: getDurationMilliseconds(start),
-        toastWording,
       });
 
-      let buttonAction: string;
-      switch (toastWording) {
-        case UpgradeToastWordingTestGroups.openChangelog:
-          buttonAction = "Open the changelog";
-          break;
-        case UpgradeToastWordingTestGroups.seeWhatChanged:
-          buttonAction = "See what changed";
-          break;
-        case UpgradeToastWordingTestGroups.seeWhatsNew:
-          buttonAction = "See what's new";
-          break;
-        default:
-          assertUnreachable(toastWording);
-      }
+      const buttonAction = "See what's new";
 
       vscode.window
         .showInformationMessage(
@@ -1032,7 +1010,6 @@ async function showWelcomeOrWhatsNew({
             AnalyticsUtils.track(VSCodeEvents.UpgradeSeeWhatsChangedClicked, {
               previousVersion: previousExtensionVersion,
               duration: getDurationMilliseconds(start),
-              toastWording,
             });
             vscode.commands.executeCommand(
               "vscode.open",


### PR DESCRIPTION
This PR ends the AB test for the upgrade toast wording. After several weeks of data, it appears that "see what's new" is a clear winner.

The chart below is the cumulative number of unique users who clicked the button after an upgrade. Over several weeks "see what's new" maintained a clear lead over the other options, so this PR sets that as the default and ends the experiment.

![Users who looked at the upgrade changelog](https://user-images.githubusercontent.com/1008124/168167597-f1aaeea7-0cb9-4d9b-be6c-4beeaa10089a.png)
