### PR TITLE
chore: give better feedback to users for invalid dendron.yml

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -116,6 +116,8 @@ export enum ConfigEvents {
   DeprecatedConfigMessageConfirm = "DeprecatedConfigMessageConfirm",
   DeprecatedConfigMessageShow = "ShowDeprecatedConfigMessage",
   MissingDefaultConfigMessageConfirm = "MissingDefaultConfigMessageConfirm",
+  DuplicateConfigMessageShow = "DuplicateConfigMessageShow",
+  DuplicateConfigMessageConfirm = "DuplicateConfigMessageConfirm",
   MissingSelfContainedVaultsMessageShow = "MissingSelfContainedVaultsMessageShow",
   MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",
 }

--- a/packages/common-server/src/files.ts
+++ b/packages/common-server/src/files.ts
@@ -64,9 +64,16 @@ export function readMD(fpath: string): { data: any; content: string } {
   return matter.read(fpath, {});
 }
 
-export function readYAML(fpath: string): any {
+/**
+ *
+ * @param fpath path of yaml file to read
+ * @param overwriteDuplcate if set to true, will not throw duplicate entry exception and use the last entry.
+ * @returns
+ */
+export function readYAML(fpath: string, overwriteDuplcate?: boolean): any {
   return YAML.load(fs.readFileSync(fpath, { encoding: "utf8" }), {
     schema: YAML.JSON_SCHEMA,
+    json: overwriteDuplcate ?? false,
   });
 }
 

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -43,9 +43,12 @@ export class DConfig {
    * Get without filling in defaults
    * @param wsRoot
    */
-  static getRaw(wsRoot: string) {
+  static getRaw(wsRoot: string, overwriteDuplcate?: boolean) {
     const configPath = DConfig.configPath(wsRoot);
-    const config = readYAML(configPath) as Partial<IntermediateDendronConfig>;
+    const config = readYAML(
+      configPath,
+      overwriteDuplcate ?? false
+    ) as Partial<IntermediateDendronConfig>;
     return config;
   }
 
@@ -227,7 +230,7 @@ export class DConfig {
   static readConfigSync(wsRoot: string) {
     const configPath = DConfig.configPath(wsRoot);
     // TODO: validate
-    const config = readYAML(configPath) as IntermediateDendronConfig;
+    const config = readYAML(configPath, true) as IntermediateDendronConfig;
     return config;
   }
 

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -138,7 +138,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     this.history = history;
     this.logger = logger || createLogger();
     const cpath = DConfig.configPath(ws);
-    this.config = readYAML(cpath) as IntermediateDendronConfig;
+    this.config = readYAML(cpath, true) as IntermediateDendronConfig;
     this.fuseEngine = new FuseEngine({
       fuzzThreshold: ConfigUtils.getLookup(this.config).note.fuzzThreshold,
     });

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -714,6 +714,11 @@ export async function _activate(
         dendronConfig,
       });
 
+      // check for duplicate config keys and prompt for a fix.
+      StartupUtils.showDuplicateConfigMessageIfNecessary({
+        ext: ws,
+      });
+
       // check for missing default config keys and prompt for a backfill.
       StartupUtils.showMissingDefaultConfigMessageIfNecessary({
         ext: ws,

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -23,6 +23,7 @@ import {
   WorkspaceService,
 } from "@dendronhq/engine-server";
 import _ from "lodash";
+import _md from "markdown-it";
 import { Duration } from "luxon";
 import * as vscode from "vscode";
 import { DoctorCommand, PluginDoctorActionsEnum } from "../commands/Doctor";
@@ -88,6 +89,102 @@ export class StartupUtils {
         currentVersion,
       });
     }
+  }
+
+  static showDuplicateConfigMessageIfNecessary(opts: {
+    ext: IDendronExtension;
+  }) {
+    const message = StartupUtils.getDuplicateKeysMessage(opts);
+    if (message !== undefined) {
+      StartupUtils.showDuplicateConfigMessage({
+        ...opts,
+        message,
+      });
+    }
+  }
+
+  static getDuplicateKeysMessage(opts: { ext: IDendronExtension }) {
+    const wsRoot = opts.ext.getDWorkspace().wsRoot;
+    try {
+      DConfig.getRaw(wsRoot);
+    } catch (error: any) {
+      if (
+        error.name === "YAMLException" &&
+        error.reason === "duplicated mapping key"
+      ) {
+        return error.message;
+      }
+    }
+  }
+
+  static showDuplicateConfigMessage(opts: {
+    ext: IDendronExtension;
+    message: string;
+  }) {
+    AnalyticsUtils.track(ConfigEvents.DuplicateConfigMessageShow);
+    const FIX_ISSUE = "Fix Issue";
+    const MESSAGE =
+      "We have detected a duplicate key mapping in your configuration. Dendron has been activated using the last entry. Please remove all duplicate mappings from dendron.yml";
+    vscode.window
+      .showInformationMessage(MESSAGE, FIX_ISSUE)
+      .then(async (resp) => {
+        if (resp === FIX_ISSUE) {
+          AnalyticsUtils.track(ConfigEvents.DuplicateConfigMessageConfirm, {
+            status: ConfirmStatus.accepted,
+          });
+          const wsRoot = opts.ext.getDWorkspace().wsRoot;
+          const configPath = DConfig.configPath(wsRoot);
+          const configUri = vscode.Uri.file(configPath);
+
+          const message = opts.message;
+          const content = [
+            `# Duplicate Mapping in \`dendron.yml\``,
+            "",
+            "The message at the bottom displays the _first_ duplicate mapping that was detected in `dendron.yml`",
+            "",
+            "**There may be more duplicate mappings**.",
+            "",
+            "Take the following steps to fix this issue.",
+            "1. Look through `dendron.yml` and remove all duplicate mappings.",
+            "",
+            `    - We recommend installing the [YAML](${vscode.Uri.parse(
+              `command:workbench.extensions.search?${JSON.stringify(
+                "@id:redhat.vscode-yaml"
+              )}`
+            )}) extension for validating \`dendron.yml\``,
+            "",
+            "1. When you are done, save your changes made to `dendron.yml`",
+            "",
+            `1. Reload the window for it to take effect. [Click here to reload window](${vscode.Uri.parse(
+              `command:workbench.action.reloadWindow`
+            )})`,
+            "",
+            "## Error message",
+            "```",
+            message,
+            "```",
+            "",
+            "",
+          ].join("\n");
+          const panel = vscode.window.createWebviewPanel(
+            "showDuplicateConfigMessagePreview",
+            "Duplicated Mapping Keys Preview",
+            vscode.ViewColumn.One,
+            {
+              enableCommandUris: true,
+            }
+          );
+          const md = _md();
+          panel.webview.html = md.render(content);
+          await VSCodeUtils.openFileInEditor(configUri, {
+            column: vscode.ViewColumn.Beside,
+          });
+        } else {
+          AnalyticsUtils.track(ConfigEvents.DuplicateConfigMessageConfirm, {
+            status: ConfirmStatus.rejected,
+          });
+        }
+      });
   }
 
   static showDeprecatedConfigMessageIfNecessary(opts: {

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -147,11 +147,11 @@ export class StartupUtils {
             "Take the following steps to fix this issue.",
             "1. Look through `dendron.yml` and remove all duplicate mappings.",
             "",
-            `    - We recommend installing the [YAML](${vscode.Uri.parse(
+            `    - We recommend installing the [YAML extension](${vscode.Uri.parse(
               `command:workbench.extensions.search?${JSON.stringify(
                 "@id:redhat.vscode-yaml"
               )}`
-            )}) extension for validating \`dendron.yml\``,
+            )}) for validating \`dendron.yml\``,
             "",
             "1. When you are done, save your changes made to `dendron.yml`",
             "",


### PR DESCRIPTION
# chore: give better feedback to users for invalid dendron.yml

This PR:
- Allows duplicate entries with `readYAML` method so that a duplicate mapping doesn't stop initialization
  - By allowing duplicates, we are overwriting the first entry with the subsequent entries.
  - Given `someConfig: 1`, `someConfig: 2`, `someConfig: 3`, we now read it as `someConfig: 3` instead of throwing an exception.
- Add a start-up prompt that detects duplicate mappings in `dendron.yml`, and give instructions to fix them.

## Note
- This PR specifically targets to gracefully initialize Dendron even when a duplicate entry exists, and also give better feedback to the users on the issue.
- This will also remove a lot of noise that is reported to Sentry.
- We should do a proper YAML validation here in the future. I'm limiting the scope here for some immediate benefits.

## Preview
![image](https://user-images.githubusercontent.com/1219789/169106816-03904757-a564-40d1-8562-693ca24cec64.png)

![image](https://user-images.githubusercontent.com/1219789/169105208-16aefb25-19fd-42b7-b246-fb1f12654ed1.png)

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)