### PR TITLE
feat: display task note status when linking to task notes in publishing and in preview

### DIFF
--- a/packages/common-all/src/constants/configs/publishing.ts
+++ b/packages/common-all/src/constants/configs/publishing.ts
@@ -202,4 +202,9 @@ export const PUBLISHING: DendronConfigEntryCollection<DendronPublishingConfig> =
       label: "The theme to use when publishing.",
       desc: "The theme to use when publishing the site. If you are using a custom theme, make sure to create the CSS file too.",
     },
+    enableTaskNotes: {
+      value: true,
+      label: "Enable special formatting for task notes.",
+      desc: "Task notes will have checkboxes, owner information and more displayed on links leading to them. This applies both in preview and publishing.",
+    },
   };

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -132,6 +132,10 @@ const TASK: DendronConfigEntryCollection<TaskConfig> = {
       return [key, value];
     })
   ),
+  taskCompleteStatus: {
+    label: "When is a task complete",
+    desc: "If the note state is set to any of these values, the note is considered to be done.",
+  },
 };
 
 export const WORKSPACE: DendronConfigEntryCollection<DendronWorkspaceConfig> = {

--- a/packages/common-all/src/types/configs/publishing/publishing.ts
+++ b/packages/common-all/src/types/configs/publishing/publishing.ts
@@ -37,6 +37,7 @@ export type DendronPublishingConfig = {
   enableFrontmatterTags: boolean;
   enableHashesForFMTags: boolean;
   enableRandomlyColoredTags?: boolean;
+  enableTaskNotes?: boolean;
   hierarchy?: { [key: string]: HierarchyConfig };
   duplicateNoteBehavior?: DuplicateNoteBehavior;
   writeStubs: boolean;
@@ -104,6 +105,7 @@ export function genDefaultPublishingConfig(): DendronPublishingConfig {
     enableFrontmatterTags: true,
     enableHashesForFMTags: false,
     enableRandomlyColoredTags: true,
+    enableTaskNotes: true,
     enablePrettyLinks: true,
   };
 }

--- a/packages/common-all/src/types/configs/workspace/task.ts
+++ b/packages/common-all/src/types/configs/workspace/task.ts
@@ -12,6 +12,8 @@ export type TaskConfig = Pick<
 > & {
   /** Maps each status to a symbol, word, or sentence. This will be displayed for the task. */
   statusSymbols: { [status: string]: string };
+  /** Sets which statuses mark the task as completed. */
+  taskCompleteStatus: string[];
   /** Maps each priority to a symbol, word, or sentence. This will be displayed for the task. */
   prioritySymbols: { [status: string]: string };
   /** Add a "TODO: <note title>" entry to the frontmatter of task notes. This can simplify integration with various Todo extensions like Todo Tree. */
@@ -40,6 +42,7 @@ export function genDefaultTaskConfig(): TaskConfig {
       dropped: "d",
       pending: "y",
     },
+    taskCompleteStatus: ["done", "x"],
     prioritySymbols: {
       H: "high",
       M: "medium",
@@ -113,6 +116,17 @@ export class TaskNoteUtils {
     const status = this.getStatusSymbolRaw(props);
     if (status === undefined) return undefined;
     return `[${this.getStatusSymbolRaw(props)}]`;
+  }
+
+  static isTaskComplete({
+    note,
+    taskConfig,
+  }: {
+    note: TaskNoteProps;
+    taskConfig: TaskConfig;
+  }) {
+    const { status } = note.custom;
+    return status && taskConfig.taskCompleteStatus?.includes(status);
   }
 
   static getPrioritySymbol({

--- a/packages/common-all/src/types/configs/workspace/task.ts
+++ b/packages/common-all/src/types/configs/workspace/task.ts
@@ -89,7 +89,7 @@ export class TaskNoteUtils {
     return props;
   }
 
-  static getStatusSymbol({
+  static getStatusSymbolRaw({
     note,
     taskConfig,
   }: {
@@ -99,11 +99,20 @@ export class TaskNoteUtils {
     const { status } = note.custom;
     if (status === undefined) return undefined;
     // If the symbol is not mapped to anything, use the symbol prop directly
-    if (!taskConfig.statusSymbols) return `[${status}]`;
+    if (!taskConfig.statusSymbols) return `${status}`;
     const symbol: string | undefined = taskConfig.statusSymbols[status];
-    if (symbol === undefined) return `[${status}]`;
+    if (symbol === undefined) return `${status}`;
     // If it does map to something, then use that
-    return `[${symbol}]`;
+    return `${symbol}`;
+  }
+
+  static getStatusSymbol(props: {
+    note: TaskNoteProps;
+    taskConfig: TaskConfig;
+  }) {
+    const status = this.getStatusSymbolRaw(props);
+    if (status === undefined) return undefined;
+    return `[${this.getStatusSymbolRaw(props)}]`;
   }
 
   static getPrioritySymbol({

--- a/packages/dendron-next-server/styles/scss/main.scss
+++ b/packages/dendron-next-server/styles/scss/main.scss
@@ -67,16 +67,7 @@ $text-color: #111 !default;
   margin-left: 0.5rem;
   opacity: 0.8;
 }
-.task-status {
-  border: 1px solid;
-  min-width: 1rem;
-  height: 1rem;
-  display: inline-block;
-  text-align: center;
-  vertical-align: text-top;
-  padding: 0 0.15rem;
-}
 .task-status-text {
-  position: relative;
-  top: -0.3rem;
+  opacity: 0.8;
+  margin-right: 0.5rem;
 }

--- a/packages/dendron-next-server/styles/scss/main.scss
+++ b/packages/dendron-next-server/styles/scss/main.scss
@@ -22,36 +22,61 @@ $text-color: #111 !default;
 
 // TODO_START: hardcoded
 .vscode-light {
-	.calendar {
-		table,
-		td,
-		th {
-			border: none; // added to remove border from calendar view
-		}
-	}
-	table,
-	td,
-	th {
-		border: 1px solid black; padding:10px; // required for tables in preview
-	}
+  .calendar {
+    table,
+    td,
+    th {
+      border: none; // added to remove border from calendar view
+    }
+  }
+  table,
+  td,
+  th {
+    border: 1px solid black;
+    padding: 10px; // required for tables in preview
+  }
 }
 
-.vscode-dark{
-	.calendar { 
-		table,
-		td,
-		th {
-			border: none; // added to remove border from calendar view
-		}
-	}
-	table,
-	td,
-	th {
-		border: 1px solid white; padding:10px; // required for tables in preview
-	}
+.vscode-dark {
+  .calendar {
+    table,
+    td,
+    th {
+      border: none; // added to remove border from calendar view
+    }
+  }
+  table,
+  td,
+  th {
+    border: 1px solid white;
+    padding: 10px; // required for tables in preview
+  }
 }
 .ant-message {
   bottom: 5vh;
   top: initial !important; // by-default top is 8
 }
 // TODO_END
+
+// for task links, the decorations around the links
+.task-before {
+  margin-right: 0.5rem;
+  opacity: 0.8;
+}
+.task-after {
+  margin-left: 0.5rem;
+  opacity: 0.8;
+}
+.task-status {
+  border: 1px solid;
+  min-width: 1rem;
+  height: 1rem;
+  display: inline-block;
+  text-align: center;
+  vertical-align: text-top;
+  padding: 0 0.15rem;
+}
+.task-status-text {
+  position: relative;
+  top: -0.3rem;
+}

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -520,14 +520,22 @@ function linkExtras({
       taskConfig,
     });
     if (status) {
-      before.push({
+      const checkbox: { [key: string]: any } = {
         type: "element",
-        tagName: "span",
+        tagName: "input",
         properties: {
+          type: "checkbox",
+          disabled: true,
           className: "task-before task-status",
         },
-        children: [span("task-status-text", status)],
-      });
+      };
+      if (TaskNoteUtils.isTaskComplete({ note, taskConfig })) {
+        checkbox.properties.checked = true;
+      } else if (status.trim().length > 0) {
+        checkbox.children = [span("task-status-text", `(${status})`)];
+      }
+
+      before.push(checkbox);
     }
     const priority = TaskNoteUtils.getPrioritySymbol({
       note,

--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -513,7 +513,11 @@ function linkExtras({
   const after = [];
 
   // For task notes, add the status, priority, due, and owner info
-  if (note && TaskNoteUtils.isTaskNote(note)) {
+  if (
+    note &&
+    TaskNoteUtils.isTaskNote(note) &&
+    ConfigUtils.getPublishing(config).enableTaskNotes
+  ) {
     const taskConfig = ConfigUtils.getTask(config);
     const status = TaskNoteUtils.getStatusSymbolRaw({
       note,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -68,6 +68,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -217,6 +220,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -356,6 +362,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -462,6 +471,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -585,6 +597,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -124,6 +124,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -279,6 +280,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -416,6 +418,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
 "
 `;
@@ -525,6 +528,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -651,6 +655,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -118,6 +118,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -273,6 +274,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -410,6 +412,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
 "
 `;
@@ -519,6 +522,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -645,6 +649,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -779,6 +784,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault
@@ -899,6 +905,7 @@ publishing:
     enableFrontmatterTags: true
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
+    enableTaskNotes: true
     enablePrettyLinks: true
     duplicateNoteBehavior:
         action: useVault

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -62,6 +62,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -211,6 +214,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -350,6 +356,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -456,6 +465,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -579,6 +591,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -709,6 +724,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium
@@ -826,6 +844,9 @@ workspace:
             delegated: l
             dropped: d
             pending: 'y'
+        taskCompleteStatus:
+            - done
+            - x
         prioritySymbols:
             H: high
             M: medium

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -714,3 +714,20 @@ VFile {
   "messages": Array [],
 }
 `;
+
+exports[`GIVEN dendronPub WHEN all notes are public WHEN publishing links to task notes THEN all links are rendered 1`] = `
+VFile {
+  "contents": "<h1 id=\\"beta\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#beta\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Beta</h1>
+<p><a href=\\"/notes/alpha.task\\"><span class=\\"task-before task-status\\"><span class=\\"task-status-text\\">x</span></span>Task<span class=\\"task-after task-priority\\">priority:high</span><span class=\\"task-after task-due\\">due:2022-08-28</span><span class=\\"task-after task-owner\\">@turing</span></a></p>
+<hr>
+<strong>Backlinks</strong>
+<ul>
+<li><a href=\\"/notes/alpha\\">Alpha (vault1)</a></li>
+<li><a title=\\"Private\\" style=\\"color: brown\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\">Omega (vault1) (Private)</a></li>
+</ul>",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/dendronPub.spec.ts.snap
@@ -718,7 +718,7 @@ VFile {
 exports[`GIVEN dendronPub WHEN all notes are public WHEN publishing links to task notes THEN all links are rendered 1`] = `
 VFile {
   "contents": "<h1 id=\\"beta\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#beta\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Beta</h1>
-<p><a href=\\"/notes/alpha.task\\"><span class=\\"task-before task-status\\"><span class=\\"task-status-text\\">x</span></span>Task<span class=\\"task-after task-priority\\">priority:high</span><span class=\\"task-after task-due\\">due:2022-08-28</span><span class=\\"task-after task-owner\\">@turing</span></a></p>
+<p><a href=\\"/notes/alpha.task\\"><input type=\\"checkbox\\" disabled class=\\"task-before task-status\\" checked>Task<span class=\\"task-after task-priority\\">priority:high</span><span class=\\"task-after task-due\\">due:2022-08-28</span><span class=\\"task-after task-owner\\">@turing</span></a></p>
 <hr>
 <strong>Backlinks</strong>
 <ul>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts
@@ -155,6 +155,50 @@ describe("GIVEN dendronPub", () => {
         await verifyPublicLink(resp, fnameAlpha);
       });
     });
+
+    describe("WHEN publishing links to task notes", () => {
+      const taskNote = "alpha.task";
+      let resp: VFile;
+      beforeAll(async () => {
+        await runEngineTestV5(
+          async (opts) => {
+            resp = await createProc({
+              ...opts,
+              config,
+              fname,
+              linkText: `[[${taskNote}]]`,
+            });
+          },
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupLinks(opts);
+              const { vaults, wsRoot } = opts;
+              await NoteTestUtilsV4.createNote({
+                fname: taskNote,
+                vault: vaults[0],
+                wsRoot,
+                custom: {
+                  status: "x",
+                  due: "2022-08-28",
+                  owner: "turing",
+                  priority: "high",
+                },
+              });
+            },
+            expect,
+          }
+        );
+      });
+      test("THEN all links are rendered", async () => {
+        await checkVFile(
+          resp,
+          "x",
+          "priority:high",
+          "due:2022-08-28",
+          "@turing"
+        );
+      });
+    });
   });
 
   describe("WHEN publish and private hierarchies", () => {

--- a/packages/nextjs-template/styles/scss/main.scss
+++ b/packages/nextjs-template/styles/scss/main.scss
@@ -123,3 +123,26 @@ $text-color: rgba(0, 0, 0, 0.85); // @text-color
     white-space: normal;
   }
 }
+
+// for task links, the decorations around the links
+.task-before {
+  margin-right: 0.5rem;
+  opacity: 0.8;
+}
+.task-after {
+  margin-left: 0.5rem;
+  opacity: 0.8;
+}
+.task-status {
+  border: 1px solid;
+  min-width: 1rem;
+  height: 1rem;
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  padding: 0 0.15rem;
+}
+.task-status-text {
+  position: relative;
+  top: -0.45rem;
+}

--- a/packages/nextjs-template/styles/scss/main.scss
+++ b/packages/nextjs-template/styles/scss/main.scss
@@ -133,16 +133,7 @@ $text-color: rgba(0, 0, 0, 0.85); // @text-color
   margin-left: 0.5rem;
   opacity: 0.8;
 }
-.task-status {
-  border: 1px solid;
-  min-width: 1rem;
-  height: 1rem;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  padding: 0 0.15rem;
-}
 .task-status-text {
-  position: relative;
-  top: -0.45rem;
+  opacity: 0.8;
+  margin-right: 0.5rem;
 }

--- a/packages/plugin-core/src/test/suite-integ/migration.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/migration.test.ts
@@ -1138,6 +1138,7 @@ suite("Migration", function () {
               cognitoUserPoolId: "qwerty",
               cognitoClientId: "azerty",
               enablePrettyLinks: true,
+              enableTaskNotes: true,
             };
 
             expect(postMigrationDendronConfig.publishing).toEqual(

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -132,6 +132,7 @@ export class WorkspaceTestUtils {
         },
         enableSiteLastModified: true,
         enableRandomlyColoredTags: true,
+        enableTaskNotes: true,
         enablePrettyLinks: true,
       },
     };

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -63,6 +63,7 @@ export class WorkspaceTestUtils {
           name: "task",
           dateFormat: "y.MM.dd",
           addBehavior: NoteAddBehaviorEnum.asOwnDomain,
+          taskCompleteStatus: ["done", "x"],
           statusSymbols: {
             "": " ",
             wip: "w",

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -70,6 +70,7 @@ workspace:
       L: low
     todoIntegration: false
     createTaskSelectionType: selection2link
+    taskCompleteStatus: ["x", "done"]
   enableUserTags: true
   enableHashTags: true
   enableEditorDecorations: true

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -97,6 +97,7 @@ publishing:
     - dendron
     - bar
     - tags
+    - task
   enableSiteLastModified: true
   siteRootDir: docs
   siteUrl: https://foo.dev.dendron.so

--- a/test-workspace/vault/task.2021.10.26.020813.prepare-report.mail-report.md
+++ b/test-workspace/vault/task.2021.10.26.020813.prepare-report.mail-report.md
@@ -1,0 +1,12 @@
+---
+id: njcq8853ym5deoxwekdvzwx
+title: Mail Report
+desc: ''
+updated: 1652737697796
+created: 1652737673213
+status: 'in-progress'
+due: ''
+priority: ''
+owner: ''
+---
+

--- a/test-workspace/vault/task.2021.10.26.020813.prepare-report.md
+++ b/test-workspace/vault/task.2021.10.26.020813.prepare-report.md
@@ -2,7 +2,7 @@
 id: sEnzNEw04L4BZ2lN00zuI
 title: Prepare Report
 desc: ''
-updated: 1637137779381
+updated: 1652737673279
 created: 1635228506689
 status: ''
 due: '2021.10.29'
@@ -13,3 +13,11 @@ owner: 'kaan'
 ## details
 
 Something about this task
+
+[[Get Documents Ready|task.2021.10.26.021747.get-documents-ready]]
+
+[[Task without Status|task.2021.10.26.031752.task-without-status]]
+
+[[Prepare Report|task.2021.10.26.020813.prepare-report]]
+
+[[mail report|task.2021.10.26.020813.prepare-report.mail-report]]


### PR DESCRIPTION
Displays the task note status when linking to task notes, both in the preview and in publishing.

Docs: https://github.com/dendronhq/dendron-site/pull/505

## preview
![](https://user-images.githubusercontent.com/1008124/168731774-d28f0cca-6535-464e-a3e5-47248fc67125.png)

## publishing

### firefox, at various widths

![2022-05-16-23-22-07-839659492](https://user-images.githubusercontent.com/1008124/168731766-39fd32de-1cd8-447d-919d-0ffaddc91443.png)
![2022-05-16-23-22-23-001724720](https://user-images.githubusercontent.com/1008124/168731770-42d28477-ccb6-40bb-b930-eba32a0a4b23.png)
![2022-05-16-23-22-35-012585009](https://user-images.githubusercontent.com/1008124/168731771-42d6a37a-0f7c-40a4-895c-a1c725c094aa.png)

### chrome

![2022-05-16-23-23-05-013744777](https://user-images.githubusercontent.com/1008124/168731773-aa514b45-692a-4077-9149-e01bda862a65.png)
