### PR TITLE
chore(workspace): support initializing variable length tutorials

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -47,7 +47,15 @@ export enum TutorialEvents {
   Tutorial_3_Show = "Tutorial_3_Show",
   Tutorial_4_Show = "Tutorial_4_Show",
   Tutorial_5_Show = "Tutorial_5_Show",
+  TutorialNoteViewed = "TutorialNoteViewed",
 }
+
+export type TutorialNoteViewedPayload = {
+  testGroup: string;
+  fname: string;
+  currentStep: number;
+  totalSteps: number;
+};
 
 export enum KeybindingConflictDetectedSource {
   activation = "activation",

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -41,17 +41,11 @@ export enum CLIEvents {
 export enum TutorialEvents {
   WelcomeShow = "WelcomeShow",
   ClickStart = "Getting_Started_Clicked",
-  Tutorial_0_Show = "Tutorial_0_Show",
-  Tutorial_1_Show = "Tutorial_1_Show",
-  Tutorial_2_Show = "Tutorial_2_Show",
-  Tutorial_3_Show = "Tutorial_3_Show",
-  Tutorial_4_Show = "Tutorial_4_Show",
-  Tutorial_5_Show = "Tutorial_5_Show",
   TutorialNoteViewed = "TutorialNoteViewed",
 }
 
 export type TutorialNoteViewedPayload = {
-  testGroup: string;
+  tutorialType: string;
   fname: string;
   currentStep: number;
   totalSteps: number;

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.conclusion.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.conclusion.md
@@ -1,9 +1,11 @@
 ---
 id: kyjfnf2rnc6vn71iyn9liz7
 title: Conclusion
-desc: ''
-updated: 1652123184798
+desc: ""
+updated: 1653980643031
 created: 1625564254964
+currentStep: 5
+totalSteps: 5
 nav_order: 4
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.linking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.linking-notes.md
@@ -2,8 +2,10 @@
 id: khv6u4514vnvvy4njhctfru
 title: Linking Notes
 desc: Linking Notes
-updated: 1652280901513
+updated: 1653980618942
 created: 1625563999532
+currentStep: 3
+totalSteps: 5
 nav_order: 2
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.md
@@ -2,8 +2,10 @@
 id: 4u6pv56mnt25d8l2wzfygu7
 title: Getting Started
 desc: ""
-updated: 1652280815854
+updated: 1653980552303
 created: 1608051264282
+currentStep: 0
+totalSteps: 5
 nav_order: 1.1
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.rich-formatting.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.rich-formatting.md
@@ -2,8 +2,10 @@
 id: lxrp006mal1tfsd7nxmsobe
 title: Rich Formatting
 desc: ""
-updated: 1652291044262
+updated: 1653980630252
 created: 1625573403967
+currentStep: 4
+totalSteps: 5
 nav_order: 3
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.taking-notes.md
@@ -4,8 +4,10 @@ title: Taking Notes
 desc: >-
   Creating notes, understanding hierarchy, and using Lookup to quickly find your
   notes
-updated: 1652388474734
+updated: 1653980609563
 created: 1625563944736
+currentStep: 2
+totalSteps: 5
 nav_order: 1
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.user-interface.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.user-interface.md
@@ -2,8 +2,10 @@
 id: epmpyk2kjdxqyvflotan2vt
 title: User Interface
 desc: 1. User Interface
-updated: 1652280851960
+updated: 1653980572188
 created: 1625563862198
+currentStep: 1
+totalSteps: 5
 nav_order: 0
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.conclusion.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.conclusion.md
@@ -1,9 +1,11 @@
 ---
 id: wmbd5xz40ohjb8rd5b737cq
 title: Conclusion
-desc: ''
-updated: 1652126817206
+desc: ""
+updated: 1653982042478
 created: 1625564254964
+currentStep: 5
+totalSteps: 5
 nav_order: 4
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.linking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.linking-notes.md
@@ -2,8 +2,10 @@
 id: rjnqumna1ye82u9u76ni42k
 title: Linking Notes
 desc: Linking Notes
-updated: 1652280770996
+updated: 1653982014592
 created: 1625563999532
+currentStep: 3
+totalSteps: 5
 nav_order: 2
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.md
@@ -2,8 +2,10 @@
 id: tbilk9to67d0dwgnjanj5ph
 title: Getting Started
 desc: ""
-updated: 1652280532205
+updated: 1653980839862
 created: 1608051264282
+currentStep: 0
+totalSteps: 5
 nav_order: 1.1
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.rich-formatting.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.rich-formatting.md
@@ -2,8 +2,10 @@
 id: ie5x2bq5yj7uvenylblnhyr
 title: Rich Formatting
 desc: ""
-updated: 1652290942993
+updated: 1653982031426
 created: 1625573403967
+currentStep: 4
+totalSteps: 5
 nav_order: 3
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.taking-notes.md
@@ -4,8 +4,10 @@ title: Taking Notes
 desc: >-
   Creating notes, understanding hierarchy, and using Lookup to quickly find your
   notes
-updated: 1652388453215
+updated: 1653982004089
 created: 1625563944736
+currentStep: 2
+totalSteps: 5
 nav_order: 1
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.user-interface.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/no-refactor/tutorial.user-interface.md
@@ -2,8 +2,10 @@
 id: kl6ndok3a1f14be6zv771c9
 title: User Interface
 desc: 1. User Interface
-updated: 1652280610218
+updated: 1653981984146
 created: 1625563862198
+currentStep: 1
+totalSteps: 5
 nav_order: 0
 ---
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.conclusion.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.conclusion.md
@@ -2,8 +2,11 @@
 id: 5pz82kyfhp2whlzfldxmkzu
 title: Conclusion
 desc: ""
-updated: 1652279068668
+updated: 1653980815279
 created: 1652278009760
+currentStep: 5
+totalSteps: 5
+nav_order: 4
 ---
 
 **Congratulations!** You've completed the Dendron Tutorial 🙌.

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.linking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.linking-notes.md
@@ -2,8 +2,11 @@
 id: 4do06cts1tme9yz7vfp46bu
 title: Linking Your Notes
 desc: Note Linking and your Knowledge Graph
-updated: 1652280371265
+updated: 1653980786307
 created: 1652278095382
+currentStep: 3
+totalSteps: 5
+nav_order: 2
 ---
 
 ### Links

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.md
@@ -2,8 +2,11 @@
 id: y60h6laqi7w462zjp3jyqtt
 title: Tutorial
 desc: "Tutorial Home Page"
-updated: 1652287311642
+updated: 1653980718180
 created: 1652278009766
+currentStep: 0
+totalSteps: 5
+nav_order: 1.1
 ---
 
 ## Welcome to Dendron

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.rich-formatting.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.rich-formatting.md
@@ -2,8 +2,11 @@
 id: kzry3qcy2y4ey1jcf1llajg
 title: Rich Formatting
 desc: "Text Formatting, Images, Formulas, and Diagrams"
-updated: 1652280413439
+updated: 1653980802473
 created: 1652278089118
+currentStep: 4
+totalSteps: 5
+nav_order: 3
 ---
 
 Dendron supports an extended Markdown syntax, which provides a lot of options for rich formatting. Take a look at some examples in this note to see what's possible. Have the preview pane opened (`Dendron: Show Preview`) to see how these will get rendered.

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.taking-notes.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.taking-notes.md
@@ -2,8 +2,11 @@
 id: mycf53kz1r7swcttcobwbdl
 title: Taking Notes
 desc: ""
-updated: 1652388439051
+updated: 1653980773142
 created: 1652278083208
+currentStep: 2
+totalSteps: 5
+nav_order: 1
 ---
 
 ### Create a Note

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.user-interface.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/original/tutorial.user-interface.md
@@ -2,8 +2,11 @@
 id: ks3b4u7gnd6yiw68qu6ba4m
 title: Navigation Basics
 desc: ""
-updated: 1652279527689
+updated: 1653980753187
 created: 1652278075049
+currentStep: 1
+totalSteps: 5
+nav_order: 0
 ---
 
 Let's do a brief overview on how to navigate the Dendron UI.

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -73,7 +73,7 @@ export class TutorialInitializer
     ws: DWorkspaceV2;
   }): TutorialNoteViewedPayload {
     const { document, ws } = opts;
-    const testGroup = AB_TUTORIAL_TEST.getUserGroup(
+    const tutorialType = AB_TUTORIAL_TEST.getUserGroup(
       SegmentClient.instance().anonymousId
     );
     const fsPath = document.uri.fsPath;
@@ -83,7 +83,7 @@ export class TutorialInitializer
     const { fname, custom } = note;
     const { currentStep, totalSteps } = custom;
     return {
-      testGroup,
+      tutorialType,
       fname,
       currentStep,
       totalSteps,
@@ -100,13 +100,17 @@ export class TutorialInitializer
       const document = e?.document;
 
       if (document !== undefined) {
-        const payload = this.getAnalyticsPayloadFromDocument({
-          document,
-          ws: opts.ws,
-        });
-        const { fname } = payload;
-        if (fname.includes("tutorial")) {
-          AnalyticsUtils.track(TutorialEvents.TutorialNoteViewed, payload);
+        try {
+          const payload = this.getAnalyticsPayloadFromDocument({
+            document,
+            ws: opts.ws,
+          });
+          const { fname } = payload;
+          if (fname.includes("tutorial")) {
+            AnalyticsUtils.track(TutorialEvents.TutorialNoteViewed, payload);
+          }
+        } catch (err) {
+          Logger.info({ ctx, msg: "Cannot get payload from document." });
         }
       }
     });

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -6,8 +6,9 @@ import {
   TutorialEvents,
   VaultUtils,
   AB_TUTORIAL_TEST,
+  TutorialNoteViewedPayload,
 } from "@dendronhq/common-all";
-import { SegmentClient, vault2Path } from "@dendronhq/common-server";
+import { file2Note, SegmentClient, vault2Path } from "@dendronhq/common-server";
 import {
   InitialSurveyStatusEnum,
   MetadataService,
@@ -67,8 +68,50 @@ export class TutorialInitializer
     );
   }
 
+  private getAnalyticsPayloadFromDocument(opts: {
+    document: vscode.TextDocument;
+    ws: DWorkspaceV2;
+  }): TutorialNoteViewedPayload {
+    const { document, ws } = opts;
+    const testGroup = AB_TUTORIAL_TEST.getUserGroup(
+      SegmentClient.instance().anonymousId
+    );
+    const fsPath = document.uri.fsPath;
+    const { vaults, wsRoot } = ws;
+    const vault = VaultUtils.getVaultByFilePath({ vaults, wsRoot, fsPath });
+    const note = file2Note(fsPath, vault);
+    const { fname, custom } = note;
+    const { currentStep, totalSteps } = custom;
+    return {
+      testGroup,
+      fname,
+      currentStep,
+      totalSteps,
+    };
+  }
+
   async onWorkspaceOpen(opts: { ws: DWorkspaceV2 }): Promise<void> {
     const ctx = "TutorialInitializer.onWorkspaceOpen";
+
+    // Register a special analytics handler for the tutorial:
+    // This needs to be registered before we open any tutorial note.
+    // Otherwise some events may be lost and not reported properly.
+    const disposable = vscode.window.onDidChangeActiveTextEditor((e) => {
+      const document = e?.document;
+
+      if (document !== undefined) {
+        const payload = this.getAnalyticsPayloadFromDocument({
+          document,
+          ws: opts.ws,
+        });
+        const { fname } = payload;
+        if (fname.includes("tutorial")) {
+          AnalyticsUtils.track(TutorialEvents.TutorialNoteViewed, payload);
+        }
+      }
+    });
+
+    ExtensionProvider.getExtension().context.subscriptions.push(disposable);
 
     const { wsRoot, vaults } = opts.ws;
     const vaultRelPath = VaultUtils.getRelPath(vaults[0]);
@@ -119,32 +162,5 @@ export class TutorialInitializer
     if (!initialSurveySubmitted) {
       await SurveyUtils.showInitialSurvey();
     }
-
-    // Register a special analytics handler for the tutorial:
-    const disposable = vscode.window.onDidChangeActiveTextEditor((e) => {
-      const fileName = e?.document.uri.fsPath;
-
-      let eventName: TutorialEvents | undefined;
-
-      if (fileName?.endsWith("tutorial.md")) {
-        eventName = TutorialEvents.Tutorial_0_Show;
-      } else if (fileName?.endsWith("tutorial.user-interface.md")) {
-        eventName = TutorialEvents.Tutorial_1_Show;
-      } else if (fileName?.endsWith("tutorial.taking-notes.md")) {
-        eventName = TutorialEvents.Tutorial_2_Show;
-      } else if (fileName?.endsWith("tutorial.linking-notes.md")) {
-        eventName = TutorialEvents.Tutorial_3_Show;
-      } else if (fileName?.endsWith("tutorial.rich-formatting.md")) {
-        eventName = TutorialEvents.Tutorial_4_Show;
-      } else if (fileName?.endsWith("tutorial.conclusion.md")) {
-        eventName = TutorialEvents.Tutorial_5_Show;
-      }
-
-      if (eventName) {
-        AnalyticsUtils.track(eventName);
-      }
-    });
-
-    ExtensionProvider.getExtension().context.subscriptions.push(disposable);
   }
 }


### PR DESCRIPTION
# chore: support initializing variable length tutorials

This PR:
- Proposes a new convention for tutorials for consolidating tutorial view events into one
- Add additional information about tutorial view event for easier analysis
  - `fname`, `currentStep`, `totalSteps`
- syncs tutorial that has additional frontmatter as per new convention
- fixes an issue where some tutorial view events were omitted

## New convention
- Tutorials now should have frontmatter `currentStep` and `totalSteps`, indexed by zero. (entry point is always `currentStep: 0`)

## omitted tutorial view events
- We have a sizable number of users who have never reported some tutorial events.
- This seems to be rooted from a race between registering the callback to `onDidChangeVisibleTextEditors`, and actually opening the note
  - This is mitigated by making sure we register the callback before we proceed with opening tutorial notes for the user.

## Deprecated events
- `Tutorial_X_Show` events

## Introduced events
- `TutorialNoteViewed`
  - `testGroup`
  - `fname`
  - `currentStep`
  - `totalSteps`

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)