### PR TITLE
fix: bullet points missing in new theme-matching preview

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -67,6 +67,10 @@ export class WebViewCommonUtils {
         color: var(--vscode-editor-foreground);
       }
 
+      .main-content ul {
+        list-style: unset;
+      }
+
       body {
         background-color: var(--vscode-editor-background);
       }


### PR DESCRIPTION
Fixes an issue where bullet points in lists would be missing when using the new theme-matching preview.

