### PR TITLE
fix(edit): email addresses and hash symbols inside words are parsed as tags

### DIFF
--- a/packages/engine-server/src/markdown/remark/hashtag.ts
+++ b/packages/engine-server/src/markdown/remark/hashtag.ts
@@ -96,7 +96,19 @@ const plugin: Plugin<[PluginOpts?]> = function plugin(
 
 function attachParser(proc: Unified.Processor) {
   function locator(value: string, fromIndex: number) {
-    return value.indexOf("#", fromIndex);
+    // Do not locate a symbol if the previous character is non-whitespace.
+    // Unified cals tokenizer starting at the index we return here,
+    // so tokenizer won't be able to reject it for not starting with a non-space character.
+    const atSymbol = value.indexOf("#", fromIndex);
+    if (atSymbol === 0) {
+      return atSymbol;
+    } else if (atSymbol > 0) {
+      const previousSymbol = value[atSymbol - 1];
+      if (!previousSymbol || /\s/.exec(previousSymbol)) {
+        return atSymbol;
+      }
+    }
+    return -1;
   }
 
   function inlineTokenizer(eat: Eat, value: string) {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
@@ -124,12 +124,21 @@ describe("hashtag", () => {
     });
 
     test("doesn't parse trailing unicode punctuation", () => {
-      const resp1 = proc().parse("彼女に「#よろしく」言って下さい。");
+      const resp1 = proc().parse("彼女に「 #よろしく」言って下さい。");
       expect(getDescendantNode(expect, resp1, 0, 1).type).toEqual(
         DendronASTTypes.HASHTAG
       );
       // @ts-ignore
       expect(getDescendantNode(expect, resp1, 0, 1).value).toEqual("#よろしく");
+    });
+
+    test("doesn't parse when it's part of a sentence", () => {
+      const resp1 = proc().parse("no#tag");
+      expect(getDescendantNode(expect, resp1, 0, 0).type).not.toEqual(
+        DendronASTTypes.HASHTAG
+      );
+      // @ts-ignore
+      expect(getDescendantNode(expect, resp1, 0, 0).value).toEqual("no#tag");
     });
   });
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
@@ -113,7 +113,7 @@ describe("user tags", () => {
     });
 
     test("doesn't parse trailing unicode punctuation", () => {
-      const resp1 = proc().parse("この人は「@松本.行弘」です。");
+      const resp1 = proc().parse("この人は「 @松本.行弘」です。");
       expect(getDescendantNode(expect, resp1, 0, 1).type).toEqual(
         DendronASTTypes.USERTAG
       );
@@ -128,6 +128,8 @@ describe("user tags", () => {
       expect(getDescendantNode(expect, resp1, 0, 0).type).toEqual(
         DendronASTTypes.LINK
       );
+      // @ts-ignore
+      expect(getDescendantNode(expect, resp1, 0, 0).children.length).toEqual(1);
       expect(getDescendantNode(expect, resp1, 0, 0, 0).type).toEqual(
         DendronASTTypes.TEXT
       );

--- a/test-workspace/vault/dendron.ref.users.md
+++ b/test-workspace/vault/dendron.ref.users.md
@@ -1,8 +1,8 @@
 ---
 id: kCsOf22GDKfYogkogB4pa
 title: Users
-desc: ''
-updated: 1630130382349
+desc: ""
+updated: 1654666546179
 created: 1630130282280
 ---
 
@@ -11,3 +11,5 @@ User notes can be linked using @username.
 These can also have hierarchies, like @customer.Foo, which helps with organization.
 
 Some user notes may be missing, like @this.one.
+
+This email@example.com should not be a user tag


### PR DESCRIPTION
For example `foo@bar` or `foo#bar` would be parsed as user or hash tags. This PR fixed this issue by requiring tags to be preceded by a space, or to start at the beginning of a line.

#3039