### PR TITLE
feat(structure): Set Task Status and Complete Task commands

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -265,6 +265,14 @@
         "title": "Dendron: Create Task Note"
       },
       {
+        "command": "dendron.setTaskStatus",
+        "title": "Dendron: Set Task Status"
+      },
+      {
+        "command": "dendron.completeTask",
+        "title": "Dendron: Complete Task"
+      },
+      {
         "command": "dendron.applyTemplate",
         "title": "Dendron: Apply Template"
       },
@@ -621,6 +629,14 @@
         },
         {
           "command": "dendron.createTask",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.setTaskStatus",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.completeTask",
           "when": "dendron:pluginActive"
         },
         {

--- a/packages/plugin-core/src/commands/ConfigureCommand.ts
+++ b/packages/plugin-core/src/commands/ConfigureCommand.ts
@@ -1,8 +1,8 @@
 import { DConfig } from "@dendronhq/engine-server";
 import { Uri } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -11,11 +11,19 @@ type CommandOutput = void;
 
 export class ConfigureCommand extends BasicCommand<CommandOpts, CommandOutput> {
   key = DENDRON_COMMANDS.CONFIGURE_RAW.key;
+  public static requireActiveWorkspace: boolean = true;
+  private _ext: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    super();
+    this._ext = extension;
+  }
+
   async gatherInputs(): Promise<any> {
     return {};
   }
   async execute() {
-    const dendronRoot = getDWorkspace().wsRoot;
+    const dendronRoot = this._ext.getDWorkspace().wsRoot;
     const configPath = DConfig.configPath(dendronRoot);
     const uri = Uri.file(configPath);
     await VSCodeUtils.openFileInEditor(uri);

--- a/packages/plugin-core/src/commands/TaskComplete
+++ b/packages/plugin-core/src/commands/TaskComplete
@@ -1,0 +1,49 @@
+import { ConfigUtils, NoteProps } from "@dendronhq/common-all";
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+import { VSCodeUtils, MessageSeverity } from "../vsCodeUtils";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { TaskStatusCommand } from "./TaskStatus";
+
+type CommandInput = {
+  setStatus?: string;
+};
+
+type CommandOpts = Required<CommandInput> & {
+  note: NoteProps;
+};
+
+type CommandOutput = {};
+
+export class CreateTaskCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.TASK_CREATE.key;
+  private _ext: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    super();
+    this._ext = extension;
+  }
+
+  async execute(opts: CommandOpts) {
+    const complete: string | undefined = ConfigUtils.getTask(
+      this._ext.getDWorkspace().config
+    ).taskCompleteStatus[0];
+
+    if (complete === undefined) {
+      await VSCodeUtils.showMessage(
+        MessageSeverity.ERROR,
+        "You have no task statuses marked as complete. Please add something to 'taskCompleteStatus' in your configuration file.",
+        {}
+      );
+      return;
+    }
+
+    const taskStatusCmd = new TaskStatusCommand(this._ext);
+    return taskStatusCmd.run({
+      setStatus: complete,
+    });
+  }
+}

--- a/packages/plugin-core/src/commands/TaskComplete.ts
+++ b/packages/plugin-core/src/commands/TaskComplete.ts
@@ -1,25 +1,20 @@
-import { ConfigUtils, NoteProps } from "@dendronhq/common-all";
+import { ConfigUtils } from "@dendronhq/common-all";
 import { DENDRON_COMMANDS } from "../constants";
 import { BasicCommand } from "./base";
 import { VSCodeUtils, MessageSeverity } from "../vsCodeUtils";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { TaskStatusCommand } from "./TaskStatus";
 
-type CommandInput = {
-  setStatus?: string;
-};
+type CommandOpts = {};
 
-type CommandOpts = Required<CommandInput> & {
-  note: NoteProps;
-};
+type CommandOutput = {} | undefined;
 
-type CommandOutput = {};
-
-export class CreateTaskCommand extends BasicCommand<
+export class TaskCompleteCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
-  key = DENDRON_COMMANDS.TASK_CREATE.key;
+  key = DENDRON_COMMANDS.TASK_COMPLETE.key;
+  public static requireActiveWorkspace: boolean = true;
   private _ext: IDendronExtension;
 
   constructor(extension: IDendronExtension) {
@@ -27,7 +22,7 @@ export class CreateTaskCommand extends BasicCommand<
     this._ext = extension;
   }
 
