### PR TITLE
chore: automate the schema updates

### DIFF
--- a/.github/workflows/publish-extension-dendron-minor.yml
+++ b/.github/workflows/publish-extension-dendron-minor.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Yarn Setup
         run: yarn setup
 
+      - name: Update schema file
+        run: yarn gen:data
+
       - name: Build the VSIX and Publish to NPM Registry
         env:
           NPM_EMAIL: ${{ secrets.NPM_EMAIL }}

--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Yarn Setup
         run: yarn setup
 
+      - name: Update schema file
+        run: yarn gen:data
+
       - name: Build the VSIX and Publish to NPM Registry
         env:
           NPM_EMAIL: ${{ secrets.NPM_EMAIL }}

--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Yarn Setup
         run: yarn setup
 
+      - name: Update schema file
+        run: yarn gen:data
+
       - name: Set Up Yarn Local Registry
         run: yarn config set registry http://localhost:4873
 

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -997,14 +997,10 @@
       "properties": {
         "zoomSpeed": {
           "type": "number"
-        },
-        "createStub": {
-          "type": "boolean"
         }
       },
       "required": [
-        "zoomSpeed",
-        "createStub"
+        "zoomSpeed"
       ],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."

--- a/packages/dendron-next-server/data/dendron-yml.validator.json
+++ b/packages/dendron-next-server/data/dendron-yml.validator.json
@@ -997,14 +997,10 @@
       "properties": {
         "zoomSpeed": {
           "type": "number"
-        },
-        "createStub": {
-          "type": "boolean"
         }
       },
       "required": [
-        "zoomSpeed",
-        "createStub"
+        "zoomSpeed"
       ],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."


### PR DESCRIPTION
This PR automates the updates to the JSON schema files by doing the updates during the release process. The schema updates should get merged back in along with the PR after the release. The updates are also done for the nightly version, which won't get merged but will keep the schema up-to-date in the nightly versions as well.