### PR TITLE
chore(internal): Remove deprecated noteutil methods

### DIFF
--- a/packages/common-all/src/noteDictsUtils.ts
+++ b/packages/common-all/src/noteDictsUtils.ts
@@ -15,6 +15,22 @@ import { VaultUtils } from "./vault";
  */
 export class NoteDictsUtils {
   /**
+   * Construct NotePropsByIdDict from list of NoteProps
+   *
+   * @param notes Used to populate map
+   * @returns NotePropsByIdDict
+   */
+  static createNotePropsByIdDict(notes: NoteProps[]): NotePropsByIdDict {
+    const notesById: NotePropsByIdDict = {};
+
+    for (const note of notes) {
+      notesById[note.id] = note;
+    }
+
+    return notesById;
+  }
+
+  /**
    * Find notes by fname. If vault is provided, filter results so that only notes with matching vault is returned
    * Return empty array if no match is found
    *

--- a/packages/engine-server/src/drivers/file/noteParser.ts
+++ b/packages/engine-server/src/drivers/file/noteParser.ts
@@ -258,7 +258,7 @@ export class NoteParser extends ParserBase {
     // add schemas
     const domains = notesById[rootNote.id].children.map(
       (ent) => notesById[ent]
-    ) as NoteProps[];
+    );
     const schemas = this.opts.store.schemas;
     await Promise.all(
       domains.map(async (d) => {

--- a/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
@@ -4,7 +4,6 @@ import {
   DendronError,
   DVault,
   NoteProps,
-  NoteUtils,
   RenderNotePayload,
 } from "@dendronhq/common-all";
 import { createServer, runEngineTestV5 } from "../../engine";
@@ -67,20 +66,19 @@ describe("api/note/render tests", () => {
     beforeAll(async () => {
       await runEngineTestV5(
         async ({ wsRoot, vaults, engine }) => {
-          const notes = engine.notes;
           const vault1 = vaults[0];
 
-          const fooNote = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes,
-            vault: vault1,
-            wsRoot,
-          }) as NoteProps;
+          const fooNote = (
+            await engine.findNotes({
+              fname: "foo",
+              vault: vault1,
+            })
+          )[0];
 
           const api = await getApiWithInitializedWS(wsRoot, vaults);
 
           renderFoo = async () => {
-            return await api.noteRender({
+            return api.noteRender({
               ws: wsRoot,
               id: fooNote.id,
             });
@@ -138,22 +136,21 @@ describe("api/note/render tests", () => {
       await runEngineTestV5(
         async ({ wsRoot: _wsRoot, vaults, engine }) => {
           wsRoot = _wsRoot;
-          const notes = engine.notes;
           const vault1 = vaults[0];
 
-          fooNote = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes,
-            vault: vault1,
-            wsRoot,
-          }) as NoteProps;
+          fooNote = (
+            await engine.findNotes({
+              fname: "foo",
+              vault: vault1,
+            })
+          )[0];
 
-          fooTwo = NoteUtils.getNoteByFnameV5({
-            fname: "foo.two",
-            notes,
-            vault: vault1,
-            wsRoot,
-          }) as NoteProps;
+          fooTwo = (
+            await engine.findNotes({
+              fname: "foo.two",
+              vault: vault1,
+            })
+          )[0];
 
           api = await getApiWithInitializedWS(wsRoot, vaults);
         },

--- a/packages/engine-test-utils/src/__tests__/common-all/nodev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/nodev2.spec.ts
@@ -4,9 +4,7 @@ import {
   SetupHookFunction,
 } from "@dendronhq/common-test-utils";
 import { tmpdir } from "os";
-import path from "path";
 import { runEngineTestV5 } from "../../engine";
-import { ENGINE_HOOKS } from "../../presets";
 
 const preSetupHook: SetupHookFunction = async ({ vaults, wsRoot }) => {
   await NoteTestUtilsV4.createNote({ fname: "foo", vault: vaults[0], wsRoot });
@@ -44,68 +42,6 @@ describe("NoteUtils", () => {
       expect(
         NoteUtils.match({ notePath: "foo.one", pattern: "foo.*" })
       ).toBeTruthy();
-    });
-  });
-
-  describe("getNoteByFnameV5", () => {
-    test("basic", async () => {
-      await runEngineTestV5(
-        async ({ vaults, engine, wsRoot }) => {
-          const fname = "foo";
-          const resp = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes: engine.notes,
-            vault: vaults[0],
-            wsRoot,
-          });
-          expect(resp).toEqual(engine.notes["foo"]);
-          return [];
-        },
-        {
-          expect,
-          preSetupHook: ENGINE_HOOKS.setupBasic,
-        }
-      );
-    });
-
-    test("full path on input", async () => {
-      await runEngineTestV5(
-        async ({ vaults, engine, wsRoot }) => {
-          const fname = "foo";
-          const resp = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes: engine.notes,
-            vault: { fsPath: path.join(wsRoot, vaults[0].fsPath) },
-            wsRoot,
-          });
-          expect(resp).toEqual(engine.notes["foo"]);
-          return [];
-        },
-        {
-          expect,
-          preSetupHook: ENGINE_HOOKS.setupBasic,
-        }
-      );
-    });
-
-    test("full path on node", async () => {
-      await runEngineTestV5(
-        async ({ vaults, engine, wsRoot }) => {
-          const fname = "foo";
-          const resp = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes: engine.notes,
-            vault: { fsPath: path.join(wsRoot, vaults[0].fsPath) },
-            wsRoot,
-          });
-          expect(resp).toEqual(engine.notes["foo"]);
-          return [];
-        },
-        {
-          expect,
-          preSetupHook: ENGINE_HOOKS.setupBasic,
-        }
-      );
     });
   });
 

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
@@ -1,4 +1,4 @@
-import { NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { VaultUtils } from "@dendronhq/common-all";
 import { ENGINE_HOOKS, ENGINE_HOOKS_MULTI } from "../../../presets";
 import {
   NoteCLICommand,
@@ -33,12 +33,12 @@ describe("WHEN run 'dendron note lookup'", () => {
             query: "gamma",
             output: NoteCLIOutput.JSON,
           });
-          const note = NoteUtils.getNoteOrThrow({
-            fname: "gamma",
-            vault,
-            notes: engine.notes,
-            wsRoot,
-          });
+          const note = (
+            await engine.findNotes({
+              fname: "gamma",
+              vault,
+            })
+          )[0];
           expect(note).toBeTruthy();
           expect(_.pick(note, ["title", "vault"])).toEqual({
             title: "Gamma",
@@ -127,12 +127,12 @@ describe("WHEN run 'dendron note lookup'", () => {
             output: NoteCLIOutput.JSON,
           });
           expect(
-            NoteUtils.getNoteOrThrow({
-              fname: "gamma",
-              vault,
-              notes: engine.notes,
-              wsRoot,
-            })
+            (
+              await engine.findNotes({
+                fname: "gamma",
+                vault,
+              })
+            )[0]
           ).toBeTruthy();
         },
         {
@@ -210,12 +210,12 @@ describe("WHEN run 'dendron note move'", () => {
             destFname: "moved-note",
           });
           expect(
-            NoteUtils.getNoteOrThrow({
-              fname: "moved-note",
-              vault,
-              notes: engine.notes,
-              wsRoot,
-            })
+            (
+              await engine.findNotes({
+                fname: "moved-note",
+                vault,
+              })
+            )[0]
           ).toBeTruthy();
         },
         {
@@ -241,12 +241,12 @@ describe("WHEN run 'dendron note move'", () => {
             destFname: "moved-note",
           });
           expect(
-            NoteUtils.getNoteOrThrow({
-              fname: "moved-note",
-              vault,
-              notes: engine.notes,
-              wsRoot,
-            })
+            (
+              await engine.findNotes({
+                fname: "moved-note",
+                vault,
+              })
+            )[0]
           ).toBeTruthy();
         },
         {
@@ -274,12 +274,12 @@ describe("WHEN run 'dendron note move'", () => {
             destVaultName: VaultUtils.getName(otherVault),
           });
           expect(
-            NoteUtils.getNoteOrThrow({
-              fname: "car",
-              vault: otherVault,
-              notes: engine.notes,
-              wsRoot,
-            })
+            (
+              await engine.findNotes({
+                fname: "car",
+                vault: otherVault,
+              })
+            )[0]
           ).toBeTruthy();
         },
         {

--- a/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
@@ -68,12 +68,12 @@ describe("GithubIssuePod import pod", () => {
           },
         });
 
-        const note = NoteUtils.getNoteOrThrow({
-          fname,
-          notes: engine.notes,
-          vault: vaults[0],
-          wsRoot,
-        });
+        const note = (
+          await engine.findNotes({
+            fname,
+            vault: vaults[0],
+          })
+        )[0];
         expect(note.custom.status).toEqual("OPEN");
         expect(note.custom.author).toEqual("https://github.com/xyzuser");
       },
@@ -107,12 +107,12 @@ describe("GithubIssuePod import pod", () => {
             fnameAsId: true,
           },
         });
-        const note = NoteUtils.getNoteOrThrow({
-          fname,
-          notes: engine.notes,
-          vault: vaults[0],
-          wsRoot,
-        });
+        const note = (
+          await engine.findNotes({
+            fname,
+            vault: vaults[0],
+          })
+        )[0];
         expect(note.id).toEqual(fname);
       },
       {
@@ -147,12 +147,12 @@ describe("GithubIssuePod import pod", () => {
             },
           },
         });
-        const note = NoteUtils.getNoteOrThrow({
-          fname,
-          notes: engine.notes,
-          vault: vaults[0],
-          wsRoot,
-        });
+        const note = (
+          await engine.findNotes({
+            fname,
+            vault: vaults[0],
+          })
+        )[0];
         expect(note.custom.type).toEqual("issue");
       },
       {

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/AirtableExportPodV2.spec.ts
@@ -145,7 +145,12 @@ const setupTestFactoryForNote = (opts: {
   return _setupTestFactoryCommon({
     ...opts,
     cb: async ({ engine, pod }) => {
-      const note = TestEngineUtils.getNoteByFname(engine, opts.fname);
+      const note = (
+        await engine.findNotes({
+          fname: opts.fname,
+          vault: engine.vaults[0],
+        })
+      )[0];
       return pod.exportNotes([note!]);
     },
   });

--- a/packages/engine-test-utils/src/__tests__/site.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/site.spec.ts
@@ -6,7 +6,6 @@ import {
   DVaultVisibility,
   NoteProps,
   NotePropsByIdDict,
-  NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import { tmpDir, vault2Path } from "@dendronhq/common-server";
@@ -380,12 +379,12 @@ describe("SiteUtils", () => {
             engine,
             config,
           });
-          const root = NoteUtils.getNoteByFnameV5({
-            fname: "root",
-            notes: engine.notes,
-            vault: vaults[0],
-            wsRoot: engine.wsRoot,
-          });
+          const root = (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[0],
+            })
+          )[0];
           expect(domains.length).toEqual(3);
           checkNotes({
             filteredNotes: notes,
@@ -721,17 +720,17 @@ describe("SiteUtils", () => {
 
     test("blacklist vault", async () => {
       await runEngineTestV5(
-        async ({ engine, vaults, wsRoot }) => {
+        async ({ engine, vaults }) => {
           const { notes, domains } = await SiteUtils.filterByConfig({
             engine,
             config: engine.config,
           });
-          const root = NoteUtils.getNoteByFnameV5({
-            fname: "root",
-            notes: engine.notes,
-            vault: vaults[0],
-            wsRoot,
-          });
+          const root = (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[0],
+            })
+          )[0];
           expect(domains.length).toEqual(2);
           checkNotes({
             filteredNotes: notes,

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -7,7 +7,6 @@ import {
   DVault,
   DWorkspace,
   IntermediateDendronConfig,
-  NoteUtils,
   WorkspaceFolderRaw,
   WorkspaceOpts,
   WorkspaceSettings,
@@ -386,14 +385,5 @@ export class TestEngineUtils {
   } & WorkspaceOpts) {
     const vault = vaults[0];
     return NoteTestUtilsV4.createNote({ wsRoot, vault, fname, body, custom });
-  }
-
-  /**
-   * Sugar for retrieving a note in the first vault
-   */
-  static getNoteByFname(engine: DEngineClient, fname: string) {
-    const { wsRoot, vaults, notes } = engine;
-    const vault = vaults[0];
-    return NoteUtils.getNoteByFnameV5({ fname, notes, vault, wsRoot });
   }
 }

