### PR TITLE
fix(workspace): dendron can fail to start due to invalid version

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -134,6 +134,7 @@ export enum ContextualUIEvents {
 
 export enum WorkspaceEvents {
   AutoFix = "AutoFix",
+  MetadataVersionAutoFix = "MetadataVersionAutoFix",
   DuplicateNoteFound = "DuplicateNoteFound",
 }
 

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -598,7 +598,6 @@ export async function _activate(
       MetadataService.instance().getGlobalVersion();
 
     if (!semver.valid(previousGlobalVersionFromMetadata)) {
-      // TODO: log
       Logger.info({
         ctx,
         msg: "fix invalid metadata",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -426,7 +426,16 @@ async function postReloadWorkspace(opts: { extension: DendronExtension }) {
     return;
   }
 
+  const newVersion = DendronExtension.version();
   const wsMeta = wsService.getMeta();
+  // deal with bad semver version
+  if (!semver.valid(wsMeta.version)) {
+    // this is only used in dendron workspace to upgrade workspace config. we currently
+    // don't rely on this for any settings besides unwanted extensions update
+    // so its save to set to latest version
+    wsMeta.version = newVersion;
+    wsService.writeMeta({ version: DendronExtension.version() });
+  }
   const previousWsVersion = wsMeta.version;
   // stats
   // NOTE: this is legacy to upgrade .code-workspace specific settings
@@ -440,38 +449,35 @@ async function postReloadWorkspace(opts: { extension: DendronExtension }) {
         Logger.info({ ctx, msg: "postUpgrade: new wsVersion", changes });
       });
     wsService.writeMeta({ version: DendronExtension.version() });
-  } else {
-    const newVersion = DendronExtension.version();
-    if (semver.lt(previousWsVersion, newVersion)) {
-      let changes: any;
-      Logger.info({ ctx, msg: "preUpgrade: new wsVersion" });
-      try {
-        changes = await vscode.commands.executeCommand(
-          DENDRON_COMMANDS.UPGRADE_SETTINGS.key
-        );
-        Logger.info({
-          ctx,
-          msg: "postUpgrade: new wsVersion",
-          changes,
-          previousWsVersion,
-          newVersion,
-        });
-        wsService.writeMeta({ version: DendronExtension.version() });
-      } catch (err) {
-        Logger.error({
-          msg: "error upgrading",
-          error: new DendronError({ message: JSON.stringify(err) }),
-        });
-        return;
-      }
-      HistoryService.instance().add({
-        source: "extension",
-        action: "upgraded",
-        data: { changes },
+  } else if (semver.lt(previousWsVersion, newVersion)) {
+    let changes: any;
+    Logger.info({ ctx, msg: "preUpgrade: new wsVersion" });
+    try {
+      changes = await vscode.commands.executeCommand(
+        DENDRON_COMMANDS.UPGRADE_SETTINGS.key
+      );
+      Logger.info({
+        ctx,
+        msg: "postUpgrade: new wsVersion",
+        changes,
+        previousWsVersion,
+        newVersion,
       });
-    } else {
-      Logger.info({ ctx, msg: "same wsVersion" });
+      wsService.writeMeta({ version: DendronExtension.version() });
+    } catch (err) {
+      Logger.error({
+        msg: "error upgrading",
+        error: new DendronError({ message: JSON.stringify(err) }),
+      });
+      return;
     }
+    HistoryService.instance().add({
+      source: "extension",
+      action: "upgraded",
+      data: { changes },
+    });
+  } else {
+    Logger.info({ ctx, msg: "same wsVersion" });
   }
   Logger.info({ ctx, msg: "exit" });
 }

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -425,7 +425,16 @@ async function postReloadWorkspace(opts: { extension: DendronExtension }) {
     return;
   }
 
+  const newVersion = DendronExtension.version();
   const wsMeta = wsService.getMeta();
+  // deal with bad semver version
+  if (!semver.valid(wsMeta.version)) {
+    // this is only used in dendron workspace to upgrade workspace config. we currently
+    // don't rely on this for any settings besides unwanted extensions update
+    // so its save to set to latest version
+    wsMeta.version = newVersion;
+    wsService.writeMeta({ version: DendronExtension.version() });
+  }
   const previousWsVersion = wsMeta.version;
   // stats
   // NOTE: this is legacy to upgrade .code-workspace specific settings
@@ -439,38 +448,35 @@ async function postReloadWorkspace(opts: { extension: DendronExtension }) {
         Logger.info({ ctx, msg: "postUpgrade: new wsVersion", changes });
       });
     wsService.writeMeta({ version: DendronExtension.version() });
-  } else {
-    const newVersion = DendronExtension.version();
-    if (semver.lt(previousWsVersion, newVersion)) {
-      let changes: any;
-      Logger.info({ ctx, msg: "preUpgrade: new wsVersion" });
-      try {
-        changes = await vscode.commands.executeCommand(
-          DENDRON_COMMANDS.UPGRADE_SETTINGS.key
-        );
-        Logger.info({
-          ctx,
-          msg: "postUpgrade: new wsVersion",
-          changes,
-          previousWsVersion,
-          newVersion,
-        });
-        wsService.writeMeta({ version: DendronExtension.version() });
-      } catch (err) {
-        Logger.error({
-          msg: "error upgrading",
-          error: new DendronError({ message: JSON.stringify(err) }),
-        });
-        return;
-      }
-      HistoryService.instance().add({
-        source: "extension",
-        action: "upgraded",
-        data: { changes },
+  } else if (semver.lt(previousWsVersion, newVersion)) {
+    let changes: any;
+    Logger.info({ ctx, msg: "preUpgrade: new wsVersion" });
+    try {
+      changes = await vscode.commands.executeCommand(
+        DENDRON_COMMANDS.UPGRADE_SETTINGS.key
+      );
+      Logger.info({
+        ctx,
+        msg: "postUpgrade: new wsVersion",
+        changes,
+        previousWsVersion,
+        newVersion,
       });
-    } else {
-      Logger.info({ ctx, msg: "same wsVersion" });
+      wsService.writeMeta({ version: DendronExtension.version() });
+    } catch (err) {
+      Logger.error({
+        msg: "error upgrading",
+        error: new DendronError({ message: JSON.stringify(err) }),
+      });
+      return;
     }
+    HistoryService.instance().add({
+      source: "extension",
+      action: "upgraded",
+      data: { changes },
+    });
+  } else {
+    Logger.info({ ctx, msg: "same wsVersion" });
   }
   Logger.info({ ctx, msg: "exit" });
 }


### PR DESCRIPTION
fix(workspace): dendron can fail to start due to invalid version

This auto fixes a bad release when we wrote a bad version number in the metadata

---
New analytics added:
- Event: 
    - MetadataVersionAutoFix, we detected a bad version in `meta.json`

- Event Properties: 
    - cause: 
        - bad_version, the version was not a valid semver version
        - outdated_version, the version was not up to date with what was stored in vscode state (should deprecate once we finish migrating away from vscode metadata)