### PR TITLE
chore(workspace): fix a few command settings

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -259,8 +259,8 @@
         "title": "Dendron: Create Task Note"
       },
       {
-        "command": "dendron.templateApply",
-        "title": "Dendron: Template Apply"
+        "command": "dendron.applyTemplate",
+        "title": "Dendron: Apply Template"
       },
       {
         "command": "dendron.archiveHierarchy",
@@ -618,7 +618,7 @@
           "when": "dendron:pluginActive"
         },
         {
-          "command": "dendron.templateApply",
+          "command": "dendron.applyTemplate",
           "when": "dendron:pluginActive"
         },
         {
@@ -1033,12 +1033,12 @@
     "keybindings": [
       {
         "command": "dendron.goto",
-        "when": "editorFocus"
+        "when": "editorFocus && dendron:pluginActive"
       },
       {
         "command": "dendron.gotoNote",
         "key": "ctrl+enter",
-        "when": "editorFocus"
+        "when": "editorFocus && dendron:pluginActive"
       },
       {
         "command": "dendron.createSchemaFromHierarchy",

--- a/packages/plugin-core/scripts/genConfig.ts
+++ b/packages/plugin-core/scripts/genConfig.ts
@@ -1,12 +1,14 @@
+/* eslint-disable no-console */
 import fs from "fs-extra";
 import _ from "lodash";
 import {
   CONFIG,
+  DendronContext,
   DENDRON_COMMANDS,
-  DENDRON_VIEWS,
   DENDRON_MENUS,
-  DENDRON_VIEWS_WELCOME,
+  DENDRON_VIEWS,
   DENDRON_VIEWS_CONTAINERS,
+  DENDRON_VIEWS_WELCOME,
 } from "../src/constants";
 
 function genEntry(entryDict: any) {
@@ -72,8 +74,19 @@ function updateKeybindings() {
     DENDRON_COMMANDS,
     (ent) => !_.isEmpty(ent.keybindings)
   ).map((keyEnt) => {
-    const configProps = keyEnt.keybindings;
+    let configProps = keyEnt.keybindings;
     const key = keyEnt["key"];
+
+    // sanity, if command depends on plugin being active, add same when clause to keybinding
+    if (
+      keyEnt.when === DendronContext.PLUGIN_ACTIVE &&
+      !configProps?.when?.includes(DendronContext.PLUGIN_ACTIVE)
+    ) {
+      const when = configProps?.when
+        ? configProps.when + ` && ${DendronContext.PLUGIN_ACTIVE}`
+        : DendronContext.PLUGIN_ACTIVE;
+      configProps = { ...configProps, when };
+    }
     return {
       command: key,
       ...configProps,


### PR DESCRIPTION
chore(workspace): fix a few command settings

- disable goto keybinding if plugin isn't active
- correct name of "Apply Template" command
- add a safety to generate plugin active when clause for keybinding if command has a similar when clause