### PR TITLE
fix(publish): assetsPrefix breaks images

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPub.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPub.ts
@@ -123,7 +123,7 @@ class ImageNodeHandler extends DendronNodeHander {
 
     if (!isWebUri(imageNode.url)) {
       const imageUrl = _.trim(imageNode.url, "/");
-      imageNode.url = "/" + (assetsPrefix ? assetsPrefix + "/" : "") + imageUrl;
+      imageNode.url = (assetsPrefix ? assetsPrefix + "/" : "/") + imageUrl;
     }
     return { node: imageNode };
   }

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/image.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/image.spec.ts.snap
@@ -35,7 +35,7 @@ VFile {
 exports[`GIVEN image link WHEN assetPrefix set "HTML: ASSET_PREFIX_SET: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading\\" href=\\"#foo\\"><svg aria-hidden=\\"true\\" viewBox=\\"0 0 16 16\\"><use xlink:href=\\"#svg-link\\"></use></svg></a>Foo</h1>
-<p><img src=\\"//some-prefix/some-image-link.png\\" alt=\\"some-image\\"></p>
+<p><img src=\\"/some-prefix/some-image-link.png\\" alt=\\"some-image\\"></p>
 <hr>
 <strong>Children</strong>
 <ol>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/image.spec.ts
@@ -2,7 +2,7 @@ import { ConfigUtils } from "@dendronhq/common-all";
 import { DendronASTDest, ProcFlavor } from "@dendronhq/engine-server";
 import { TestConfigUtils } from "../../../..";
 import { ENGINE_HOOKS } from "../../../../presets";
-import { checkString } from "../../../../utils";
+import { checkNotInString, checkString } from "../../../../utils";
 import { createProcCompileTests } from "../utils";
 import { getOpts, runTestCases } from "./utils";
 
@@ -51,6 +51,8 @@ describe("GIVEN image link", () => {
                 resp.contents,
                 "/some-prefix/some-image-link.png"
               );
+              // Make sure to avoid extra slash
+              await checkNotInString(resp.contents, "//some-prefix");
             },
           },
         },


### PR DESCRIPTION
Fixes an issue that was reported on the Discord about a recent update breaking images in publishing. The issue turns out to be `assetsPrefix` introducing an extra leading slash for images, which breaks publishing for some servers that are strict about URLs.

Modified an existing test so it would fail without this fix.

# Dendron Extended PR Checklist

## Code

### Basics

- [ ] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [ ] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)