### PR TITLE
fix: block anchor after table crashes preview

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -427,6 +427,10 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
           // Can't install as a child of the list, has to go into a list item
           target = target.children[0];
         }
+        if (RemarkUtils.isTable(target)) {
+          // Can't install as a child of the table directly, has to go into a table cell
+          target = target.children[0].children[0];
+        }
 
         if (RemarkUtils.isParent(target)) {
           // Install the block anchor at the target node

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/blockAnchors.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/blockAnchors.spec.ts.snap
@@ -19,6 +19,31 @@ VFile {
 }
 `;
 
+exports[`blockAnchors rendering compile "HTML: after table" 1`] = `
+"<h1 id=\\"root\\">Root</h1>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table><thead><tr><th><a aria-hidden=\\"true\\" class=\\"block-anchor anchor-heading\\" id=\\"^my-block-anchor-0\\" href=\\"#^my-block-anchor-0\\"><svg viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>t</th><th>a</th></tr></thead><tbody><tr><td>c</td><td>d</td></tr></tbody></table>
+<p></p>
+<hr>
+<strong>Children</strong>
+<ol>
+<li><a href=\\"bar.html\\">Bar</a></li>
+<li><a href=\\"foo.html\\">Foo</a></li>
+</ol>"
+`;
+
 exports[`blockAnchors rendering compile "HTML: end of paragraph" 1`] = `
 VFile {
   "contents": "<h1 id=\\"root\\">Root</h1>

--- a/test-workspace/vault/dendron.ref.links.block-anchors.md
+++ b/test-workspace/vault/dendron.ref.links.block-anchors.md
@@ -2,7 +2,7 @@
 id: links.block-anchors
 title: Block Anchors
 desc: ""
-updated: 1630537995313
+updated: 1652829410663
 created: 1608147795766
 ---
 
@@ -21,7 +21,9 @@ Voluptatem ipsum et possimus aut. In modi quaerat temporibus. ^last-paragraph
 | Sapiente | accusamus |
 |----------|-----------|
 | Laborum  | libero    |
-| Ullam    | optio     | ^table
+| Ullam    | optio     |
+
+^table
 
 ```js
 const x = 0;
@@ -56,7 +58,9 @@ Eaque ipsa recusandae exercitationem unde illum est. Sed eos vel eos impedit adi
 | Delectus   | exercitationem |
 |------------|----------------|
 | provident  | Accusamus      |
-| tempore    | blanditiis     | ^table2
+| tempore    | blanditiis     |
+
+^table2
 
 ## Aliquam repudiandae dolorem id
 


### PR DESCRIPTION
A block anchor located after a table would cause the preview to crash (and likely publishing too, although I did not test if it does). This fix solves the issue.

We also decided to standardize on supporting block anchors after tables and not next to them. This works around a bug with the table parser, but also is a best practice since formatters and markdown table extensions otherwise misinterpret block anchors.

Co-authored-by: Kevin Lin <kevin@dendron.so>