### PR TITLE
chore(internal): Refactor notepropsfnamedict to primitive typing

### DIFF
--- a/packages/api-server/src/modules/schemas/index.ts
+++ b/packages/api-server/src/modules/schemas/index.ts
@@ -54,7 +54,7 @@ export class SchemaController {
 
   async query({ ws, qs }: SchemaQueryRequest): Promise<SchemaQueryPayload> {
     const engine = await getWSEngine({ ws: ws || "" });
-    return await engine.querySchema(qs);
+    return engine.querySchema(qs);
   }
 
   async update({

--- a/packages/api-server/src/modules/workspace/index.ts
+++ b/packages/api-server/src/modules/workspace/index.ts
@@ -1,8 +1,6 @@
 import {
   error2PlainObject,
   ERROR_SEVERITY,
-  NotePropsDict,
-  SchemaModuleDict,
   InitializePayload,
   WorkspaceInitRequest,
   WorkspaceSyncPayload,
@@ -25,8 +23,6 @@ export class WorkspaceController {
   async init({ uri }: WorkspaceInitRequest): Promise<InitializePayload> {
     const start = process.hrtime();
 
-    let notes: NotePropsDict;
-    let schemas: SchemaModuleDict;
     const ctx = "WorkspaceController:init";
     const logger = getLogger();
     logger.info({ ctx, msg: "enter", uri });
@@ -39,8 +35,6 @@ export class WorkspaceController {
       logger.error({ ctx, msg: "fatal error initializing notes", error });
       return { error };
     }
-    notes = engine.notes;
-    schemas = engine.schemas;
     await putWS({ ws: uri, engine });
     const duration = getDurationMilliseconds(start);
     logger.info({ ctx, msg: "finish init", duration, uri, error });
@@ -50,8 +44,8 @@ export class WorkspaceController {
     const payload: InitializePayload = {
       error,
       data: {
-        notes,
-        schemas,
+        notes: engine.notes,
+        schemas: engine.schemas,
         config: engine.config,
         vaults: engine.vaults,
         wsRoot: engine.wsRoot,

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -922,6 +922,7 @@ export class NoteUtils {
     return existingNote;
   }
 
+  /** @deprecated see {@link NoteUtils.getNoteByFnameFromEngine} */
   static getNoteOrThrow({
     fname,
     notes,

--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -6,7 +6,7 @@ import {
   NoteProps,
   SchemaModuleDict,
   SchemaUtils,
-  NotePropsDict,
+  NotePropsByIdDict,
   SchemaModuleProps,
   NoteUtils,
   DNodeUtils,
@@ -60,7 +60,7 @@ function createFuse<T>(
 }
 
 export function createFuseNote(
-  publishedNotes: NotePropsDict | NoteProps[],
+  publishedNotes: NotePropsByIdDict | NoteProps[],
   overrideOpts?: Partial<Fuse.IFuseOptions<NoteProps>>,
   index?: Fuse.FuseIndex<NoteProps>
 ) {
@@ -83,7 +83,7 @@ export function createFuseNote(
 }
 
 export function createSerializedFuseNoteIndex(
-  publishedNotes: NotePropsDict | NoteProps[],
+  publishedNotes: NotePropsByIdDict | NoteProps[],
   overrideOpts?: Partial<Parameters<typeof createFuse>[1]>
 ) {
   return createFuseNote(publishedNotes, overrideOpts).getIndex().toJSON();
@@ -251,7 +251,7 @@ export class FuseEngine {
     );
   }
 
-  async updateNotesIndex(notes: NotePropsDict) {
+  async updateNotesIndex(notes: NotePropsByIdDict) {
     this.notesIndex.setCollection(
       _.map(notes, ({ fname, title, id, vault, updated, stub }, _key) => ({
         fname,
@@ -431,7 +431,7 @@ export class NoteLookupUtils {
     return lastDotIndex < 0 ? "" : qs.slice(0, lastDotIndex + 1);
   };
 
-  static fetchRootResults = (notes: NotePropsDict) => {
+  static fetchRootResults = (notes: NotePropsByIdDict) => {
     const roots: NoteProps[] = NoteUtils.getRoots(notes);
 
     const childrenOfRoot = roots.flatMap((ent) => ent.children);

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -26,6 +26,7 @@ export * from "./config";
 export * from "./schema";
 export * from "./abTesting";
 export * from "./abTests";
+export * from "./notePropDict";
 export { axios, AxiosError };
 export { DateTime };
 

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -26,7 +26,7 @@ export * from "./config";
 export * from "./schema";
 export * from "./abTesting";
 export * from "./abTests";
-export * from "./notePropDict";
+export * from "./noteDictsUtils";
 export { axios, AxiosError };
 export { DateTime };
 

--- a/packages/common-all/src/notePropDict.ts
+++ b/packages/common-all/src/notePropDict.ts
@@ -1,0 +1,134 @@
+import _ from "lodash";
+import {
+  NotePropsDict,
+  NotePropsByFnameDict,
+  DVault,
+  NoteProps,
+  NotePropsFullDict,
+} from "./types";
+import { cleanName, isNotUndefined } from "./utils";
+import { VaultUtils } from "./vault";
+
+/**
+ * Utilities for working with NotePropsFullDict. The reason NotePropsFullDict is not a class is due to needing
+ * to work with primitive objects with redux
+ */
+export class NoteFullDictUtils {
+  /**
+   * Find notes by fname. If vault is provided, filter results so that only notes with matching vault is returned
+   * Return empty array if no match is found
+   *
+   * @param fname
+   * @param notesDict
+   * @param vault If provided, use to filter results
+   * @returns Copy of NoteProps array
+   */
+  static findNotesByFname(
+    fname: string,
+    notesDict: NotePropsFullDict,
+    vault?: DVault
+  ): NoteProps[] {
+    const { notesById, notesByFname } = notesDict;
+    const cleanedFname = cleanName(fname);
+    const ids: string[] | undefined = notesByFname[cleanedFname];
+    if (!ids) {
+      return [];
+    }
+    let notes = ids.map((id) => notesById[id]).filter(isNotUndefined);
+    if (vault) {
+      notes = notes.filter((note) => VaultUtils.isEqualV2(note.vault, vault));
+    }
+    return _.cloneDeep(notes);
+  }
+
+  /**
+   * Remove note from both notesById and notesByFname
+   *
+   * @param note note to delete
+   * @param notesDict
+   */
+  static deleteNote(note: NoteProps, notesDict: NotePropsFullDict) {
+    const { notesById, notesByFname } = notesDict;
+    delete notesById[note.id];
+    NoteFnameDictUtils.deleteNote(note, notesByFname);
+  }
+
+  /**
+   * Add note to notesById and notesByFname.
+   * If note id already exists, check to see if it corresponds to same note by fname.
+   * If fname match, then we only need to update notesById. If fname doesn't match, remove old id from notesByFname first before updating both.
+   *
+   * Otherwise, if note id doesn't exist, add to both dictionaries
+   *
+   * @param note to add
+   * @returns
+   */
+  static addNote(note: NoteProps, notesDict: NotePropsFullDict) {
+    const { notesById, notesByFname } = notesDict;
+    const maybeNote = notesById[note.id];
+    if (maybeNote) {
+      if (cleanName(maybeNote.fname) === cleanName(note.fname)) {
+        notesById[note.id] = note;
+        return;
+      } else {
+        // Remove old fname from fname dict
+        NoteFnameDictUtils.deleteNote(maybeNote, notesByFname);
+      }
+    }
+    notesById[note.id] = note;
+    NoteFnameDictUtils.addNote(note, notesByFname);
+  }
+}
+
+/**
+ * Utilities for working with NotePropsByFnameDict.
+ */
+export class NoteFnameDictUtils {
+  /**
+   * Create a map of {key -> value} where key = noteFname and value is list of ids corresponding to that fname from NotePropsDict
+   *
+   * @param notesById NotePropsDict used to populate map
+   * @returns
+   */
+  static create(notesById: NotePropsDict): NotePropsByFnameDict {
+    const notesByFname = {};
+    _.values(notesById).forEach((note) =>
+      NoteFnameDictUtils.addNote(note, notesByFname)
+    );
+    return notesByFname;
+  }
+
+  /**
+   * Add note to notesByFname dictionary. If note fname exists, add note id to existing list of ids
+   *
+   * @param note to add
+   * @param notesByFname dictionary to modify
+   */
+  static addNote(note: NoteProps, notesByFname: NotePropsByFnameDict) {
+    const fname = cleanName(note.fname);
+    let ids = notesByFname[fname];
+    if (_.isUndefined(ids)) ids = [];
+    ids.push(note.id);
+    notesByFname[fname] = ids;
+  }
+
+  /**
+   * Delete note id from notesByFname dictionary. If note exists and it corresponds to last entry for that fname, delete fname entry
+   * from dictionary as well
+   *
+   * @param note to delete
+   * @param notesByFname dictionary to modify
+   * @returns
+   */
+  static deleteNote(note: NoteProps, notesByFname: NotePropsByFnameDict) {
+    const fname = cleanName(note.fname);
+    const ids = notesByFname[fname];
+    if (_.isUndefined(ids)) return;
+    _.pull(ids, note.id);
+    if (ids.length === 0) {
+      delete notesByFname[fname];
+    } else {
+      notesByFname[fname] = ids;
+    }
+  }
+}

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -19,6 +19,7 @@ export * from "./unified";
 export * from "./events";
 export * from "./cacheData";
 export * from "./errorTypes";
+export * from "./rest";
 
 export type Stage = "dev" | "prod" | "test";
 export type DEngineQuery = {

--- a/packages/common-all/src/types/rest.ts
+++ b/packages/common-all/src/types/rest.ts
@@ -1,0 +1,7 @@
+import { DVault } from "./workspace";
+
+export type FindNoteOpts = {
+  fname: string;
+  // If vault is provided, filter results so that only notes with matching vault is returned
+  vault?: DVault;
+};

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -173,7 +173,7 @@ export type DNodePropsDict = {
 /**
  * Map of noteId -> noteProp
  */
-export type NotePropsDict = {
+export type NotePropsByIdDict = {
   [key: string]: NoteProps;
 };
 
@@ -184,8 +184,12 @@ export type NotePropsByFnameDict = {
   [key: string]: string[];
 };
 
-export type NotePropsFullDict = {
-  notesById: NotePropsDict;
+/**
+ * Type to keep track of forward index (notesById) and inverted indices (notesByFname)
+ * Use {@link NoteDictsUtils} to perform operations that need to update all indices
+ */
+export type NoteDicts = {
+  notesById: NotePropsByIdDict;
   notesByFname: NotePropsByFnameDict;
 };
 
@@ -340,7 +344,7 @@ export type EngineWriteOptsV2 = {
 } & Partial<EngineUpdateNodesOptsV2>;
 
 export type DEngineInitPayload = {
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   schemas: SchemaModuleDict;
   wsRoot: string;
   vaults: DVault[];
@@ -393,7 +397,7 @@ export type GetDecorationsOpts = {
 
 export type DCommonProps = {
   /** Dictionary where key is the note id. */
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   /** Dictionary where the key is lowercase note fname, and values are ids of notes with that fname (multiple ids since there might be notes with same fname in multiple vaults). */
   noteFnames: NotePropsByFnameDict;
   schemas: SchemaModuleDict;
@@ -633,11 +637,11 @@ export type DStore = DCommonProps &
     /**
      * Get NoteProps by id. If note doesn't exist, return undefined
      */
-    getNote: (id: string) => NoteProps | undefined;
+    getNote: (id: string) => Promise<NoteProps | undefined>;
     /**
      * Find NoteProps by note properties
      */
-    findNotes: (opts: FindNoteOpts) => NoteProps[];
+    findNotes: (opts: FindNoteOpts) => Promise<NoteProps[]>;
     deleteNote: (
       id: string,
       opts?: EngineDeleteOptsV2
@@ -652,7 +656,7 @@ export type DStore = DCommonProps &
 // TODO: not used yet
 export type DEngineV4 = {
   // Properties
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   schemas: SchemaModuleDict;
   wsRoot: string;
   vaults: DVault[];

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -14,7 +14,8 @@ import { DVault } from "./workspace";
 import { IntermediateDendronConfig } from "./intermediateConfigs";
 import { VSRange } from "./compat";
 import { Decoration, Diagnostic } from ".";
-import type { NoteFNamesDict, Optional } from "../utils";
+import { FindNoteOpts } from "./rest";
+import type { Optional } from "../utils";
 import { DendronASTDest, ProcFlavor } from "./unified";
 import { GetAnchorsRequest, GetLinksRequest } from "..";
 
@@ -169,8 +170,23 @@ export type DNodePropsDict = {
   [key: string]: DNodeProps;
 };
 
+/**
+ * Map of noteId -> noteProp
+ */
 export type NotePropsDict = {
   [key: string]: NoteProps;
+};
+
+/**
+ * Map of noteFname -> list of noteIds. Since fname is not unique across vaults, there can be multiple ids with the same fname
+ */
+export type NotePropsByFnameDict = {
+  [key: string]: string[];
+};
+
+export type NotePropsFullDict = {
+  notesById: NotePropsDict;
+  notesByFname: NotePropsByFnameDict;
 };
 
 export type SchemaPropsDict = {
@@ -379,7 +395,7 @@ export type DCommonProps = {
   /** Dictionary where key is the note id. */
   notes: NotePropsDict;
   /** Dictionary where the key is lowercase note fname, and values are ids of notes with that fname (multiple ids since there might be notes with same fname in multiple vaults). */
-  noteFnames: NoteFNamesDict;
+  noteFnames: NotePropsByFnameDict;
   schemas: SchemaModuleDict;
   wsRoot: string;
   /**
@@ -614,6 +630,14 @@ export type DEngineClient = Omit<DEngine, "store">;
 export type DStore = DCommonProps &
   DCommonMethods & {
     init: () => Promise<DEngineInitResp>;
+    /**
+     * Get NoteProps by id. If note doesn't exist, return undefined
+     */
+    getNote: (id: string) => NoteProps | undefined;
+    /**
+     * Find NoteProps by note properties
+     */
+    findNotes: (opts: FindNoteOpts) => NoteProps[];
     deleteNote: (
       id: string,
       opts?: EngineDeleteOptsV2

--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { TAGS_HIERARCHY, TAGS_HIERARCHY_BASE } from "../constants";
-import { NotePropsDict, NoteProps } from "../types";
+import { NotePropsByIdDict, NoteProps } from "../types";
 import { isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
 
@@ -32,7 +32,7 @@ export enum TreeViewItemLabelTypeEnum {
 
 export class TreeUtils {
   static generateTreeData(
-    allNotes: NotePropsDict,
+    allNotes: NotePropsByIdDict,
     domains: NoteProps[]
   ): TreeMenu {
     // --- Calc
@@ -75,7 +75,7 @@ export class TreeUtils {
     noteDict,
   }: {
     noteId: string;
-    noteDict: NotePropsDict;
+    noteDict: NotePropsByIdDict;
   }): TreeMenuNode | undefined {
     const note = noteDict[noteId];
     if (_.isUndefined(note)) {
@@ -120,7 +120,7 @@ export class TreeUtils {
     labelType,
   }: {
     noteIds: string[];
-    noteDict: NotePropsDict;
+    noteDict: NotePropsByIdDict;
     reverse?: boolean;
     labelType?: TreeViewItemLabelTypeEnum;
   }): string[] => {

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -22,7 +22,6 @@ import {
   LegacyHierarchyConfig,
   NoteChangeEntry,
   NoteProps,
-  NotePropsDict,
   SEOProps,
 } from "./types";
 import { GithubConfig } from "./types/configs/publishing/github";
@@ -235,39 +234,6 @@ export class DefaultMap<K, V> {
   }
 }
 
-/** Maps a `K` to a list of `V`s. */
-export class ListMap<K, V> {
-  private _internalMap = new Map<K, V[]>();
-
-  public get(key: K) {
-    return this._internalMap.get(key);
-  }
-
-  public add(key: K, ...toAdd: V[]) {
-    let values = this._internalMap.get(key);
-    if (values === undefined) values = [];
-    values.push(...toAdd);
-    this._internalMap.set(key, values);
-  }
-
-  public delete(key: K, ...toDelete: V[]) {
-    const values = this._internalMap.get(key);
-    if (values === undefined) return;
-    _.pull(values, ...toDelete);
-    if (values.length === 0) {
-      this._internalMap.delete(key);
-    } else {
-      this._internalMap.set(key, values);
-    }
-  }
-
-  public has(key: K, value: V) {
-    const values = this._internalMap.get(key);
-    if (values === undefined) return false;
-    return values.includes(value);
-  }
-}
-
 /** Memoizes function results, but allows a custom function to decide if the
  * value needs to be recalculated.
  *
@@ -314,48 +280,6 @@ export function memoize<Inputs extends any[], Key, Output>({
   };
   wrapped.cache = new LruCache<Key, Output>({ maxItems: maxCache });
   return wrapped;
-}
-
-export class NoteFNamesDict {
-  private _internalMap = new ListMap<string, string>();
-
-  public constructor(initialNotes?: NoteProps[]) {
-    if (initialNotes) this.addAll(initialNotes);
-  }
-
-  public get(notes: Readonly<NotePropsDict>, fname: string, vault?: DVault) {
-    const keys = this._internalMap.get(cleanName(fname));
-    if (keys === undefined) return [];
-    let matchedNotes = keys.map((key) => notes[key]).filter(isNotUndefined);
-    if (vault) {
-      matchedNotes = matchedNotes.filter((note) =>
-        VaultUtils.isEqualV2(note.vault, vault)
-      );
-    }
-    return matchedNotes;
-  }
-
-  /** Returns true if dict has `note` exactly with this fname and id. */
-  public has(note: NoteProps): boolean {
-    return !!this._internalMap
-      // there are notes with this fname
-      .get(cleanName(note.fname))
-      // and one of those has matching id
-      ?.some((maybeMatch) => maybeMatch === note.id);
-  }
-
-  public add(note: NoteProps) {
-    if (this.has(note)) return; // avoid duplicates
-    this._internalMap.add(cleanName(note.fname), note.id);
-  }
-
-  public addAll(notes: NoteProps[]) {
-    notes.forEach((note) => this.add(note));
-  }
-
-  public delete(note: NoteProps) {
-    this._internalMap.delete(cleanName(note.fname), note.id);
-  }
 }
 export class FIFOQueue<T> {
   private _internalQueue: T[] = [];

--- a/packages/common-frontend/src/engine.ts
+++ b/packages/common-frontend/src/engine.ts
@@ -2,14 +2,14 @@ import {
   IntermediateDendronConfig,
   DEngineClient,
   DVault,
-  NotePropsDict,
+  NotePropsByIdDict,
   SchemaModuleDict,
 } from "@dendronhq/common-all";
 import { EngineState } from "./features/engine/slice";
 
 // @ts-ignore
 export class WebEngine implements DEngineClient {
-  public notes: NotePropsDict;
+  public notes: NotePropsByIdDict;
   public wsRoot: string;
   public schemas: SchemaModuleDict;
   public configRoot: string;

--- a/packages/common-frontend/src/features/engine/slice.ts
+++ b/packages/common-frontend/src/features/engine/slice.ts
@@ -2,12 +2,12 @@ import {
   DendronApiV2,
   DEngineInitPayload,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   stringifyError,
   NoteUtils,
   ConfigGetPayload,
   NoteFnameDictUtils,
-  NoteFullDictUtils,
+  NoteDictsUtils,
 } from "@dendronhq/common-all";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import _ from "lodash";
@@ -168,12 +168,12 @@ export const engineSlice = createSlice({
       state.schemas = schemas;
       state.vaults = vaults;
       state.config = config;
-      state.noteFName = NoteFnameDictUtils.create(notes);
+      state.noteFName = NoteFnameDictUtils.createNotePropsByFnameDict(notes);
     },
     setConfig: (state, action: PayloadAction<ConfigGetPayload>) => {
       state.config = action.payload;
     },
-    setNotes: (state, action: PayloadAction<NotePropsDict>) => {
+    setNotes: (state, action: PayloadAction<NotePropsByIdDict>) => {
       state.notes = action.payload;
     },
     setError: (state, action: PayloadAction<any>) => {
@@ -205,22 +205,22 @@ export const engineSlice = createSlice({
         state.notes = {};
       }
       // this is a new node
-      const notesDict = {
+      const noteDicts = {
         notesById: state.notes,
         notesByFname: state.noteFName,
       };
       if (!state.notes[note.id]) {
         const changed = NoteUtils.addOrUpdateParents({
           note,
-          notesDict,
+          noteDicts,
           createStubs: true,
           wsRoot: state.wsRoot!,
         });
         changed.forEach((noteChangeEntry) =>
-          NoteFullDictUtils.addNote(noteChangeEntry.note, notesDict)
+          NoteDictsUtils.add(noteChangeEntry.note, noteDicts)
         );
       }
-      NoteFullDictUtils.addNote(note, notesDict);
+      NoteDictsUtils.add(note, noteDicts);
     },
   },
   extraReducers: (builder) => {

--- a/packages/common-frontend/src/types.ts
+++ b/packages/common-frontend/src/types.ts
@@ -1,4 +1,7 @@
-import { DEngineInitPayload, NoteFNamesDict } from "@dendronhq/common-all";
+import {
+  DEngineInitPayload,
+  NotePropsByFnameDict,
+} from "@dendronhq/common-all";
 import _ from "lodash";
 
 export enum LoadingStatus {
@@ -11,7 +14,7 @@ export type EngineSliceState = {
   error: any;
   loading: LoadingStatus;
   currentRequestId: string | undefined;
-  noteFName: NoteFNamesDict;
+  noteFName: NotePropsByFnameDict;
 } & Partial<DEngineInitPayload> &
   Pick<DEngineInitPayload, "notes" | "schemas" | "vaults">;
 

--- a/packages/common-frontend/src/utils/tree-view.tsx
+++ b/packages/common-frontend/src/utils/tree-view.tsx
@@ -2,7 +2,7 @@ import { BookOutlined, PlusOutlined, NumberOutlined } from "@ant-design/icons";
 import {
   isNotUndefined,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   TAGS_HIERARCHY,
   TAGS_HIERARCHY_BASE,
   VaultUtils,
@@ -25,7 +25,7 @@ export class TreeViewUtils {
     notes,
     noteId,
   }: {
-    notes: NotePropsDict;
+    notes: NotePropsByIdDict;
     noteId: string;
   }) => {
     let pNote: NoteProps = notes[noteId];
@@ -44,7 +44,7 @@ export class TreeViewUtils {
     applyNavExclude = false,
   }: {
     noteId: string;
-    noteDict: NotePropsDict;
+    noteDict: NotePropsByIdDict;
     showVaultName?: boolean;
     applyNavExclude: boolean;
   }): DataNode | undefined {

--- a/packages/common-test-utils/src/index.ts
+++ b/packages/common-test-utils/src/index.ts
@@ -3,7 +3,7 @@ import {
   DVault,
   NoteOpts,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   SchemaModuleOpts,
   SchemaModuleProps,
@@ -315,7 +315,7 @@ export class NodeTestUtilsV2 {
     withBody?: boolean;
     vaultPath: string;
     noteProps?: (Omit<NoteOpts, "vault"> & { vault?: DVault })[];
-  }): Promise<NotePropsDict> => {
+  }): Promise<NotePropsByIdDict> => {
     const cleanOpts = _.defaults(opts, {
       withBody: true,
       noteProps: [] as NoteOpts[],
@@ -329,7 +329,7 @@ export class NodeTestUtilsV2 {
       ...defaultOpts,
       vault,
     });
-    const out: NotePropsDict = {
+    const out: NotePropsByIdDict = {
       root: rootNote,
     };
     await Promise.all(
@@ -449,7 +449,7 @@ export class NodeTestUtilsV2 {
   }
 
   static normalizeNotes(
-    notes: NoteProps[] | NotePropsDict
+    notes: NoteProps[] | NotePropsByIdDict
   ): Partial<NoteProps>[] {
     if (!_.isArray(notes)) {
       notes = _.values(notes);

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -6,7 +6,7 @@ import {
   SchemaModuleProps,
   SchemaUtils,
   DNodePropsQuickInputV2,
-  NotePropsDict,
+  NotePropsByIdDict,
   DEngineClient,
   EngineWriteOptsV2,
 } from "@dendronhq/common-all";
@@ -112,16 +112,6 @@ export class TestNoteFactory {
 
   async createForFNames(fnames: string[]): Promise<NoteProps[]> {
     return Promise.all(fnames.map((name) => this.createForFName(name)));
-  }
-
-  toNotePropsDict(notes: NoteProps[]): NotePropsDict {
-    const dict: NotePropsDict = {};
-
-    for (const note of notes) {
-      dict[note.id] = note;
-    }
-
-    return dict;
   }
 }
 

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -6,7 +6,6 @@ import {
   SchemaModuleProps,
   SchemaUtils,
   DNodePropsQuickInputV2,
-  NotePropsByIdDict,
   DEngineClient,
   EngineWriteOptsV2,
 } from "@dendronhq/common-all";

--- a/packages/common-test-utils/src/utils.ts
+++ b/packages/common-test-utils/src/utils.ts
@@ -1,7 +1,7 @@
 import {
   DEngineClient,
   DEngineInitResp,
-  NotePropsDict,
+  NotePropsByIdDict,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import assert from "assert";
@@ -113,7 +113,7 @@ export class TestPresetEntry<
   public after: (_opts: TAfterOpts) => Promise<any>;
   public results: (_opts: TResultsOpts) => Promise<TestResult[]>;
   public init: () => Promise<void>;
-  public notes: NotePropsDict = {};
+  public notes: NotePropsByIdDict = {};
 
   constructor({
     label,

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -1,8 +1,8 @@
 import {
   DVault,
-  NoteFullDictUtils,
+  NoteDictsUtils,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NotePropsByFnameDict,
   NoteUtils,
   SchemaModuleDict,
@@ -40,7 +40,7 @@ const getLocalNoteGraphElements = ({
   vaults,
   fNameDict,
 }: {
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   fNameDict: NotePropsByFnameDict;
   wsRoot: string;
   vaults: DVault[] | undefined;
@@ -217,7 +217,7 @@ const getLocalNoteGraphElements = ({
       }
 
       const fname = fnameArray[fnameArray.length - 1];
-      let to = NoteFullDictUtils.findNotesByFname(
+      const to = NoteDictsUtils.findByFname(
         fname,
         {
           notesById: notes,
@@ -276,7 +276,7 @@ const getLocalNoteGraphElements = ({
   };
 };
 
-function getNoteColor(opts: { fname: string; notes: NotePropsDict }) {
+function getNoteColor(opts: { fname: string; notes: NotePropsByIdDict }) {
   // Avoiding using color for non-tag notes because it's a little expensive right now,
   // it requires multiple getNotesByFName calls. Once that function is cheaper
   // we can use this for all notes.
@@ -291,7 +291,7 @@ const getFullNoteGraphElements = ({
   vaults,
   noteActive,
 }: {
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   fNameDict: NotePropsByFnameDict;
   wsRoot: string;
   vaults: DVault[] | undefined;
@@ -378,7 +378,7 @@ const getFullNoteGraphElements = ({
         }
 
         const fname = fnameArray[fnameArray.length - 1];
-        let to = NoteFullDictUtils.findNotesByFname(
+        let to = NoteDictsUtils.findByFname(
           fname,
           {
             notesById: notes,

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -1,8 +1,9 @@
 import {
   DVault,
-  NoteFNamesDict,
+  NoteFullDictUtils,
   NoteProps,
   NotePropsDict,
+  NotePropsByFnameDict,
   NoteUtils,
   SchemaModuleDict,
   SchemaProps,
@@ -40,7 +41,7 @@ const getLocalNoteGraphElements = ({
   fNameDict,
 }: {
   notes: NotePropsDict;
-  fNameDict: NoteFNamesDict;
+  fNameDict: NotePropsByFnameDict;
   wsRoot: string;
   vaults: DVault[] | undefined;
   noteActive: NoteProps | undefined;
@@ -216,10 +217,13 @@ const getLocalNoteGraphElements = ({
       }
 
       const fname = fnameArray[fnameArray.length - 1];
-      let toNotes = fNameDict.get(notes, fname);
-
-      const to = toNotes.filter((note) =>
-        VaultUtils.isEqualV2(note.vault, toVault)
+      let to = NoteFullDictUtils.findNotesByFname(
+        fname,
+        {
+          notesById: notes,
+          notesByFname: fNameDict,
+        },
+        toVault
       )[0];
 
       if (!to) {
@@ -288,7 +292,7 @@ const getFullNoteGraphElements = ({
   noteActive,
 }: {
   notes: NotePropsDict;
-  fNameDict: NoteFNamesDict;
+  fNameDict: NotePropsByFnameDict;
   wsRoot: string;
   vaults: DVault[] | undefined;
   noteActive: NoteProps | undefined;
@@ -374,10 +378,13 @@ const getFullNoteGraphElements = ({
         }
 
         const fname = fnameArray[fnameArray.length - 1];
-        let toNotes = fNameDict.get(notes, fname);
-
-        const to = toNotes.filter((note) =>
-          VaultUtils.isEqualV2(note.vault, toVault)
+        let to = NoteFullDictUtils.findNotesByFname(
+          fname,
+          {
+            notesById: notes,
+            notesByFname: fNameDict,
+          },
+          toVault
         )[0];
 
         if (!to) {

--- a/packages/engine-server/src/backfillV2/service.ts
+++ b/packages/engine-server/src/backfillV2/service.ts
@@ -2,7 +2,7 @@ import {
   DEngineClient,
   genUUID,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
 } from "@dendronhq/common-all";
 import _ from "lodash";
@@ -18,7 +18,7 @@ export class BackfillService {
     const { engine, note, overwriteFields } = _.defaults(opts, {
       overwriteFields: [],
     });
-    const candidates: NotePropsDict = _.isUndefined(note)
+    const candidates: NotePropsByIdDict = _.isUndefined(note)
       ? engine.notes
       : { [note.id]: note };
     const notes = await Promise.all(

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -380,7 +380,8 @@ export class DoctorService implements Disposable {
           note.id = genUUID();
           await engine.writeNote(note, {
             runHooks: false,
-            updateExisting: true,
+            // Old note needs to be removed
+            updateExisting: false,
           });
           numChanges += 1;
         };

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -26,7 +26,6 @@ import {
   NoteChangeEntry,
   NoteProps,
   NotePropsDict,
-  NoteFNamesDict,
   NotesCacheEntryMap,
   NoteUtils,
   RenameNoteOpts,
@@ -47,6 +46,10 @@ import {
   NoteChangeUpdateEntry,
   DNodeUtils,
   asyncLoopOneAtATime,
+  NotePropsByFnameDict,
+  NoteFullDictUtils,
+  NoteFnameDictUtils,
+  FindNoteOpts,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -75,7 +78,7 @@ export class FileStorage implements DStore {
    * the backlink data in this dictionary hence it starts to contain stale backlink data.
    *  */
   public notes: NotePropsDict;
-  public noteFnames: NoteFNamesDict;
+  public noteFnames: NotePropsByFnameDict;
   public schemas: SchemaModuleDict;
   public logger: DLogger;
   public links: DLink[];
@@ -92,7 +95,7 @@ export class FileStorage implements DStore {
     this.configRoot = wsRoot;
     this.vaults = vaults;
     this.notes = {};
-    this.noteFnames = new NoteFNamesDict();
+    this.noteFnames = {};
     this.schemas = {};
     this.links = [];
     this.anchors = [];
@@ -185,6 +188,30 @@ export class FileStorage implements DStore {
   }
 
   /**
+   * See {@link DStore.getNote}
+   */
+  getNote(id: string): NoteProps | undefined {
+    const maybeNote = this.notes[id];
+    if (maybeNote) {
+      return _.cloneDeep(maybeNote);
+    } else {
+      return undefined;
+    }
+  }
+
+  /**
+   * See {@link DStore.findNotes}
+   */
+  findNotes(opts: FindNoteOpts): NoteProps[] {
+    const { fname, vault } = opts;
+    return NoteFullDictUtils.findNotesByFname(
+      fname,
+      { notesById: this.notes, notesByFname: this.noteFnames },
+      vault
+    );
+  }
+
+  /**
    *
    * @param id id of note to be deleted
    * @param opts EngineDeleteOptsV2 the flag `replaceWithNewStub` is used
@@ -265,11 +292,13 @@ export class FileStorage implements DStore {
           prevNote: parentNotePrev,
         });
 
-        delete this.notes[noteToDelete.id];
-        this.noteFnames.delete(noteToDelete);
-        await this.writeNote(replacingStub, { newNode: true });
+        NoteFullDictUtils.deleteNote(noteToDelete, {
+          notesById: this.notes,
+          notesByFname: this.noteFnames,
+        });
+        const changed = await this.writeNote(replacingStub, { newNode: true });
         out.push({ note: noteToDelete, status: "delete" });
-        out.push({ note: replacingStub, status: "create" });
+        out = out.concat(changed.data);
       }
     } else {
       // no children, delete reference from parent
@@ -287,8 +316,10 @@ export class FileStorage implements DStore {
         (ent) => ent === noteToDelete.id
       );
       // delete from note dictionary
-      delete this.notes[noteToDelete.id];
-      this.noteFnames.delete(noteToDelete);
+      NoteFullDictUtils.deleteNote(noteToDelete, {
+        notesById: this.notes,
+        notesByFname: this.noteFnames,
+      });
       // if parent note is not a stub, update it
       if (!parentNote.stub) {
         out.push({
@@ -447,8 +478,8 @@ export class FileStorage implements DStore {
       })
     );
     this.notes = Object.assign({}, ...out);
+    this.noteFnames = NoteFnameDictUtils.create(this.notes);
     const allNotes = _.values(this.notes);
-    this.noteFnames = new NoteFNamesDict(allNotes);
     if (_.size(this.notes) === 0) {
       errors.push(
         new DendronError({
@@ -945,8 +976,7 @@ export class FileStorage implements DStore {
   }
 
   /**
-   * Update a note. If note exists, call {@link NoteUtils.hydrate} to populate new note with parent/children/backlink properties
-   * of the existing note
+   * Update a note.
    *
    * If {@link newNode} is set, set the {@link NoteProps["parent"]} property and create stubs as necessary
    *
@@ -957,25 +987,24 @@ export class FileStorage implements DStore {
   async updateNote(note: NoteProps, opts?: EngineUpdateNodesOptsV2) {
     const ctx = "updateNote";
     this.logger.debug({ ctx, note: NoteUtils.toLogObj(note), msg: "enter" });
-    const maybeNote: NoteProps | undefined = this.notes[note.id];
-    if (maybeNote) {
-      note = NoteUtils.hydrate({ noteRaw: note, noteHydrated: maybeNote });
-    }
+
+    const notesDict = {
+      notesById: this.notes,
+      notesByFname: this.noteFnames,
+    };
     if (opts?.newNode) {
-      NoteUtils.addOrUpdateParentsWithDict({
+      const changed = NoteUtils.addOrUpdateParents({
         note,
-        notesDict: this.notes,
-        notesByFnameDict: this.noteFnames,
+        notesDict,
         createStubs: true,
         wsRoot: this.wsRoot,
       });
+      changed.forEach((changedEntry) =>
+        NoteFullDictUtils.addNote(changedEntry.note, notesDict)
+      );
     }
     this.logger.debug({ ctx, note: NoteUtils.toLogObj(note) });
-    this.notes[note.id] = note;
-    if (maybeNote && maybeNote.fname !== note.fname) {
-      this.noteFnames.delete(maybeNote);
-    }
-    this.noteFnames.add(note);
+    NoteFullDictUtils.addNote(note, notesDict);
     return note;
   }
 
@@ -1008,6 +1037,10 @@ export class FileStorage implements DStore {
     });
 
     let changed: NoteChangeEntry[] = [];
+    const notesDict = {
+      notesById: this.notes,
+      notesByFname: this.noteFnames,
+    };
     // in this case, we are deleting the old note and writing a new note in its place with the same hierarchy
     // the parent of this note needs to have the old note removed (because the id is now different)
     // the new note needs to have the old note's children
@@ -1024,8 +1057,7 @@ export class FileStorage implements DStore {
       const prevParentState = { ...parent };
 
       // delete the existing note.
-      delete this.notes[existingNote.id];
-      this.noteFnames.delete(existingNote);
+      NoteFullDictUtils.deleteNote(existingNote, notesDict);
 
       // first, update existing note's parent
       // so that it doesn't hold the deleted existing note's id as children
@@ -1036,7 +1068,7 @@ export class FileStorage implements DStore {
 
       // then update parent note of existing note
       // so that the newly created note is a child
-      DNodeUtils.addChild(this.notes[existingNote.parent], note);
+      DNodeUtils.addChild(parent, note);
 
       // add an entry for the updated parent if there was a change
       changed.push({
@@ -1064,13 +1096,13 @@ export class FileStorage implements DStore {
     // this is the default behavior
     // only do this if we aren't writing to existing note. we never hit this case in that situation.
     if (!opts?.noAddParent && !existingNote) {
-      const out = NoteUtils.addOrUpdateParentsWithDict({
+      const out = NoteUtils.addOrUpdateParents({
         note,
-        notesDict: this.notes,
-        notesByFnameDict: this.noteFnames,
+        notesDict,
         createStubs: true,
         wsRoot: this.wsRoot,
       });
+      // add one entry for each parent updated
       changed = changed.concat(out);
     }
     this.logger.info({
@@ -1095,11 +1127,11 @@ export class FileStorage implements DStore {
       note: NoteUtils.toLogObj(note),
     });
     // check if note might already exist
-    const maybeNote = NoteUtils.getNoteByFnameFromEngine({
-      fname: note.fname,
-      vault: note.vault,
-      engine: this.engine,
-    });
+    const maybeNote = NoteFullDictUtils.findNotesByFname(
+      note.fname,
+      { notesById: this.notes, notesByFname: this.noteFnames },
+      note.vault
+    )[0];
     this.logger.info({
       ctx,
       msg: "check:existing",

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -34,8 +34,10 @@ import {
   GetNotePayload,
   IntermediateDendronConfig,
   NoteChangeEntry,
-  NoteFNamesDict,
+  NoteFnameDictUtils,
+  NoteFullDictUtils,
   NoteProps,
+  NotePropsByFnameDict,
   NotePropsDict,
   NoteUtils,
   Optional,
@@ -71,7 +73,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   private _onNoteChangedEmitter = new EventEmitter<NoteChangeEntry[]>();
 
   public notes: NotePropsDict;
-  public noteFnames: NoteFNamesDict;
+  public noteFnames: NotePropsByFnameDict;
   public wsRoot: string;
   public schemas: SchemaModuleDict;
   public links: DLink[];
@@ -128,7 +130,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   } & DendronEngineClientOpts) {
     this.api = api;
     this.notes = {};
-    this.noteFnames = new NoteFNamesDict();
+    this.noteFnames = {};
     this.schemas = {};
     this.links = [];
     this.vaults = vaults;
@@ -183,7 +185,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     }
     const { notes, schemas } = resp.data;
     this.notes = notes;
-    this.noteFnames = new NoteFNamesDict(_.values(notes));
+    this.noteFnames = NoteFnameDictUtils.create(this.notes);
     this.schemas = schemas;
     await this.fuseEngine.updateNotesIndex(notes);
     await this.fuseEngine.updateSchemaIndex(schemas);
@@ -244,7 +246,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     }
     const { notes, schemas } = resp.data;
     this.notes = notes;
-    this.noteFnames = new NoteFNamesDict(_.values(notes));
+    this.noteFnames = NoteFnameDictUtils.create(this.notes);
     this.schemas = schemas;
     this.fuseEngine.updateNotesIndex(notes);
     this.fuseEngine.updateSchemaIndex(schemas);
@@ -334,26 +336,23 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   }
 
   async refreshNotesV2(notes: NoteChangeEntry[]) {
+    const notesDict = {
+      notesById: this.notes,
+      notesByFname: this.noteFnames,
+    };
     notes.forEach((ent: NoteChangeEntry) => {
-      const { id } = ent.note;
       const uri = NoteUtils.getURI({ note: ent.note, wsRoot: this.wsRoot });
       if (ent.status === "delete") {
-        delete this.notes[id];
-        this.noteFnames.delete(ent.note);
+        NoteFullDictUtils.deleteNote(ent.note, notesDict);
         this.history?.add({ source: "engine", action: "delete", uri });
       } else {
         if (ent.status === "create") {
-          this.noteFnames.add(ent.note);
           this.history?.add({ source: "engine", action: "create", uri });
         }
         if (ent.status === "update") {
-          // If the note id or fname has been changed, need to update fname dict
-          if (
-            ent.prevNote?.fname !== ent.note.fname ||
-            ent.prevNote?.id !== ent.note.id
-          ) {
-            if (ent.prevNote) this.noteFnames.delete(ent.prevNote);
-            this.noteFnames.add(ent.note);
+          // If the note id has changed, delete previous entry from dict before adding
+          if (ent.prevNote && ent.prevNote.id !== ent.note.id) {
+            NoteFullDictUtils.deleteNote(ent.prevNote, notesDict);
           }
           ent.note.children = _.sortBy(
             ent.note.children,
@@ -367,7 +366,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
               ).title
           );
         }
-        this.notes[id] = ent.note;
+        NoteFullDictUtils.addNote(ent.note, notesDict);
       }
     });
     this.fuseEngine.updateNotesIndex(this.notes);
@@ -406,7 +405,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     }
     const { notes, schemas } = resp.data;
     this.notes = notes;
-    this.noteFnames = new NoteFNamesDict(_.values(notes));
+    this.noteFnames = NoteFnameDictUtils.create(this.notes);
     this.schemas = schemas;
     await this.fuseEngine.updateNotesIndex(notes);
     await this.fuseEngine.updateSchemaIndex(schemas);

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -31,7 +31,7 @@ import {
   milliseconds,
   NoteChangeEntry,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   NullCache,
   QueryNotesOpts,
@@ -60,7 +60,7 @@ import {
   GetNoteLinksPayload,
   Optional,
   assertUnreachable,
-  NoteFullDictUtils,
+  NoteDictsUtils,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -233,7 +233,7 @@ export class DendronEngineV2 implements DEngine {
     return DendronEngineV2._instance;
   }
 
-  get notes(): NotePropsDict {
+  get notes(): NotePropsByIdDict {
     return this.store.notes;
   }
   get noteFnames() {
@@ -247,7 +247,7 @@ export class DendronEngineV2 implements DEngine {
     return this._vaults;
   }
 
-  set notes(notes: NotePropsDict) {
+  set notes(notes: NotePropsByIdDict) {
     this.store.notes = notes;
   }
 
@@ -703,7 +703,7 @@ export class DendronEngineV2 implements DEngine {
       notes.map(async (ent: NoteChangeEntry) => {
         const { id } = ent.note;
         if (ent.status === "delete") {
-          NoteFullDictUtils.deleteNote(ent.note, {
+          NoteDictsUtils.delete(ent.note, {
             notesById: this.notes,
             notesByFname: this.noteFnames,
           });

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -60,6 +60,7 @@ import {
   GetNoteLinksPayload,
   Optional,
   assertUnreachable,
+  NoteFullDictUtils,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -702,8 +703,10 @@ export class DendronEngineV2 implements DEngine {
       notes.map(async (ent: NoteChangeEntry) => {
         const { id } = ent.note;
         if (ent.status === "delete") {
-          delete this.notes[id];
-          this.noteFnames.delete(ent.note);
+          NoteFullDictUtils.deleteNote(ent.note, {
+            notesById: this.notes,
+            notesByFname: this.noteFnames,
+          });
         } else {
           const note = await EngineUtils.refreshNoteLinksAndAnchors({
             note: ent.note,

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -5,7 +5,7 @@ import {
   DEngineClient,
   DVault,
   ERROR_STATUS,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   NoteProps,
   DateTime,
@@ -103,7 +103,7 @@ export type ProcDataFullOptsV5 = {
   /**
    * Supply alternative dictionary of notes to use when resolving note ids
    */
-  notes?: NotePropsDict;
+  notes?: NotePropsByIdDict;
   /**
    * Check to see if we are in a note reference.
    */
@@ -133,7 +133,7 @@ export type ProcDataFullV5 = {
   // derived: unless passed in, these come from engine or are set by
   // other unified plugins
   config: IntermediateDendronConfig;
-  notes?: NotePropsDict;
+  notes?: NotePropsByIdDict;
   insideNoteRef?: boolean;
 
   fm?: any;

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -339,6 +339,9 @@ export class SiteUtils {
         delete note.stub;
         // eslint-disable-next-line no-await-in-loop
         await engine.writeNote(note);
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        await engine.updateNote(note);
       }
 
       // if `skipLevels` is enabled, the children of the current note are descendants

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -10,7 +10,7 @@ import {
   DVault,
   DVaultVisibility,
   HierarchyConfig,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteProps,
   NoteUtils,
   UseVaultBehavior,
@@ -157,7 +157,7 @@ export class SiteUtils {
     engine: DEngineClient;
     config: IntermediateDendronConfig;
     noExpandSingleDomain?: boolean;
-  }): Promise<{ notes: NotePropsDict; domains: NoteProps[] }> {
+  }): Promise<{ notes: NotePropsByIdDict; domains: NoteProps[] }> {
     const logger = createLogger(LOGGER_NAME);
     const { engine, config } = opts;
     const notes = _.clone(engine.notes);
@@ -176,7 +176,7 @@ export class SiteUtils {
     const { siteHierarchies } = cleanPublishingConfig;
     logger.info({ ctx: "filterByConfig", config });
     let domains: NoteProps[] = [];
-    const hiearchiesToPublish: NotePropsDict[] = [];
+    const hiearchiesToPublish: NotePropsByIdDict[] = [];
 
     // async pass to process all notes
     const domainsAndhiearchiesToPublish = await Promise.all(
@@ -240,7 +240,7 @@ export class SiteUtils {
     config: IntermediateDendronConfig;
     engine: DEngineClient;
     navOrder: number;
-  }): Promise<{ notes: NotePropsDict; domain: NoteProps } | undefined> {
+  }): Promise<{ notes: NotePropsByIdDict; domain: NoteProps } | undefined> {
     const { domain, engine, navOrder, config } = opts;
     const logger = createLogger(LOGGER_NAME);
     logger.info({ ctx: "filterByHierarchy:enter", domain, config });
@@ -318,7 +318,7 @@ export class SiteUtils {
     });
 
     // gather all the children of this hierarchy
-    const out: NotePropsDict = {};
+    const out: NotePropsByIdDict = {};
     const processQ = [domainNote];
 
     while (!_.isEmpty(processQ)) {
@@ -512,7 +512,7 @@ export class SiteUtils {
     fname: string;
     config: IntermediateDendronConfig;
     noteCandidates: NoteProps[];
-    noteDict: NotePropsDict;
+    noteDict: NotePropsByIdDict;
   }) {
     const {
       engine,

--- a/packages/engine-server/src/utils.ts
+++ b/packages/engine-server/src/utils.ts
@@ -9,7 +9,7 @@ import {
   ErrorFactory,
   getSlugger,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NotesCacheEntry,
   NoteUtils,
   RespV3,
@@ -264,7 +264,7 @@ export class HierarchyUtils {
   static getChildren = (opts: {
     skipLevels: number;
     note: NoteProps;
-    notes: NotePropsDict;
+    notes: NotePropsByIdDict;
   }) => {
     const { skipLevels, note, notes } = opts;
     let children = note.children

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -2,7 +2,7 @@ import {
   FuseEngine,
   getCleanThresholdValue,
   NoteIndexProps,
-  NotePropsDict,
+  NotePropsByIdDict,
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import Fuse from "fuse.js";
@@ -13,10 +13,10 @@ type TestData = {
   stub?: boolean;
 };
 
-async function testDataToNotePropsDict(
+async function testDataToNotePropsByIdDict(
   testData: TestData[]
-): Promise<NotePropsDict> {
-  const dict: NotePropsDict = {};
+): Promise<NotePropsByIdDict> {
+  const dict: NotePropsByIdDict = {};
 
   for (const td of testData) {
     // eslint-disable-next-line no-await-in-loop
@@ -50,8 +50,9 @@ function assertDoesNotHaveFName(queryResult: NoteIndexProps[], fname: string) {
 
 async function initializeFuseEngine(testData: TestData[]): Promise<FuseEngine> {
   const fuseEngine = new FuseEngine({ fuzzThreshold: 0.2 });
-  const notePropsDict: NotePropsDict = await testDataToNotePropsDict(testData);
-  await fuseEngine.updateNotesIndex(notePropsDict);
+  const notePropsByIdDict: NotePropsByIdDict =
+    await testDataToNotePropsByIdDict(testData);
+  await fuseEngine.updateNotesIndex(notePropsByIdDict);
   return fuseEngine;
 }
 

--- a/packages/engine-test-utils/src/__tests__/site.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/site.spec.ts
@@ -5,7 +5,7 @@ import {
   DVault,
   DVaultVisibility,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
@@ -55,8 +55,8 @@ const dupNote = (payload: DVault | string[]) => {
 };
 
 const checkNotes = (opts: {
-  filteredNotes: NotePropsDict;
-  engineNotes: NotePropsDict;
+  filteredNotes: NotePropsByIdDict;
+  engineNotes: NotePropsByIdDict;
   match: ({
     id: string;
   } & Partial<NoteProps>)[];

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -1599,7 +1599,7 @@ const NOTES = {
           expected: "foo1",
         },
         {
-          actual: changedEntries && changedEntries.length === 5,
+          actual: changedEntries && changedEntries.length === 6,
           expected: true,
         },
       ];

--- a/packages/engine-test-utils/src/presets/engine-server/update.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/update.ts
@@ -10,6 +10,7 @@ import {
 } from "@dendronhq/engine-server";
 import _ from "lodash";
 import path from "path";
+import { setupBasic } from "./utils";
 
 const NOTES = {
   NOTE_NO_CHILDREN: new TestPresetEntryV4(
@@ -63,6 +64,57 @@ const NOTES = {
       preSetupHook: async ({ vaults, wsRoot }) => {
         await NOTE_PRESETS_V4.NOTE_SIMPLE.create({ wsRoot, vault: vaults[0] });
       },
+    }
+  ),
+  NOTE_UPDATE_CHILDREN: new TestPresetEntryV4(
+    async ({ vaults, wsRoot, engine }) => {
+      const vault = vaults[0];
+      const logger = (engine as DendronEngineClient).logger;
+      const cachePath = path.join(
+        vault2Path({ wsRoot, vault }),
+        CONSTANTS.DENDRON_CACHE_FILE
+      );
+      const notesCache = new NotesFileSystemCache({ cachePath, logger });
+      const keySet = notesCache.getCacheEntryKeys();
+      const noteOld = NoteUtils.getNoteByFnameFromEngine({
+        fname: "foo",
+        engine,
+        vault,
+      }) as NoteProps;
+      const cnote = _.clone(noteOld);
+      cnote.children = ["random note"];
+      await engine.updateNote(cnote);
+      const noteNew = NoteUtils.getNoteByFnameFromEngine({
+        fname: "foo",
+        engine,
+        vault,
+      }) as NoteProps;
+      await engine.init();
+
+      return [
+        {
+          actual: noteOld.children[0],
+          expected: "foo.ch1",
+        },
+        {
+          actual: noteNew.children[0],
+          expected: "random note",
+        },
+        {
+          actual: keySet.size,
+          expected: 4,
+        },
+        {
+          actual: new NotesFileSystemCache({
+            cachePath,
+            logger,
+          }).getCacheEntryKeys().size,
+          expected: 4,
+        },
+      ];
+    },
+    {
+      preSetupHook: setupBasic,
     }
   ),
 };

--- a/packages/nextjs-template/features/engine/slice.ts
+++ b/packages/nextjs-template/features/engine/slice.ts
@@ -1,7 +1,7 @@
 import {
   IntermediateDendronConfig,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
 } from "@dendronhq/common-all";
 import {
   createSlice,
@@ -33,7 +33,7 @@ export const slice = createSlice({
     ) => {
       state.config = action.payload;
     },
-    setNotes: (state, action: PayloadAction<NotePropsDict>) => {
+    setNotes: (state, action: PayloadAction<NotePropsByIdDict>) => {
       state.notes = action.payload;
     },
     setNoteIndex: (state, action: PayloadAction<NoteProps>) => {

--- a/packages/nextjs-template/utils/fuse.ts
+++ b/packages/nextjs-template/utils/fuse.ts
@@ -3,8 +3,7 @@ import {
   DendronError,
   FuseNote,
   FuseNoteIndex,
-  NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
 } from "@dendronhq/common-all";
 import { fetchFuseIndex } from "./fetchers";
 import { useEffect, useState } from "react";
@@ -20,7 +19,7 @@ type FuseIndexProvider = () => Promise<FuseNoteIndex | FuseNote>;
  * good example of what to do.
  */
 function useFuse(
-  notes: NotePropsDict | undefined,
+  notes: NotePropsByIdDict | undefined,
   provider: FuseIndexProvider
 ) {
   const [error, setError] = useState<any>();
@@ -68,13 +67,13 @@ function useFuse(
 }
 
 /** A react hook to fetch the exported fuse index. */
-export function useFetchFuse(notes: NotePropsDict | undefined) {
+export function useFetchFuse(notes: NotePropsByIdDict | undefined) {
   return useFuse(notes, fetchFuseIndex);
 }
 
 /** A react hook to generate the fuse index on the client side. */
 export function useGenerateFuse(
-  notes: NotePropsDict,
+  notes: NotePropsByIdDict,
   overrideOpts?: Parameters<typeof createFuseNote>[1]
 ) {
   return useFuse(notes, async () => {

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -3,7 +3,7 @@ import {
   FuseEngine,
   IntermediateDendronConfig,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
 } from "@dendronhq/common-all";
 import { verifyEngineSliceState } from "@dendronhq/common-frontend";
 import { Grid } from "antd";
@@ -32,7 +32,7 @@ export function useDendronRouter() {
   const getActiveNote = ({
     notes,
   }: {
-    notes: NotePropsDict;
+    notes: NotePropsByIdDict;
   }): NoteProps | undefined => {
     const maybeIdByQuery = query?.id;
     return !_.isUndefined(maybeIdByQuery) ? notes[maybeIdByQuery] : undefined;

--- a/packages/nextjs-template/utils/types.ts
+++ b/packages/nextjs-template/utils/types.ts
@@ -1,9 +1,4 @@
-import {
-  DVault,
-  NoteProps,
-  NotePropsDict,
-  TreeMenu,
-} from "@dendronhq/common-all";
+import { DVault, NoteProps, NotePropsByIdDict } from "@dendronhq/common-all";
 import _ from "lodash";
 import { DendronRouterProps } from "./hooks";
 
@@ -17,7 +12,7 @@ export type NoteData = {
   /**
    * All notes that are published
    */
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   /**
    * All top level domains that are published
    */

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -334,6 +334,7 @@ export class WorkspaceWatcher {
       // eslint-disable-next-line  no-async-promise-executor
       const p = new Promise(async (resolve) => {
         note.updated = now;
+        await engine.updateNote(note);
         return resolve(changes);
       });
       event.waitUntil(p);

--- a/packages/plugin-core/src/commands/GoUpCommand.ts
+++ b/packages/plugin-core/src/commands/GoUpCommand.ts
@@ -26,8 +26,7 @@ export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
     const engine = getDWorkspace().engine;
     const nparent = DNodeUtils.findClosestParent(
       path.basename(maybeTextEditor.document.uri.fsPath, ".md"),
-      engine.notes,
-      engine.noteFnames,
+      { notesById: engine.notes, notesByFname: engine.noteFnames },
       {
         noStubs: true,
         vault: PickerUtilsV2.getVaultForOpenEditor(),

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -31,7 +31,7 @@ import {
   NoteChangeEntry,
   NoteProps,
   NotePropsByFnameDict,
-  NotePropsDict,
+  NotePropsByIdDict,
   Optional,
   QueryNotesOpts,
   RefreshNotesOpts,
@@ -124,10 +124,10 @@ export class EngineAPIService
     this._trustedWorkspace = value;
   }
 
-  public get notes(): NotePropsDict {
+  public get notes(): NotePropsByIdDict {
     return this._internalEngine.notes;
   }
-  public set notes(arg: NotePropsDict) {
+  public set notes(arg: NotePropsByIdDict) {
     this._internalEngine.notes = arg;
   }
 

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -29,8 +29,8 @@ import {
   GetNotePayload,
   IntermediateDendronConfig,
   NoteChangeEntry,
-  NoteFNamesDict,
   NoteProps,
+  NotePropsByFnameDict,
   NotePropsDict,
   Optional,
   QueryNotesOpts,
@@ -131,10 +131,10 @@ export class EngineAPIService
     this._internalEngine.notes = arg;
   }
 
-  public get noteFnames(): NoteFNamesDict {
+  public get noteFnames(): NotePropsByFnameDict {
     return this._internalEngine.noteFnames;
   }
-  public set noteFnames(arg: NoteFNamesDict) {
+  public set noteFnames(arg: NotePropsByFnameDict) {
     this._internalEngine.noteFnames = arg;
   }
 

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -25,7 +25,7 @@ import {
   NoteChangeEntry,
   NoteProps,
   NotePropsByFnameDict,
-  NotePropsDict,
+  NotePropsByIdDict,
   Optional,
   QueryNotesOpts,
   RefreshNotesOpts,
@@ -42,7 +42,7 @@ import { EngineEventEmitter } from "@dendronhq/engine-server";
 
 export interface IEngineAPIService {
   trustedWorkspace: boolean;
-  notes: NotePropsDict;
+  notes: NotePropsByIdDict;
   noteFnames: NotePropsByFnameDict;
   wsRoot: string;
   schemas: SchemaModuleDict;

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -23,8 +23,8 @@ import {
   GetNotePayload,
   IntermediateDendronConfig,
   NoteChangeEntry,
-  NoteFNamesDict,
   NoteProps,
+  NotePropsByFnameDict,
   NotePropsDict,
   Optional,
   QueryNotesOpts,
@@ -43,7 +43,7 @@ import { EngineEventEmitter } from "@dendronhq/engine-server";
 export interface IEngineAPIService {
   trustedWorkspace: boolean;
   notes: NotePropsDict;
-  noteFnames: NoteFNamesDict;
+  noteFnames: NotePropsByFnameDict;
   wsRoot: string;
   schemas: SchemaModuleDict;
   links: DLink[];

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -588,7 +588,8 @@ suite("REGENERATE_NOTE_ID", function () {
             vault,
             wsRoot,
           });
-          expect(root?.id).toNotEqual(oldRootId);
+          // Root should not change
+          expect(root?.id).toEqual(oldRootId);
           expect(foo?.id).toNotEqual(oldFooId);
           expect(bar?.id).toNotEqual(oldBarId);
         } finally {

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -153,7 +153,7 @@ suite("MoveNoteCommand", function () {
               },
             ],
           });
-          expect(resp?.changed?.length).toEqual(5);
+          expect(resp?.changed?.length).toEqual(6);
           active = VSCodeUtils.getActiveTextEditor() as vscode.TextEditor;
           expect(DNodeUtils.fname(active.document.uri.fsPath)).toEqual(
             "foobar"

--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -2,7 +2,7 @@ import {
   DendronError,
   DNodeUtils,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   TreeUtils,
   TreeViewItemLabelTypeEnum,
@@ -199,7 +199,7 @@ export class EngineNoteProvider
 
   private async parseTree(
     note: NoteProps,
-    ndict: NotePropsDict
+    ndict: NotePropsByIdDict
   ): Promise<TreeNote> {
     const ctx = "parseTree";
     const tn = this.createTreeNote(note);

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -3,7 +3,7 @@ import {
   DendronSiteConfig,
   DEngineClient,
   NoteProps,
-  NotePropsDict,
+  NotePropsByIdDict,
   NoteUtils,
   createSerializedFuseNoteIndex,
   ConfigUtils,
@@ -59,8 +59,8 @@ export const mapObject = (
 export const removeBodyFromNote = ({ body, ...note }: Record<string, any>) =>
   note;
 
-export const removeBodyFromNotesDict = (notes: NotePropsDict) =>
-  mapObject(notes, (_k, note: NotePropsDict) => removeBodyFromNote(note));
+export const removeBodyFromNotesDict = (notes: NotePropsByIdDict) =>
+  mapObject(notes, (_k, note: NotePropsByIdDict) => removeBodyFromNote(note));
 
 function getSiteConfig({
   config,
@@ -259,7 +259,7 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
   }: {
     engine: DEngineClient;
     note: NoteProps;
-    notes: NotePropsDict;
+    notes: NotePropsByIdDict;
     engineConfig: IntermediateDendronConfig;
   }) {
     const proc = MDUtilsV5.procRehypeFull(


### PR DESCRIPTION
**Background**
According to their official docs, Redux highly discourages use of non-serializable types (this includes classes and maps/sets). To bring parity between the redux state and storev2 state, we should use the same primitive javascript object typing.

In addition, `getNotesByFnameFromEngine` currently returns a reference to notes in the engine state. This means that any changes to the notes will affect the engine state. To prevent this side effect, we will return a copy instead.

**Major Changes**
1. Change type of `storev2.noteFnames` from NoteFNamesDict class object to NotePropsByFnameDict Object
2. Create `NoteFullDictUtils` class with static methods to work with both `NotePropsByFnameDict` and `NotePropsDict`. This will be used to add/update/delete from both dictionaries at same time
3. `getNotesByFnameFromEngine` will return a DEEP COPY instead of reference of notes from the engine. 
4. Update `DStore` api to include `getNote` and `findNotes`. These will be called by the engine to access notes from the store

**Minor Changes**
1. Move usages of `getNoteOrThrow` to `getNoteByFnameFromEngine` + throw themselves. getNoteOrThrow takes linear time to search
2. When DoctorService regenerates id, old note should be deleted
3. Minor bug fixes in store where we didn't keep track of all the NoteChangedEntry
4. Remove hydration step from `updateNote`. Notes should be hydrated on the client/engine side. This can lead to bugs where it removes parents/children from newNote if oldNote doesn't have.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)