### PR TITLE
chore: check vault path usages for self contained vaults

### DIFF
--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -66,6 +66,11 @@ export class VaultUtils {
     return vault.fsPath;
   }
 
+  static getRelVaultRootPath(vault: DVault) {
+    if (VaultUtils.isSelfContained(vault)) return vault.fsPath;
+    return VaultUtils.getRelPath(vault);
+  }
+
   static getVaultByName({
     vaults,
     vname,

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -47,9 +47,16 @@ export class VaultUtils {
   }
 
   /**
-   * Path of vault relative to workspace root
+   * Path for the location of notes in this vault, relative to the workspace
+   * root.
+   *
+   * While for old vaults this is the same as
+   * {@link VaultUtils.getRelVaultRootPath}, for self contained vaults the notes
+   * are located inside the vault in the `notes` subdirectory.
+   *
    * @param vault
-   * @returns
+   * @returns path for location of the notes in the vault, relative to the
+   * workspace root
    */
   static getRelPath(vault: DVault) {
     if (VaultUtils.isSelfContained(vault)) {
@@ -66,6 +73,16 @@ export class VaultUtils {
     return vault.fsPath;
   }
 
+  /**
+   * Path for the location of vault root, relative to the workspace root.
+   *
+   * While for old vaults this is the same as {@link VaultUtils.getRelPath}, for
+   * self contained vaults the notes are located inside the vault in the `notes`
+   * subdirectory.
+   *
+   * @param vault
+   * @returns path for root of the vault, relative to the workspace root. May be "." for the top level self contained vault.
+   */
   static getRelVaultRootPath(vault: DVault) {
     if (VaultUtils.isSelfContained(vault)) return vault.fsPath;
     return VaultUtils.getRelPath(vault);

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -17,7 +17,7 @@ import {
 import {
   createDisposableLogger,
   isSelfContainedVaultFolder,
-  vault2Path,
+  pathForVaultRoot,
 } from "@dendronhq/common-server";
 import throttle from "@jcoreio/async-throttle";
 import _ from "lodash";
@@ -419,7 +419,7 @@ export class DoctorService implements Disposable {
         const vaultsToFix = (
           await Promise.all(
             vaults.map(async (vault) => {
-              const vaultDir = vault2Path({ wsRoot, vault });
+              const vaultDir = pathForVaultRoot({ wsRoot, vault });
               const gitPath = path.join(vaultDir, ".git");
               // Already a remote vault
               if (vault.remote !== undefined) return;
@@ -452,7 +452,7 @@ export class DoctorService implements Disposable {
           await asyncLoopOneAtATime(
             vaultsToFix,
             async ({ vault, remoteUrl }) => {
-              const vaultDir = vault2Path({ wsRoot, vault });
+              const vaultDir = pathForVaultRoot({ wsRoot, vault });
               this.L.info({
                 ctx,
                 vaultDir,

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -873,13 +873,12 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
 
     const vaults = ConfigUtils.getVaults(config);
     const vaultsAfterReject = _.reject(vaults, (ent: DVault) => {
-      const checks = [
-        VaultUtils.getRelPath(ent) === VaultUtils.getRelPath(vault),
-      ];
-      if (vault.workspace) {
-        checks.push(ent.workspace === vault.workspace);
-      }
-      return _.every(checks);
+      return (
+        // Same vault, and
+        VaultUtils.isEqualV2(ent, vault) &&
+        // Either not a workspace vault, or the same workspace
+        (!vault.workspace || ent.workspace === vault.workspace)
+      );
     });
     ConfigUtils.setVaults(config, vaultsAfterReject);
 

--- a/packages/plugin-core/src/settings.ts
+++ b/packages/plugin-core/src/settings.ts
@@ -1,4 +1,4 @@
-import { vault2Path } from "@dendronhq/common-server";
+import { pathForVaultRoot } from "@dendronhq/common-server";
 import {
   CodeConfigChanges,
   ConfigChanges,
@@ -18,8 +18,8 @@ import {
   WorkspaceConfiguration,
 } from "vscode";
 import { CONFIG } from "./constants";
+import { ExtensionProvider } from "./ExtensionProvider";
 import { Logger } from "./logger";
-import { DendronExtension, getDWorkspace } from "./workspace";
 
 export { Snippets };
 
@@ -42,10 +42,10 @@ export class Extensions extends EngineExtension {
 export class WorkspaceConfig extends EngineWorkspaceConfig {
   static async update(_wsRoot: string): Promise<Required<CodeConfigChanges>> {
     const ctx = "WorkspaceConfig:update";
-    const src = DendronExtension.configuration();
+    const src = ExtensionProvider.getWorkspaceConfig();
     const changes = await Settings.upgrade(src, _SETTINGS);
-    const { wsRoot, vaults } = getDWorkspace();
-    const vpath = vault2Path({ wsRoot, vault: vaults[0] });
+    const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+    const vpath = pathForVaultRoot({ wsRoot, vault: vaults[0] });
     const vscodeDir = path.join(vpath, ".vscode");
     const snippetChanges = await Snippets.upgradeOrCreate(vscodeDir);
     Logger.info({ ctx, vscodeDir, snippetChanges });

--- a/packages/pods-core/src/builtin/GDocPod.ts
+++ b/packages/pods-core/src/builtin/GDocPod.ts
@@ -16,6 +16,7 @@ import {
   stringifyError,
   DEngineClient,
   Time,
+  FOLDERS,
 } from "@dendronhq/common-all";
 import path from "path";
 import { vault2Path } from "@dendronhq/common-server";
@@ -399,9 +400,8 @@ export class GDocImportPod extends ImportPod<GDocImportPodConfig> {
     } = config as GDocImportPodConfig;
 
     let { accessToken } = config as GDocImportPodConfig;
-    const assetDirName = "assets";
     const vpath = vault2Path({ vault, wsRoot });
-    const assetDir = path.join(vpath, assetDirName);
+    const assetDir = path.join(vpath, FOLDERS.ASSETS);
 
     /** refreshes token if token has already expired */
     if (Time.now().toSeconds() > expirationTime) {

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -1,6 +1,7 @@
 import {
   DNodeUtils,
   DVault,
+  FOLDERS,
   genUUIDInsecure,
   NoteProps,
   NoteUtils,
@@ -602,16 +603,15 @@ export class MarkdownExportPod extends ExportPod {
     // Export Assets
     await Promise.all(
       vaults.map(async (vault) => {
-        //TODO: Avoid hardcoding of assets directory, or else extract to global const
         const destPath = path.join(
           dest.fsPath,
           VaultUtils.getRelPath(vault),
-          "assets"
+          FOLDERS.ASSETS
         );
         const srcPath = path.join(
           wsRoot,
           VaultUtils.getRelPath(vault),
-          "assets"
+          FOLDERS.ASSETS
         );
         if (fs.pathExistsSync(srcPath)) {
           await fs.copy(srcPath, destPath);

--- a/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
@@ -4,6 +4,7 @@ import {
   DendronError,
   DEngineClient,
   DVault,
+  FOLDERS,
   IDendronError,
   IntermediateDendronConfig,
   NoteProps,
@@ -116,12 +117,12 @@ export class MarkdownExportPodV2
         const destPath = path.join(
           destination,
           VaultUtils.getRelPath(vault),
-          "assets"
+          FOLDERS.ASSETS
         );
         const srcPath = path.join(
           this._engine.wsRoot,
           VaultUtils.getRelPath(vault),
-          "assets"
+          FOLDERS.ASSETS
         );
         if (fs.pathExistsSync(srcPath)) {
           await fs.copy(srcPath, destPath);


### PR DESCRIPTION
Fixed some usages of `vault2Path` and `VaultUtils.getRelPath` to be self contained vault aware.

Also performed some minor cleanup of the codebase as I hit warnings/deprecations.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [ ] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)