### PR TITLE
chore(internal): add safeguard for unexpected segment client instantiation

### DIFF
--- a/packages/api-server/src/Server.ts
+++ b/packages/api-server/src/Server.ts
@@ -67,6 +67,10 @@ export function appModule({
   const staticDir = path.join(__dirname, "static");
   app.use(express.static(staticDir));
 
+  // this is the first time we are accessing the segment client instance (when this is run as a separate process).
+  // unlock Segment client.
+  SegmentClient.unlock();
+
   if (!SegmentClient.instance().hasOptedOut && getStage() === "prod") {
     initializeSentry({ environment: getStage(), release: getSentryRelease() });
   }

--- a/packages/common-server/src/analytics.ts
+++ b/packages/common-server/src/analytics.ts
@@ -169,11 +169,6 @@ export class SegmentClient {
       }
       return this._singleton;
     }
-
-    // if (_.isUndefined(this._singleton) || opts?.forceNew) {
-    //   this._singleton = new SegmentClient(opts);
-    // }
-    // return this._singleton;
   }
 
   /** Legacy: If exists, Dendron telemetry has been disabled. */

--- a/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/segmentClient.spec.ts
@@ -159,6 +159,7 @@ type flushResponse = {
 describe("GIVEN a SegmentClient", () => {
   const filepath = path.join(tmpDir().name, "test.log");
 
+  SegmentClient.unlock();
   const instance = SegmentClient.instance({
     forceNew: true,
     cachePath: filepath,
@@ -369,6 +370,24 @@ describe("GIVEN a SegmentClient", () => {
     test("AND the file should keep the payload contents of ONLY data that was not sent", (done) => {
       const fileContents = fs.readFileSync(filepath, "utf-8");
       expect(fileContents).toMatchSnapshot();
+      done();
+    });
+  });
+});
+
+describe("Instantiation safeguard", () => {
+  describe("WHEN SegmentClient is locked", () => {
+    test("THEN SegmentClient.instance() throws", (done) => {
+      expect(SegmentClient.instance).toThrow();
+      done();
+    });
+  });
+
+  describe("WHEN SegmentClient is unlocked", () => {
+    test("THEN SegmentClient.instance() is accessible", (done) => {
+      SegmentClient.unlock();
+      const out = SegmentClient.instance();
+      expect(out instanceof SegmentClient).toBeTruthy();
       done();
     });
   });

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -547,6 +547,10 @@ export async function _activate(
   const maybeUUIDPath = path.join(os.homedir(), CONSTANTS.DENDRON_ID);
   const UUIDPathExists = await fs.pathExists(maybeUUIDPath);
 
+  // this is the first time we are accessing the segment client instance.
+  // unlock Segment client.
+  SegmentClient.unlock();
+
   // If telemetry is not disabled, we enable telemetry and error reporting ^rw8l1w51hnjz
   // - NOTE: we do this outside of the try/catch block in case we run into an error with initialization
   if (!SegmentClient.instance().hasOptedOut && getStage() === "prod") {


### PR DESCRIPTION
# chore(internal): add safeguard for unexpected segment client instantiation

This PR:
- Adds a static _lock_ to `SegmentClient` that will prevent access of `SegmentClient.instance()` before it has been explicitly _unlocked_.
- Unlocking is done right at the beginning of `_activate` in `plugin-core`, and when the server is run as a separate process
- This prevents `SegmentClient` from being accessed (thus potentially creating a uuid file) during module load time.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)