### PR TITLE
chore: gracefully handle tree view sort error to avoid crashing the tree view

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -172,6 +172,11 @@ export enum GraphEvents {
   GraphPanelUsed = "GraphPanelUsed",
 }
 
+export enum TreeViewEvents {
+  NoteOmittedErrorMessageShow = "NoteOmittedErrorMessageShow",
+  NoteOmittedErrorMessageConfirm = "NoteOmittedErrorMessageConfirm",
+}
+
 export const DendronEvents = {
   VSCodeEvents,
   CLIEvents,
@@ -185,4 +190,5 @@ export const DendronEvents = {
   WorkspaceEvents,
   EngagementEvents,
   GraphEvents,
+  TreeViewEvents,
 };

--- a/packages/common-frontend/src/utils/tree-view.tsx
+++ b/packages/common-frontend/src/utils/tree-view.tsx
@@ -78,15 +78,17 @@ export class TreeViewUtils {
       );
     }
 
+    const { data } = TreeUtils.sortNotesAtLevel({
+      noteIds: note.children,
+      noteDict,
+      reverse: note.custom?.sort_order === "reverse",
+    });
+
     return {
       key: note.id,
       title,
       icon,
-      children: TreeUtils.sortNotesAtLevel({
-        noteIds: note.children,
-        noteDict,
-        reverse: note.custom?.sort_order === "reverse",
-      })
+      children: data
         .map((noteId) =>
           TreeViewUtils.note2TreeDatanote({
             noteId,

--- a/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
@@ -2,6 +2,7 @@ import {
   DendronError,
   NoteChangeEntry,
   NoteProps,
+  TreeUtils,
   TreeViewItemLabelTypeEnum,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
@@ -9,7 +10,8 @@ import { NoteTestUtilsV4, NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { MetadataService } from "@dendronhq/engine-server";
 import { ENGINE_HOOKS_MULTI } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
-import { describe, after } from "mocha";
+import { describe, after, before } from "mocha";
+import sinon from "sinon";
 import * as vscode from "vscode";
 import { EngineNoteProvider } from "../../views/EngineNoteProvider";
 import { expect } from "../testUtilsv2";
@@ -146,6 +148,56 @@ suite("EngineNoteProvider Tests", function testSuite() {
         },
       });
     };
+
+    describe("drift in engine state", function () {
+      describeMultiWS(
+        "GIVEN note id that is not in noteDict",
+        {
+          preSetupHook: async (opts) => preSetupHookFunc(opts),
+        },
+        () => {
+          let sortNotesAtLevelSpy: sinon.SinonSpy;
+
+          before(() => {
+            sortNotesAtLevelSpy = sinon.spy(TreeUtils, "sortNotesAtLevel");
+          });
+
+          after(() => {
+            sortNotesAtLevelSpy.restore();
+          });
+
+          test("THEN omit rendering note id that can't be found and render the rest.", async () => {
+            const mockEvents = new MockEngineEvents();
+            const provider = new EngineNoteProvider(mockEvents);
+
+            const props = await (provider.getChildren() as Promise<
+              NoteProps[]
+            >);
+
+            const vault1RootProps = props[0];
+
+            vault1RootProps.children.push("fake-id");
+
+            const resp = await (provider.getChildren(
+              vault1RootProps
+            ) as Promise<NoteProps[]>);
+            const sortResp = sortNotesAtLevelSpy.lastCall.returnValue;
+            const expectedResp = ["zebra", "_underscore", "aardvark", "aaron"];
+            expect(sortResp.data).toEqual(expectedResp);
+            expect(sortResp.error !== undefined);
+            expect(sortResp.error.payload).toEqual('{"omitted":["fake-id"]}');
+            expect(resp).toBeTruthy();
+            expect(resp.map((props) => props.id)).toEqual([
+              "zebra",
+              "_underscore",
+              "aardvark",
+              "aaron",
+            ]);
+          });
+        }
+      );
+    });
+
     describe("sort / label config", function () {
       describeMultiWS(
         "WHEN treeViewItemLabelType is omitted",

--- a/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
@@ -182,17 +182,9 @@ suite("EngineNoteProvider Tests", function testSuite() {
               vault1RootProps
             ) as Promise<NoteProps[]>);
             const sortResp = sortNotesAtLevelSpy.lastCall.returnValue;
-            const expectedResp = ["zebra", "_underscore", "aardvark", "aaron"];
-            expect(sortResp.data).toEqual(expectedResp);
             expect(sortResp.error !== undefined);
             expect(sortResp.error.payload).toEqual('{"omitted":["fake-id"]}');
             expect(resp).toBeTruthy();
-            expect(resp.map((props) => props.id)).toEqual([
-              "zebra",
-              "_underscore",
-              "aardvark",
-              "aaron",
-            ]);
           });
         }
       );

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -1845,7 +1845,9 @@ suite("NativeTreeView tests", function () {
           });
 
           expect(sortRespWithError !== undefined);
-          expect(sortRespWithError.payload).toEqual('{omitted:["fake-id"]}');
+          expect(sortRespWithError.error.payload).toEqual(
+            '{"omitted":["fake-id"]}'
+          );
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -1,14 +1,15 @@
 import { expect } from "../testUtilsv2";
-import { describe, beforeEach } from "mocha";
+import { describe, beforeEach, before, after } from "mocha";
 import { EngineNoteProvider } from "../../views/EngineNoteProvider";
 import { describeMultiWS } from "../testUtilsV3";
 import { MockEngineEvents } from "./MockEngineEvents";
-import { NoteProps } from "@dendronhq/common-all";
+import { DendronError, NoteProps, TreeUtils } from "@dendronhq/common-all";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { RenameNoteV2aCommand } from "../../commands/RenameNoteV2a";
 import { vault2Path } from "@dendronhq/common-server";
 import { Uri } from "vscode";
 import path from "path";
+import sinon from "sinon";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
@@ -1789,6 +1790,65 @@ suite("NativeTreeView tests", function () {
         });
       });
     });
