### PR TITLE
fix(publish): Export gets stuck if `logoPath` is set but the logo doesn't exist

### DIFF
--- a/packages/engine-test-utils/src/__tests__/pods-core/NextjsExportPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/NextjsExportPod.spec.ts
@@ -165,6 +165,75 @@ describe("GIVEN NextExport pod", () => {
       });
     });
   });
+  describe("WHEN logoPath is set", () => {
+    describe("AND the logo file exists", () => {
+      test("THEN logo is copied over", async () => {
+        await runEngineTestV5(
+          async ({ engine, vaults, wsRoot }) => {
+            const dest = await setupExport({ engine, wsRoot, vaults });
+            await verifyExport(dest);
+            await checkDir(
+              { fpath: path.join(dest, "public", "assets") },
+              "logo.png"
+            );
+          },
+          {
+            expect,
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              const logoPath = path.join(
+                opts.vaults[0].fsPath,
+                "assets",
+                "logo.png"
+              );
+              await fs.ensureFile(path.join(opts.wsRoot, logoPath));
+              setupConfig({
+                ...opts,
+                siteConfig: {
+                  logoPath,
+                },
+              });
+            },
+          }
+        );
+      });
+    });
+
+    describe("AND the logo file is missing", () => {
+      test("THEN export still works", async () => {
+        await runEngineTestV5(
+          async ({ engine, vaults, wsRoot }) => {
+            const dest = await setupExport({ engine, wsRoot, vaults });
+            // Site still exported
+            await verifyExport(dest);
+            // Logo was not exported out
+            expect(
+              await fs.pathExists(
+                path.join(dest, "public", "assets", "logo.png")
+              )
+            ).toBeFalsy();
+          },
+          {
+            expect,
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              const logoPath = path.join(
+                opts.vaults[0].fsPath,
+                "assets",
+                "logo.png"
+              );
+              setupConfig({
+                ...opts,
+                siteConfig: {
+                  logoPath,
+                },
+              });
+            },
+          }
+        );
+      });
+    });
+  });
   describe("WHEN execute", () => {
     test("THEN create expected data files", async () => {
       await runEngineTestV5(


### PR DESCRIPTION
Fixes an issue that was reported on Discord, where the logo file was moved without updating the configuration, which caused the export to get stuck and hang forever.

This fix solves the issue by recognizing it when the logo file is missing, warning the user, and continuing with the export.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [ ] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)