### PR TITLE
fix: fix corrupt .dendron.ws version to unblock activation

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -680,6 +680,8 @@ export async function _activate(
       const wsService = new WorkspaceService({ wsRoot });
       let previousWorkspaceVersionFromWSService = wsService.getMeta().version;
       if (
+        // Fix a temporary issue where CLI was writing an invalid version number to .dendron.ws:
+        !semver.valid(previousWorkspaceVersionFromWSService) ||
         semver.gt(
           previousWorkspaceVersionFromState,
           previousWorkspaceVersionFromWSService

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -679,8 +679,14 @@ export async function _activate(
       const wsRoot = wsImpl.wsRoot;
       const wsService = new WorkspaceService({ wsRoot });
       let previousWorkspaceVersionFromWSService = wsService.getMeta().version;
+
+      // Fix a temporary issue where CLI was writing an invalid version number
+      // to .dendron.ws:
+      if (previousWorkspaceVersionFromWSService === "dendron-cli") {
+        previousWorkspaceVersionFromWSService = "0.91.0";
+      }
+
       if (
-        // Fix a temporary issue where CLI was writing an invalid version number to .dendron.ws:
         !semver.valid(previousWorkspaceVersionFromWSService) ||
         semver.gt(
           previousWorkspaceVersionFromState,


### PR DESCRIPTION
## fix: fix corrupt .dendron.ws version to unblock activation

Some users have a corrupt value for 'version' in their `.dendron.ws` file if they ran the CLI.  This would cause their activation to fail.

Related: https://github.com/dendronhq/dendron/pull/2871
