### PR TITLE
fix: added default initial theme for webviews

### DIFF
--- a/packages/plugin-core/src/components/views/PreviewPanel.ts
+++ b/packages/plugin-core/src/components/views/PreviewPanel.ts
@@ -12,6 +12,7 @@ import {
   OnDidChangeActiveTextEditorMsg,
   memoize,
   DendronError,
+  ConfigUtils,
 } from "@dendronhq/common-all";
 import {
   DendronASTTypes,
@@ -109,13 +110,15 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
       );
 
       const webViewAssets = WebViewUtils.getJsAndCss();
-
+      const initialTheme =
+        ConfigUtils.getPreview(this._ext.getDWorkspace().config).theme || "";
       const html = await WebViewUtils.getWebviewContent({
         ...webViewAssets,
         name,
         port,
         wsRoot,
         panel: this._panel,
+        initialTheme,
       });
 
       this._panel.webview.html = html;

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -1,12 +1,12 @@
 import {
   APIUtils,
-  ConfigUtils,
   CONSTANTS,
   DendronEditorViewKey,
   DendronTreeViewKey,
   DUtils,
   getStage,
   getWebTreeViewEntry,
+  ThemeType,
 } from "@dendronhq/common-all";
 import {
   findUpTo,
@@ -77,6 +77,7 @@ export class WebViewUtils {
     port,
     wsRoot,
     panel,
+    initialTheme,
   }: {
     name: string;
     jsSrc: vscode.Uri;
@@ -84,6 +85,7 @@ export class WebViewUtils {
     port: number;
     wsRoot: string;
     panel: vscode.WebviewPanel | vscode.WebviewView;
+    initialTheme?: string;
   }) {
     const root = VSCodeUtils.getAssetUri(
       ExtensionProvider.getExtension().context
@@ -105,6 +107,14 @@ export class WebViewUtils {
         )
         .toString();
     });
+
+    const vscodeColorTheme = vscode.window.activeColorTheme.kind;
+    const defaultInitialTheme =
+      vscodeColorTheme === vscode.ColorThemeKind.Dark ||
+      vscodeColorTheme === vscode.ColorThemeKind.HighContrast
+        ? ThemeType.DARK
+        : ThemeType.LIGHT;
+
     const out = WebViewCommonUtils.genVSCodeHTMLIndex({
       jsSrc: panel.webview.asWebviewUri(jsSrc).toString(),
       cssSrc: panel.webview.asWebviewUri(cssSrc).toString(),
@@ -125,9 +135,7 @@ export class WebViewUtils {
       // and hand it out to any other functions that need to use it.
       acquireVsCodeApi: `const vscode = acquireVsCodeApi(); window.vscode = vscode;`,
       themeMap: themeMap as WebViewThemeMap,
-      initialTheme: ConfigUtils.getPreview(
-        ExtensionProvider.getDWorkspace().config
-      ).theme,
+      initialTheme: initialTheme ?? defaultInitialTheme,
       name,
     });
     return out;


### PR DESCRIPTION
This PR aims to add a default initial theme for webviews. This is to fix a bug with graph CSS that got introduced with custom preview theme support.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

NA

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
NA
## Close the Loop

### Extended
NA