### PR TITLE
chore: temporary fix for tree view race condition

### DIFF
--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -74,6 +74,10 @@ export class EngineNoteProvider
     }
   }
 
+  getTree(): { [key: string]: TreeNote } {
+    return this._tree;
+  }
+
   getTreeItem(noteProps: NoteProps): TreeItem {
     try {
       return this._tree[noteProps.id];

--- a/packages/plugin-core/src/views/NativeTreeView.ts
+++ b/packages/plugin-core/src/views/NativeTreeView.ts
@@ -3,6 +3,7 @@ import {
   DendronTreeViewKey,
   NoteProps,
   NoteUtils,
+  TimeUtils,
   TreeViewItemLabelTypeEnum,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -160,7 +161,7 @@ export class NativeTreeView implements Disposable {
           !_.keys(this._provider.getTree()).includes(note.id)
         ) {
           // eslint-disable-next-line no-await-in-loop
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await TimeUtils.sleep(10);
         }
         this.treeView.reveal(note);
       }

--- a/packages/plugin-core/src/views/NativeTreeView.ts
+++ b/packages/plugin-core/src/views/NativeTreeView.ts
@@ -9,7 +9,13 @@ import {
 import { WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
-import { Disposable, TextEditor, TreeView, window } from "vscode";
+import {
+  Disposable,
+  TextEditor,
+  TreeDataProvider,
+  TreeView,
+  window,
+} from "vscode";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { EngineNoteProvider } from "./EngineNoteProvider";
 import { TreeNote } from "./TreeNote";
@@ -22,6 +28,7 @@ export class NativeTreeView implements Disposable {
   private treeView: TreeView<NoteProps> | undefined;
   private _handler: Disposable | undefined;
   private _createDataProvider: () => EngineNoteProvider;
+  private _provider: EngineNoteProvider | undefined;
   private _updateLabelTypeHandler:
     | ((opts: {
         labelType: TreeViewItemLabelTypeEnum;
@@ -51,6 +58,7 @@ export class NativeTreeView implements Disposable {
    */
   async show() {
     const treeDataProvider = this._createDataProvider();
+    this._provider = treeDataProvider;
     this._updateLabelTypeHandler = _.bind(
       treeDataProvider.updateLabelType,
       treeDataProvider
@@ -107,6 +115,7 @@ export class NativeTreeView implements Disposable {
     if (
       _.isUndefined(editor) ||
       _.isUndefined(this.treeView) ||
+      _.isUndefined(this._provider) ||
       !this.treeView.visible
     ) {
       return;
@@ -140,6 +149,25 @@ export class NativeTreeView implements Disposable {
       });
 
       if (note) {
+        let waitForTree = true;
+        setTimeout(() => {
+          waitForTree = false;
+        }, 500);
+
+        // This is a hack to prevent race condition between tree view reveal
+        // and tree data provider.
+        // without this `reveal` is called before tree items are reconstructed,
+        // causing an exception.
+        // we only wait for 500ms to prevent this from running indefinitely
+        // in case of a faulty engine event that leads to the tree view
+        // never creating a tree item for a note.
+        while (
+          waitForTree &&
+          !_.keys(this._provider.getTree()).includes(note.id)
+        ) {
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
         this.treeView.reveal(note);
       }
     }

--- a/packages/plugin-core/src/views/NativeTreeView.ts
+++ b/packages/plugin-core/src/views/NativeTreeView.ts
@@ -9,13 +9,7 @@ import {
 import { WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
-import {
-  Disposable,
-  TextEditor,
-  TreeDataProvider,
-  TreeView,
-  window,
-} from "vscode";
+import { Disposable, TextEditor, TreeView, window } from "vscode";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { EngineNoteProvider } from "./EngineNoteProvider";
 import { TreeNote } from "./TreeNote";


### PR DESCRIPTION
# chore: temporary fix for tree view race condition

This PR:
- Attempts to fix an issue with the tree view where the `onOpenTextDocument` calls `treeView.reveal` too early.
  - This causes an exception because `reveal` expects the tree item to be already there, but we haven't given the tree data provider to fully parse the tree yet.

To reproduce this issue:
1. pull in master branch
1. build
1. create note `a.b`, (`a` is a stub here)
1. create note `a.c`

You will see an exception raised by the extension host when creating a tree item handle. 
```
rejected promise not handled within 1 second: TypeError: Cannot destructure property 'id' of 'undefined' as it is undefined.
internal/timers:557
stack trace: TypeError: Cannot destructure property 'id' of 'undefined' as it is undefined.
	at _.createHandle (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:99:22147)
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:99:18769
```

This isn't a proper solution as it will still fail if the tree doesn't get constructed in time, but I'm raising this PR for visibility / discussion. Any suggestions? @kevinslin @jonathanyeung

- _maybe related_: https://discord.com/channels/717965437182410783/802578902429597726/974343847721173092
  - this PR isn't directly addressing this error (I have yet to successfully reproduce this.), but I have a feeling that this is also caused by some race condition.