### PR TITLE
fix(workspace): fix duplicated panel titles

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -61,7 +61,6 @@
         {
           "id": "dendron.sample",
           "name": "Sample View",
-          "contextualTitle": "Sample View",
           "type": "webview",
           "when": "dendron:devMode"
         }
@@ -81,21 +80,18 @@
         {
           "id": "dendron.treeView",
           "name": "Tree View",
-          "contextualTitle": "Tree View",
           "when": "dendron:pluginActive",
           "icon": "media/icons/dendron-vscode.svg"
         },
         {
           "id": "dendron.lookup-view",
           "name": "Lookup View",
-          "contextualTitle": "Lookup View",
           "type": "webview",
           "when": "dendron:pluginActive && dendron:noteLookupActive && dendron:shouldShowLookupView"
         },
         {
           "id": "dendron.calendar-view",
           "name": "Calendar View",
-          "contextualTitle": "Calendar View",
           "type": "webview",
           "when": "dendron:pluginActive"
         },
@@ -106,7 +102,6 @@
         {
           "id": "dendron.graph-panel",
           "name": "Graph Panel",
-          "contextualTitle": "Graph Panel",
           "type": "webview",
           "when": "dendron:pluginActive"
         }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -28,12 +28,10 @@ const treeViewConfig2VSCodeEntry = (id: DendronTreeViewKey) => {
   const out: {
     id: string;
     name: string;
-    contextualTitle: string;
     type?: "webview";
   } = {
     id,
     name: entry.label,
-    contextualTitle: entry.label,
   };
   if (isWebViewEntry(entry)) {
     out.type = "webview";


### PR DESCRIPTION
## fix(workspace): fix duplicated panel titles

Fixing an issue where some of our panels have Duplicated Titles: 

<img width="461" alt="image" src="https://user-images.githubusercontent.com/3203268/171386554-282af70b-2834-4052-9888-3b98e4b84ef7.png">
