### PR TITLE
chore: add `create_test_vault` dev method, fix issue with `createWorkspace`, other backend changes

### DIFF
--- a/packages/common-all/src/fuse.ts
+++ b/packages/common-all/src/fuse.ts
@@ -201,6 +201,7 @@ export class FuseEngine {
         _.filter(results, (ent) => ent.item.fname === "root"),
         (ent) => ent.item
       );
+      /// seearch eveyrthing
     } else if (qs === "*") {
       // @ts-ignore
       items = this.notesIndex._docs as NoteProps[];
@@ -284,6 +285,10 @@ export class FuseEngine {
     });
   }
 
+  /**
+   * Fuse does not support '*' as a wildcard. This replaces the `*` to a fuse equivalent
+   * to make the engine do the right thing
+   */
   static formatQueryForFuse({ qs }: { qs: string }): string {
     // Fuse does not appear to see [*] as anything special.
     // For example:
@@ -295,9 +300,7 @@ export class FuseEngine {
     // Fuse extended search https://fusejs.io/examples.html#extended-search
     // uses spaces for AND and '|' for OR hence this function will replace '*' with spaces.
     // We do this replacement since VSCode quick pick actually appears to respect '*'.
-    let result = qs.split("*").join(" ");
-
-    return result;
+    return qs.split("*").join(" ");
   }
 
   /**
@@ -340,7 +343,7 @@ export class FuseEngine {
       },
     ];
 
-    let sorted = _.orderBy(
+    const sorted = _.orderBy(
       results.map((res) => ({
         ...res,
         levenshteinDist: levenshteinDistance(res.item.fname, originalQS),

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -4,6 +4,8 @@ import {
   DendronError,
   error2PlainObject,
   ERROR_STATUS,
+  NoteProps,
+  NoteUtils,
   TimeUtils,
 } from "@dendronhq/common-all";
 import {
@@ -23,7 +25,7 @@ import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
 import yargs from "yargs";
-import { CLIAnalyticsUtils } from "..";
+import { CLIAnalyticsUtils, setupEngine } from "..";
 import {
   BuildUtils,
   ExtensionTarget,
@@ -40,6 +42,7 @@ type CommandCLIOpts = {
 export enum DevCommands {
   GENERATE_JSON_SCHEMA_FROM_CONFIG = "generate_json_schema_from_config",
   BUILD = "build",
+  CREATE_TEST_VAULT = "create_test_vault",
   BUMP_VERSION = "bump_version",
   PUBLISH = "publish",
   SYNC_ASSETS = "sync_assets",
@@ -57,7 +60,8 @@ export enum DevCommands {
 type CommandOpts = CommandCLIOpts &
   CommandCommonProps &
   Partial<BuildCmdOpts> &
-  Partial<RunMigrationOpts>;
+  Partial<RunMigrationOpts> &
+  Partial<CreateTestVaultOpts>;
 
 type CommandOutput = Partial<{ error: DendronError; data: any }>;
 
@@ -68,6 +72,14 @@ type BuildCmdOpts = {
   skipSentry?: boolean;
 } & BumpVersionOpts &
   PrepPluginOpts;
+
+type CreateTestVaultOpts = {
+  wsRoot: string;
+  /**
+   * Location of json data
+   */
+  jsonData: string;
+} & CommandCLIOpts;
 
 type BumpVersionOpts = {
   upgradeType: SemverVersion;
@@ -81,6 +93,15 @@ type RunMigrationOpts = {
   migrationVersion: string;
   wsRoot: string;
 } & CommandCLIOpts;
+
+type JsonDataForCreateTestVault = {
+  numNotes: number;
+  ratios: {
+    tag: number;
+    user: number;
+    reg: number;
+  };
+};
 
 export { CommandOpts as DevCLICommandOpts };
 
@@ -138,11 +159,59 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     args.option("wsRoot", {
       describe: "root directory of the Dendron workspace",
     });
+    args.option("jsonData", {
+      describe: "json data to pass into command",
+    });
   }
 
   async enrichArgs(args: CommandCLIOpts) {
     this.addArgsToPayload({ cmd: args.cmd });
     return { data: { ...args } };
+  }
+
+  async createTestVault({
+    wsRoot,
+    payload,
+  }: {
+    wsRoot: string;
+    payload: JsonDataForCreateTestVault;
+  }) {
+    fs.ensureDirSync(wsRoot);
+    fs.emptyDirSync(wsRoot);
+
+    const svc = await WorkspaceService.createWorkspace({
+      vaults: [{ fsPath: "vault" }],
+      wsRoot,
+      createCodeWorkspace: false,
+      useSelfContainedVault: true,
+    });
+    await svc.initialize();
+    const vault = svc.vaults[0];
+
+    const ratioTotal = _.values(payload.ratios).reduce(
+      (acc, cur) => acc + cur,
+      0
+    );
+
+    const { engine, server } = await setupEngine({ wsRoot });
+
+    await Promise.all(
+      _.keys(payload.ratios).map(async (key) => {
+        const numNotes = Math.round(
+          (payload.ratios[key as keyof JsonDataForCreateTestVault["ratios"]] /
+            ratioTotal) *
+            payload.numNotes
+        );
+        this.print(`creating ${numNotes} ${key} notes...`);
+        const notes: NoteProps[] = await Promise.all(
+          _.times(numNotes, async (i) => {
+            return NoteUtils.create({ fname: `${key}.${i}`, vault });
+          })
+        );
+        await engine.bulkAddNotes({ notes });
+      })
+    );
+    return { server };
   }
 
   async generateJSONSchemaFromConfig() {
@@ -210,6 +279,26 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             };
           }
           await this.build(opts);
