### PR TITLE
chore: defer user group calc in GraphThemeTip to after activation

### DIFF
--- a/packages/plugin-core/src/showcase/GraphThemeTip.ts
+++ b/packages/plugin-core/src/showcase/GraphThemeTip.ts
@@ -13,12 +13,6 @@ import {
 } from "./IFeatureShowcaseMessage";
 
 export class GraphThemeTip implements IFeatureShowcaseMessage {
-  private ABUserGroup: GraphThemeFeatureShowcaseTestGroups;
-  constructor() {
-    this.ABUserGroup = GRAPH_THEME_FEATURE_SHOWCASE_TEST.getUserGroup(
-      SegmentClient.instance().anonymousId
-    );
-  }
   shouldShow(displayLocation: DisplayLocation): boolean {
     switch (displayLocation) {
       case DisplayLocation.InformationMessage:
@@ -33,13 +27,14 @@ export class GraphThemeTip implements IFeatureShowcaseMessage {
   }
 
   getDisplayMessage(displayLocation: DisplayLocation): string {
+    const ABUserGroup = GRAPH_THEME_FEATURE_SHOWCASE_TEST.getUserGroup(
+      SegmentClient.instance().anonymousId
+    );
     const tipofTheDayMessage =
       "Change the appearance of the note graph by clicking the config button on the top left corner of the graph view and selecting one of the built-in styles. You can even customize the appearance to your liking with css";
     switch (displayLocation) {
       case DisplayLocation.InformationMessage:
-        if (
-          this.ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow
-        ) {
+        if (ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow) {
           return `Dendron now has new themes for Graph View. Check it out`;
         }
         return `New themes for Graph View! ${tipofTheDayMessage}`;
@@ -51,7 +46,10 @@ export class GraphThemeTip implements IFeatureShowcaseMessage {
   }
 
   onConfirm() {
-    if (this.ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow) {
+    const ABUserGroup = GRAPH_THEME_FEATURE_SHOWCASE_TEST.getUserGroup(
+      SegmentClient.instance().anonymousId
+    );
+    if (ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow) {
       showMeHowView(
         "Graph Theme",
         "https://org-dendron-public-assets.s3.amazonaws.com/images/graph-theme.gif"
@@ -62,7 +60,10 @@ export class GraphThemeTip implements IFeatureShowcaseMessage {
   }
 
   get confirmText(): string {
-    if (this.ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow) {
+    const ABUserGroup = GRAPH_THEME_FEATURE_SHOWCASE_TEST.getUserGroup(
+      SegmentClient.instance().anonymousId
+    );
+    if (ABUserGroup === GraphThemeFeatureShowcaseTestGroups.showMeHow) {
       return "Show me how";
     }
     return "Open graph view";


### PR DESCRIPTION
# chore: defer user group calc in GraphThemeTip to after activation

This PR:
- defers AB testing user group calculation in `GraphThemeTip` to each call that needs the user group.
- determining the user group in the constructor caused `SegmentClient` to be instantiated during module load, which comes before the activation lifecycle.
  - Our activate logic assumes that the segment client is not instantiated when it starts.

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [~] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)