### PR TITLE
chore: make lookup control appear faster

### DIFF
--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -208,20 +208,27 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     // initial call of update
     if (!nonInteractive) {
       // Show the quickpick first before getting item data to ensure we don't
-      // miss user key strokes
+      // miss user key strokes. Furthermore, set a small delay prior to updating
+      // the picker items, which is an expensive call. The VSCode API
+      // QuickPick.show() seems to be a non-awaitable async operation, which
+      // sometimes will get 'stuck' behind provider.onUpdatePickerItems in the
+      // execution queue. Adding a small delay appears to fix the ordering
+      // issue.
       quickpick.show();
 
-      provider.onUpdatePickerItems({
-        picker: quickpick,
-        token: cancelToken.token,
-        fuzzThreshold: this.fuzzThreshold,
-      });
+      setTimeout(() => {
+        provider.onUpdatePickerItems({
+          picker: quickpick,
+          token: cancelToken.token,
+          fuzzThreshold: this.fuzzThreshold,
+        });
 
-      provider.provide({
-        quickpick,
-        token: cancelToken,
-        fuzzThreshold: this.fuzzThreshold,
-      });
+        provider.provide({
+          quickpick,
+          token: cancelToken,
+          fuzzThreshold: this.fuzzThreshold,
+        });
+      }, 10);
     } else {
       await provider.onUpdatePickerItems({
         picker: quickpick,


### PR DESCRIPTION
## chore: make lookup control appear faster

There's a lag between hitting Ctrl+L and the lookup quick pick showing up when you have a lot of notes.  This causes a lot of stray keystrokes to get added in notes.  This change attempts to fix the initial lag.

---

## Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)