+          return { error: null };
+        }
+        case DevCommands.CREATE_TEST_VAULT: {
+          if (!this.validateCreateTestVaultArgs(opts)) {
+            return {
+              error: new DendronError({
+                message: "missing required options",
+              }),
+            };
+          }
+          const { wsRoot, jsonData } = opts;
+          const payload = fs.readJSONSync(
+            jsonData
+          ) as JsonDataForCreateTestVault;
+          this.print(`reading json data from ${jsonData}`);
+          const { server } = await this.createTestVault({ wsRoot, payload });
+          if (server.close) {
+            this.print("closing server...");
+            server.close();
+          }
           return { error: null };
         }
         case DevCommands.BUMP_VERSION: {
@@ -486,6 +575,13 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
 
   validateBumpVersionArgs(opts: CommandOpts): opts is BumpVersionOpts {
     if (!opts.upgradeType) {
+      return false;
+    }
+    return true;
+  }
+
+  validateCreateTestVaultArgs(opts: CommandOpts): opts is CreateTestVaultOpts {
+    if (!opts.wsRoot || !opts.jsonData) {
       return false;
     }
     return true;

--- a/packages/engine-server/src/seed/service.ts
+++ b/packages/engine-server/src/seed/service.ts
@@ -175,7 +175,6 @@ export class SeedService {
         writeYAML(cpath, seed);
         const ws = await WorkspaceService.createWorkspace({
           wsRoot,
-          vaults: [],
           createCodeWorkspace: true,
         });
         const config = ws.config;

--- a/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
@@ -25,6 +25,7 @@ import {
   GitTestUtils,
 } from "../../utils";
 import { TestSeedUtils } from "../../utils/seed";
+import sinon from "sinon";
 
 describe("WorkspaceUtils", () => {
   describe("findWSRoot", () => {
@@ -88,7 +89,10 @@ describe("WorkspaceService", () => {
     test("basic", async () => {
       const wsRoot = tmpDir().name;
       const vaults = [{ fsPath: "vault1" }];
-      await WorkspaceService.createWorkspace({ wsRoot, vaults });
+      await WorkspaceService.createWorkspace({
+        wsRoot,
+        additionalVaults: vaults,
+      });
       const gitignore = path.join(wsRoot, ".gitignore");
       expect(
         fs.readFileSync(gitignore, { encoding: "utf8" })
@@ -98,7 +102,10 @@ describe("WorkspaceService", () => {
     test("workspace Vault", async () => {
       const wsRoot = tmpDir().name;
       const vaults: DVault[] = [{ fsPath: "vault1", workspace: "foo" }];
-      await WorkspaceService.createWorkspace({ wsRoot, vaults });
+      await WorkspaceService.createWorkspace({
+        wsRoot,
+        additionalVaults: vaults,
+      });
       expect(fs.existsSync(path.join(wsRoot, "foo", "vault1"))).toBeTruthy();
     });
   });
@@ -177,12 +184,10 @@ describe("WorkspaceService", () => {
           await WorkspaceService.createWorkspace({
             wsRoot: tmp,
             useSelfContainedVault: true,
-            vaults: [
-              {
-                fsPath: ".",
-                name: vaultName,
-              },
-            ],
+            wsVault: {
+              fsPath: ".",
+              name: vaultName,
+            },
           });
           const vaultFsPath = path.join(
             FOLDERS.DEPENDENCIES,

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -176,7 +176,7 @@ export async function setupWS(opts: {
         await resp;
         await WorkspaceService.createWorkspace({
           wsRoot: path.join(wsRoot, ent.name),
-          vaults: ent.vaults,
+          additionalVaults: ent.vaults,
         });
         return ws.addWorkspace({ workspace: ent });
       },

--- a/packages/engine-test-utils/src/utils/workspace.ts
+++ b/packages/engine-test-utils/src/utils/workspace.ts
@@ -10,6 +10,9 @@ export class TestWorkspaceUtils {
     vaults: DVault[];
     wsRoot?: string;
   }) {
-    return WorkspaceService.createWorkspace({ wsRoot, vaults });
+    return WorkspaceService.createWorkspace({
+      wsRoot,
+      additionalVaults: vaults,
+    });
   }
 }

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -97,6 +97,7 @@ const NOTE_AUTOCOMPLETEABLE_REGEX = new RegExp("" +
 export const provideCompletionItems = sentryReportingCallback(
   (document: TextDocument, position: Position) => {
     const ctx = "provideCompletionItems";
+    const startTime = process.hrtime();
 
     // No-op if we're not in a Dendron Workspace
     if (!DendronExtension.isActive()) {
@@ -219,7 +220,12 @@ export const provideCompletionItems = sentryReportingCallback(
       }
       completionItems.push(item);
     });
-    Logger.info({ ctx, completionItemsLength: completionItems.length });
+    const duration = getDurationMilliseconds(startTime);
+    Logger.info({
+      ctx,
+      completionItemsLength: completionItems.length,
+      duration,
+    });
     return completionItems;
   }
 );

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -20,7 +20,7 @@ import {
 suite("CopyNoteRef", function () {
   const ctx = setupBeforeAfter(this, {});
 
-  describe.only("multi", () => {
+  describe("multi", () => {
     describeMultiWS(
       "WHEN xvault link when allowed in config",
       {

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -178,7 +178,7 @@ suite("VaultAddCommand", function () {
           const vaultsRemote: DVault[] = [{ fsPath: vaultPath }];
           await WorkspaceService.createWorkspace({
             wsRoot: remoteDir,
-            vaults: vaultsRemote,
+            additionalVaults: vaultsRemote,
           });
           await GitTestUtils.createRepoWithReadme(remoteDir);
 

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -10,7 +10,7 @@ import { WorkspaceWatcher } from "../../WorkspaceWatcher";
 import { WSUtils } from "../../WSUtils";
 import { MockDendronExtension } from "../MockDendronExtension";
 import { MockPreviewProxy } from "../MockPreviewProxy";
-import { expect, runSingleVaultTest } from "../testUtilsv2";
+import { expect } from "../testUtilsv2";
 import {
   describeSingleWS,
   runLegacyMultiWorkspaceTest,
@@ -35,11 +35,15 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
   let watcher: WindowWatcher | undefined;
 
   describe("WHEN onDidChangeActiveTextEditor is triggered", () => {
-    test("basic", (done) => {
-      runSingleVaultTest({
-        ctx,
+    describeSingleWS(
+      "WHEN check decorator",
+      {
         postSetupHook: setupBasic,
-        onInit: async ({ vault, wsRoot }) => {
+        ctx,
+      },
+      () => {
+        test("decorators are updated", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
           const mockExtension = new MockDendronExtension({
             engine: ExtensionProvider.getEngine(),
             wsRoot,
@@ -52,16 +56,14 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
             extension: mockExtension,
             previewProxy,
           });
-          const vaultPath = vault.fsPath;
+          const vaultPath = vaults[0].fsPath;
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           const editor = await VSCodeUtils.openFileInEditor(uri);
           await watcher.triggerUpdateDecorations(editor!);
-          // TODO: check for decorations
-          done();
-        },
-      });
-    });
+        });
+      }
+    );
 
     describeSingleWS(
       "AND WHEN automaticallyShowPreview is set to false",

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -200,14 +200,18 @@ export async function setupLegacyWorkspace(
     wsRoot,
   });
 
-  const vaults = await new SetupWorkspaceCommand().execute({
-    rootDirRaw: wsRoot,
-    skipOpenWs: true,
-    ...copts.setupWsOverride,
-    workspaceInitializer: new BlankInitializer(),
-    workspaceType: copts.workspaceType,
-    selfContained: copts.selfContained,
-  });
+  const { wsVault, additionalVaults } =
+    await new SetupWorkspaceCommand().execute({
+      rootDirRaw: wsRoot,
+      skipOpenWs: true,
+      ...copts.setupWsOverride,
+      workspaceInitializer: new BlankInitializer(),
+      workspaceType: copts.workspaceType,
+      selfContained: copts.selfContained,
+    });
+  const vaults = [wsVault, ...(additionalVaults || [])].filter(
+    (v) => !_.isUndefined(v)
+  ) as DVault[];
   stubWorkspaceFolders(wsRoot, vaults);
 
   // update config

--- a/packages/plugin-core/src/workspace/blankInitializer.ts
+++ b/packages/plugin-core/src/workspace/blankInitializer.ts
@@ -2,7 +2,10 @@ import { DVault } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import { Snippets } from "@dendronhq/engine-server";
 import path from "path";
-import { WorkspaceInitializer } from "./workspaceInitializer";
+import {
+  OnWorkspaceCreationOpts,
+  WorkspaceInitializer,
+} from "./workspaceInitializer";
 
 /**
  * Blank Workspace Initializer. Creates the barebones requirements for a functioning workspace
@@ -13,11 +16,8 @@ export class BlankInitializer implements WorkspaceInitializer {
     return [{ fsPath: vaultPath }];
   }
 
-  async onWorkspaceCreation(opts: {
-    vaults: DVault[];
-    wsRoot: string;
-  }): Promise<void> {
-    const vpath = vault2Path({ vault: opts.vaults[0], wsRoot: opts.wsRoot });
+  async onWorkspaceCreation(opts: OnWorkspaceCreationOpts): Promise<void> {
+    const vpath = vault2Path({ vault: opts.wsVault, wsRoot: opts.wsRoot });
 
     // write snippets
     const vscodeDir = path.join(vpath, ".vscode");

--- a/packages/plugin-core/src/workspace/blankInitializer.ts
+++ b/packages/plugin-core/src/workspace/blankInitializer.ts
@@ -11,16 +11,17 @@ import {
  * Blank Workspace Initializer. Creates the barebones requirements for a functioning workspace
  */
 export class BlankInitializer implements WorkspaceInitializer {
-  createVaults(vault?: DVault) {
-    const vaultPath = vault?.fsPath || "vault";
-    return [{ fsPath: vaultPath }];
+  createVaults(wsVault?: DVault) {
+    const vaultPath = wsVault?.fsPath || "vault";
+    return { wsVault: { fsPath: vaultPath } };
   }
 
   async onWorkspaceCreation(opts: OnWorkspaceCreationOpts): Promise<void> {
-    const vpath = vault2Path({ vault: opts.wsVault, wsRoot: opts.wsRoot });
-
-    // write snippets
-    const vscodeDir = path.join(vpath, ".vscode");
-    Snippets.create(vscodeDir);
+    if (opts.wsVault) {
+      const vpath = vault2Path({ vault: opts.wsVault, wsRoot: opts.wsRoot });
+      // write snippets
+      const vscodeDir = path.join(vpath, ".vscode");
+      Snippets.create(vscodeDir);
+    }
   }
 }

--- a/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
+++ b/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
@@ -2,7 +2,6 @@ import { DVault, DWorkspaceV2 } from "@dendronhq/common-all";
 import {
   MetadataService,
   WorkspaceActivationContext,
-  WorkspaceService,
 } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
 import {
@@ -10,7 +9,10 @@ import {
   WebViewPanelFactory,
 } from "../commands/SeedBrowseCommand";
 import { getExtension } from "../workspace";
-import { WorkspaceInitializer } from "./workspaceInitializer";
+import {
+  OnWorkspaceCreationOpts,
+  WorkspaceInitializer,
+} from "./workspaceInitializer";
 
 /**
  * Seed Browser Workspace Initializer - Open the Seed Browser
@@ -26,11 +28,7 @@ export class SeedBrowserInitializer implements WorkspaceInitializer {
   /**
    * No-op
    */
-  async onWorkspaceCreation(_opts: {
-    vaults: DVault[];
-    wsRoot: string;
-    svc?: WorkspaceService;
-  }): Promise<void> {
+  async onWorkspaceCreation(_opts: OnWorkspaceCreationOpts): Promise<void> {
     return;
   }
 

--- a/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
+++ b/packages/plugin-core/src/workspace/seedBrowserInitializer.ts
@@ -1,4 +1,4 @@
-import { DVault, DWorkspaceV2 } from "@dendronhq/common-all";
+import { DWorkspaceV2 } from "@dendronhq/common-all";
 import {
   MetadataService,
   WorkspaceActivationContext,
@@ -9,29 +9,12 @@ import {
   WebViewPanelFactory,
 } from "../commands/SeedBrowseCommand";
 import { getExtension } from "../workspace";
-import {
-  OnWorkspaceCreationOpts,
-  WorkspaceInitializer,
-} from "./workspaceInitializer";
+import { WorkspaceInitializer } from "./workspaceInitializer";
 
 /**
  * Seed Browser Workspace Initializer - Open the Seed Browser
  */
 export class SeedBrowserInitializer implements WorkspaceInitializer {
-  /**
-   * No-op
-   */
-  createVaults(_vault?: DVault): DVault[] {
-    return [];
-  }
-
-  /**
-   * No-op
-   */
-  async onWorkspaceCreation(_opts: OnWorkspaceCreationOpts): Promise<void> {
-    return;
-  }
-
   /**
    * Launch Seed Browser Webview
    * @param _opts

--- a/packages/plugin-core/src/workspace/templateInitializer.ts
+++ b/packages/plugin-core/src/workspace/templateInitializer.ts
@@ -1,7 +1,8 @@
-import { DVault } from "@dendronhq/common-all";
-import { WorkspaceService } from "@dendronhq/engine-server";
 import { BlankInitializer } from "./blankInitializer";
-import { WorkspaceInitializer } from "./workspaceInitializer";
+import {
+  OnWorkspaceCreationOpts,
+  WorkspaceInitializer,
+} from "./workspaceInitializer";
 
 /**
  * Template Workspace Initializer - add the templates seed to the workspace:
@@ -10,11 +11,7 @@ export class TemplateInitializer
   extends BlankInitializer
   implements WorkspaceInitializer
 {
-  async onWorkspaceCreation(opts: {
-    vaults: DVault[];
-    wsRoot: string;
-    svc?: WorkspaceService;
-  }): Promise<void> {
+  async onWorkspaceCreation(opts: OnWorkspaceCreationOpts): Promise<void> {
     await super.onWorkspaceCreation(opts);
 
     await opts.svc?.seedService.addSeed({

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -50,7 +50,7 @@ export class TutorialInitializer
     const assetUri = VSCodeUtils.getAssetUri(DendronExtension.context());
     const dendronWSTemplate = VSCodeUtils.joinPath(assetUri, "dendron-ws");
 
-    const vpath = vault2Path({ vault: opts.wsVault, wsRoot: opts.wsRoot });
+    const vpath = vault2Path({ vault: opts.wsVault!, wsRoot: opts.wsRoot });
 
     const ABUserGroup = AB_TUTORIAL_TEST.getUserGroup(
       SegmentClient.instance().anonymousId

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -1,12 +1,11 @@
 import {
+  AB_TUTORIAL_TEST,
   DendronError,
-  DVault,
   DWorkspaceV2,
   getStage,
   TutorialEvents,
-  VaultUtils,
-  AB_TUTORIAL_TEST,
   TutorialNoteViewedPayload,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { file2Note, SegmentClient, vault2Path } from "@dendronhq/common-server";
 import {
@@ -28,7 +27,10 @@ import { AnalyticsUtils } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { DendronExtension } from "../workspace";
 import { BlankInitializer } from "./blankInitializer";
-import { WorkspaceInitializer } from "./workspaceInitializer";
+import {
+  OnWorkspaceCreationOpts,
+  WorkspaceInitializer,
+} from "./workspaceInitializer";
 
 /**
  * Workspace Initializer for the Tutorial Experience. Copies tutorial notes and
@@ -38,10 +40,7 @@ export class TutorialInitializer
   extends BlankInitializer
   implements WorkspaceInitializer
 {
-  async onWorkspaceCreation(opts: {
-    vaults: DVault[];
-    wsRoot: string;
-  }): Promise<void> {
+  async onWorkspaceCreation(opts: OnWorkspaceCreationOpts): Promise<void> {
     super.onWorkspaceCreation(opts);
 
     MetadataService.instance().setActivationContext(
@@ -51,7 +50,7 @@ export class TutorialInitializer
     const assetUri = VSCodeUtils.getAssetUri(DendronExtension.context());
     const dendronWSTemplate = VSCodeUtils.joinPath(assetUri, "dendron-ws");
 
-    const vpath = vault2Path({ vault: opts.vaults[0], wsRoot: opts.wsRoot });
+    const vpath = vault2Path({ vault: opts.wsVault, wsRoot: opts.wsRoot });
 
     const ABUserGroup = AB_TUTORIAL_TEST.getUserGroup(
       SegmentClient.instance().anonymousId

--- a/packages/plugin-core/src/workspace/workspaceInitializer.ts
+++ b/packages/plugin-core/src/workspace/workspaceInitializer.ts
@@ -2,7 +2,7 @@ import { DVault, DWorkspaceV2 } from "@dendronhq/common-all";
 import { WorkspaceService } from "@dendronhq/engine-server";
 
 export type OnWorkspaceCreationOpts = {
-  wsVault: DVault;
+  wsVault?: DVault;
   additionalVaults?: DVault[];
   wsRoot: string;
   svc?: WorkspaceService;
@@ -15,7 +15,7 @@ export type WorkspaceInitializer = {
   /**
    * Create the vaults to be added to the workspace being initialized.
    */
-  createVaults(vault?: DVault): DVault[];
+  createVaults?(wsVault?: DVault): { wsVault?: DVault; additionalVaults?: [] };
 
   /**
    * Invoked after workspace has been created. Perform operations such as copying over notes.

--- a/packages/plugin-core/src/workspace/workspaceInitializer.ts
+++ b/packages/plugin-core/src/workspace/workspaceInitializer.ts
@@ -1,6 +1,13 @@
 import { DVault, DWorkspaceV2 } from "@dendronhq/common-all";
 import { WorkspaceService } from "@dendronhq/engine-server";
 
+export type OnWorkspaceCreationOpts = {
+  wsVault: DVault;
+  additionalVaults?: DVault[];
+  wsRoot: string;
+  svc?: WorkspaceService;
+};
+
 /**
  * Type that can execute custom code as part of workspace creation and opening of a workspace.
  */
@@ -13,11 +20,7 @@ export type WorkspaceInitializer = {
   /**
    * Invoked after workspace has been created. Perform operations such as copying over notes.
    */
-  onWorkspaceCreation?(opts: {
-    vaults: DVault[];
-    wsRoot: string;
-    svc?: WorkspaceService;
-  }): Promise<void>;
+  onWorkspaceCreation?(opts: OnWorkspaceCreationOpts): Promise<void>;
 
   /**
    * Invoked after the workspace has been opened. Perform any operations such as re-arranging the layout.


### PR DESCRIPTION
chore: add `create_test_vault` dev method, fix issue with `createWorkspace`, other backend changes

- introduce `dendron dev create_test_vault` which can create vaults with pre-configured distribution of notes/vaults (useful for diagnosing performance issues)
- fix issue with `createWorkspace` cmd - when passing in multiple vaults to a self contained workspace, only the first vault is actually added to the `dendron.yml`
  - this led to a larger refactoring of the `createWorkspace` to make a distinction between the `wsVault` (for sc vault, this is the vault in `notes` folder) and `additionalVaults`
- also modified `WorkspaceInitializer` interface to account for `wsVault` and `additionalVaults`
- cleaned up some tests