### PR TITLE
feat(edit): template helpers

### DIFF
--- a/packages/common-server/src/template.ts
+++ b/packages/common-server/src/template.ts
@@ -238,4 +238,19 @@ export class TemplateUtils {
     );
     return targetNote;
   }
+
+  static genTrackPayload(templateNote: NoteProps) {
+    const fname2Date =
+      templateNote.body.match(/\{\{\s+fname2Date[^}]+\}\}/)?.length || 0;
+    const eq = templateNote.body.match(/\{\{\s+eq[^}]+\}\}/)?.length || 0;
+    const getDayOfWeek =
+      templateNote.body.match(/\{\{\s+getDayOfWeek[^}]+\}\}/)?.length || 0;
+    return {
+      helperStats: {
+        fname2Date,
+        eq,
+        getDayOfWeek,
+      },
+    };
+  }
 }

--- a/packages/common-server/src/template.ts
+++ b/packages/common-server/src/template.ts
@@ -6,13 +6,21 @@ import {
   SchemaUtils,
   Time,
 } from "@dendronhq/common-all";
-import Handlebars from "handlebars";
+import Handlebars, { HelperOptions } from "handlebars";
 import _ from "lodash";
 
 type TemplateFunctionProps = {
   templateNote: NoteProps;
   targetNote: NoteProps;
 };
