### PR TITLE
feat(views): Preview setting for light, dark, or custom themes

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -937,6 +937,13 @@
           },
           "description": "Maps each status to a symbol, word, or sentence. This will be displayed for the task."
         },
+        "taskCompleteStatus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Sets which statuses mark the task as completed."
+        },
         "prioritySymbols": {
           "type": "object",
           "additionalProperties": {
@@ -969,6 +976,7 @@
         "name",
         "prioritySymbols",
         "statusSymbols",
+        "taskCompleteStatus",
         "todoIntegration"
       ],
       "description": "Namespace for configuring scratch note behavior"
@@ -1029,6 +1037,9 @@
         },
         "automaticallyShowPreview": {
           "type": "boolean"
+        },
+        "theme": {
+          "$ref": "#/definitions/Theme"
         }
       },
       "required": [
@@ -1043,6 +1054,14 @@
       ],
       "additionalProperties": false,
       "description": "Namespace for all preview related configurations"
+    },
+    "Theme": {
+      "type": "string",
+      "enum": [
+        "dark",
+        "light",
+        "custom"
+      ]
     },
     "DendronPublishingConfig": {
       "type": "object",
@@ -1117,6 +1136,9 @@
           "type": "boolean"
         },
         "enableRandomlyColoredTags": {
+          "type": "boolean"
+        },
+        "enableTaskNotes": {
           "type": "boolean"
         },
         "hierarchy": {
@@ -1335,14 +1357,6 @@
       "enum": [
         "tree",
         "edit"
-      ]
-    },
-    "Theme": {
-      "type": "string",
-      "enum": [
-        "dark",
-        "light",
-        "custom"
       ]
     }
   }

--- a/packages/common-all/src/constants/configs/preview.ts
+++ b/packages/common-all/src/constants/configs/preview.ts
@@ -11,8 +11,8 @@ import {
 } from "./global";
 
 export const PREVIEW: DendronConfigEntryCollection<DendronPreviewConfig> = {
-  enableFMTitle: ENABLE_FM_TITLE("preview"), // TODO: split
-  enableNoteTitleForLink: ENABLE_NOTE_TITLE_FOR_LINK("preview"), // TODO: split
+  enableFMTitle: ENABLE_FM_TITLE("preview"),
+  enableNoteTitleForLink: ENABLE_NOTE_TITLE_FOR_LINK("preview"),
   enableFrontmatterTags: ENABLE_FRONTMATTER_TAGS("preview"),
   enableHashesForFMTags: ENABLE_HASHES_FOR_FM_TAGS("preview"),
   enableMermaid: ENABLE_MERMAID("preview"),
@@ -21,5 +21,9 @@ export const PREVIEW: DendronConfigEntryCollection<DendronPreviewConfig> = {
   automaticallyShowPreview: {
     label: "Automatically Show Preview",
     desc: "Automatically show preview when opening VSCode and switching between notes.",
+  },
+  theme: {
+    label: "The theme to use in the preview.",
+    desc: "The theme to use in the preview. If unset, preview will follow your editor theme for light or dark mode. If you are using a custom theme, make sure to create the CSS file too.",
   },
 };

--- a/packages/common-all/src/types/configs/preview/preview.ts
+++ b/packages/common-all/src/types/configs/preview/preview.ts
@@ -1,3 +1,5 @@
+import { Theme } from "../publishing";
+
 /**
  * Namespace for all preview related configurations
  */
@@ -10,6 +12,7 @@ export type DendronPreviewConfig = {
   enablePrettyRefs: boolean;
   enableKatex: boolean;
   automaticallyShowPreview: boolean;
+  theme?: Theme;
 };
 
 /**

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -937,6 +937,13 @@
           },
           "description": "Maps each status to a symbol, word, or sentence. This will be displayed for the task."
         },
+        "taskCompleteStatus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Sets which statuses mark the task as completed."
+        },
         "prioritySymbols": {
           "type": "object",
           "additionalProperties": {
@@ -969,6 +976,7 @@
         "name",
         "prioritySymbols",
         "statusSymbols",
+        "taskCompleteStatus",
         "todoIntegration"
       ],
       "description": "Namespace for configuring scratch note behavior"
@@ -1029,6 +1037,9 @@
         },
         "automaticallyShowPreview": {
           "type": "boolean"
+        },
+        "theme": {
+          "$ref": "#/definitions/Theme"
         }
       },
       "required": [
@@ -1043,6 +1054,14 @@
       ],
       "additionalProperties": false,
       "description": "Namespace for all preview related configurations"
+    },
+    "Theme": {
+      "type": "string",
+      "enum": [
+        "dark",
+        "light",
+        "custom"
+      ]
     },
     "DendronPublishingConfig": {
       "type": "object",
@@ -1117,6 +1136,9 @@
           "type": "boolean"
         },
         "enableRandomlyColoredTags": {
+          "type": "boolean"
+        },
+        "enableTaskNotes": {
           "type": "boolean"
         },
         "hierarchy": {
@@ -1335,14 +1357,6 @@
       "enum": [
         "tree",
         "edit"
-      ]
-    },
-    "Theme": {
-      "type": "string",
-      "enum": [
-        "dark",
-        "light",
-        "custom"
       ]
     }
   }


### PR DESCRIPTION
This PR adds the ability to set the preview to a light or dark theme independent of the IDE theme, as well as a custom theme option for custom themes.

The custom theme support reads the same CSS file as the publishing right now, which I think is advantageous as it means the preview will look identical to published notes. We can add support to set independent custom themes for preview and publishing in a later iteration if desired.