-  async execute(opts: CommandOpts) {
+  async execute(_opts: CommandOpts) {
     const complete: string | undefined = ConfigUtils.getTask(
       this._ext.getDWorkspace().config
     ).taskCompleteStatus[0];
@@ -38,7 +33,7 @@ export class CreateTaskCommand extends BasicCommand<
         "You have no task statuses marked as complete. Please add something to 'taskCompleteStatus' in your configuration file.",
         {}
       );
-      return;
+      return {};
     }
 
     const taskStatusCmd = new TaskStatusCommand(this._ext);

--- a/packages/plugin-core/src/commands/TaskComplete.ts
+++ b/packages/plugin-core/src/commands/TaskComplete.ts
@@ -4,6 +4,7 @@ import { BasicCommand } from "./base";
 import { VSCodeUtils, MessageSeverity } from "../vsCodeUtils";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { TaskStatusCommand } from "./TaskStatus";
+import { ConfigureCommand } from "./ConfigureCommand";
 
 type CommandOpts = {};
 
@@ -28,11 +29,19 @@ export class TaskCompleteCommand extends BasicCommand<
     ).taskCompleteStatus[0];
 
     if (complete === undefined) {
+      const title = "Open the configuration file";
+
       await VSCodeUtils.showMessage(
         MessageSeverity.ERROR,
-        "You have no task statuses marked as complete. Please add something to 'taskCompleteStatus' in your configuration file.",
-        {}
-      );
+        "You have no task statuses marked as complete. Please add something to 'taskCompleteStatus' in your configuration file. See: https://wiki.dendron.so/notes/SEASewZSteDK7ry1AshNG#taskcompletestatus",
+        {},
+        { title }
+      ).then((pressed) => {
+        if (pressed?.title === title) {
+          const openConfig = new ConfigureCommand(this._ext);
+          openConfig.run();
+        }
+      });
       return {};
     }
 

--- a/packages/plugin-core/src/commands/TaskStatus.ts
+++ b/packages/plugin-core/src/commands/TaskStatus.ts
@@ -10,6 +10,7 @@ import { VSCodeUtils, MessageSeverity } from "../vsCodeUtils";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { QuickPickItem } from "vscode";
 import { getLinkFromSelectionWithWorkspace } from "../utils/editor";
+import { delayedUpdateDecorations } from "../features/windowDecorations";
 
 type CommandInput = {
   setStatus?: string;
@@ -151,6 +152,8 @@ export class TaskStatusCommand extends BasicCommand<
     opts.note.custom.status = opts.setStatus;
 
     await this._ext.getEngine().writeNote(opts.note, { updateExisting: true });
+
+    delayedUpdateDecorations();
 
     return {};
   }

