### PR TITLE
enhance(navigate): make wikilinks clickable in hover

### DIFF
--- a/packages/common-all/src/types/unified.ts
+++ b/packages/common-all/src/types/unified.ts
@@ -2,6 +2,10 @@
 
 /** The expected output from the processor, if the processor is used to process or stringify a tree. */
 export enum DendronASTDest {
+  /**
+   * @deprecated - no longer needed since we don't use the markdown preview
+   * enhanced anymore
+   */
   MD_ENHANCED_PREVIEW = "MD_ENHANCED_PREVIEW",
   MD_REGULAR = "MD_REGULAR",
   MD_DENDRON = "MD_DENDRON",

--- a/packages/engine-server/src/markdown/remark/dendronPreview.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPreview.ts
@@ -1,13 +1,13 @@
 import { vault2Path } from "@dendronhq/common-server";
 import _ from "lodash";
 import { Image } from "mdast";
-import { DendronASTTypes } from "../types";
 import path from "path";
 import Unified, { Transformer } from "unified";
 import { Node } from "unist";
 import visit from "unist-util-visit";
 import { VFile } from "vfile";
-import { RemarkUtils } from ".";
+import { AnchorUtils, RemarkUtils } from ".";
+import { DendronASTTypes, WikiLinkNoteV4 } from "../types";
 import { MDUtilsV5 } from "../utilsv5";
 
 type PluginOpts = {};
@@ -30,6 +30,32 @@ export function makeImageUrlFullPath({
   node.url = fpath;
 }
 
+/**
+ * Transforms any wiklinks into a vscode command URI for gotoNote.
+ */
+function commandUriForWikilink({
+  proc,
+  node,
+}: {
+  proc: Unified.Processor;
+  node: WikiLinkNoteV4;
+}) {
+  const { vault } = MDUtilsV5.getProcData(proc);
+
+  const anchor = node.data.anchorHeader
+    ? AnchorUtils.string2anchor(node.data.anchorHeader)
+    : undefined;
+
+  const goToNoteCommandOpts = {
+    qs: node.value,
+    vault,
+    anchor,
+  };
+
+  const encodedArgs = encodeURIComponent(JSON.stringify(goToNoteCommandOpts));
+  node.value = `command:dendron.gotoNote?${encodedArgs}`;
+}
+
 export function dendronHoverPreview(
   this: Unified.Processor,
   _opts?: PluginOpts
@@ -42,6 +68,7 @@ export function dendronHoverPreview(
         DendronASTTypes.FRONTMATTER,
         DendronASTTypes.IMAGE,
         DendronASTTypes.EXTENDED_IMAGE,
+        DendronASTTypes.WIKI_LINK,
       ],
       (node, index, parent) => {
         // Remove the frontmatter because it will break the output
@@ -53,6 +80,8 @@ export function dendronHoverPreview(
         }
         if (RemarkUtils.isImage(node) || RemarkUtils.isExtendedImage(node)) {
           makeImageUrlFullPath({ proc, node });
+        } else if (RemarkUtils.isWikiLink(node)) {
+          commandUriForWikilink({ proc, node });
         }
         return undefined; // continue
       }

--- a/packages/engine-server/src/markdown/remark/dendronPreview.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPreview.ts
@@ -33,7 +33,7 @@ export function makeImageUrlFullPath({
 /**
  * Transforms any wiklinks into a vscode command URI for gotoNote.
  */
-function commandUriForWikilink({
+function modifyWikilinkValueToCommandUri({
   proc,
   node,
 }: {
@@ -81,7 +81,7 @@ export function dendronHoverPreview(
         if (RemarkUtils.isImage(node) || RemarkUtils.isExtendedImage(node)) {
           makeImageUrlFullPath({ proc, node });
         } else if (RemarkUtils.isWikiLink(node)) {
-          commandUriForWikilink({ proc, node });
+          modifyWikilinkValueToCommandUri({ proc, node });
         }
         return undefined; // continue
       }

--- a/packages/plugin-core/src/features/ReferenceHoverProvider.ts
+++ b/packages/plugin-core/src/features/ReferenceHoverProvider.ts
@@ -17,7 +17,7 @@ import * as Sentry from "@sentry/node";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
-import vscode, { Uri } from "vscode";
+import vscode, { MarkdownString, Uri } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
@@ -237,7 +237,11 @@ export default class ReferenceHoverProvider implements vscode.HoverProvider {
         });
       }
       if (rendered.data) {
-        return new vscode.Hover(rendered.data, hoverRange);
+        const markdownString = new MarkdownString(rendered.data);
+
+        // Support the usage of command URI's for gotoNote navigation
+        markdownString.isTrusted = true;
+        return new vscode.Hover(markdownString, hoverRange);
       }
       return null;
     } catch (error) {

--- a/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
@@ -9,6 +9,7 @@ import fs from "fs-extra";
 import { before, describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";
+import { MarkdownString } from "vscode";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import ReferenceHoverProvider from "../../features/ReferenceHoverProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -117,7 +118,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             );
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -187,7 +188,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             expect(hover).toBeTruthy();
             // Local images should get full path to image, because hover preview otherwise can't find the image
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 `![](${path.join(
@@ -235,7 +236,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             expect(hover).toBeTruthy();
             // remote images should be unmodified
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "![](https://example.com/image.png)",
@@ -274,7 +275,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -320,7 +321,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -368,7 +369,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             );
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -412,7 +413,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -464,7 +465,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -493,7 +494,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
               expect(hover).toBeTruthy();
               expect(
                 await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
+                  body: (hover!.contents[0] as MarkdownString).value,
                   match: ["vault 1"],
                   nomatch: ["vault 0", "the test note"],
                 })
@@ -520,7 +521,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
               expect(hover).toBeTruthy();
               expect(
                 await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
+                  body: (hover!.contents[0] as MarkdownString).value,
                   match: ["vault 0"],
                   nomatch: ["vault 1", "the test note"],
                 })
@@ -547,7 +548,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
               expect(hover).toBeTruthy();
               expect(
                 await AssertUtils.assertInString({
-                  body: hover!.contents.join(""),
+                  body: (hover!.contents[0] as MarkdownString).value,
                   match: ["vault 1"],
                   nomatch: ["vault 0", "the test note"],
                 })
@@ -654,7 +655,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -700,7 +701,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -744,7 +745,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -788,7 +789,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Sint quo sunt maxime.",
                 "Nisi nam dolorem qui ut minima.",
@@ -835,7 +836,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             const hover = await provideForNote(editor);
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: [
                 "Numquam occaecati",
                 "Sint quo sunt maxime.",
@@ -881,7 +882,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
           );
           expect(hover).toBeTruthy();
           await AssertUtils.assertInString({
-            body: hover!.contents.join(""),
+            body: (hover!.contents[0] as MarkdownString).value,
             match: ["this is tag foo.test"],
           });
           done();
@@ -955,7 +956,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
           );
           expect(hover).toBeTruthy();
           await AssertUtils.assertInString({
-            body: hover!.contents.join(""),
+            body: (hover!.contents[0] as MarkdownString).value,
             match: ["this is user test.mctestface"],
           });
           done();
@@ -1032,7 +1033,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             );
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: ["this is tag foo.test"],
             });
             done();
@@ -1083,7 +1084,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
             );
             expect(hover).toBeTruthy();
             await AssertUtils.assertInString({
-              body: hover!.contents.join(""),
+              body: (hover!.contents[0] as MarkdownString).value,
               match: ["this is tag foo.test"],
             });
             done();


### PR DESCRIPTION
## enhance(navigate): make wikilinks clickable in hover

Makes any wikilinks in hover clickable, which will navigate to the note via `GoToNote`

Coauthored by @SeriousBug.

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)