+  });
+  describe("error handling", function () {
+    describeMultiWS(
+      "GIVEN note id that is not in noteDict",
+      {
+        preSetupHook: async (opts) => {
+          const { wsRoot, vaults } = opts;
+          await NoteTestUtilsV4.createNote({
+            wsRoot,
+            vault: vaults[0],
+            fname: "foo",
+          });
+        },
+      },
+      () => {
+        let sortNotesAtLevelSpy: sinon.SinonSpy;
+
+        before(() => {
+          sortNotesAtLevelSpy = sinon.spy(TreeUtils, "sortNotesAtLevel");
+        });
+
+        after(() => {
+          sortNotesAtLevelSpy.restore();
+        });
+
+        test("THEN gracefully render only the available notes and log omitted note id.", async () => {
+          const mockEvents = new MockEngineEvents();
+          const provider = new EngineNoteProvider(mockEvents);
+
+          const props = await (provider.getChildren() as Promise<NoteProps[]>);
+
+          const vault1RootProps = props[0];
+
+          vault1RootProps.children.push("fake-id");
+
+          const fullTree = await getFullTree({
+            root: vault1RootProps,
+            provider,
+          });
+
+          const sortResps = sortNotesAtLevelSpy.returnValues;
+          const sortRespWithError = sortResps.find((sortResp) => {
+            return sortResp.error instanceof DendronError;
+          });
+          expect(fullTree).toEqual({
+            fname: "root",
+            childNodes: [
+              {
+                fname: "foo",
+                childNodes: [],
+              },
+            ],
+          });
+
+          expect(sortRespWithError !== undefined);
+          expect(sortRespWithError.payload).toEqual('{omitted:["fake-id"]}');
+        });
+      }
+    );
   });
   describe("filesystem change interactions", function () {});
 });

--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -1,15 +1,18 @@
 import {
+  ConfirmStatus,
   DendronError,
   DNodeUtils,
   NoteProps,
   NotePropsByIdDict,
   NoteUtils,
   TreeUtils,
+  TreeViewEvents,
   TreeViewItemLabelTypeEnum,
 } from "@dendronhq/common-all";
 import { EngineEventEmitter, MetadataService } from "@dendronhq/engine-server";
 import * as Sentry from "@sentry/node";
 import _ from "lodash";
