### PR TITLE
chore(markdown): this moves templating functionality to common-server

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -43,7 +43,6 @@
     "fuse.js": "^6.4.6",
     "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.2",
-    "handlebars": "^4.7.7",
     "http-status-codes": "^2.1.4",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.15",

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -46,7 +46,6 @@ import {
 import { genUUID } from "./uuid";
 import { VaultUtils } from "./vault";
 import { NoteDictsUtils } from "./noteDictsUtils";
-import { TemplateUtils } from "./template";
 
 /**
  * Utilities for dealing with nodes

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -457,35 +457,6 @@ export class NoteUtils {
     if (maybeMatch) {
       const { schema, schemaModule } = maybeMatch;
       NoteUtils.addSchema({ note, schemaModule, schema });
-      const maybeTemplate = schema.data.template;
-      if (maybeTemplate) {
-        // TODO: Support xvault with user prompting for this flow
-        /*
-         * Get first valid template note.
-         * First look for template in same vault as note. Otherwise, look across all vaults.
-         * If there are multiple template matches, apply first one.
-         * This is temp until we get xvault support
-         */
-        const tempInSameVault = NoteUtils.getNoteByFnameFromEngine({
-          fname: maybeTemplate.id,
-          vault: note.vault,
-          engine,
-        });
-        const tempNote =
-          tempInSameVault ||
-          NoteUtils.getNotesByFnameFromEngine({
-            fname: maybeTemplate.id,
-            engine,
-          })[0];
-
-        if (tempNote) {
-          TemplateUtils.applyTemplate({
-            templateNote: tempNote,
-            targetNote: note,
-            engine,
-          });
-        }
-      }
     }
     return note;
   }

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -4,7 +4,6 @@ import minimatch from "minimatch";
 
 export * from "./colors";
 export * from "./dnode";
-export * from "./template";
 export * from "./helpers";
 export * from "./env";
 export * from "./assert";

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -41,6 +41,7 @@
     "@sentry/integrations": "^6.13.3",
     "@sentry/node": "^6.13.3",
     "ajv": "^8.6.0",
+    "handlebars": "^4.7.7",
     "ajv-errors": "^3.0.0",
     "analytics-node": "^5.1.0",
     "anymatch": "^3.1.2",

--- a/packages/common-server/src/index.ts
+++ b/packages/common-server/src/index.ts
@@ -10,3 +10,4 @@ export * from "./errorReporting";
 export * from "./types";
 export * from "./server";
 export * from "./yaml";
+export * from "./template";

--- a/packages/common-server/src/template.ts
+++ b/packages/common-server/src/template.ts
@@ -1,8 +1,11 @@
+import {
+  ConfigUtils,
+  DEngineClient,
+  NoteProps,
+  Time,
+} from "@dendronhq/common-all";
 import Handlebars from "handlebars";
 import _ from "lodash";
-import { Time } from "./time";
-import { DEngineClient, NoteProps } from "./types";
-import { ConfigUtils } from "./utils";
 
 type TemplateFunctionProps = {
   templateNote: NoteProps;

--- a/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
@@ -1,5 +1,6 @@
-import { NoteProps, TemplateUtils } from "@dendronhq/common-all";
+import { NoteProps } from "@dendronhq/common-all";
 import { TestNoteFactory } from "@dendronhq/common-test-utils";
+import { TemplateUtils } from "@dendronhq/common-server";
 import sinon from "sinon";
 import { runEngineTestV5 } from "../../engine";
 import { ENGINE_HOOKS } from "../../presets";

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -17,11 +17,13 @@ import {
   RespV3,
   SchemaTemplate,
   SchemaUtils,
-  TemplateUtils,
   VaultUtils,
   VSCodeEvents,
 } from "@dendronhq/common-all";
-import { getDurationMilliseconds } from "@dendronhq/common-server";
+import {
+  getDurationMilliseconds,
+  TemplateUtils,
+} from "@dendronhq/common-server";
 import { HistoryService, MetadataService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { Uri, window } from "vscode";


### PR DESCRIPTION
chore(markdown): this moves templating functionality to `common-server`

Handlebars has a node dependency which would cause frontend build to fail when bundled with `common-all`

https://github.com/dendronhq/dendron/pull/2969