--- a/packages/engine-test-utils/src/presets/engine-server/getByPath.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getByPath.ts
@@ -1,4 +1,3 @@
-import { NoteUtils } from "@dendronhq/common-all";
 import {
   TestPresetEntryV4,
   NOTE_PRESETS_V4,
@@ -9,21 +8,21 @@ const NOTES = {
   /**
    * Check that we can get both roots from both vaults
    */
-  ROOT: new TestPresetEntryV4(async ({ vaults, engine, wsRoot }) => {
+  ROOT: new TestPresetEntryV4(async ({ vaults, engine }) => {
     const vault = vaults[0];
     const vault2 = vaults[1];
-    const root = NoteUtils.getNoteByFnameV5({
-      fname: "root",
-      notes: engine.notes,
-      vault,
-      wsRoot,
-    });
-    const root2 = NoteUtils.getNoteByFnameV5({
-      fname: "root",
-      notes: engine.notes,
-      vault: vault2,
-      wsRoot,
-    });
+    const root = (
+      await engine.findNotes({
+        fname: "root",
+        vault,
+      })
+    )[0];
+    const root2 = (
+      await engine.findNotes({
+        fname: "root",
+        vault: vault2,
+      })
+    )[0];
     const { data } = await engine.getNoteByPath({ npath: "root", vault });
     const { data: data2 } = await engine.getNoteByPath({
       npath: "root",
@@ -47,12 +46,12 @@ const NOTES = {
   EXISTING_NOTE: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "foo",
-        notes: engine.notes,
-        vault,
-        wsRoot: engine.wsRoot,
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "foo",
+          vault,
+        })
+      )[0];
       const { data } = await engine.getNoteByPath({ npath: "foo", vault });
       return [
         {
@@ -75,12 +74,12 @@ const NOTES = {
   NOTE_WITH_CAPS_AND_SPACES: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "000 Index",
-        notes: engine.notes,
-        vault,
-        wsRoot: engine.wsRoot,
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "000 Index",
+          vault,
+        })
+      )[0];
       const { data } = await engine.getNoteByPath({
         npath: "000 Index",
         vault,

--- a/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/getNoteBlocks.ts
@@ -3,7 +3,6 @@ import {
   DVault,
   GetNoteBlocksPayload,
   NoteProps,
-  NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import {
@@ -17,7 +16,6 @@ const runGetNoteBlocks = async ({
   engine,
   vaults,
   note,
-  wsRoot,
   filterByAnchorType,
   cb,
 }: {
@@ -29,12 +27,12 @@ const runGetNoteBlocks = async ({
   cb: (opts: GetNoteBlocksPayload) => TestResult[];
 }) => {
   if (_.isUndefined(note))
-    note = NoteUtils.getNoteByFnameV5({
-      fname: "test",
-      notes: engine.notes,
-      vault: vaults[0],
-      wsRoot,
-    });
+    note = (
+      await engine.findNotes({
+        fname: "test",
+        vault: vaults[0],
+      })
+    )[0];
   const out = await engine.getNoteBlocks({
     id: note!.id,
     filterByAnchorType,

--- a/packages/engine-test-utils/src/presets/engine-server/init.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/init.ts
@@ -2,8 +2,6 @@ import {
   ConfigUtils,
   ERROR_SEVERITY,
   ERROR_STATUS,
-  NoteProps,
-  NoteUtils,
   Position,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
@@ -323,12 +321,12 @@ const NOTES = {
   ),
   LINKS: new TestPresetEntryV4(
     async ({ engine, vaults }) => {
-      const noteAlpha = NoteUtils.getNoteByFnameV5({
-        fname: "alpha",
-        notes: engine.notes,
-        vault: vaults[0],
-        wsRoot: engine.wsRoot,
-      }) as NoteProps;
+      const noteAlpha = (
+        await engine.findNotes({
+          fname: "alpha",
+          vault: vaults[0],
+        })
+      )[0];
       return [
         {
           actual: noteAlpha.links,
@@ -397,19 +395,19 @@ const NOTES = {
   ),
   DOMAIN_STUB: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
-      const noteRoot = NoteUtils.getNoteByFnameV5({
-        fname: "root",
-        notes: engine.notes,
-        vault: vaults[0],
-        wsRoot: engine.wsRoot,
-      }) as NoteProps;
+      const noteRoot = (
+        await engine.findNotes({
+          fname: "root",
+          vault: vaults[0],
+        })
+      )[0];
 
-      const noteChild = NoteUtils.getNoteByFnameV5({
-        wsRoot: engine.wsRoot,
-        fname: "foo",
-        notes: engine.notes,
-        vault: vaults[0],
-      }) as NoteProps;
+      const noteChild = (
+        await engine.findNotes({
+          fname: "foo",
+          vault: vaults[0],
+        })
+      )[0];
       const checkVault = await FileTestUtils.assertInVault({
         wsRoot,
         vault: vaults[0],
@@ -438,12 +436,12 @@ const NOTES = {
   ),
   NOTE_WITH_CUSTOM_ATT: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
-      const noteRoot = NoteUtils.getNoteByFnameV5({
-        fname: "foo",
-        notes: engine.notes,
-        vault: vaults[0],
-        wsRoot: engine.wsRoot,
-      }) as NoteProps;
+      const noteRoot = (
+        await engine.findNotes({
+          fname: "foo",
+          vault: vaults[0],
+        })
+      )[0];
 
       return [
         {

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -1,4 +1,4 @@
-import { DNodeUtils, NoteUtils, SchemaUtils } from "@dendronhq/common-all";
+import { DNodeUtils, SchemaUtils } from "@dendronhq/common-all";
 import {
   TestPresetEntryV4,
   SCHEMA_PRESETS_V4,
@@ -76,18 +76,17 @@ const NOTES = {
   EMPTY_QS: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const notes = engine.notes;
       const { data } = await engine.queryNotes({
         qs: "",
         originalQS: "",
         vault,
       });
-      const expectedNote = NoteUtils.getNoteByFnameV5({
-        wsRoot: engine.wsRoot,
-        fname: "root",
-        notes,
-        vault,
-      });
+      const expectedNote = (
+        await engine.findNotes({
+          fname: "root",
+          vault,
+        })
+      )[0];
       const matchNote = _.find(data, { id: expectedNote?.id });
       return [
         {
@@ -142,19 +141,18 @@ const NOTES = {
   DOMAIN_QUERY_WITH_SCHEMA: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const notes = engine.notes;
       const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
       const { data } = await engine.queryNotes({
         qs: fname,
         originalQS: fname,
         vault,
       });
-      const expectedNote = NoteUtils.getNoteByFnameV5({
-        fname,
-        notes,
-        vault,
-        wsRoot: engine.wsRoot,
-      });
+      const expectedNote = (
+        await engine.findNotes({
+          fname,
+          vault,
+        })
+      )[0];
       return [
         {
           actual: data[0],
@@ -176,19 +174,18 @@ const NOTES = {
   CHILD_QUERY_WITH_SCHEMA: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
       const vault = vaults[0];
-      const notes = engine.notes;
       const fname = NOTE_PRESETS_V4.NOTE_SIMPLE_CHILD.fname;
       const { data } = await engine.queryNotes({
         qs: fname,
         originalQS: fname,
         vault,
       });
-      const expectedNote = NoteUtils.getNoteByFnameV5({
-        fname,
-        notes,
-        vault,
-        wsRoot: engine.wsRoot,
-      });
+      const expectedNote = (
+        await engine.findNotes({
+          fname,
+          vault,
+        })
+      )[0];
       const matchNote = _.find(data, { id: expectedNote?.id });
       return [
         {

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -781,12 +781,12 @@ const NOTES = {
         match: ["gamma.md"],
         nomatch: [`${fnameOld}.md`],
       });
-      const changedNote = NoteUtils.getNoteByFnameV5({
-        fname: "root",
-        notes: engine.notes,
-        vault,
-        wsRoot: engine.wsRoot,
-      });
+      const changedNote = (
+        await engine.findNotes({
+          fname: "root",
+          vault,
+        })
+      )[0];
       return [
         {
           actual: changed.data?.length,
@@ -1181,12 +1181,12 @@ const NOTES = {
         },
         newLoc: { fname: "tags.bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         match: ["#bar"],
@@ -1226,12 +1226,12 @@ const NOTES = {
         },
         newLoc: { fname: "user.bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         match: ["@bar"],
@@ -1270,12 +1270,12 @@ const NOTES = {
         },
         newLoc: { fname: "tags.bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         match: ["tags: bar"],
@@ -1320,12 +1320,12 @@ const NOTES = {
         },
         newLoc: { fname: "tags.bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         match: ["bar"],
@@ -1370,12 +1370,12 @@ const NOTES = {
         },
         newLoc: { fname: "bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         nomatch: [
@@ -1424,12 +1424,12 @@ const NOTES = {
         },
         newLoc: { fname: "bar", vaultName: VaultUtils.getName(vaults[0]) },
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "primary",
-        notes: engine.notes,
-        wsRoot,
-        vault: vaults[0],
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "primary",
+          vault: vaults[0],
+        })
+      )[0];
       const containsTag = checkFileNoExpect({
         fpath: NoteUtils.getFullPath({ note: note!, wsRoot }),
         nomatch: ["foo", "bar", "undefined"],
@@ -1480,8 +1480,12 @@ const NOTES = {
   //     const vault = vaults[0];
   //     const notes = engine.notes;
   //     const alphaFname = NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname;
-  //     const noteOrig = NoteUtils.getNoteByFnameV5({fname: alphaFname, vault, notes});
-
+  //     const noteOrig = (
+  //      await engine.findNotes({
+  //        fname: "alphaFname",
+  //        vault,
+  //      })
+  //    )[0];
   //   let alphaNoteNew = NoteUtils.create({
   //     fname: "alpha",
   //     id: "alpha",

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -157,20 +157,20 @@ const NOTES = {
   }),
   CUSTOM_ATT_ADD: new TestPresetEntryV4(
     async ({ vaults, engine }) => {
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "foo",
-        notes: engine.notes,
-        vault: vaults[0],
-        wsRoot: engine.wsRoot,
-      }) as NoteProps;
+      const note = (
+        await engine.findNotes({
+          fname: "foo",
+          vault: vaults[0],
+        })
+      )[0];
       note.custom = { bond: 43 };
       await engine.writeNote(note, { updateExisting: true });
-      const newNote = NoteUtils.getNoteByFnameV5({
-        fname: "foo",
-        notes: engine.notes,
-        vault: vaults[0],
-        wsRoot: engine.wsRoot,
-      }) as NoteProps;
+      const newNote = (
+        await engine.findNotes({
+          fname: "foo",
+          vault: vaults[0],
+        })
+      )[0];
       return [
         {
           actual: newNote,
@@ -231,12 +231,12 @@ const NOTES = {
 
       return [
         {
-          actual: NoteUtils.getNoteByFnameV5({
-            fname: "foo.ch1",
-            notes: engine.notes,
-            vault,
-            wsRoot: engine.wsRoot,
-          })?.schema,
+          actual: (
+            await engine.findNotes({
+              fname: "foo.ch1",
+              vault,
+            })
+          )[0].schema,
           expected: {
             moduleId: "foo",
             schemaId: "ch1",
@@ -270,26 +270,25 @@ const NOTES = {
       noWrite: true,
     });
     await engine.writeNote(note);
-    const { notes } = engine;
     const vault = vaults[0];
-    const root = NoteUtils.getNoteByFnameV5({
-      fname: "root",
-      notes,
-      vault,
-      wsRoot: engine.wsRoot,
-    }) as NoteProps;
-    const bar = NoteUtils.getNoteByFnameV5({
-      fname: "bar",
-      notes,
-      vault,
-      wsRoot: engine.wsRoot,
-    }) as NoteProps;
-    const child = NoteUtils.getNoteByFnameV5({
-      fname: "bar.ch1",
-      notes,
-      vault,
-      wsRoot: engine.wsRoot,
-    }) as NoteProps;
+    const root = (
+      await engine.findNotes({
+        fname: "root",
+        vault,
+      })
+    )[0];
+    const bar = (
+      await engine.findNotes({
+        fname: "bar",
+        vault,
+      })
+    )[0];
+    const child = (
+      await engine.findNotes({
+        fname: "bar.ch1",
+        vault,
+      })
+    )[0];
     return [
       {
         actual: _.size(root.children),
@@ -413,30 +412,30 @@ const NOTES = {
       await engine.writeNote(noteC);
       return [
         {
-          actual: NoteUtils.getNoteByFnameV5({
-            fname: "Upper Upper",
-            notes: engine.notes,
-            vault,
-            wsRoot: engine.wsRoot,
-          })?.title,
+          actual: (
+            await engine.findNotes({
+              fname: "Upper Upper",
+              vault,
+            })
+          )[0].title,
           expected: "Upper Upper",
         },
         {
-          actual: NoteUtils.getNoteByFnameV5({
-            fname: "lower lower",
-            notes: engine.notes,
-            vault,
-            wsRoot: engine.wsRoot,
-          })?.title,
+          actual: (
+            await engine.findNotes({
+              fname: "lower lower",
+              vault,
+            })
+          )[0].title,
           expected: "Lower Lower",
         },
         {
-          actual: NoteUtils.getNoteByFnameV5({
-            fname: "lower Upper",
-            notes: engine.notes,
-            vault,
-            wsRoot: engine.wsRoot,
-          })?.title,
+          actual: (
+            await engine.findNotes({
+              fname: "lower Upper",
+              vault,
+            })
+          )[0].title,
           expected: "lower Upper",
         },
       ];
@@ -459,21 +458,21 @@ const NOTES = {
     await engine.writeNote(noteB);
     return [
       {
-        actual: NoteUtils.getNoteByFnameV5({
-          fname: "foo-with-dash",
-          notes: engine.notes,
-          vault,
-          wsRoot: engine.wsRoot,
-        })?.title,
+        actual: (
+          await engine.findNotes({
+            fname: "foo-with-dash",
+            vault,
+          })
+        )[0].title,
         expected: "Foo with Dash",
       },
       {
-        actual: NoteUtils.getNoteByFnameV5({
-          fname: "foo.foo-with-dash",
-          notes: engine.notes,
-          vault,
-          wsRoot: engine.wsRoot,
-        })?.title,
+        actual: (
+          await engine.findNotes({
+            fname: "foo.foo-with-dash",
+            vault,
+          })
+        )[0].title,
         expected: "Foo with Dash",
       },
     ];

--- a/packages/engine-test-utils/src/presets/pods-core/json.ts
+++ b/packages/engine-test-utils/src/presets/pods-core/json.ts
@@ -1,4 +1,4 @@
-import { DPod, DVault, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { DPod, DVault, VaultUtils } from "@dendronhq/common-all";
 import { tmpDir, vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
@@ -117,12 +117,12 @@ const IMPORT = {
         wsRoot,
         engine,
       });
-      const note = NoteUtils.getNoteByFnameV5({
-        fname: "baz",
-        vault,
-        notes: engine.notes,
-        wsRoot: engine.wsRoot,
-      });
+      const note = (
+        await engine.findNotes({
+          fname: "baz",
+          vault,
+        })
+      )[0];
 
       return [
         {

--- a/packages/plugin-core/src/commands/CopyNoteLink.ts
+++ b/packages/plugin-core/src/commands/CopyNoteLink.ts
@@ -215,11 +215,9 @@ export class CopyNoteLinkCommand
       // Do nothing as engine may still not be up-to-date
       return;
     } else {
-      const note = NoteUtils.getNoteByFnameFromEngine({
-        fname,
-        vault,
-        engine,
-      }) as NoteProps;
+      const note: NoteProps | undefined = (
+        await engine.findNotes({ fname, vault })
+      )[0];
       return this.executeCopyNoteLink(note, editor);
     }
   }
@@ -231,7 +229,10 @@ export class CopyNoteLinkCommand
     }
   }
 
-  private async executeCopyNoteLink(note: NoteProps, editor: TextEditor) {
+  private async executeCopyNoteLink(
+    note: NoteProps | undefined,
+    editor: TextEditor
+  ) {
     let link: string;
     let type;
     let anchor;

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -92,7 +92,7 @@ export class FileWatcher {
     // check if ignore
     const recentEvents = HistoryService.instance().lookBack();
     this.L.debug({ ctx, recentEvents, fname });
-    let note: NoteProps | undefined;
+    let note: NoteProps;
     if (
       _.find(recentEvents, (event) => {
         return _.every([
@@ -134,7 +134,7 @@ export class FileWatcher {
         fmChangeOnly: false,
         engine,
       });
-      await engine.updateNote(note as NoteProps, {
+      await engine.updateNote(note, {
         newNode: true,
       });
     } catch (err: any) {

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -41,15 +41,15 @@ suite("completionProvider", function () {
     },
     () => {
       test("THEN provide completions", async () => {
-        const { wsRoot, engine, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
         // Open a note, add [[]]
         await WSUtils.openNote(
-          NoteUtils.getNoteOrThrow({
-            fname: "root",
-            vault: vaults[1],
-            wsRoot,
-            notes: engine.notes,
-          })
+          (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0]
         );
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         await editor.edit((editBuilder) => {
@@ -125,15 +125,15 @@ suite("completionProvider", function () {
     },
     () => {
       test("THEN provide correct completion", async () => {
-        const { wsRoot, engine, vaults } = ExtensionProvider.getDWorkspace();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
         // Open a note, add [[]]
         await WSUtils.openNote(
-          NoteUtils.getNoteOrThrow({
-            fname: "root",
-            vault: vaults[1],
-            wsRoot,
-            notes: engine.notes,
-          })
+          (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0]
         );
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         await editor.edit((editBuilder) => {
@@ -178,15 +178,15 @@ suite("completionProvider", function () {
     },
     () => {
       test("THEN provide correct completions", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         // Open a note, add [[]]
         await WSUtils.openNote(
-          NoteUtils.getNoteOrThrow({
-            fname: "root",
-            vault: vaults[1],
-            wsRoot,
-            notes: engine.notes,
-          })
+          (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0]
         );
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         await editor.edit((editBuilder) => {
@@ -231,15 +231,15 @@ suite("completionProvider", function () {
     },
     () => {
       test("THEN provide correct completions", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         // Open a note, add [[]]
         await WSUtils.openNote(
-          NoteUtils.getNoteOrThrow({
-            fname: "root",
-            vault: vaults[1],
-            wsRoot,
-            notes: engine.notes,
-          })
+          (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0]
         );
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         await editor.edit((editBuilder) => {
@@ -271,14 +271,14 @@ suite("completionProvider", function () {
     () => {
       let items: CompletionItem[] | undefined;
       before(async () => {
-        const { vaults, wsRoot, engine } = getDWorkspace();
+        const { vaults, engine } = getDWorkspace();
         await WSUtils.openNote(
-          NoteUtils.getNoteOrThrow({
-            fname: "root",
-            vault: vaults[1],
-            wsRoot,
-            notes: engine.notes,
-          })
+          (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0]
         );
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         await editor.edit((editBuilder) => {
@@ -317,15 +317,15 @@ suite("completionProvider", function () {
       },
       () => {
         test("THEN doesn't provide outside wikilink", async () => {
-          const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           // Open a note, add [[]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "root",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "root",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {
@@ -362,15 +362,15 @@ suite("completionProvider", function () {
       },
       () => {
         test("THEN provide correct completions", async () => {
-          const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           // Open a note, add [[^]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "test",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "test",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {
@@ -412,15 +412,15 @@ suite("completionProvider", function () {
       },
       () => {
         test("THEN provide correct completions", async () => {
-          const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           // Open a note, add [[^]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "test",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "test",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {
@@ -440,15 +440,15 @@ suite("completionProvider", function () {
     // TODO: flaky
     test.skip("provides headers for other files", (done) => {
       runLegacyMultiWorkspaceTest({
-        onInit: async ({ wsRoot, vaults, engine }) => {
+        onInit: async ({ vaults, engine }) => {
           // Open a note, add [[test2#]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "test",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "test",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {
@@ -522,15 +522,15 @@ suite("completionProvider", function () {
       },
       () => {
         test("THEN provide correct completions", async () => {
-          const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           // Open a note, add [[test2#^]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "test",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "test",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {
@@ -591,15 +591,15 @@ suite("completionProvider", function () {
       },
       () => {
         test("THEN provide correct completions", async () => {
-          const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           // Open a note, add [[^]]
           await WSUtils.openNote(
-            NoteUtils.getNoteOrThrow({
-              fname: "test",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            })
+            (
+              await engine.findNotes({
+                fname: "test",
+                vault: vaults[0],
+              })
+            )[0]
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           await editor.edit((editBuilder) => {

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -124,7 +124,7 @@ suite("DoctorCommandTest", function () {
     },
     () => {
       test("THEN fix id", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         await WSUtils.openNote(note);
 
         const ext = ExtensionProvider.getExtension();
@@ -136,12 +136,7 @@ suite("DoctorCommandTest", function () {
           })
         );
         await cmd.run();
-        note = NoteUtils.getNoteByFnameV5({
-          wsRoot,
-          notes: engine.notes,
-          fname: "test",
-          vault: vaults[0],
-        })!;
+        note = (await engine.findNotes({ fname: "test", vault: vaults[0] }))[0];
         expect(note.id === "-bad-id").toBeFalsy();
       });
     }
@@ -483,14 +478,14 @@ suite("REGENERATE_NOTE_ID", function () {
     },
     () => {
       test("THEN fix file", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         const vault = vaults[0];
-        const oldNote = NoteUtils.getNoteOrThrow({
-          fname: "foo",
-          notes: engine.notes,
-          vault,
-          wsRoot,
-        });
+        const oldNote = (
+          await engine.findNotes({
+            fname: "foo",
+            vault,
+          })
+        )[0];
         const oldId = oldNote.id;
         await WSUtils.openNote(oldNote);
         const ext = ExtensionProvider.getExtension();
@@ -510,12 +505,7 @@ suite("REGENERATE_NOTE_ID", function () {
               Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
             );
           await cmd.run();
-          const note = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes: engine.notes,
-            vault,
-            wsRoot,
-          });
+          const note = (await engine.findNotes({ fname: "foo", vault }))[0];
           expect(note?.id).toNotEqual(oldId);
         } finally {
           gatherInputsStub.restore();
@@ -532,26 +522,26 @@ suite("REGENERATE_NOTE_ID", function () {
     },
     () => {
       test("THEN regenerate note id", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         const vault = vaults[0];
-        const oldRootId = NoteUtils.getNoteOrThrow({
-          fname: "root",
-          notes: engine.notes,
-          vault,
-          wsRoot,
-        }).id;
-        const oldFooId = NoteUtils.getNoteOrThrow({
-          fname: "foo",
-          notes: engine.notes,
-          vault,
-          wsRoot,
-        }).id;
-        const oldBarId = NoteUtils.getNoteOrThrow({
-          fname: "bar",
-          notes: engine.notes,
-          vault,
-          wsRoot,
-        }).id;
+        const oldRootId = (
+          await engine.findNotes({
+            fname: "root",
+            vault,
+          })
+        )[0].id;
+        const oldFooId = (
+          await engine.findNotes({
+            fname: "foo",
+            vault,
+          })
+        )[0].id;
+        const oldBarId = (
+          await engine.findNotes({
+            fname: "bar",
+            vault,
+          })
+        )[0].id;
 
         const ext = ExtensionProvider.getExtension();
         const cmd = new DoctorCommand(ext);
@@ -570,24 +560,9 @@ suite("REGENERATE_NOTE_ID", function () {
               Promise.resolve("proceed") as Thenable<vscode.QuickPickItem>
             );
           await cmd.run();
-          const root = NoteUtils.getNoteByFnameV5({
-            fname: "root",
-            notes: engine.notes,
-            vault,
-            wsRoot,
-          });
-          const foo = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes: engine.notes,
-            vault,
-            wsRoot,
-          });
-          const bar = NoteUtils.getNoteByFnameV5({
-            fname: "bar",
-            notes: engine.notes,
-            vault,
-            wsRoot,
-          });
+          const root = (await engine.findNotes({ fname: "root", vault }))[0];
+          const foo = (await engine.findNotes({ fname: "foo", vault }))[0];
+          const bar = (await engine.findNotes({ fname: "bar", vault }))[0];
           // Root should not change
           expect(root?.id).toEqual(oldRootId);
           expect(foo?.id).toNotEqual(oldFooId);

--- a/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
@@ -1,4 +1,3 @@
-import { NoteUtils } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import {
   ENGINE_HOOKS_MULTI,
@@ -43,12 +42,12 @@ suite("GIVEN FileWatcher", function () {
             const uri = vscode.Uri.file(notePath);
             await watcher.onDidCreate(uri.fsPath);
             const note = engine.notes["newbar"];
-            const root = NoteUtils.getNoteOrThrow({
-              fname: "root",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            });
+            const root = (
+              await engine.findNotes({
+                fname: "root",
+                vault: vaults[0],
+              })
+            )[0];
             expect(note.parent).toEqual(root.id);
             done();
           },
@@ -89,12 +88,12 @@ suite("GIVEN FileWatcher", function () {
             const uri = vscode.Uri.file(notePath);
             await watcher.onDidCreate(uri.fsPath);
             const note = engine.notes["newbar"];
-            const root = NoteUtils.getNoteOrThrow({
-              fname: "root",
-              vault: vaults[0],
-              wsRoot,
-              notes: engine.notes,
-            });
+            const root = (
+              await engine.findNotes({
+                fname: "root",
+                vault: vaults[0],
+              })
+            )[0];
             expect(note.parent).toEqual(root.id);
             done();
           },

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -1,4 +1,4 @@
-import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { NoteProps, VaultUtils } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
@@ -73,12 +73,7 @@ suite("GotoNote", function () {
         test("THEN get note", async () => {
           const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
-          const note = NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes: engine.notes,
-            vault,
-            wsRoot: getDWorkspace().wsRoot,
-          }) as NoteProps;
+          const note = (await engine.findNotes({ fname: "foo", vault }))[0];
           expect(_.pick(note, ["fname", "stub"])).toEqual({
             fname: "foo",
             stub: true,

--- a/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
@@ -1,4 +1,4 @@
-import { LookupNoteTypeEnum, NoteUtils } from "@dendronhq/common-all";
+import { LookupNoteTypeEnum } from "@dendronhq/common-all";
 import {
   NOTE_PRESETS_V4,
   runJestHarnessV2,
@@ -29,13 +29,8 @@ suite("Journal Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const notes = getDWorkspace().engine.notes;
-          const note = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes,
-            vault,
-            wsRoot: getDWorkspace().wsRoot,
-          });
+          const engine = getDWorkspace().engine;
+          const note = (await engine.findNotes({ fname, vault }))[0];
           await WSUtils.openNote(note!);
           await new NoteLookupCommand().run({
             noteType: LookupNoteTypeEnum.journal,
@@ -72,13 +67,8 @@ suite("Journal Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = "daily";
-          const notes = getDWorkspace().engine.notes;
-          const note = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes,
-            vault,
-            wsRoot: getDWorkspace().wsRoot,
-          });
+          const engine = getDWorkspace().engine;
+          const note = (await engine.findNotes({ fname, vault }))[0];
           await WSUtils.openNote(note!);
           await new NoteLookupCommand().run({
             noteType: LookupNoteTypeEnum.journal,

--- a/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
@@ -3,7 +3,6 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionTypeEnum,
   NoteAddBehaviorEnum,
-  NoteUtils,
 } from "@dendronhq/common-all";
 import { NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { describe } from "mocha";
@@ -11,11 +10,7 @@ import * as vscode from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
-import {
-  expect,
-  getNoteFromFname,
-  getNoteFromTextEditor,
-} from "../testUtilsv2";
+import { expect, getNoteFromTextEditor } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("Scratch Notes", function () {
@@ -34,13 +29,8 @@ suite("Scratch Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const notes = getDWorkspace().engine.notes;
-          const note = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes,
-            vault,
-            wsRoot: getDWorkspace().wsRoot,
-          });
+          const engine = getDWorkspace().engine;
+          const note = (await engine.findNotes({ fname, vault }))[0];
           const editor = await WSUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);
           editor.selection = SIMPLE_SELECTION;
@@ -73,11 +63,12 @@ suite("Scratch Notes", function () {
             wsRoot,
           });
         },
-        onInit: async ({ vaults }) => {
+        onInit: async ({ vaults, engine }) => {
           const vault = vaults[0];
           const { fname, selection } =
             NOTE_PRESETS_V4.NOTE_DOMAIN_NAMESPACE_CHILD;
-          const editor = await getNoteFromFname({ fname, vault });
+          const note = (await engine.findNotes({ fname, vault }))[0];
+          const editor = await WSUtils.openNote(note);
           editor.selection = new vscode.Selection(...selection);
           await new NoteLookupCommand().run({
             selectionType: LookupSelectionTypeEnum.selection2link,
@@ -105,13 +96,8 @@ suite("Scratch Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const notes = getDWorkspace().engine.notes;
-          const note = NoteUtils.getNoteByFnameV5({
-            fname,
-            notes,
-            vault,
-            wsRoot: getDWorkspace().wsRoot,
-          });
+          const engine = getDWorkspace().engine;
+          const note = (await engine.findNotes({ fname, vault }))[0];
           const editor = await WSUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);
           editor.selection = SIMPLE_SELECTION;
@@ -144,11 +130,12 @@ suite("Scratch Notes", function () {
             wsRoot,
           });
         },
-        onInit: async ({ vaults }) => {
+        onInit: async ({ vaults, engine }) => {
           const vault = vaults[1];
           const { fname, selection } =
             NOTE_PRESETS_V4.NOTE_DOMAIN_NAMESPACE_CHILD;
-          const editor = await getNoteFromFname({ fname, vault });
+          const note = (await engine.findNotes({ fname, vault }))[0];
+          const editor = await WSUtils.openNote(note);
           editor.selection = new vscode.Selection(...selection);
           await new NoteLookupCommand().run({
             selectionType: LookupSelectionTypeEnum.selection2link,

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -69,6 +69,15 @@ const createEngine = createEngineFactory({
     };
     return rename;
   },
+  findNotes: () => {
+    const findNotes: DendronEngineV2["findNotes"] = async ({
+      fname,
+      vault,
+    }) => {
+      return ExtensionProvider.getEngine().findNotes({ fname, vault });
+    };
+    return findNotes;
+  },
 });
 
 suite("MoveNoteCommand", function () {
@@ -184,7 +193,7 @@ suite("MoveNoteCommand", function () {
     },
     () => {
       test("THEN update hashtags correctly", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         await WSUtils.openNote(tagNote);
 
         const cmd = new MoveNoteCommand();
@@ -202,12 +211,9 @@ suite("MoveNoteCommand", function () {
             },
           ],
         });
-        const testNote = NoteUtils.getNoteByFnameV5({
-          fname: "test",
-          notes: engine.notes,
-          wsRoot,
-          vault: vaults[0],
-        })!;
+        const testNote = (
+          await engine.findNotes({ fname: "test", vault: vaults[0] })
+        )[0];
         expect(
           await AssertUtils.assertInString({
             body: testNote?.body,
@@ -237,7 +243,7 @@ suite("MoveNoteCommand", function () {
     },
     () => {
       test("THEN  turns links to hashtags", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         await WSUtils.openNote(tagNote);
 
         const cmd = new MoveNoteCommand();
@@ -255,12 +261,9 @@ suite("MoveNoteCommand", function () {
             },
           ],
         });
-        const testNote = NoteUtils.getNoteByFnameV5({
-          fname: "test",
-          notes: engine.notes,
-          wsRoot,
-          vault: vaults[0],
-        })!;
+        const testNote = (
+          await engine.findNotes({ fname: "test", vault: vaults[0] })
+        )[0];
         expect(
           await AssertUtils.assertInString({
             body: testNote?.body,
@@ -290,7 +293,7 @@ suite("MoveNoteCommand", function () {
     },
     () => {
       test("THEN turns hashtags into regular links", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         await WSUtils.openNote(tagNote);
 
         const cmd = new MoveNoteCommand();
@@ -308,12 +311,9 @@ suite("MoveNoteCommand", function () {
             },
           ],
         });
-        const testNote = NoteUtils.getNoteByFnameV5({
-          fname: "test",
-          notes: engine.notes,
-          wsRoot,
-          vault: vaults[0],
-        })!;
+        const testNote = (
+          await engine.findNotes({ fname: "test", vault: vaults[0] })
+        )[0];
         expect(
           await AssertUtils.assertInString({
             body: testNote?.body,
@@ -454,15 +454,11 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN do right thing", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const notes = engine.notes;
         const vault1 = vaults[0];
         const vault2 = vaults[1];
-        const fooNote = NoteUtils.getNoteByFnameV5({
-          fname: "foo",
-          notes,
-          vault: vault1,
-          wsRoot,
-        }) as NoteProps;
+        const fooNote = (
+          await engine.findNotes({ fname: "foo", vault: vault1 })
+        )[0];
         await WSUtils.openNote(fooNote);
         const cmd = new MoveNoteCommand();
         await cmd.execute({
@@ -513,12 +509,7 @@ suite("MoveNoteCommand", function () {
         expect(!_.isUndefined(vault2Foo)).toBeTruthy();
         expect(
           _.isUndefined(
-            NoteUtils.getNoteByFnameV5({
-              fname: "foo",
-              notes,
-              vault: vault2,
-              wsRoot,
-            })
+            (await engine.findNotes({ fname: "foo", vault: vault2 }))[0]
           )
         ).toBeFalsy();
       });
@@ -535,17 +526,13 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN do right thing", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const notes = engine.notes;
         const vault1 = vaults[0];
         const vault2 = vaults[1];
         const vault3 = vaults[2];
 
-        const fooNote = NoteUtils.getNoteByFnameV5({
-          fname: "foo",
-          notes,
-          vault: vault1,
-          wsRoot,
-        }) as NoteProps;
+        const fooNote = (
+          await engine.findNotes({ fname: "foo", vault: vault1 })
+        )[0];
 
         await WSUtils.openNote(fooNote);
         const cmd = new MoveNoteCommand();
@@ -598,12 +585,7 @@ suite("MoveNoteCommand", function () {
         expect(!_.isUndefined(vault1Foo) && vault1Foo.stub).toBeTruthy();
         expect(
           _.isUndefined(
-            NoteUtils.getNoteByFnameV5({
-              fname: "bar",
-              notes,
-              vault: vault2,
-              wsRoot,
-            })
+            (await engine.findNotes({ fname: "bar", vault: vault2 }))[0]
           )
         ).toBeTruthy();
 
@@ -617,20 +599,10 @@ suite("MoveNoteCommand", function () {
         ).toBeTruthy();
 
         expect(
-          NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes,
-            vault: vault3,
-            wsRoot,
-          })
+          (await engine.findNotes({ fname: "foo", vault: vault3 }))[0]
         ).toBeTruthy();
         expect(
-          NoteUtils.getNoteByFnameV5({
-            fname: "bar",
-            notes,
-            vault: vault3,
-            wsRoot,
-          })
+          (await engine.findNotes({ fname: "bar", vault: vault3 }))[0]
         ).toBeTruthy();
       });
     }
@@ -646,15 +618,11 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN do right thing", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const notes = engine.notes;
         const vault1 = vaults[0];
         const vault2 = vaults[1];
-        const fooNote = NoteUtils.getNoteByFnameV5({
-          fname: "foo",
-          notes,
-          vault: vault1,
-          wsRoot,
-        }) as NoteProps;
+        const fooNote = (
+          await engine.findNotes({ fname: "foo", vault: vault1 })
+        )[0];
 
         await WSUtils.openNote(fooNote);
         const cmd = new MoveNoteCommand();
@@ -702,21 +670,11 @@ suite("MoveNoteCommand", function () {
         ).toBeTruthy();
 
         expect(
-          NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes,
-            vault: vault1,
-            wsRoot,
-          })?.stub
+          (await engine.findNotes({ fname: "foo", vault: vault1 }))[0].stub
         ).toBeTruthy();
         expect(
           _.isUndefined(
-            NoteUtils.getNoteByFnameV5({
-              fname: "foo.ch1",
-              notes,
-              vault: vault1,
-              wsRoot,
-            })
+            (await engine.findNotes({ fname: "foo.ch1", vault: vault1 }))[0]
           )
         ).toBeTruthy();
 
@@ -729,20 +687,10 @@ suite("MoveNoteCommand", function () {
         ).toBeTruthy();
 
         expect(
-          NoteUtils.getNoteByFnameV5({
-            fname: "foo",
-            notes,
-            vault: vault2,
-            wsRoot,
-          })
+          (await engine.findNotes({ fname: "foo", vault: vault2 }))[0]
         ).toBeTruthy();
         expect(
-          NoteUtils.getNoteByFnameV5({
-            fname: "foo.ch1",
-            notes,
-            vault: vault2,
-            wsRoot,
-          })
+          (await engine.findNotes({ fname: "foo.ch1", vault: vault2 }))[0]
         ).toBeTruthy();
       });
     }
@@ -766,15 +714,11 @@ suite("MoveNoteCommand", function () {
     },
     () => {
       test("THEN do right thing", async () => {
-        const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const notes = engine.notes;
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         const vault1 = vaults[0];
-        const fooNote = NoteUtils.getNoteByFnameV5({
-          fname: "foo",
-          notes,
-          vault: vault1,
-          wsRoot,
-        }) as NoteProps;
+        const fooNote = (
+          await engine.findNotes({ fname: "foo", vault: vault1 })
+        )[0];
 
         await WSUtils.openNote(fooNote);
         const lc =

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -725,7 +725,7 @@ suite("NoteLookupCommand", function () {
       },
       () => {
         test("THEN a note is created and stub property is removed", async () => {
-          const { vaults, engine, wsRoot } = ExtensionProvider.getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const cmd = new NoteLookupCommand();
           const vault = TestEngineUtils.vault1(vaults);
           stubVaultPick(vaults);
@@ -734,12 +734,12 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo",
           }))!;
           expect(_.first(opts.quickpick.selectedItems)?.fname).toEqual("foo");
-          const fooNote = NoteUtils.getNoteOrThrow({
-            fname: "foo",
-            notes: engine.notes,
-            vault,
-            wsRoot,
-          });
+          const fooNote = (
+            await engine.findNotes({
+              fname: "foo",
+              vault,
+            })
+          )[0];
           expect(fooNote.stub).toBeFalsy();
         });
       }
@@ -2361,7 +2361,7 @@ suite("NoteLookupCommand", function () {
           preSetupHook: async ({ wsRoot, vaults }) => {
             await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           },
-          onInit: async ({ wsRoot, vaults, engine }) => {
+          onInit: async ({ vaults, engine }) => {
             const { selectedText, cmd } = await prepareCommandFunc({
               vaults,
               engine,
@@ -2370,12 +2370,12 @@ suite("NoteLookupCommand", function () {
 
             const dateFormat = ConfigUtils.getJournal(engine.config).dateFormat;
             const today = Time.now().toFormat(dateFormat);
-            const newNote = NoteUtils.getNoteOrThrow({
-              fname: `foo.journal.${today}`,
-              notes: engine.notes,
-              vault: vaults[0],
-              wsRoot,
-            });
+            const newNote = (
+              await engine.findNotes({
+                fname: `foo.journal.${today}`,
+                vault: vaults[0],
+              })
+            )[0];
 
             expect(newNote.body.trim()).toEqual(selectedText);
 
@@ -2391,19 +2391,19 @@ suite("NoteLookupCommand", function () {
           preSetupHook: async ({ wsRoot, vaults }) => {
             await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
           },
-          onInit: async ({ wsRoot, vaults, engine }) => {
+          onInit: async ({ vaults, engine }) => {
             const { cmdOut, selectedText, cmd } = await prepareCommandFunc({
               vaults,
               engine,
               noteType: LookupNoteTypeEnum.scratch,
             });
 
-            const newNote = NoteUtils.getNoteOrThrow({
-              fname: cmdOut!.quickpick.value,
-              notes: engine.notes,
-              vault: vaults[0],
-              wsRoot,
-            });
+            const newNote = (
+              await engine.findNotes({
+                fname: cmdOut!.quickpick.value,
+                vault: vaults[0],
+              })
+            )[0];
             expect(newNote.body.trim()).toEqual(selectedText);
 
             cmd.cleanUp();

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -12,7 +12,7 @@ import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import sinon from "sinon";
 import { getEngine } from "../../workspace";
-import { DNodeProps, DVault, NoteUtils } from "@dendronhq/common-all";
+import { DNodeProps, DVault } from "@dendronhq/common-all";
 import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
 
 suite("RefactorHierarchy", function () {
@@ -115,12 +115,9 @@ suite("RefactorHierarchy", function () {
               })
             ).toBeTruthy();
 
-            const noteAfterRefactor = NoteUtils.getNoteByFnameV5({
-              fname: "prefix",
-              notes: engine.notes,
-              vault,
-              wsRoot,
-            });
+            const noteAfterRefactor = (
+              await engine.findNotes({ fname: "prefix", vault })
+            )[0];
             expect(noteAfterRefactor?.body).toEqual(
               "- [[prefix.one]]\n- [[prefix.two]]\n"
             );
@@ -168,22 +165,16 @@ suite("RefactorHierarchy", function () {
               })
             ).toBeTruthy();
 
-            const noteAfterRefactor = NoteUtils.getNoteByFnameV5({
-              fname: "refactor",
-              notes: engine.notes,
-              vault,
-              wsRoot,
-            });
+            const noteAfterRefactor = (
+              await engine.findNotes({ fname: "refactor", vault })
+            )[0];
             expect(noteAfterRefactor?.body).toEqual(
               "- [[refactor.one]]\n- [[prefix.two]]\n"
             );
 
-            const noteOneAfterRefactor = NoteUtils.getNoteByFnameV5({
-              fname: "refactor.one",
-              notes: engine.notes,
-              vault,
-              wsRoot,
-            });
+            const noteOneAfterRefactor = (
+              await engine.findNotes({ fname: "refactor.one", vault })
+            )[0];
             expect(noteOneAfterRefactor?.body).toEqual("- [[prefix.two]]\n");
             done();
           },

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -1,4 +1,4 @@
-import { NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { NoteProps } from "@dendronhq/common-all";
 import { note2String } from "@dendronhq/common-server";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { beforeEach, afterEach, describe } from "mocha";
@@ -115,7 +115,7 @@ suite("RenameNote", function () {
             body: "[[has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -125,12 +125,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -138,12 +135,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -177,7 +171,7 @@ suite("RenameNote", function () {
             body: "[[Lorem ipsum dolor amet|has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -187,12 +181,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -200,12 +191,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -242,7 +230,7 @@ suite("RenameNote", function () {
             body: "[[has-header#maxime-distinctio-officia]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -252,12 +240,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -265,12 +250,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -312,12 +294,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             await checkFile({
               note: afterRename!,
               wsRoot,
@@ -356,7 +335,7 @@ suite("RenameNote", function () {
             body: "[[has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -366,12 +345,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -379,12 +355,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -418,7 +391,7 @@ suite("RenameNote", function () {
             body: "[[has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -428,12 +401,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -441,12 +411,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -480,7 +447,7 @@ suite("RenameNote", function () {
             body: "[[has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -490,12 +457,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -503,12 +467,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -542,7 +503,7 @@ suite("RenameNote", function () {
             body: "![[has-header#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -552,12 +513,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -565,12 +523,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -610,7 +565,7 @@ suite("RenameNote", function () {
             body: "![[has-header#lorem-ipsum-dolor-amet:#end]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -620,12 +575,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -633,12 +585,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -681,7 +630,7 @@ suite("RenameNote", function () {
             body: "![[has-header#start:#lorem-ipsum-dolor-amet]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
             line: 11,
@@ -693,12 +642,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -706,12 +652,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,
@@ -757,7 +700,7 @@ suite("RenameNote", function () {
             body: "![[has-header#maxime-distinctio-officia:#end]]",
           });
         },
-        onInit: async ({ engine, vaults, wsRoot }) => {
+        onInit: async ({ engine, vaults }) => {
           const editor = await WSUtils.openNote(note);
           editor.selection = LocationTestUtils.getPresetWikiLinkSelection();
 
@@ -767,12 +710,9 @@ suite("RenameNote", function () {
           try {
             await new RenameHeaderCommand().run({});
 
-            const afterRename = NoteUtils.getNoteByFnameV5({
-              fname: "has-header",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRename = (
+              await engine.findNotes({ fname: "has-header", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRename!.body,
@@ -780,12 +720,9 @@ suite("RenameNote", function () {
                 nomatch: ["Lorem", "ipsum", "dolor", "amet"],
               })
             ).toBeTruthy();
-            const afterRenameLink = NoteUtils.getNoteByFnameV5({
-              fname: "has-link",
-              wsRoot,
-              vault: vaults[0],
-              notes: engine.notes,
-            });
+            const afterRenameLink = (
+              await engine.findNotes({ fname: "has-link", vault: vaults[0] })
+            )[0];
             expect(
               await AssertUtils.assertInString({
                 body: afterRenameLink!.body,

--- a/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
@@ -1,4 +1,4 @@
-import { NoteChangeEntry, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { NoteChangeEntry, NoteProps } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
 import { before, beforeEach, describe } from "mocha";
@@ -100,14 +100,10 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const active = NoteUtils.getNoteByFnameV5({
-            fname: "active",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const active = (
+            await engine.findNotes({ fname: "active", vault: vaults[0] })
+          )[0];
           const expectedBody = [
             "[[new-target]]",
             "[[New Target|new-target]]",
@@ -118,40 +114,33 @@ suite("RenameProvider", function () {
           expect(active?.body).toEqual(expectedBody);
         });
 
-        test("AND target note is correctly renamed", (done) => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const newTarget = NoteUtils.getNoteByFnameV5({
-            fname: "new-target",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+        test("AND target note is correctly renamed", async () => {
+          const { vaults, engine } = getDWorkspace();
+          const newTarget = (
+            await engine.findNotes({ fname: "new-target", vault: vaults[0] })
+          )[0];
           expect(newTarget).toBeTruthy();
-          done();
         });
-        test("THEN references to target note is correctly updated", (done) => {
+        test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(7);
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const noteWithLink = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
-          const noteWithLinkInAnotherVault = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link-in-another-vault",
-            vault: vaults[1],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const noteWithLink = (
+            await engine.findNotes({
+              fname: "note-with-link",
+              vault: vaults[0],
+            })
+          )[0];
+          const noteWithLinkInAnotherVault = (
+            await engine.findNotes({
+              fname: "note-with-link-in-another-vault",
+              vault: vaults[1],
+            })
+          )[0];
 
           expect(noteWithLink?.body).toEqual("[[new-target]]\n");
           expect(noteWithLinkInAnotherVault?.body).toEqual(
             "[[dendron://vault1/new-target]]\n"
           );
-          done();
         });
       });
     }
@@ -236,14 +225,13 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const active = NoteUtils.getNoteByFnameV5({
-            fname: "active",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const active = (
+            await engine.findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
           const expectedBody = [
             "![[new-target]]",
             "![[dendron://vault1/new-target]]",
@@ -253,40 +241,35 @@ suite("RenameProvider", function () {
           expect(active?.body).toEqual(expectedBody);
         });
 
-        test("AND target note is correctly renamed", (done) => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const newTarget = NoteUtils.getNoteByFnameV5({
-            fname: "new-target",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+        test("AND target note is correctly renamed", async () => {
+          const { vaults, engine } = getDWorkspace();
+          const newTarget = (
+            await engine.findNotes({
+              fname: "new-target",
+              vault: vaults[0],
+            })
+          )[0];
           expect(newTarget).toBeTruthy();
-          done();
         });
-        test("THEN references to target note is correctly updated", (done) => {
+        test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(7);
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const noteWithLink = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
-          const noteWithLinkInAnotherVault = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link-in-another-vault",
-            vault: vaults[1],
-            notes,
-            wsRoot,
-          });
-
+          const { vaults, engine } = getDWorkspace();
+          const noteWithLink = (
+            await engine.findNotes({
+              fname: "note-with-link",
+              vault: vaults[0],
+            })
+          )[0];
+          const noteWithLinkInAnotherVault = (
+            await engine.findNotes({
+              fname: "note-with-link-in-another-vault",
+              vault: vaults[1],
+            })
+          )[0];
           expect(noteWithLink?.body).toEqual("![[new-target]]\n");
           expect(noteWithLinkInAnotherVault?.body).toEqual(
             "![[dendron://vault1/new-target]]\n"
           );
-          done();
         });
       });
     }
@@ -345,43 +328,38 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const active = NoteUtils.getNoteByFnameV5({
-            fname: "active",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const active = (
+            await engine.findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
           const expectedBody = "#new-target\n";
           expect(active?.body).toEqual(expectedBody);
         });
 
-        test("AND target note is correctly renamed", (done) => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const newTarget = NoteUtils.getNoteByFnameV5({
-            fname: "tags.new-target",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+        test("AND target note is correctly renamed", async () => {
+          const { vaults, engine } = getDWorkspace();
+          const newTarget = (
+            await engine.findNotes({
+              fname: "tags.new-target",
+              vault: vaults[0],
+            })
+          )[0];
           expect(newTarget).toBeTruthy();
-          done();
         });
-        test("THEN references to target note is correctly updated", (done) => {
+        test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(8);
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const noteWithLink = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const noteWithLink = (
+            await engine.findNotes({
+              fname: "note-with-link",
+              vault: vaults[0],
+            })
+          )[0];
 
           expect(noteWithLink?.body).toEqual("#new-target\n");
-          done();
         });
       });
     }
@@ -437,43 +415,37 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const active = NoteUtils.getNoteByFnameV5({
-            fname: "active",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const active = (
+            await engine.findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
           expect(active?.tags).toEqual("new-target");
         });
 
-        test("AND target note is correctly renamed", (done) => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const newTarget = NoteUtils.getNoteByFnameV5({
-            fname: "tags.new-target",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+        test("AND target note is correctly renamed", async () => {
+          const { vaults, engine } = getDWorkspace();
+          const newTarget = (
+            await engine.findNotes({
+              fname: "tags.new-target",
+              vault: vaults[0],
+            })
+          )[0];
           expect(newTarget).toBeTruthy();
-          done();
         });
-        test("THEN references to target note is correctly updated", (done) => {
+        test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(8);
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const noteWithLink = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const noteWithLink = (
+            await engine.findNotes({
+              fname: "note-with-link",
+              vault: vaults[0],
+            })
+          )[0];
 
           expect(noteWithLink?.tags).toEqual("new-target");
-
-          done();
         });
       });
     }
@@ -532,43 +504,38 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const active = NoteUtils.getNoteByFnameV5({
-            fname: "active",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const active = (
+            await engine.findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
           const expectedBody = "@new-target\n";
           expect(active?.body).toEqual(expectedBody);
         });
 
-        test("AND target note is correctly renamed", (done) => {
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const newTarget = NoteUtils.getNoteByFnameV5({
-            fname: "user.new-target",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+        test("AND target note is correctly renamed", async () => {
+          const { vaults, engine } = getDWorkspace();
+          const newTarget = (
+            await engine.findNotes({
+              fname: "user.new-target",
+              vault: vaults[0],
+            })
+          )[0];
           expect(newTarget).toBeTruthy();
-          done();
         });
-        test("THEN references to target note is correctly updated", (done) => {
+        test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(8);
-          const { vaults, engine, wsRoot } = getDWorkspace();
-          const { notes } = engine;
-          const noteWithLink = NoteUtils.getNoteByFnameV5({
-            fname: "note-with-link",
-            vault: vaults[0],
-            notes,
-            wsRoot,
-          });
+          const { vaults, engine } = getDWorkspace();
+          const noteWithLink = (
+            await engine.findNotes({
+              fname: "note-with-link",
+              vault: vaults[0],
+            })
+          )[0];
 
           expect(noteWithLink?.body).toEqual("@new-target\n");
-          done();
         });
       });
     }

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -1,4 +1,4 @@
-import { ConfigUtils, NoteUtils, WorkspaceOpts } from "@dendronhq/common-all";
+import { ConfigUtils, WorkspaceOpts } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { describe } from "mocha";
 import path from "path";
@@ -159,7 +159,7 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
     test("does when opening new note", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        onInit: async ({ vaults, wsRoot, engine }) => {
+        onInit: async ({ vaults, engine }) => {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
           const previewProxy = new MockPreviewProxy();
@@ -180,12 +180,12 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           watcher!.activate();
           // Open a note
           await WSUtils.openNote(
-            NoteUtils.getNoteByFnameV5({
-              vault: vaults[0],
-              notes: engine.notes,
-              wsRoot,
-              fname: "root",
-            })!
+            (
+              await engine.findNotes({
+                fname: "root",
+                vault: vaults[0],
+              })
+            )[0]
           );
           // The selection should have been moved to after the frontmatter
           checkPosition(7);
@@ -197,7 +197,7 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
     test("does not when switching between open notes", (done) => {
       runLegacyMultiWorkspaceTest({
         ctx,
-        onInit: async ({ vaults, wsRoot, engine }) => {
+        onInit: async ({ vaults, engine }) => {
           // Try to make sure we're opening this for the first time
           await VSCodeUtils.closeAllEditors();
 
@@ -219,12 +219,12 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
 
           watcher!.activate();
           // Open a note
-          const first = NoteUtils.getNoteByFnameV5({
-            vault: vaults[0],
-            notes: engine.notes,
-            wsRoot,
-            fname: "root",
-          })!;
+          const first = (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[0],
+            })
+          )[0];
           await WSUtils.openNote(first);
           checkPosition(7);
           // Move the selection so it's not where it has been auto-moved
@@ -235,12 +235,12 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           );
           checkPosition(3);
           // Switch to another note
-          const second = NoteUtils.getNoteByFnameV5({
-            vault: vaults[1],
-            notes: engine.notes,
-            wsRoot,
-            fname: "root",
-          })!;
+          const second = (
+            await engine.findNotes({
+              fname: "root",
+              vault: vaults[1],
+            })
+          )[0];
           await WSUtils.openNote(second);
           checkPosition(7);
           // Switch back to first note again

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -201,7 +201,6 @@ suite("WorkspaceWatcher", function () {
               vault: vaults[0],
             })
           )[0];
-
           expect(newFile.title).toEqual(`Newfile`);
         }
       });

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -1,4 +1,4 @@
-import { assert, DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { assert, DVault, NoteProps } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import {
   NoteTestUtilsV4,
@@ -199,19 +199,19 @@ suite("BaseExportPodCommand", function () {
             ExtensionProvider.getExtension()
           );
           const engine = ExtensionProvider.getEngine();
-          const { wsRoot, vaults } = engine;
-          const testNote1 = NoteUtils.getNoteByFnameV5({
-            fname: "test-note-for-pod1",
-            notes: engine.notes,
-            wsRoot,
-            vault: vaults[0],
-          }) as NoteProps;
-          const testNote2 = NoteUtils.getNoteByFnameV5({
-            fname: "test-note-for-pod2",
-            notes: engine.notes,
-            wsRoot,
-            vault: vaults[0],
-          }) as NoteProps;
+          const { vaults } = engine;
+          const testNote1 = (
+            await engine.findNotes({
+              fname: "test-note-for-pod1",
+              vault: vaults[0],
+            })
+          )[0];
+          const testNote2 = (
+            await engine.findNotes({
+              fname: "test-note-for-pod2",
+              vault: vaults[0],
+            })
+          )[0];
           const selectedItems = [
             { ...testNote1, label: "" },
             { ...testNote2, label: "" },

--- a/packages/plugin-core/src/test/suite-integ/components/traits/CreateNoteWithTraitCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/CreateNoteWithTraitCommand.test.ts
@@ -1,4 +1,3 @@
-import { NoteUtils } from "@dendronhq/common-all";
 import { afterEach, beforeEach, describe } from "mocha";
 import path from "path";
 import { CreateNoteWithTraitCommand } from "../../../../commands/CreateNoteWithTraitCommand";
@@ -44,12 +43,12 @@ suite("CreateNoteWithTraitCommand tests", () => {
           expectedFName
         );
 
-        const props = NoteUtils.getNoteByFnameV5({
-          fname: "test",
-          notes: engine.notes,
-          vault: vaults[0],
-          wsRoot,
-        });
+        const props = (
+          await engine.findNotes({
+            fname: "test",
+            vault: vaults[0],
+          })
+        )[0];
 
         expect(props?.title).toEqual(testTrait.TEST_TITLE_MODIFIER);
       });

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -2,7 +2,6 @@ import {
   DNodeUtils,
   DVault,
   NoteProps,
-  NoteUtils,
   VaultUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
@@ -25,8 +24,8 @@ import {
 import { SetupWorkspaceOpts } from "../commands/SetupWorkspace";
 import { CONFIG } from "../constants";
 import { DendronExtension, getDWorkspace } from "../workspace";
-import { WSUtils } from "../WSUtils";
 import { createMockConfig } from "./testUtils";
+import { _activate } from "../_extension";
 
 export type SetupCodeConfigurationV2 = {
   configOverride?: { [key: string]: any };
@@ -120,15 +119,6 @@ export async function resetCodeWorkspace() {
   }
 }
 
-export const getNoteFromFname = (opts: { fname: string; vault: DVault }) => {
-  const notes = getDWorkspace().engine.notes;
-  const note = NoteUtils.getNoteByFnameV5({
-    ...opts,
-    notes,
-    wsRoot: getDWorkspace().wsRoot,
-  });
-  return WSUtils.openNote(note!);
-};
 export const getNoteFromTextEditor = (): NoteProps => {
   const txtPath = window.activeTextEditor?.document.uri.fsPath as string;
   const vault = { fsPath: path.dirname(txtPath) };

--- a/packages/pods-core/src/builtin/GraphvizPod.ts
+++ b/packages/pods-core/src/builtin/GraphvizPod.ts
@@ -1,6 +1,11 @@
 import fs from "fs-extra";
 import _ from "lodash";
-import { DLink, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import {
+  DLink,
+  NoteDictsUtils,
+  NoteFnameDictUtils,
+  NoteProps,
+} from "@dendronhq/common-all";
 import path from "path";
 import { ExportPod, ExportPodPlantOpts, ExportPodConfig } from "../basev3";
 import { JSONSchemaType } from "ajv";
@@ -64,7 +69,6 @@ export class GraphvizExportPod extends ExportPod<GraphvizExportConfig> {
       notes,
       connections,
       parentDictionary,
-      wsRoot,
       showGraphByHierarchy,
       showGraphByEdges,
     } = opts;
@@ -92,16 +96,19 @@ export class GraphvizExportPod extends ExportPod<GraphvizExportConfig> {
       (child: string) => (parentDictionary[child] = note.id)
     );
 
+    const notesById = NoteDictsUtils.createNotePropsByIdDict(notes);
+    const notesByFname =
+      NoteFnameDictUtils.createNotePropsByFnameDict(notesById);
     // Note -> Linked Notes connections
     if (showGraphByEdges) {
       note.links.forEach((link: DLink) => {
         if (link.to) {
-          const destinationNote = NoteUtils.getNoteByFnameV5({
-            fname: link.to!.fname as string,
-            vault: note.vault,
-            notes: notes,
-            wsRoot,
-          });
+          const destinationNote: NoteProps | undefined =
+            NoteDictsUtils.findByFname(
+              link.to!.fname as string,
+              { notesById, notesByFname },
+              note.vault
+            )[0];
 
           if (!_.isUndefined(destinationNote)) {
             if (

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -557,7 +557,7 @@ export class MarkdownPublishPod extends PublishPod<MarkdownPublishPodConfig> {
     } else {
       remark = remark.use(RemarkUtils.convertLinksFromDotNotation(note, []));
     }
-    const out = remark.processSync(note.body).toString();
+    const out = (await remark.process(note.body)).toString();
     return _.trim(out);
   }
 }

--- a/packages/pods-core/src/builtin/OrbitPod.ts
+++ b/packages/pods-core/src/builtin/OrbitPod.ts
@@ -2,10 +2,10 @@ import { ImportPod, ImportPodConfig, ImportPodPlantOpts } from "../basev3";
 import { JSONSchemaType } from "ajv";
 import { ConflictHandler, PodUtils } from "../utils";
 import {
+  cleanName,
   Conflict,
   DendronError,
   DEngineClient,
-  DNodeUtils,
   DVault,
   ERROR_SEVERITY,
   MergeConflictOptions,
@@ -159,7 +159,7 @@ export class OrbitImportPod extends ImportPod<OrbitImportPodConfig> {
       } else {
         let noteName =
           name || github || discord || twitter || this.getNameFromEmail(email);
-        noteName = DNodeUtils.cleanFname(noteName);
+        noteName = cleanName(noteName);
         this.L.debug({ ctx: "membersToNotes", msg: "enter", member });
         let fname;
         const note = NoteUtils.getNoteByFnameFromEngine({

--- a/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
@@ -63,7 +63,7 @@ export class MarkdownExportPodV2
     const { destination, exportScope } = this._config;
 
     if (destination === "clipboard") {
-      const exportedNotes = this.renderNote(input[0]);
+      const exportedNotes = await this.renderNote(input[0]);
       return ResponseUtil.createHappyResponse({
         data: {
           exportedNotes,
@@ -84,7 +84,7 @@ export class MarkdownExportPodV2
     const result = await Promise.all(
       input.map(async (note) => {
         try {
-          const body = this.renderNote(note);
+          const body = await this.renderNote(note);
           const hpath = this.dot2Slash(note.fname) + ".md";
           const vname = VaultUtils.getName(note.vault);
           const fpath = path.join(destination, vname, hpath);
@@ -152,7 +152,7 @@ export class MarkdownExportPodV2
     }
   }
 
-  renderNote(input: NoteProps) {
+  async renderNote(input: NoteProps) {
     const {
       convertTagNotesToLinks = false,
       convertUserNotesToLinks = false,
@@ -192,7 +192,7 @@ export class MarkdownExportPodV2
     } else {
       remark = remark.use(RemarkUtils.convertLinksFromDotNotation(input, []));
     }
-    const out = remark.processSync(input.body).toString();
+    const out = (await remark.process(input.body)).toString();
     return _.trim(out);
   }
 


### PR DESCRIPTION
Some cleanup on NoteUtil side

**Changes**
1. Removed unused methods
2. Migrated and removed uses of deprecated `getNoteByFnameV5`
3. Migrated and removed uses of deprecated `getNoteOrThrow `
4. Removed redundant `getNoteFromMultiVault` 
5. Replaced `this[notes]... as NoteProps` with undefined checks + error handling