--- a/packages/plugin-core/src/commands/TaskStatus.ts
+++ b/packages/plugin-core/src/commands/TaskStatus.ts
@@ -1,0 +1,156 @@
+import {
+  ConfigUtils,
+  DendronError,
+  NoteProps,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import { DENDRON_COMMANDS } from "../constants";
+import { BasicCommand } from "./base";
+import { VSCodeUtils, MessageSeverity } from "../vsCodeUtils";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { QuickPickItem } from "vscode";
+import { getLinkFromSelectionWithWorkspace } from "../utils/editor";
+
+type CommandInput = {
+  setStatus?: string;
+};
+
+type CommandOpts = Required<CommandInput> & {
+  note: NoteProps;
+};
+
+type CommandOutput = {};
+
+export class TaskStatusCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.TASK_CREATE.key;
+  private _ext: IDendronExtension;
+
+  constructor(extension: IDendronExtension) {
+    super();
+    this._ext = extension;
+  }
+
+  async gatherInputs(opts?: CommandInput): Promise<CommandOpts | undefined> {
+    const selection = await getLinkFromSelectionWithWorkspace();
+    let selectedNote: NoteProps | undefined;
+
+    if (!selection) {
+      // Then they are changing the status for the current note
+      selectedNote = this._ext.wsUtils.getActiveNote();
+      if (!selectedNote) {
+        // No active note either
+        VSCodeUtils.showMessage(
+          MessageSeverity.WARN,
+          "Please open a task note, or select a link to a task note before using this command.",
+          {}
+        );
+        return;
+      }
+    }
+
+    const engine = this._ext.getDWorkspace().engine;
+    const vault = selection.vaultName
+      ? VaultUtils.getVaultByName({
+          vaults: this._ext.getDWorkspace().vaults,
+          vname: selection.vaultName,
+        })
+      : undefined;
+
+    if (!selectedNote) {
+      const notes = await engine.findNotes({ fname: selection.value, vault });
+      if (notes.length === 0) {
+        VSCodeUtils.showMessage(
+          MessageSeverity.WARN,
+          `Linked note ${selection.value} is not found, make sure the note exists first.`,
+          {}
+        );
+        return;
+      } else if (notes.length > 1) {
+        const picked = await VSCodeUtils.showQuickPick(
+          notes.map((note): QuickPickItem => {
+            return {
+              label: note.title,
+              description: VaultUtils.getName(note.vault),
+              detail: note.vault.fsPath,
+            };
+          }),
+          {
+            canPickMany: false,
+            ignoreFocusOut: true,
+            matchOnDescription: true,
+            title: "Multiple notes match selected link, please pick one",
+          }
+        );
+        if (!picked) {
+          // Cancelled prompt
+          return;
+        }
+        const pickedNote = notes.find(
+          (note) => note.vault.fsPath === picked.detail
+        );
+        if (!pickedNote) {
+          throw new DendronError({
+            message: "Can't find selected note",
+            payload: {
+              notes,
+              picked,
+            },
+          });
+        }
+        selectedNote = pickedNote;
+      } else {
+        selectedNote = notes[0];
+      }
+    }
+
+    let setStatus = opts?.setStatus;
+    if (!setStatus) {
+      // If no status has been provided already (e.g. a custom shortcut),
+      // then prompt for the status
+      const currentStatus = selectedNote.custom?.status;
+      const knownStatuses = Object.entries(
+        ConfigUtils.getTask(this._ext.getDWorkspace().config).statusSymbols
+      ).filter(
+        ([key, value]) =>
+          // Don't suggest the current status as an option
+          key !== currentStatus && value !== currentStatus
+      );
+
+      const pickedStatus = await VSCodeUtils.showQuickPick(
+        knownStatuses.map(([key, value]): QuickPickItem => {
+          return {
+            label: key,
+            description: value,
+          };
+        }),
+        {
+          canPickMany: false,
+          ignoreFocusOut: true,
+          matchOnDescription: true,
+          title: `Pick the new status for "${selectedNote.title}"`,
+        }
+      );
+      if (!pickedStatus) {
+        // Prompt cancelled, do not change task status
+        return;
+      }
+      setStatus = pickedStatus.label;
+    }
+
+    return {
+      note: selectedNote,
+      setStatus,
+    };
+  }
+
+  async execute(opts: CommandOpts) {
+    opts.note.custom.status = opts.setStatus;
+
+    await this._ext.getEngine().writeNote(opts.note, { updateExisting: true });
+
+    return {};
+  }
+}

