### PR TITLE
feat(publish): ability to exclude children in dendron side nav

### DIFF
--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -27,6 +27,7 @@ export * from "./schema";
 export * from "./abTesting";
 export * from "./abTests";
 export * from "./noteDictsUtils";
+export * from "./publish";
 export { axios, AxiosError };
 export { DateTime };
 

--- a/packages/common-all/src/publish.ts
+++ b/packages/common-all/src/publish.ts
@@ -1,0 +1,53 @@
+import { DendronSiteConfig, DendronSiteFM, NoteProps, SEOProps } from "./types";
+import {
+  configIsV4,
+  IntermediateDendronConfig,
+} from "./types/intermediateConfigs";
+import { ConfigUtils } from "./utils";
+
+export class PublishUtils {
+  static getPublishFM(note: NoteProps): DendronSiteFM {
+    if (!note.custom) {
+      return {};
+    }
+    return note.custom as DendronSiteFM;
+  }
+  static getSEOPropsFromConfig(
+    config: IntermediateDendronConfig
+  ): Partial<SEOProps> {
+    if (configIsV4(config)) {
+      const {
+        title,
+        twitter,
+        description: excerpt,
+        image,
+      } = ConfigUtils.getSite(config) as DendronSiteConfig;
+      return { title, twitter, excerpt, image };
+    } else {
+      const {
+        title,
+        twitter,
+        description: excerpt,
+        image,
+      } = ConfigUtils.getPublishing(config).seo;
+      return { title, twitter, excerpt, image };
+    }
+  }
+
+  static getSEOPropsFromNote(note: NoteProps): SEOProps {
+    const { title, created, updated, image } = note;
+    const { excerpt, canonicalUrl, noindex, canonicalBaseUrl, twitter } =
+      note.custom ? note.custom : ({} as any);
+    return {
+      title,
+      excerpt,
+      updated,
+      created,
+      canonicalBaseUrl,
+      canonicalUrl,
+      noindex,
+      image,
+      twitter,
+    };
+  }
+}

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -73,7 +73,7 @@ export type DendronSiteFM = {
   /**
    * Should exclude children from nav
    */
-  nav_children_exclude?: boolean;
+  nav_exclude_children?: boolean;
   permalink?: string;
   /**
    * If collection, don't show in nav

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -70,6 +70,10 @@ export type DendronSiteFM = {
   canonicalUrl?: string;
   nav_order?: number;
   nav_exclude?: boolean;
+  /**
+   * Should exclude children from nav
+   */
+  nav_children_exclude?: boolean;
   permalink?: string;
   /**
    * If collection, don't show in nav

--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -101,7 +101,7 @@ export class TreeUtils {
       vaultName: VaultUtils.getName(note.vault),
       navExclude: fm.nav_exclude || false,
       children:
-        fm.nav_children_exclude || fm.has_collection
+        fm.nav_exclude_children || fm.has_collection
           ? []
           : this.sortNotesAtLevel({
               noteIds: note.children,

--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { TAGS_HIERARCHY, TAGS_HIERARCHY_BASE } from "../constants";
+import { PublishUtils } from "../publish";
 import { NotePropsByIdDict, NoteProps } from "../types";
 import { isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
@@ -90,6 +91,7 @@ export class TreeUtils {
     } else if (note.stub) {
       icon = TreeMenuNodeIcon.plusOutlined;
     }
+    const fm = PublishUtils.getPublishFM(note);
 
     return {
       key: note.id,
@@ -97,19 +99,22 @@ export class TreeUtils {
       icon,
       hasTitleNumberOutlined: note.fname.startsWith(TAGS_HIERARCHY),
       vaultName: VaultUtils.getName(note.vault),
-      navExclude: note.custom?.nav_exclude,
-      children: this.sortNotesAtLevel({
-        noteIds: note.children,
-        noteDict,
-        reverse: note.custom?.sort_order === "reverse",
-      })
-        .map((noteId) =>
-          TreeUtils.note2Tree({
-            noteId,
-            noteDict,
-          })
-        )
-        .filter(isNotUndefined),
+      navExclude: fm.nav_exclude || false,
+      children:
+        fm.nav_children_exclude || fm.has_collection
+          ? []
+          : this.sortNotesAtLevel({
+              noteIds: note.children,
+              noteDict,
+              reverse: fm.sort_order === "reverse",
+            })
+              .map((noteId) =>
+                TreeUtils.note2Tree({
+                  noteId,
+                  noteDict,
+                })
+              )
+              .filter(isNotUndefined),
     };
   }
 

--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -79,6 +79,27 @@ export class TreeUtils {
     noteDict: NotePropsByIdDict;
   }): TreeMenuNode | undefined {
     const note = noteDict[noteId];
+
+    // return children of the curren tnote
+    const getChildren = () => {
+      if (fm.nav_exclude_children || fm.has_collection) {
+        return [];
+      }
+
+      return this.sortNotesAtLevel({
+        noteIds: note.children,
+        noteDict,
+        reverse: fm.sort_order === "reverse",
+      })
+        .map((noteId) =>
+          TreeUtils.note2Tree({
+            noteId,
+            noteDict,
+          })
+        )
+        .filter(isNotUndefined);
+    };
+
     if (_.isUndefined(note)) {
       return undefined;
     }
@@ -100,21 +121,7 @@ export class TreeUtils {
       hasTitleNumberOutlined: note.fname.startsWith(TAGS_HIERARCHY),
       vaultName: VaultUtils.getName(note.vault),
       navExclude: fm.nav_exclude || false,
-      children:
-        fm.nav_exclude_children || fm.has_collection
-          ? []
-          : this.sortNotesAtLevel({
-              noteIds: note.children,
-              noteDict,
-              reverse: fm.sort_order === "reverse",
-            })
-              .map((noteId) =>
-                TreeUtils.note2Tree({
-                  noteId,
-                  noteDict,
-                })
-              )
-              .filter(isNotUndefined),
+      children: getChildren(),
     };
   }
 

--- a/packages/common-all/src/utils.ts
+++ b/packages/common-all/src/utils.ts
@@ -22,7 +22,6 @@ import {
   LegacyHierarchyConfig,
   NoteChangeEntry,
   NoteProps,
-  SEOProps,
 } from "./types";
 import { GithubConfig } from "./types/configs/publishing/github";
 import {
@@ -481,47 +480,6 @@ export class TagUtils {
         _.pull(note.tags, oldTag);
       }
     }
-  }
-}
-
-export class PublishUtils {
-  static getSEOPropsFromConfig(
-    config: IntermediateDendronConfig
-  ): Partial<SEOProps> {
-    if (configIsV4(config)) {
-      const {
-        title,
-        twitter,
-        description: excerpt,
-        image,
-      } = ConfigUtils.getSite(config) as DendronSiteConfig;
-      return { title, twitter, excerpt, image };
-    } else {
-      const {
-        title,
-        twitter,
-        description: excerpt,
-        image,
-      } = ConfigUtils.getPublishing(config).seo;
-      return { title, twitter, excerpt, image };
-    }
-  }
-
-  static getSEOPropsFromNote(note: NoteProps): SEOProps {
-    const { title, created, updated, image } = note;
-    const { excerpt, canonicalUrl, noindex, canonicalBaseUrl, twitter } =
-      note.custom ? note.custom : ({} as any);
-    return {
-      title,
-      excerpt,
-      updated,
-      created,
-      canonicalBaseUrl,
-      canonicalUrl,
-      noindex,
-      image,
-      twitter,
-    };
   }
 }
 

--- a/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
@@ -14,7 +14,7 @@ Array [
 ]
 `;
 
-exports[`WHEN nav_children_exclude enabled THEN return only root 1`] = `
+exports[`WHEN nav_exclude_children enabled THEN return only root 1`] = `
 Array [
   Object {
     "children": Array [],

--- a/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WHEN has_collection enabled THEN return only root 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "hasTitleNumberOutlined": false,
+    "icon": "bookOutlined",
+    "key": "foo",
+    "navExclude": false,
+    "title": "Foo",
+    "vaultName": "vault1",
+  },
+]
+`;
+
 exports[`WHEN nav_children_exclude enabled THEN return only root 1`] = `
 Array [
   Object {

--- a/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WHEN has_collection enabled AND nav_children_exclude set to false THEN return only root 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "hasTitleNumberOutlined": false,
+    "icon": "bookOutlined",
+    "key": "foo",
+    "navExclude": false,
+    "title": "Foo",
+    "vaultName": "vault1",
+  },
+]
+`;
+
 exports[`WHEN has_collection enabled THEN return only root 1`] = `
 Array [
   Object {

--- a/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/__snapshots__/treeUtil.spec.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WHEN nav_children_exclude enabled THEN return only root 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "hasTitleNumberOutlined": false,
+    "icon": "bookOutlined",
+    "key": "foo",
+    "navExclude": false,
+    "title": "Foo",
+    "vaultName": "vault1",
+  },
+]
+`;
+
+exports[`WHEN regular tree THEN return regular tree 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [],
+        "hasTitleNumberOutlined": false,
+        "icon": "bookOutlined",
+        "key": "foo.ch1",
+        "navExclude": false,
+        "title": "Ch1",
+        "vaultName": "vault1",
+      },
+    ],
+    "hasTitleNumberOutlined": false,
+    "icon": "bookOutlined",
+    "key": "foo",
+    "navExclude": false,
+    "title": "Foo",
+    "vaultName": "vault1",
+  },
+]
+`;

--- a/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
@@ -19,12 +19,12 @@ describe("WHEN regular tree", () => {
   });
 });
 
-describe("WHEN nav_children_exclude enabled", () => {
+describe("WHEN nav_exclude_children enabled", () => {
   test("THEN return only root", async () => {
     await runEngineTestV5(
       async ({ engine }) => {
         const domain = engine.notes["foo"];
-        domain.custom.nav_children_exclude = true;
+        domain.custom.nav_exclude_children = true;
         const treeData = TreeUtils.generateTreeData(engine.notes, [domain]);
         expect(treeData.roots).toMatchSnapshot();
         expect(treeData.roots[0].children).toEqual([]);
@@ -42,7 +42,7 @@ describe("WHEN has_collection enabled", () => {
     await runEngineTestV5(
       async ({ engine }) => {
         const domain = engine.notes["foo"];
-        domain.custom.nav_children_exclude = true;
+        domain.custom.nav_exclude_children = true;
         const treeData = TreeUtils.generateTreeData(engine.notes, [domain]);
         expect(treeData.roots).toMatchSnapshot();
         expect(treeData.roots[0].children).toEqual([]);

--- a/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
@@ -1,0 +1,38 @@
+import { TreeUtils } from "@dendronhq/common-all";
+import { runEngineTestV5 } from "../../../engine";
+import { ENGINE_HOOKS } from "../../../presets";
+
+describe("WHEN regular tree", () => {
+  test("THEN return regular tree", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const treeData = TreeUtils.generateTreeData(engine.notes, [
+          engine.notes["foo"],
+        ]);
+        expect(treeData.roots).toMatchSnapshot();
+      },
+      {
+        expect,
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      }
+    );
+  });
+});
+
+describe("WHEN nav_children_exclude enabled", () => {
+  test("THEN return only root", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const domain = engine.notes["foo"];
+        domain.custom.nav_children_exclude = true;
+        const treeData = TreeUtils.generateTreeData(engine.notes, [domain]);
+        expect(treeData.roots).toMatchSnapshot();
+        expect(treeData.roots[0].children).toEqual([]);
+      },
+      {
+        expect,
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      }
+    );
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
@@ -54,3 +54,21 @@ describe("WHEN has_collection enabled", () => {
     );
   });
 });
+
+describe("WHEN has_collection enabled AND nav_children_exclude set to false", () => {
+  test("THEN return only root", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const domain = engine.notes["foo"];
+        domain.custom.nav_exclude_children = true;
+        const treeData = TreeUtils.generateTreeData(engine.notes, [domain]);
+        expect(treeData.roots).toMatchSnapshot();
+        expect(treeData.roots[0].children).toEqual([]);
+      },
+      {
+        expect,
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      }
+    );
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/treeUtil.spec.ts
@@ -36,3 +36,21 @@ describe("WHEN nav_children_exclude enabled", () => {
     );
   });
 });
+
+describe("WHEN has_collection enabled", () => {
+  test("THEN return only root", async () => {
+    await runEngineTestV5(
+      async ({ engine }) => {
+        const domain = engine.notes["foo"];
+        domain.custom.nav_children_exclude = true;
+        const treeData = TreeUtils.generateTreeData(engine.notes, [domain]);
+        expect(treeData.roots).toMatchSnapshot();
+        expect(treeData.roots[0].children).toEqual([]);
+      },
+      {
+        expect,
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      }
+    );
+  });
+});

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -194,6 +194,8 @@ function MenuView({
       inlineIndent={DENDRON_STYLE_CONSTANTS.SIDER.INDENT}
       expandIcon={ExpandIcon}
       inlineCollapsed={collapsed}
+      // results in gray box otherwise when nav bar is too short for display
+      style={{ height: "100%" }}
     >
       {roots.map((menu) => {
         return createMenu(menu);


### PR DESCRIPTION
feat(publish): ability to exclude children in dendron side nav

For notes with a lot of children, the side nav can become overcrowded. Introduce an option to disable children on the nav. Also make this the default when `has_collection` is `true`

- before: https://loom.com/i/710825588ced436487dc7687d5cf30f8
- after: https://www.loom.com/i/5b0330bb90b347838158b99ac3f3a5ef

- diff size:
    - small: https://www.loom.com/i/0fe71bb4be94402a90d77f999ea2fd06
    - large: https://www.loom.com/i/caf5d9e47fa446e1bb4d864de5f437a9
    - reg: https://www.loom.com/i/5b0330bb90b347838158b99ac3f3a5ef

Docs: https://github.com/dendronhq/dendron-site/pull/509

***
# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [~] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [~] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [x] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [x] display is correct for following browsers (across the various dimensions)
    - [x] safari
    - [x] firefox
    - [x] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)
