### PR TITLE
feat(sync): Obsidian Import Flow

### DIFF
--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -23,6 +23,23 @@ export enum ShowcaseEntry {
   PreviewTheme = "PreviewTheme",
   GraphPanel = "GraphPanel",
   BacklinksPanelHover = "BacklinksPanelHover",
+  ObsidianImport = "ObsidianImport",
+}
+
+/**
+ * Survey for users on which prior note-taking tools they've used.
+ */
+export enum PriorTools {
+  No = "No",
+  Foam = "Foam",
+  Roam = "Roam",
+  Logseq = "Logseq",
+  Notion = "Notion",
+  OneNote = "OneNote",
+  Obsidian = "Obsidian",
+  Evernote = "Evernote",
+  GoogleKeep = "Google Keep",
+  Other = "Other",
 }
 
 export enum BacklinkPanelSortOrder {
@@ -108,6 +125,12 @@ type Metadata = Partial<{
    * When the user first used Daily Journal command
    */
   firstDailyJournalTime: number;
+
+  /**
+   * Responses from this user to the initial survey about prior note-taking
+   * tools used.
+   */
+  priorTools: [PriorTools];
 }>;
 
 export enum InactvieUserMsgStatusEnum {
@@ -206,6 +229,10 @@ export class MetadataService {
     return this.getMeta().backlinksPanelSortOrder;
   }
 
+  get priorTools(): PriorTools[] | undefined {
+    return this.getMeta().priorTools;
+  }
+
   setMeta(key: keyof Metadata, value: any) {
     const stateFromFile = this.getMeta();
     stateFromFile[key] = value;
@@ -296,7 +323,12 @@ export class MetadataService {
   set BacklinksPanelSortOrder(sortOrder: BacklinkPanelSortOrder | undefined) {
     this.setMeta("backlinksPanelSortOrder", sortOrder);
   }
+
   setFirstDailyJournalTime() {
     this.setMeta("firstDailyJournalTime", Time.now().toSeconds());
+  }
+
+  set priorTools(priorTools: PriorTools[] | undefined) {
+    this.setMeta("priorTools", priorTools);
   }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -355,6 +355,10 @@
         "title": "Dendron: Import Pod"
       },
       {
+        "command": "dendron.importObsidianPod",
+        "title": "Dendron: Import Obsidian Vault"
+      },
+      {
         "command": "dendron.exportPod",
         "title": "Dendron: Export Pod"
       },
@@ -701,6 +705,10 @@
         },
         {
           "command": "dendron.importPod",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.importObsidianPod",
           "when": "dendron:pluginActive"
         },
         {

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -27,9 +27,9 @@ import { ReloadIndexCommand } from "./ReloadIndex";
 
 type CommandOutput = void;
 
-type CommandInput = { podChoice: PodItemV4 };
+export type CommandInput = { podChoice: PodItemV4 };
 
-type CommandOpts = CommandInput & { config: any };
+export type CommandOpts = CommandInput & { config: any };
 
 export class ImportPodCommand extends BaseCommand<
   CommandOpts,

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -1,3 +1,4 @@
+import { NoteProps } from "@dendronhq/common-all";
 import {
   getAllImportPods,
   ImportPod,
@@ -25,7 +26,7 @@ import { getDWorkspace, getExtension } from "../workspace";
 import { BaseCommand } from "./base";
 import { ReloadIndexCommand } from "./ReloadIndex";
 
-type CommandOutput = void;
+type CommandOutput = NoteProps[];
 
 export type CommandInput = { podChoice: PodItemV4 };
 
@@ -172,9 +173,14 @@ export class ImportPodCommand extends BaseCommand<
     window.showInformationMessage(
       `${importedNotes.length} notes imported successfully.`
     );
+
+    return importedNotes;
   }
 
-  addAnalyticsPayload(opts?: CommandOpts) {
-    return PodUtils.getAnalyticsPayload(opts);
+  addAnalyticsPayload(opts: CommandOpts, out: NoteProps[]) {
+    return {
+      ...PodUtils.getAnalyticsPayload(opts),
+      importCount: out.length,
+    };
   }
 }

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -78,6 +78,7 @@ import { MigrateSelfContainedVaultCommand } from "./MigrateSelfContainedVault";
 import { ApplyTemplateCommand } from "./ApplyTemplateCommand";
 import { TaskStatusCommand } from "./TaskStatus";
 import { TaskCompleteCommand } from "./TaskComplete";
+import { ImportObsidianCommand } from "./pods/ImportObsidianCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -117,6 +118,7 @@ const ALL_COMMANDS = [
   GotoCommand,
   GotoNoteCommand,
   ImportPodCommand,
+  ImportObsidianCommand,
   InsertNoteCommand,
   InsertNoteLinkCommand,
   InsertNoteIndexCommand,

--- a/packages/plugin-core/src/commands/pods/ImportObsidianCommand.ts
+++ b/packages/plugin-core/src/commands/pods/ImportObsidianCommand.ts
@@ -1,0 +1,70 @@
+import {
+  getAllImportPods,
+  MarkdownImportPod,
+  podClassEntryToPodItemV4,
+} from "@dendronhq/pods-core";
+import vscode from "vscode";
+import { PickerUtilsV2 } from "../../components/lookup/utils";
+import { DENDRON_COMMANDS } from "../../constants";
+import { PodQuickPickItemV4 } from "../../utils/pods";
+import { CommandOpts, ImportPodCommand } from "../ImportPod";
+
+/**
+ * Convenience command that uses the same flow as {@link ImportPodCommand} for
+ * Markdown Pod but simplifies the steps by not requiring the user to fill out a
+ * config.yml file.
+ */
+export class ImportObsidianCommand extends ImportPodCommand {
+  key = DENDRON_COMMANDS.IMPORT_OBSIDIAN_POD.key;
+
+  constructor(_name?: string) {
+    super(_name);
+    this.pods = getAllImportPods();
+  }
+
+  /**
+   * Hardcoded to use markdown pod, as Obsidian is a markdown import.
+   * @returns
+   */
+  override async gatherInputs() {
+    const markdownPod = podClassEntryToPodItemV4(MarkdownImportPod);
+
+    const podChoice = {
+      label: markdownPod.id,
+      ...markdownPod,
+    } as PodQuickPickItemV4;
+
+    return { podChoice };
+  }
+
+  /**
+   * Use a file picker control instead of a pod config YAML file to get the
+   * Obsidian vault location. Also, just default to the current vault.
+   * @returns
+   */
+  override async enrichInputs(): Promise<CommandOpts | undefined> {
+    const podChoice = podClassEntryToPodItemV4(MarkdownImportPod);
+
+    const uri = await vscode.window.showOpenDialog({
+      title: "Obsidian vault location to import",
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+    });
+
+    if (!uri || uri.length === 0) {
+      return;
+    }
+
+    const src = uri[0].fsPath;
+
+    const vault = PickerUtilsV2.getVaultForOpenEditor();
+
+    const config = {
+      src,
+      vaultName: vault.name,
+    };
+
+    return { podChoice, config };
+  }
+}

--- a/packages/plugin-core/src/commands/pods/ImportObsidianCommand.ts
+++ b/packages/plugin-core/src/commands/pods/ImportObsidianCommand.ts
@@ -1,3 +1,4 @@
+import { VaultUtils } from "@dendronhq/common-all";
 import {
   getAllImportPods,
   MarkdownImportPod,
@@ -62,7 +63,7 @@ export class ImportObsidianCommand extends ImportPodCommand {
 
     const config = {
       src,
-      vaultName: vault.name,
+      vaultName: VaultUtils.getName(vault),
     };
 
     return { podChoice, config };

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -661,6 +661,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Import Pod`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
+  IMPORT_OBSIDIAN_POD: {
+    key: "dendron.importObsidianPod",
+    title: `${CMD_PREFIX} Import Obsidian Vault`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
   EXPORT_POD: {
     key: "dendron.exportPod",
     title: `${CMD_PREFIX} Export Pod`,

--- a/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
+++ b/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
@@ -4,6 +4,7 @@ import { GraphPanelTip } from "./GraphPanelTip";
 import { GraphThemeTip } from "./GraphThemeTip";
 import { IFeatureShowcaseMessage } from "./IFeatureShowcaseMessage";
 import { MeetingNotesTip } from "./MeetingNotesTip";
+import { ObsidianImportTip } from "./ObsidianImportTip";
 import {
   createSimpleTipOfDayMsg,
   createTipOfDayMsgWithDocsLink,
@@ -86,4 +87,5 @@ export const ALL_FEATURE_SHOWCASES: IFeatureShowcaseMessage[] = [
   new GraphPanelTip(),
   PREVIEW_THEME_LINK,
   new BacklinksPanelHoverTip(),
+  new ObsidianImportTip(),
 ];

--- a/packages/plugin-core/src/showcase/FeatureShowcaseToaster.ts
+++ b/packages/plugin-core/src/showcase/FeatureShowcaseToaster.ts
@@ -15,7 +15,6 @@ import {
  */
 export class FeatureShowcaseToaster {
   /**
-   *
    * Show a toast containing information about a Dendron Feature. Doesn't show
    * messages more than once, and it also doesn't show to new user's in their
    * first week of Dendron.
@@ -28,6 +27,7 @@ export class FeatureShowcaseToaster {
     }
 
     for (const message of ALL_FEATURE_SHOWCASES) {
+      // Keep cycling through messages until there's one that should be shown
       if (
         !this.hasShownMessage(message.showcaseEntry) &&
         message.shouldShow(DisplayLocation.InformationMessage)
@@ -39,6 +39,26 @@ export class FeatureShowcaseToaster {
 
         return true;
       }
+    }
+
+    return false;
+  }
+
+  /**
+   * Show a specific toast message. This will not show if the message has
+   * already been shown to the user, but unlike {@link showToast}, it will show
+   * even if the user is still in their first week of usage.
+   * @param message
+   * @returns
+   */
+  public showSpecificToast(message: IFeatureShowcaseMessage): boolean {
+    if (
+      !this.hasShownMessage(message.showcaseEntry) &&
+      message.shouldShow(DisplayLocation.InformationMessage)
+    ) {
+      this.showInformationMessage(DisplayLocation.InformationMessage, message);
+
+      return true;
     }
 
     return false;

--- a/packages/plugin-core/src/showcase/ObsidianImportTip.ts
+++ b/packages/plugin-core/src/showcase/ObsidianImportTip.ts
@@ -1,0 +1,49 @@
+import {
+  MetadataService,
+  PriorTools,
+  ShowcaseEntry,
+} from "@dendronhq/engine-server";
+import _ from "lodash";
+import vscode from "vscode";
+import {
+  DisplayLocation,
+  IFeatureShowcaseMessage,
+} from "./IFeatureShowcaseMessage";
+
+export class ObsidianImportTip implements IFeatureShowcaseMessage {
+  /**
+   * Only shows a toast, this tip does not appear in tip of day.
+   * @param displayLocation
+   * @returns
+   */
+  shouldShow(displayLocation: DisplayLocation): boolean {
+    if (displayLocation === DisplayLocation.TipOfTheDayView) {
+      return false;
+    }
+
+    return _.includes(
+      MetadataService.instance().priorTools,
+      PriorTools.Obsidian
+    );
+  }
+
+  get showcaseEntry(): ShowcaseEntry {
+    return ShowcaseEntry.ObsidianImport;
+  }
+
+  getDisplayMessage(_displayLocation: DisplayLocation): string {
+    return `Would you like to import your notes from an existing Obsidian vault?`;
+  }
+
+  onConfirm() {
+    vscode.commands.executeCommand("dendron.importObsidianPod");
+  }
+
+  get confirmText(): string {
+    return "Import Now";
+  }
+
+  get deferText(): string {
+    return "Later";
+  }
+}

--- a/packages/plugin-core/src/survey.ts
+++ b/packages/plugin-core/src/survey.ts
@@ -10,6 +10,7 @@ import {
   InitialSurveyStatusEnum,
   LapsedUserSurveyStatusEnum,
   MetadataService,
+  PriorTools,
 } from "@dendronhq/engine-server";
 
 export class DendronQuickInputSurvey {
@@ -245,6 +246,12 @@ export class PriorToolsSurvey extends DendronQuickPickSurvey {
       results: results.map((result) => result.label),
       other: maybeOtherResult,
     });
+
+    // Store the results into metadata so that we can later alter functionality
+    // based on the user's response
+    MetadataService.instance().priorTools = resultsList.map(
+      (result) => PriorTools[result as keyof typeof PriorTools]
+    );
   }
 
   onReject() {
@@ -254,16 +261,16 @@ export class PriorToolsSurvey extends DendronQuickPickSurvey {
   static create() {
     const title = "Are you coming from an existing tool?";
     const choices = [
-      { label: "No" },
-      { label: "Foam" },
-      { label: "Roam" },
-      { label: "Logseq" },
-      { label: "Notion" },
-      { label: "OneNote" },
-      { label: "Obsidian" },
-      { label: "Evernote" },
-      { label: "Google Keep" },
-      { label: "Other" },
+      { label: PriorTools.No },
+      { label: PriorTools.Foam },
+      { label: PriorTools.Roam },
+      { label: PriorTools.Logseq },
+      { label: PriorTools.Notion },
+      { label: PriorTools.OneNote },
+      { label: PriorTools.Obsidian },
+      { label: PriorTools.Evernote },
+      { label: PriorTools.GoogleKeep },
+      { label: PriorTools.Other },
     ];
     return new PriorToolsSurvey({ title, choices, canPickMany: true });
   }

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -57,6 +57,7 @@ import {
 import { SchemaSyncService } from "./services/SchemaSyncService";
 import { ISchemaSyncService } from "./services/SchemaSyncServiceInterface";
 import { ALL_FEATURE_SHOWCASES } from "./showcase/AllFeatureShowcases";
+import { DisplayLocation } from "./showcase/IFeatureShowcaseMessage";
 import { UserDefinedTraitV1 } from "./traits/UserDefinedTraitV1";
 import { DisposableStore } from "./utils";
 import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
@@ -559,7 +560,9 @@ export class DendronExtension implements IDendronExtension {
 
   private setupTipOfTheDayView() {
     const featureShowcaseWebview = new TipOfTheDayWebview(
-      ALL_FEATURE_SHOWCASES
+      _.filter(ALL_FEATURE_SHOWCASES, (message) =>
+        message.shouldShow(DisplayLocation.TipOfTheDayView)
+      )
     );
 
     return vscode.window.registerWebviewViewProvider(


### PR DESCRIPTION
## feat(sync): Obsidian Import Flow

MVP flow for Obsidian Import, specifically targeting onboarding users who are coming from Obsidian. This utilizes markdown import pod under the hood, but gets rid of the need to fill out a `config.yml` file.  All a user needs to do is use a file picker control to pick the folder. 

This will show up in a feature toaster to users under the following conditions:
1. user marked 'Obsidian' in prior tools in the survey
2. user opened a tutorial workspace
3. Either the user reached the last page of the tutorial, or 10 minutes has elapsed, whichever comes first.

This change doesn't improve or fix existing issues in the Markdown Import Pod.  That will be deferred to a subsequent PR. 

TODO: 
1. Need to resolve the tutorialInitializer logic against Mark's change here: https://github.com/dendronhq/dendron/pull/3009

---

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [N/A] check if this change adversely impact performance
- Operations
  - [N/A] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [N/A] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [N/A] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs
https://github.com/dendronhq/dendron-site/pull/522

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