--- a/packages/plugin-core/src/commands/TaskStatus.ts
+++ b/packages/plugin-core/src/commands/TaskStatus.ts
@@ -2,6 +2,7 @@ import {
   ConfigUtils,
   DendronError,
   NoteProps,
+  TaskNoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
 import { DENDRON_COMMANDS } from "../constants";
@@ -42,7 +43,7 @@ export class TaskStatusCommand extends BasicCommand<
     if (!selection) {
       // Then they are changing the status for the current note
       selectedNote = this._ext.wsUtils.getActiveNote();
-      if (!selectedNote) {
+      if (!selectedNote || !TaskNoteUtils.isTaskNote(selectedNote)) {
         // No active note either
         VSCodeUtils.showMessage(
           MessageSeverity.WARN,
@@ -149,7 +150,10 @@ export class TaskStatusCommand extends BasicCommand<
   }
 
   async execute(opts: CommandOpts) {
-    opts.note.custom.status = opts.setStatus;
+    opts.note.custom = {
+      ...opts.note.custom,
+      status: opts.setStatus,
+    };
 
     await this._ext.getEngine().writeNote(opts.note, { updateExisting: true });
 

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -76,6 +76,8 @@ import { CreateMeetingNoteCommand } from "./CreateMeetingNoteCommand";
 import { GotoCommand } from "./Goto";
 import { MigrateSelfContainedVaultCommand } from "./MigrateSelfContainedVault";
 import { ApplyTemplateCommand } from "./ApplyTemplateCommand";
+import { TaskStatusCommand } from "./TaskStatus";
+import { TaskCompleteCommand } from "./TaskComplete";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -156,6 +158,8 @@ const ALL_COMMANDS = [
   ConvertCandidateLinkCommand,
   RunMigrationCommand,
   CreateTaskCommand,
+  TaskStatusCommand,
+  TaskCompleteCommand,
   RegisterNoteTraitCommand,
   CreateNoteWithUserDefinedTrait,
   OpenBackupCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -532,6 +532,16 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Create Task Note`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
+  TASK_SET_STATUS: {
+    key: "dendron.setTaskStatus",
+    title: `${CMD_PREFIX} Set Task Status`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
+  TASK_COMPLETE: {
+    key: "dendron.completeTask",
+    title: `${CMD_PREFIX} Complete Task`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
   APPLY_TEMPLATE: {
     key: "dendron.applyTemplate",
     title: `${CMD_PREFIX} Apply Template`,

--- a/packages/plugin-core/src/test/suite-integ/ConfigureCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureCommand.test.ts
@@ -1,42 +1,44 @@
-import { describe } from "mocha";
 import path from "path";
 import { ConfigureCommand } from "../../commands/ConfigureCommand";
-import { CONFIG } from "../../constants";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
-import { runLegacySingleWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
+import { before } from "mocha";
 
-suite("ConfigureCommand", () => {
-  describe("basic", function () {
-    const ctx = setupBeforeAfter(this);
-
-    test("ok", (done) => {
-      runLegacySingleWorkspaceTest({
-        ctx,
-        onInit: async ({ wsRoot }) => {
-          await new ConfigureCommand().run();
-          expect(
-            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
-          ).toEqual(path.join(wsRoot, "dendron.yml").toLowerCase());
-          done();
-        },
-      });
+suite("ConfigureCommand", function () {
+  describeSingleWS("WHEN run", {}, () => {
+    before(async () => {
+      const ext = ExtensionProvider.getExtension();
+      await new ConfigureCommand(ext).run();
     });
 
-    test.skip("diff dendronRoot", (done) => {
-      runLegacySingleWorkspaceTest({
-        ctx,
-        configOverride: {
-          [CONFIG.DENDRON_DIR.key]: "dendron",
-        },
-        onInit: async ({ wsRoot }) => {
-          await new ConfigureCommand().run();
-          expect(
-            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath
-          ).toEqual(path.join(wsRoot, "dendron", "dendron.yml"));
-          done();
-        },
-      });
+    test("THEN opens the configuration file", () => {
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
+      expect(
+        VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
+      ).toEqual(path.join(wsRoot, "dendron.yml").toLowerCase());
     });
   });
+
+  describeMultiWS(
+    "WHEN there are multiple config files inside the workspace",
+    {
+      // Self contained workspace with multiple vaults will have a config file in each vault
+      selfContained: true,
+    },
+    () => {
+      before(async () => {
+        const ext = ExtensionProvider.getExtension();
+        await new ConfigureCommand(ext).run();
+      });
+
+      test("THEN opens the configuration file", () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        expect(
+          VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
+        ).toEqual(path.join(wsRoot, "dendron.yml").toLowerCase());
+      });
+    }
+  );
 });

--- a/packages/plugin-core/src/test/suite-integ/TaskStatus.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/TaskStatus.test.ts
@@ -1,0 +1,250 @@
+import _ from "lodash";
+import sinon from "sinon";
+import { expect, LocationTestUtils } from "../testUtilsv2";
+import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
+import { before, after, describe } from "mocha";
+import { NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { NoteTestUtilsV4, SinonStubbedFn } from "@dendronhq/common-test-utils";
+import { TaskStatusCommand } from "../../commands/TaskStatus";
+
+suite("GIVEN TaskStatus", function () {
+  describeSingleWS("WHEN a link to a task note is selected", {}, () => {
+    let taskNote: NoteProps;
+    let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+    before(async () => {
+      const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+      const extension = ExtensionProvider.getExtension();
+      showQuickPick = sinon.stub(VSCodeUtils, "showQuickPick").resolves({
+        label: "y",
+      });
+      taskNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "task.test",
+        vault: vaults[0],
+        wsRoot,
+        body: "",
+        custom: {
+          status: "",
+        },
+      });
+      const currentNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "base",
+        vault: vaults[0],
+        wsRoot,
+        body: "[[task.test]]",
+      });
+      const editor = await ExtensionProvider.getWSUtils().openNote(currentNote);
+      editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
+
+      const cmd = new TaskStatusCommand(extension);
+      await cmd.run();
+    });
+    after(() => {
+      showQuickPick.restore();
+    });
+
+    test("THEN prompts for the status", () => {
+      expect(showQuickPick.calledOnce).toBeTruthy();
+    });
+    test("THEN updates the task status", async () => {
+      const { engine } = ExtensionProvider.getDWorkspace();
+      const task = NoteUtils.getNoteByFnameFromEngine({
+        fname: "task.test",
+        engine,
+        vault: taskNote.vault,
+      });
+      expect(task?.custom.status === "y");
+    });
+  });
+
+  describeSingleWS("WHEN a broken link is selected", {}, () => {
+    let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+    before(async () => {
+      const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+      const extension = ExtensionProvider.getExtension();
+      showQuickPick = sinon.stub(VSCodeUtils, "showQuickPick").resolves({
+        label: "y",
+      });
+      const currentNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "base",
+        vault: vaults[0],
+        wsRoot,
+        body: "[[task.test]]",
+      });
+      const editor = await ExtensionProvider.getWSUtils().openNote(currentNote);
+      editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
+
+      const cmd = new TaskStatusCommand(extension);
+      await cmd.run();
+    });
+    after(() => {
+      showQuickPick.restore();
+    });
+
+    test("THEN didn't prompt for the status", () => {
+      expect(showQuickPick.called).toBeFalsy();
+    });
+  });
+
+  describeMultiWS("WHEN the selected link is ambiguous", {}, () => {
+    let taskNote: NoteProps;
+    let otherTaskNote: NoteProps;
+    let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+    before(async () => {
+      const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+      const extension = ExtensionProvider.getExtension();
+
+      taskNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "task.test",
+        vault: vaults[0],
+        wsRoot,
+        body: "",
+        genRandomId: true,
+        custom: {
+          status: "",
+        },
+      });
+      otherTaskNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "task.test",
+        vault: vaults[1],
+        wsRoot,
+        body: "",
+        genRandomId: true,
+        custom: {
+          status: "",
+        },
+      });
+      const currentNote = await NoteTestUtilsV4.createNoteWithEngine({
+        engine,
+        fname: "base",
+        vault: vaults[0],
+        wsRoot,
+        body: "[[task.test]]",
+      });
+      const editor = await ExtensionProvider.getWSUtils().openNote(currentNote);
+      editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
+
+      showQuickPick = sinon.stub(VSCodeUtils, "showQuickPick");
+      showQuickPick
+        .onFirstCall()
+        .resolves({ label: taskNote.title, detail: taskNote.vault.fsPath });
+      showQuickPick.onSecondCall().resolves({
+        label: "y",
+      });
+
+      const cmd = new TaskStatusCommand(extension);
+      await cmd.run();
+    });
+    after(() => {
+      showQuickPick.restore();
+    });
+
+    test("THEN prompts for the note and the status", () => {
+      expect(showQuickPick.callCount).toEqual(2);
+    });
+    test("THEN updates the task status for the right task", async () => {
+      const { engine } = ExtensionProvider.getDWorkspace();
+      const task = await engine.getNote(taskNote.id);
+      expect(task?.custom.status === "y");
+      const otherTask = await engine.getNote(otherTaskNote.id);
+      expect(_.isEmpty(otherTask?.custom?.status)).toBeTruthy();
+    });
+  });
+
+  describe("WHEN no link is selected", () => {
+    describeMultiWS("AND a task note is open", {}, () => {
+      let taskNote: NoteProps;
+      let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+      before(async () => {
+        const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+        const extension = ExtensionProvider.getExtension();
+
+        taskNote = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          fname: "task.test",
+          vault: vaults[0],
+          wsRoot,
+          body: "",
+          genRandomId: true,
+          custom: {
+            status: "",
+          },
+        });
+        await ExtensionProvider.getWSUtils().openNote(taskNote);
+        showQuickPick = sinon
+          .stub(VSCodeUtils, "showQuickPick")
+          .resolves({ label: "y" });
+
+        const cmd = new TaskStatusCommand(extension);
+        await cmd.run();
+      });
+
+      test("THEN prompts for the status", () => {
+        expect(showQuickPick.calledOnce).toBeTruthy();
+      });
+      test("THEN sets the status for the current note", async () => {
+        const { engine } = ExtensionProvider.getDWorkspace();
+        const task = await engine.getNote(taskNote.id);
+        expect(task?.custom.status === "y");
+      });
+    });
+
+    describeMultiWS("AND the current note is NOT a task", {}, () => {
+      let otherNote: NoteProps;
+      let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+      before(async () => {
+        const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
+        const extension = ExtensionProvider.getExtension();
+
+        otherNote = await NoteTestUtilsV4.createNoteWithEngine({
+          engine,
+          fname: "test",
+          vault: vaults[0],
+          wsRoot,
+          body: "",
+        });
+        await ExtensionProvider.getWSUtils().openNote(otherNote);
+        showQuickPick = sinon
+          .stub(VSCodeUtils, "showQuickPick")
+          .resolves({ label: "y" });
+
+        const cmd = new TaskStatusCommand(extension);
+        await cmd.run();
+      });
+
+      test("THEN doesn't prompt for the status", () => {
+        expect(showQuickPick.called).toBeFalsy();
+      });
+      test("THEN doesn't set a status for the current note", async () => {
+        const { engine } = ExtensionProvider.getDWorkspace();
+        const note = await engine.getNote(otherNote.id);
+        expect(note?.custom?.status === undefined).toBeTruthy();
+      });
+    });
+
+    describeMultiWS("AND no note is open", {}, () => {
+      let showQuickPick: SinonStubbedFn<typeof VSCodeUtils["showQuickPick"]>;
+      before(async () => {
+        const extension = ExtensionProvider.getExtension();
+
+        await VSCodeUtils.closeAllEditors();
+        showQuickPick = sinon
+          .stub(VSCodeUtils, "showQuickPick")
+          .resolves({ label: "y" });
+
+        const cmd = new TaskStatusCommand(extension);
+        await cmd.run();
+      });
+
+      test("THEN doesn't prompt for the status", () => {
+        expect(showQuickPick.called).toBeFalsy();
+      });
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/TaskStatus.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/TaskStatus.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import { expect, LocationTestUtils } from "../testUtilsv2";
 import { describeMultiWS, describeSingleWS } from "../testUtilsV3";
 import { before, after, describe } from "mocha";
-import { NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { NoteProps } from "@dendronhq/common-all";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { NoteTestUtilsV4, SinonStubbedFn } from "@dendronhq/common-test-utils";
@@ -51,11 +51,12 @@ suite("GIVEN TaskStatus", function () {
     });
     test("THEN updates the task status", async () => {
       const { engine } = ExtensionProvider.getDWorkspace();
-      const task = NoteUtils.getNoteByFnameFromEngine({
-        fname: "task.test",
-        engine,
-        vault: taskNote.vault,
-      });
+      const task = (
+        await engine.findNotes({
+          fname: "task.test",
+          vault: taskNote.vault,
+        })
+      )[0];
       expect(task?.custom.status === "y");
     });
   });


### PR DESCRIPTION
Adds the commands "Set Task Status" and "Complete Task".

Set Task Status will prompt the user for the status to use based on the task symbol mappings, while "Complete Task" uses the first `taskCompleteStatus` without prompting.

For both commands, if the user has a link to a note selected, they will set the status for that note. If they don't have any links selected but are currently in a task note, then it will set the status for that note (only if the current note is a task note, to avoid setting the status accidentally in non-task notes).

If the user has a link selected but the link is ambiguous (multiple notes across vaults with the same name, and the link isn't x-vault), then it will also prompt for which note the user wanted.

Docs: https://github.com/dendronhq/dendron-site/pull/525

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [ ] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [ ] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)