### PR TITLE
fix(workspace): Help and Feedback Panel shows info when not in Dendron WS

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -91,6 +91,7 @@ import { DendronExtension, getDWorkspace, getExtension } from "./workspace";
 import { WorkspaceActivator } from "./workspace/workspaceActivater";
 import { WorkspaceInitFactory } from "./workspace/WorkspaceInitFactory";
 import { WSUtils } from "./WSUtils";
+import setupHelpFeedbackTreeView from "./features/HelpFeedbackTreeview";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -648,6 +649,11 @@ export async function _activate(
       previousGlobalVersion,
       extensionInstallStatus,
     });
+
+    // Setup the help and feedback view here so that it still works even if
+    // we're not in a Dendron workspace.
+    const helpAndFeedbackView = setupHelpFeedbackTreeView();
+    context.subscriptions.push(helpAndFeedbackView);
 
     if (await DendronExtension.isDendronWorkspace()) {
       const activator = new WorkspaceActivator();

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -70,7 +70,6 @@ import { IWSUtilsV2 } from "./WSUtilsV2Interface";
 import { CalendarView } from "./views/CalendarView";
 import TipOfTheDayWebview from "./features/TipOfTheDayWebview";
 import { ALL_FEATURE_SHOWCASES } from "./showcase/AllFeatureShowcases";
-import setupHelpFeedbackTreeView from "./features/HelpFeedbackTreeview";
 import { GraphPanel } from "./views/GraphPanel";
 
 let _DendronWorkspace: DendronExtension | null;

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -525,9 +525,6 @@ export class DendronExtension implements IDendronExtension {
         // Tip of the Day
         const tipOfDayView = this.setupTipOfTheDayView();
 
-        // Help and Feedback
-        const helpAndFeedbackView = setupHelpFeedbackTreeView();
-
         // Graph panel (side)
         const graphPanel = new GraphPanel(this);
         this.treeViews[DendronTreeViewKey.GRAPH_PANEL] = graphPanel;
@@ -540,7 +537,6 @@ export class DendronExtension implements IDendronExtension {
 
         context.subscriptions.push(backlinkTreeView);
         context.subscriptions.push(tipOfDayView);
-        context.subscriptions.push(helpAndFeedbackView);
       }
     });
   }


### PR DESCRIPTION
## fix(workspace): Help and Feedback Panel shows info when not in Dendron Workspace

Previously, the help and feedback panel would be empty if you weren't in a Dendron workspace.  This change fixes that issue.