### PR TITLE
chore: fixing crash in POST api/notes/links

### DIFF
--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -210,7 +210,7 @@ const getLinks = ({
   });
   const dlinks: DLink[] = [];
 
-  if (isNotUndefined(note.tags)) {
+  if (!_.isNil(note.tags)) {
     let tags: string[];
     if (_.isString(note.tags)) {
       tags = [note.tags];


### PR DESCRIPTION
## chore: fixing crash in POST api/notes/links

Fixing a relatively large Sentry hitter in `POST api/notes/links`.  isNotUndefined doesn't address the case where the value of `note.tags` is `null`. 

Example Hit: https://sentry.io/organizations/dendron/issues/3263381836/?project=5898219
