### PR TITLE
chore(internal): track note changed entry counts in refactoring commands

### DIFF
--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -1399,3 +1399,22 @@ export function extractNoteChangeEntriesByType(
 ): NoteChangeEntry[] {
   return entries.filter((entry) => entry.status === status);
 }
+
+export function extractNoteChangeEntryCountByType(
+  entries: NoteChangeEntry[],
+  status: "create" | "delete" | "update"
+): number {
+  return extractNoteChangeEntriesByType(entries, status).length;
+}
+
+export function extractNoteChangeEntryCounts(entries: NoteChangeEntry[]): {
+  createdCount: number;
+  deletedCount: number;
+  updatedCount: number;
+} {
+  return {
+    createdCount: extractNoteChangeEntryCountByType(entries, "create"),
+    deletedCount: extractNoteChangeEntryCountByType(entries, "delete"),
+    updatedCount: extractNoteChangeEntryCountByType(entries, "update"),
+  };
+}

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -599,4 +599,10 @@ export class MoveHeaderCommand extends BasicCommand<
     );
     return { ...opts, updated };
   }
+
+  addAnalyticsPayload(_opts?: CommandOpts, out?: CommandOutput) {
+    return {
+      updatedCount: out?.updated.length || 0,
+    };
+  }
 }

--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -1,6 +1,7 @@
 import {
   DendronError,
   DEngineClient,
+  extractNoteChangeEntryCounts,
   NoteChangeEntry,
   RenameNoteOpts,
   VaultUtils,
@@ -316,13 +317,9 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }
 
   addAnalyticsPayload(_opts?: CommandOpts, out?: CommandOutput) {
-    return {
-      movedNotesCount:
-        // `out.changed` also includes the notes that had to be renamed in the
-        // process, but the created notes are the ones we moved
-        out?.changed?.filter((change) => change?.status === "create").length ||
-        0,
-    };
+    const payload =
+      out !== undefined ? { ...extractNoteChangeEntryCounts(out.changed) } : {};
+    return payload;
   }
 }
 

--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -4,6 +4,7 @@ import {
   DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
+  extractNoteChangeEntryCounts,
   NoteUtils,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
@@ -37,7 +38,7 @@ type CommandOpts = {
   noConfirm?: boolean;
 };
 
-type CommandOutput = any;
+type CommandOutput = RenameNoteOutputV2a;
 
 type RenameOperation = {
   vault: DVault;
@@ -418,7 +419,7 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
         return out;
       }
     );
-    return { changed: _.uniqBy(out.changed, (ent) => ent.note.fname) };
+    return out;
   }
 
   async showResponse(res: CommandOutput) {
@@ -429,7 +430,15 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
     window.showInformationMessage("Done refactoring.");
     const { changed } = res;
     if (changed.length > 0) {
-      window.showInformationMessage(`Dendron updated ${changed.length} files`);
+      window.showInformationMessage(
+        `Dendron updated ${_.uniqBy(changed, (ent) => ent.note.fname)} files`
+      );
     }
+  }
+
+  addAnalyticsPayload(_opts?: CommandOpts, out?: CommandOutput) {
+    const payload =
+      out !== undefined ? { ...extractNoteChangeEntryCounts(out.changed) } : {};
+    return payload;
   }
 }

--- a/packages/plugin-core/src/commands/RenameHeader.ts
+++ b/packages/plugin-core/src/commands/RenameHeader.ts
@@ -1,5 +1,6 @@
 import {
   DendronError,
+  extractNoteChangeEntryCounts,
   getSlugger,
   RenameNotePayload,
   RespV2,
@@ -148,7 +149,14 @@ export class RenameHeaderCommand extends BasicCommand<
     return out;
   }
 
-  addAnalyticsPayload(opts?: CommandOpts) {
-    return getAnalyticsPayload(opts?.source);
+  addAnalyticsPayload(opts?: CommandOpts, out?: CommandOutput) {
+    const payload =
+      out && out.data !== undefined
+        ? { ...extractNoteChangeEntryCounts(out.data) }
+        : {};
+    return {
+      ...payload,
+      ...getAnalyticsPayload(opts?.source),
+    };
   }
 }


### PR DESCRIPTION
# chore(internal): track note changed entry counts in refactoring commands

This PR:
- adds `createdCount`, `deletedCount`, and `updatedCount` to analytics payload of the following commands:
  - `MoveNote`
  - `RefactorHierarchy`
  - `MoveHeader` (only adds `updatedCount`)
  - `RenameHeader`

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)