### PR TITLE
fix(publish): "edit this page on ..." link uses the wrong path for self contained vaults

### DIFF
--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -84,7 +84,7 @@ class GitUtils {
     }
 
     let gitNotePath = _.join(
-      [path.basename(vault.fsPath), note.fname + ".md"],
+      [VaultUtils.getRelPath(vault), note.fname + ".md"],
       "/"
     );
     if (_.has(note?.custom, RESERVED_KEYS.GIT_NOTE_PATH)) {


### PR DESCRIPTION
Fixes an issue reported on Discord where the `edit this page on...` links on published pages would point to the wrong location for self contained vaults.