### PR TITLE
fix: Images with encoded URI are not rendered in the Preview

### DIFF
--- a/packages/engine-server/src/markdown/remark/dendronPreview.ts
+++ b/packages/engine-server/src/markdown/remark/dendronPreview.ts
@@ -26,7 +26,7 @@ export function makeImageUrlFullPath({
   }
   // assume that the path is relative to vault
   const { wsRoot, vault } = MDUtilsV5.getProcData(proc);
-  const fpath = path.join(vault2Path({ wsRoot, vault }), node.url);
+  const fpath = path.join(vault2Path({ wsRoot, vault }), decodeURI(node.url));
   node.url = fpath;
 }
 

--- a/packages/plugin-core/src/test/suite-integ/PreviewPanel.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PreviewPanel.test.ts
@@ -116,6 +116,34 @@ suite("GIVEN PreviewPanel", function () {
         });
       });
 
+      describe("AND image URI is encoded", () => {
+        test("THEN URL is correctly rewritten", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          const note = await makeTestNote({
+            previewPanel,
+            body: "![](assets/Pasted%20image%20%CE%B1.png)",
+          });
+          expect(
+            await AssertUtils.assertInString({
+              body: note.body,
+              match: [
+                "https://file",
+                "vscode",
+                path.posix.join(
+                  VaultUtils.getRelPath(vaults[0]),
+                  "assets",
+                  // `makeTestNote()` will invoke `rewriteImageUrls()`
+                  //  in which `makeImageUrlFullPath()` will expectedly decode "Pasted%20image%20%CE%B1.png"
+                  //    to "Pasted image α.png",
+                  //  then `panel.webview.asWebviewUri` encodes it back to "Pasted%20image%20%CE%B1.png".
+                  "Pasted%20image%20%CE%B1.png"
+                ),
+              ],
+            })
+          ).toBeTruthy();
+        });
+      });
+
       describe("AND image is an absolute path", () => {
         test("THEN URL is correctly rewritten", async () => {
           const { wsRoot } = ExtensionProvider.getDWorkspace();


### PR DESCRIPTION
For example: `![](images/Pasted%20image%2020220529172111.png)` is not rendered in the Preview, while this is perhaps not caused by pasting images directly into the Dendron Paste Image extension, some users might use other editors to edit the same note, those editors may store the image from clipboard with a space-separated name and return an unexpectedly encoded URI.