### PR TITLE
enhance(views): configure note creation with graph view

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -768,6 +768,9 @@
         },
         "apiEndpoint": {
           "type": "string"
+        },
+        "templateHierarchy": {
+          "type": "string"
         }
       },
       "required": [
@@ -994,10 +997,14 @@
       "properties": {
         "zoomSpeed": {
           "type": "number"
+        },
+        "createStub": {
+          "type": "boolean"
         }
       },
       "required": [
-        "zoomSpeed"
+        "zoomSpeed",
+        "createStub"
       ],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -42,6 +42,10 @@ const GRAPH: DendronConfigEntryCollection<DendronGraphConfig> = {
     label: "Zoom Speed",
     desc: "The speed at which the graph zooms in and out. Lower is slower, higher is faster.",
   },
+  createStub: {
+    label: "Create Stub",
+    desc: "When enabled, create a note if it hasn't been created already when clicked on a graph node",
+  },
 };
 
 /**

--- a/packages/common-all/src/types/configs/workspace/graph.ts
+++ b/packages/common-all/src/types/configs/workspace/graph.ts
@@ -3,6 +3,10 @@
  */
 export type DendronGraphConfig = {
   zoomSpeed: number;
+  /**
+   * If true, create a note if it hasn't been created already when clicked on a graph node
+   */
+  createStub: boolean;
 };
 
 /**
@@ -12,5 +16,6 @@ export type DendronGraphConfig = {
 export function genDefaultGraphConfig(): DendronGraphConfig {
   return {
     zoomSpeed: 1,
+    createStub: false,
   };
 }

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -768,6 +768,9 @@
         },
         "apiEndpoint": {
           "type": "string"
+        },
+        "templateHierarchy": {
+          "type": "string"
         }
       },
       "required": [
@@ -994,10 +997,14 @@
       "properties": {
         "zoomSpeed": {
           "type": "number"
+        },
+        "createStub": {
+          "type": "boolean"
         }
       },
       "required": [
-        "zoomSpeed"
+        "zoomSpeed",
+        "createStub"
       ],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -79,6 +79,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -234,6 +235,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -379,6 +381,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -491,6 +494,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -620,6 +624,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -73,6 +73,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -228,6 +229,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -373,6 +375,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -485,6 +488,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -614,6 +618,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -750,6 +755,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false
@@ -873,6 +879,7 @@ workspace:
         createTaskSelectionType: selection2link
     graph:
         zoomSpeed: 1
+        createStub: false
     enableAutoCreateOnDefinition: false
     enableHandlebarTemplates: false
     enableXVaultWikiLink: false

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -85,6 +85,7 @@ export class WorkspaceTestUtils {
         },
         graph: {
           zoomSpeed: 1,
+          createStub: false,
         },
         enableHandlebarTemplates: false,
         enableAutoCreateOnDefinition: false,

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -43,6 +43,7 @@ workspace:
     addBehavior: asOwnDomain
   graph:
     zoomSpeed: 1
+    createStub: false
   enableAutoCreateOnDefinition: false
   enableXVaultWikiLink: false
   enableRemoteVaultInit: true


### PR DESCRIPTION
This PR aims to add a graph config `createStub` with default value as `false`. This is to have graph nodes not create default stubs when clicked. The graph view will still update the view around node clicked.

Docs PR: https://github.com/dendronhq/dendron-site/pull/524
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [~] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR 
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)