+
+interface DendronHandlebarsHelpers extends HelperOptions {
+  data: {
+    root: NoteProps & {
+      FNAME: string;
+    };
+  };
+}
 
 function copyTemplateProps({
   templateNote,
@@ -65,6 +73,52 @@ function genDefaultContext(targetNote: NoteProps) {
   };
 }
 
+let _INIT_HELPERS = false;
+
+class TemplateHelpers {
+  static init() {
+    _.map(this.helpers, (v, k) => {
+      Handlebars.registerHelper(k, v);
+    });
+  }
+
+  static helpers = {
+    eq: (a: any, b: any) => {
+      return a === b;
+    },
+
+    fname2Date: (
+      patternOrOptions: string | DendronHandlebarsHelpers,
+      options?: DendronHandlebarsHelpers
+    ) => {
+      let pattern = "(?<year>[\\d]{4}).(?<month>[\\d]{2}).(?<day>[\\d]{2})";
+      let fname;
+      if (_.isString(patternOrOptions)) {
+        pattern = patternOrOptions;
+        fname = options!.data.root.FNAME;
+      } else {
+        fname = patternOrOptions.data.root.FNAME;
+      }
+
+      const resp = fname.match(new RegExp(pattern, "i"))?.groups;
+      if (_.isUndefined(resp)) {
+        return "ERROR: no match found for {year}, {month}, or {day}";
+      }
+      const { year, month, day } = resp;
+      return new Date(
+        parseInt(year, 10),
+        parseInt(month, 10) - 1,
+        parseInt(day, 10)
+      );
+    },
+
+    getDayOfWeek: (date: Date) => {
+      const day = date.getDay();
+      return day;
+    },
+  };
+}
+
 export class TemplateUtils {
   /** The props of a template note that will get copied over when the template is applied. */
   static TEMPLATE_COPY_PROPS: readonly (keyof NoteProps)[] = [
@@ -85,6 +139,10 @@ export class TemplateUtils {
     targetNote: NoteProps;
     engine: DEngineClient;
   }): NoteProps {
+    if (!_INIT_HELPERS) {
+      TemplateHelpers.init();
+      _INIT_HELPERS = true;
+    }
     if (ConfigUtils.getWorkspace(opts.engine.config).enableHandlebarTemplates) {
       return this.applyHBTemplate(opts);
     } else {

--- a/packages/common-server/src/template.ts
+++ b/packages/common-server/src/template.ts
@@ -82,12 +82,17 @@ class TemplateHelpers {
     });
   }
 
+  /**
+   * WARNING: these helpers are part of the public template api
+   * any changes in these names will result in a breaking change
+   * and needs to be marked as such
+   */
   static helpers = {
     eq: (a: any, b: any) => {
       return a === b;
     },
 
-    fname2Date: (
+    fnameToDate: (
       patternOrOptions: string | DendronHandlebarsHelpers,
       options?: DendronHandlebarsHelpers
     ) => {
@@ -240,14 +245,14 @@ export class TemplateUtils {
   }
 
   static genTrackPayload(templateNote: NoteProps) {
-    const fname2Date =
-      templateNote.body.match(/\{\{\s+fname2Date[^}]+\}\}/)?.length || 0;
+    const fnameToDate =
+      templateNote.body.match(/\{\{\s+fnameToDate[^}]+\}\}/)?.length || 0;
     const eq = templateNote.body.match(/\{\{\s+eq[^}]+\}\}/)?.length || 0;
     const getDayOfWeek =
       templateNote.body.match(/\{\{\s+getDayOfWeek[^}]+\}\}/)?.length || 0;
     return {
       helperStats: {
-        fname2Date,
+        fnameToDate,
         eq,
         getDayOfWeek,
       },

--- a/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
@@ -61,8 +61,8 @@ describe(`WHEN running applyTemplate tests`, () => {
       sinon.restore();
     });
     const eqHelper = "{{ eq fm.arg1 fm.arg2 }}";
-    const fname2DateHelper = "{{ fname2Date }}";
-    const getDayOfWeekHelper = "{{ getDayOfWeek (fname2Date) }}";
+    const fnameToDateHelper = "{{ fnameToDate }}";
+    const getDayOfWeekHelper = "{{ getDayOfWeek (fnameToDate) }}";
 
     describe("AND WHEN track helper usage", () => {
       describe("AND WHEN comparing equal args", () => {
@@ -72,7 +72,7 @@ describe(`WHEN running applyTemplate tests`, () => {
           expect(
             TemplateUtils.genTrackPayload(templateNote).helperStats
           ).toEqual({
-            fname2Date: 0,
+            fnameToDate: 0,
             eq: 1,
             getDayOfWeek: 0,
           });
@@ -84,13 +84,13 @@ describe(`WHEN running applyTemplate tests`, () => {
           const templateNote = await noteFactory.createForFName("foo");
           templateNote.body = [
             eqHelper,
-            fname2DateHelper,
+            fnameToDateHelper,
             getDayOfWeekHelper,
           ].join("\n");
           expect(
             TemplateUtils.genTrackPayload(templateNote).helperStats
           ).toEqual({
-            fname2Date: 1,
+            fnameToDate: 1,
             eq: 1,
             getDayOfWeek: 1,
           });
@@ -129,8 +129,8 @@ describe(`WHEN running applyTemplate tests`, () => {
       });
     });
 
-    describe("AND WHEN using fname2Date helper", () => {
-      const testTemplateNoteBody = "{{ fname2Date }}";
+    describe("AND WHEN using fnameToDate helper", () => {
+      const testTemplateNoteBody = "{{ fnameToDate }}";
 
       describe("AND WHEN no args and date in fname", () => {
         it("THEN extract date", async () => {
@@ -168,7 +168,7 @@ describe(`WHEN running applyTemplate tests`, () => {
         it("THEN extract date", async () => {
           await setupTemplateTest(
             {
-              templateNoteBody: `{{ fname2Date '(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})' }}`,
+              templateNoteBody: `{{ fnameToDate '(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})' }}`,
               templateNoteFname: "daily.journal.2022-01-10",
               fm: {},
             },
@@ -180,7 +180,7 @@ describe(`WHEN running applyTemplate tests`, () => {
       });
 
       describe("AND WHEN using getDayOfWeek helper", () => {
-        const testTemplateNoteBody = "{{ getDayOfWeek (fname2Date) }}";
+        const testTemplateNoteBody = "{{ getDayOfWeek (fnameToDate) }}";
         it("THEN get day of week", async () => {
           await setupTemplateTest(
             {

--- a/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
@@ -60,6 +60,43 @@ describe(`WHEN running applyTemplate tests`, () => {
     afterEach(() => {
       sinon.restore();
     });
+    const eqHelper = "{{ eq fm.arg1 fm.arg2 }}";
+    const fname2DateHelper = "{{ fname2Date }}";
+    const getDayOfWeekHelper = "{{ getDayOfWeek (fname2Date) }}";
+
+    describe("AND WHEN track helper usage", () => {
+      describe("AND WHEN comparing equal args", () => {
+        it("THEN show true", async () => {
+          const templateNote = await noteFactory.createForFName("foo");
+          templateNote.body = eqHelper;
+          expect(
+            TemplateUtils.genTrackPayload(templateNote).helperStats
+          ).toEqual({
+            fname2Date: 0,
+            eq: 1,
+            getDayOfWeek: 0,
+          });
+        });
+      });
+
+      describe("AND WHEN comparing all args", () => {
+        it("THEN show true", async () => {
+          const templateNote = await noteFactory.createForFName("foo");
+          templateNote.body = [
+            eqHelper,
+            fname2DateHelper,
+            getDayOfWeekHelper,
+          ].join("\n");
+          expect(
+            TemplateUtils.genTrackPayload(templateNote).helperStats
+          ).toEqual({
+            fname2Date: 1,
+            eq: 1,
+            getDayOfWeek: 1,
+          });
+        });
+      });
+    });
 
     describe("AND WHEN using eq helper", () => {
       const testTemplateNoteBody = "{{ eq fm.arg1 fm.arg2 }}";

--- a/packages/plugin-core/src/commands/ApplyTemplateCommand.ts
+++ b/packages/plugin-core/src/commands/ApplyTemplateCommand.ts
@@ -101,6 +101,7 @@ export class ApplyTemplateCommand extends BasicCommand<
     const resp = await engine.writeNote(updatedTargetNote);
     AnalyticsUtils.track(EngagementEvents.TemplateApplied, {
       source: this.key,
+      ...TemplateUtils.genTrackPayload(templateNote),
     });
     if (resp.error) {
       throw new DendronError({

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -557,6 +557,7 @@ export class NoteLookupCommand
         });
         AnalyticsUtils.track(EngagementEvents.TemplateApplied, {
           source: this.key,
+          ...TemplateUtils.genTrackPayload(resp.data),
         });
       }
     }

--- a/test-workspace/vault/daily.journal.2022.05.30.md
+++ b/test-workspace/vault/daily.journal.2022.05.30.md
@@ -1,0 +1,9 @@
+---
+id: l94hrqvh5cbleeb1djqm6kj
+title: '30'
+desc: ''
+updated: 1654130414784
+created: 1654130403870
+---
+
+- [ ] my tasks for monday

--- a/test-workspace/vault/daily.journal.2022.05.31.md
+++ b/test-workspace/vault/daily.journal.2022.05.31.md
@@ -1,0 +1,9 @@
+---
+id: aad9fqh1w53z75g1rerdzr3
+title: '31'
+desc: ''
+updated: 1654130431283
+created: 1654130427988
+---
+
+- [ ] my tasks for tuesday

--- a/test-workspace/vault/template.daily.md
+++ b/test-workspace/vault/template.daily.md
@@ -2,9 +2,13 @@
 id: z8Jr41tR1PJxWc7qXrgwD
 title: Daily
 desc: ''
-updated: 1634725357715
+updated: 1654130425505
 created: 1634725228527
 ---
 
-
-Daily Journal template value.
+{{#if (eq (getDayOfWeek (fname2Date)) 1) }}
+- [ ] my tasks for monday
+{{/if}}
+{{#if (eq (getDayOfWeek (fname2Date)) 2) }}
+- [ ] my tasks for tuesday
+{{/if}}


### PR DESCRIPTION
feat(edit): template helpers

built-in helpers to make handlebar templates more powerful in Dendron.
This PR introduces 3 new helpers: `eq`, `fname2Date`, and `getDayOfWeek`

Docs: https://github.com/dendronhq/dendron-site/pull/523

Adds follwoing analytics to `TemplateApplied` event that show how many times each helper was invoked per template
```
helperStats: {
    fname2Date: number
    eq: number
    getDayOfWeek: number
}
```

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

NA

## Docs

### Basics

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)