+import * as vscode from "vscode";
 import {
   Disposable,
   Event,
@@ -24,6 +27,7 @@ import {
 import { DendronContext, ICONS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
+import { AnalyticsUtils } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { TreeNote } from "./TreeNote";
 
@@ -74,6 +78,42 @@ export class EngineNoteProvider
     }
   }
 
+  private showNoteOmittedErrorMessage(opts: { error: DendronError }) {
+    const { error } = opts;
+    const { payload } = error;
+    const fixText = "Reload";
+    if (payload === undefined) return;
+
+    const omittedNotes = JSON.parse(payload).omitted;
+
+    AnalyticsUtils.track(TreeViewEvents.NoteOmittedErrorMessageShow, {
+      count: omittedNotes.length,
+    });
+    vscode.window
+      .showErrorMessage(
+        `Note(s) with note id ${omittedNotes.join(
+          ", "
+        )} have been omitted from the tree view due to an error. Please reload to fix the issue.`,
+        fixText
+      )
+      .then(async (resp) => {
+        if (resp === fixText) {
+          // need to save it because we are
+          AnalyticsUtils.trackForNextRun(
+            TreeViewEvents.NoteOmittedErrorMessageConfirm,
+            {
+              status: ConfirmStatus.accepted,
+            }
+          );
+          await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        } else {
+          AnalyticsUtils.track(TreeViewEvents.NoteOmittedErrorMessageConfirm, {
+            status: ConfirmStatus.rejected,
+          });
+        }
+      });
+  }
+
   getTree(): { [key: string]: TreeNote } {
     return this._tree;
   }
@@ -119,6 +159,7 @@ export class EngineNoteProvider
         });
 
         if (error !== undefined) {
+          this.showNoteOmittedErrorMessage({ error });
           Logger.warn({ ctx, error });
         }
 
@@ -222,6 +263,7 @@ export class EngineNoteProvider
     });
 
     if (error !== undefined) {
+      this.showNoteOmittedErrorMessage({ error });
       Logger.warn({ ctx, error });
     }
 

--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -119,7 +119,7 @@ export class EngineNoteProvider
         });
 
         if (error !== undefined) {
-          Logger.error({ ctx, error });
+          Logger.warn({ ctx, error });
         }
 
         const childrenNoteProps = childrenIds.map((id) => {
@@ -222,7 +222,7 @@ export class EngineNoteProvider
     });
 
     if (error !== undefined) {
-      Logger.error({ ctx, error });
+      Logger.warn({ ctx, error });
     }
 
     tn.children = await Promise.all(

--- a/packages/plugin-core/src/views/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/EngineNoteProvider.ts
@@ -112,11 +112,15 @@ export class EngineNoteProvider
         return Promise.resolve([]);
       }
       if (noteProps) {
-        const childrenIds = TreeUtils.sortNotesAtLevel({
+        const { data: childrenIds, error } = TreeUtils.sortNotesAtLevel({
           noteIds: noteProps.children,
           noteDict: engine.notes,
           labelType: this._labelType,
         });
+
+        if (error !== undefined) {
+          Logger.error({ ctx, error });
+        }
 
         const childrenNoteProps = childrenIds.map((id) => {
           return engine.notes[id];
@@ -211,11 +215,16 @@ export class EngineNoteProvider
 
     const labelType = this._labelType;
 
-    const children = TreeUtils.sortNotesAtLevel({
+    const { data: children, error } = TreeUtils.sortNotesAtLevel({
       noteIds: note.children,
       noteDict: ndict,
       labelType,
     });
+
+    if (error !== undefined) {
+      Logger.error({ ctx, error });
+    }
+
     tn.children = await Promise.all(
       children.map(async (c) => {
         const childNote = ndict[c];


### PR DESCRIPTION
# chore: gracefully handle tree view sort error to avoid crashing the tree view
This PR:
- Preemptively filters out note ids that will cause the sort logic to fatally crash the tree view rendering (note ids not in sync with noteDict)
  - tree view will omit the out-of-sync note ids from rendering.
- Properly log when this happens so we can troubleshoot the root cause with the surrounding context available.

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)