### PR TITLE
enhance(edit): this sets handlebars as the default template format

### DIFF
--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -67,7 +67,7 @@ export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
     task: genDefaultTaskConfig(),
     graph: genDefaultGraphConfig(),
     enableAutoCreateOnDefinition: false,
-    enableHandlebarTemplates: false,
+    enableHandlebarTemplates: true,
     enableXVaultWikiLink: false,
     enableRemoteVaultInit: true,
     enableUserTags: true,

--- a/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/template.spec.ts
@@ -1,4 +1,4 @@
-import { NoteProps } from "@dendronhq/common-all";
+import { IntermediateDendronConfig, NoteProps } from "@dendronhq/common-all";
 import { TemplateUtils } from "@dendronhq/common-server";
 import { AssertUtils, TestNoteFactory } from "@dendronhq/common-test-utils";
 import sinon from "sinon";
@@ -298,6 +298,10 @@ describe(`WHEN running applyTemplate tests`, () => {
   });
 
   describe("WHEN non-handlebars", () => {
+    const modConfigCb = (cfg: IntermediateDendronConfig) => {
+      cfg.workspace.enableHandlebarTemplates = false;
+      return cfg;
+    };
     describe(`GIVEN current note's body is empty`, () => {
       beforeEach(async () => {
         targetNote = await noteFactory.createForFName("new note");
@@ -323,6 +327,7 @@ describe(`WHEN running applyTemplate tests`, () => {
           {
             expect,
             preSetupHook: ENGINE_HOOKS.setupSchemaPreseet,
+            modConfigCb,
           }
         );
       });
@@ -354,6 +359,7 @@ describe(`WHEN running applyTemplate tests`, () => {
           {
             expect,
             preSetupHook: ENGINE_HOOKS.setupRefs,
+            modConfigCb,
           }
         );
       });
@@ -375,6 +381,7 @@ describe(`WHEN running applyTemplate tests`, () => {
           {
             expect,
             preSetupHook: ENGINE_HOOKS.setupRefs,
+            modConfigCb,
           }
         );
       });
@@ -405,6 +412,7 @@ describe(`WHEN running applyTemplate tests`, () => {
           {
             expect,
             preSetupHook: ENGINE_HOOKS.setupSchemaPreseet,
+            modConfigCb,
           }
         );
       });

--- a/packages/engine-test-utils/src/__tests__/common-server/abTesting.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/abTesting.spec.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 // To make checks more accurate, make FLOAT_SAME smaller and LOOP much larger.
 // The tests to pass when the accuracy is higher, they just take longer.
-const FLOAT_SAME = 0.01; // accurate to 1 percent
+const FLOAT_SAME = 0.05; // accurate to 1 percent
 const LOOP = 20000;
 
 function estimateABTestOutcomes<Out>(test: ABTest<Out>): Map<Out, number> {

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -81,7 +81,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -237,7 +237,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -383,7 +383,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -496,7 +496,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -626,7 +626,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -75,7 +75,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -231,7 +231,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -377,7 +377,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -490,7 +490,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -620,7 +620,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -757,7 +757,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true
@@ -881,7 +881,7 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: false
+    enableHandlebarTemplates: true
     enableXVaultWikiLink: false
     enableRemoteVaultInit: true
     enableUserTags: true

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -87,7 +87,7 @@ export class WorkspaceTestUtils {
           zoomSpeed: 1,
           createStub: false,
         },
-        enableHandlebarTemplates: false,
+        enableHandlebarTemplates: true,
         enableAutoCreateOnDefinition: false,
         enableXVaultWikiLink: false,
         enableRemoteVaultInit: true,


### PR DESCRIPTION
enhance(edit): this sets handlebars as the default template format

BREAKING: this sets handlebars as the default template format. users that were using `<% %>` syntax for template variables will no longer work. please see the [[Migration|dendron://dendron.dendron-site/dendron.topic.templates.handlebars.migration]] guide to switch to handlebar based templates