### PR TITLE
chore: make self contained vaults default for all new workspaces

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -11,27 +11,6 @@ import { GraphThemeEnum } from "./types/typesv2";
  * See [[A/B Testing|dendron://dendron.docs/ref.ab-testing]] for more details.
  */
 
-export enum SelfContainedVaultsTestGroups {
-  /** User will get a regular workspace and vaults set up, like before. */
-  regular = "regularVaults",
-  /** User will get a self contained vault as a workspace. */
-  selfContained = "selfContainedVaults",
-}
-
-export const SELF_CONTAINED_VAULTS_TEST = new ABTest(
-  "SelfContainedVaultsTest",
-  [
-    {
-      name: SelfContainedVaultsTestGroups.regular,
-      weight: 1,
-    },
-    {
-      name: SelfContainedVaultsTestGroups.selfContained,
-      weight: 1,
-    },
-  ]
-);
-
 export enum MeetingNoteTestGroups {
   show = "show",
   noShow = "noShow",
@@ -135,7 +114,6 @@ export const AB_TUTORIAL_TEST = new ABTest("AB_TUTORIAL_TEST", [
  * ^tkqhy45hflfd
  */
 export const CURRENT_AB_TESTS = [
-  SELF_CONTAINED_VAULTS_TEST,
   GRAPH_THEME_TEST,
   GRAPH_THEME_FEATURE_SHOWCASE_TEST,
   AB_TUTORIAL_TEST,

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1002,8 +1002,8 @@
         },
         "dendron.enableSelfContainedVaultWorkspace": {
           "type": "boolean",
-          "default": false,
-          "description": "When enabled, newly created workspaces will be created as self contained vaults. This is an experimental feature."
+          "default": true,
+          "description": "When enabled, newly created workspaces will be created as self contained vaults."
         }
       }
     },

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -9,7 +9,6 @@ import {
   CONSTANTS,
   CURRENT_AB_TESTS,
   DendronError,
-  DENDRON_VSCODE_CONFIG_KEYS,
   getStage,
   GitEvents,
   GraphEvents,
@@ -19,8 +18,6 @@ import {
   InstallStatus,
   IntermediateDendronConfig,
   isDisposable,
-  SelfContainedVaultsTestGroups,
-  SELF_CONTAINED_VAULTS_TEST,
   Time,
   VaultUtils,
   VSCodeEvents,
@@ -617,21 +614,6 @@ export async function _activate(
       !isSecondaryInstall &&
       extensionInstallStatus === InstallStatus.INITIAL_INSTALL
     ) {
-      // For new users, we want to roll out self contained vaults to some of
-      // them. We'll do that by setting the global config, so all workspace
-      // they create from now on will be self contained, and they can turn off
-      // the config if there are problems.
-      const split = SELF_CONTAINED_VAULTS_TEST.getUserGroup(
-        SegmentClient.instance().anonymousId
-      );
-      if (split === SelfContainedVaultsTestGroups.selfContained) {
-        VSCodeUtils.setWorkspaceConfig(
-          DENDRON_VSCODE_CONFIG_KEYS.ENABLE_SELF_CONTAINED_VAULTS_WORKSPACE,
-          true,
-          vscode.ConfigurationTarget.Global
-        );
-      }
-
       // For new users, we want to load graph with new graph themes as default
       let graphTheme;
       const ABUserGroup = GRAPH_THEME_TEST.getUserGroup(

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -1027,9 +1027,9 @@ export const CONFIG: { [key: string]: ConfigEntry } = {
   ENABLE_SELF_CONTAINED_VAULT_WORKSPACE: {
     key: DENDRON_VSCODE_CONFIG_KEYS.ENABLE_SELF_CONTAINED_VAULTS_WORKSPACE,
     type: "boolean",
-    default: false,
+    default: true,
     description:
-      "When enabled, newly created workspaces will be created as self contained vaults. This is an experimental feature.",
+      "When enabled, newly created workspaces will be created as self contained vaults.",
   },
 };
 


### PR DESCRIPTION
This PR makes self contained vaults the default for all new workspaces, both for new and existing users. This ends the self contained vaults AB-test, although the self contained vaults experiment itself is still ongoing.