### PR TITLE
enhance(workspace): "Migrate to Self Contained Vault" updates logoPath and moves gitignore file

### DIFF
--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -637,6 +637,24 @@ export async function isSelfContainedVaultFolder(dir: string) {
   );
 }
 
+/** Move a file from `from` to `to`, if the file exists.
+ *
+ * @returns True if the file did exist and was moved successfully, false otherwise.
+ */
+export async function moveIfExists(from: string, to: string): Promise<boolean> {
+  try {
+    if (await fs.pathExists(from)) {
+      await fs.move(from, to);
+      return true;
+    }
+  } catch (err) {
+    // Permissions error or similar issue when moving the path
+    // deliberately left empty
+  }
+  return false;
+}
+
+/** Utility functions for dealing with file extensions. */
 export class ExtensionUtils {
   private static textExtensions: ReadonlySet<string>;
   private static ensureTextExtensions() {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -48,7 +48,6 @@ import _ from "lodash";
 import os from "os";
 import path, { basename } from "path";
 import { WorkspaceUtils } from ".";
-import { BackupKeyEnum, BackupService } from "../backup";
 import { DConfig } from "../config";
 import { MetadataService } from "../metadata";
 import {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -19,6 +19,7 @@ import {
   InstallStatus,
   IntermediateDendronConfig,
   isNotUndefined,
+  isWebUri,
   NoteUtils,
   SchemaUtils,
   SeedEntry,
@@ -32,6 +33,7 @@ import {
   createDisposableLogger,
   DLogger,
   GitUtils,
+  moveIfExists,
   note2File,
   pathForVaultRoot,
   readJSONWithComments,
@@ -46,6 +48,7 @@ import _ from "lodash";
 import os from "os";
 import path, { basename } from "path";
 import { WorkspaceUtils } from ".";
+import { BackupKeyEnum, BackupService } from "../backup";
 import { DConfig } from "../config";
 import { MetadataService } from "../metadata";
 import {
@@ -500,6 +503,24 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
         VaultUtils.isEqualV2(confVault, vault)
       );
       if (configVault) configVault.selfContained = true;
+
+      // Update logoPath if needed
+      let logoPath = config.publishing?.logoPath;
+      if (
+        // If the logo exists, and it was an asset inside the vault we're migrating
+        config.publishing &&
+        logoPath &&
+        !isWebUri(logoPath) &&
+        logoPath.startsWith(VaultUtils.getRelPath(vault))
+      ) {
+        // Then we need to update the logo path for the new path
+        logoPath = logoPath.slice(VaultUtils.getRelPath(vault).length);
+        logoPath = VaultUtils.getRelPath(newVault) + logoPath;
+        config.publishing.logoPath = logoPath;
+      }
+
+      // All updates to the config are done, finish by writing it
+      await DConfig.createBackup(this.wsRoot, "migrate-vault-sc");
       await DConfig.writeConfig({ wsRoot: this.wsRoot, config });
 
       // Add the config file into the vault make it self contained
@@ -518,20 +539,14 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       throw err;
     }
     // Except if there's `.git` inside the vault, that has to stay at the root of the vault
-    try {
-      if (await fs.pathExists(path.join(vaultFolder, FOLDERS.NOTES, ".git"))) {
-        await fs.move(
-          path.join(vaultFolder, FOLDERS.NOTES, ".git"),
-          path.join(vaultFolder, ".git")
-        );
-      }
-    } catch (err) {
-      this.logger.error({
-        ctx,
-        msg: "failed to move the git directory into the new folder",
-        err,
-      });
-    }
+    await moveIfExists(
+      path.join(vaultFolder, FOLDERS.NOTES, ".git"),
+      path.join(vaultFolder, ".git")
+    );
+    await moveIfExists(
+      path.join(vaultFolder, FOLDERS.NOTES, ".gitignore"),
+      path.join(vaultFolder, ".gitignore")
+    );
     // Update the config for the vault
     vault.selfContained = true;
     return vault;


### PR DESCRIPTION
This PR improves the "Migrate to Self Contained Vault" command to:
- Update the logoPath, if one was set, and it was a logo inside of the vault that's being migrated
- If there's a gitignore file, moves it along with the migrated vault (before the gitignore file would be left in the notes subfolder)

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [ ] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [ ] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)