### PR TITLE
feat(views): depth filter for local graph

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -176,6 +176,7 @@ export enum GraphEvents {
   GraphThemeChanged = "GraphThemeChanged",
   GraphViewUsed = "GraphViewUsed",
   GraphPanelUsed = "GraphPanelUsed",
+  GraphDepthChanged = "GraphDepthChanged",
 }
 
 export enum TreeViewEvents {

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -176,7 +176,6 @@ export enum GraphEvents {
   GraphThemeChanged = "GraphThemeChanged",
   GraphViewUsed = "GraphViewUsed",
   GraphPanelUsed = "GraphPanelUsed",
-  GraphDepthChanged = "GraphDepthChanged",
 }
 
 export enum TreeViewEvents {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -794,11 +794,12 @@ export enum GraphViewMessageEnum {
   "onSelect" = "onSelect",
   "onGetActiveEditor" = "onGetActiveEditor",
   "onReady" = "onReady",
-  "onRequestGraphStyleAndTheme" = "onRequestGraphStyleAndTheme",
-  "onGraphStyleAndThemeLoad" = "onGraphStyleAndThemeLoad",
+  "onRequestGraphOpts" = "onRequestGraphOpts",
+  "onGraphOptsLoad" = "onGraphOptsLoad",
   "onGraphThemeChange" = "onGraphThemeChange",
   "configureCustomStyling" = "configureCustomStyling",
   "toggleGraphView" = "toggleGraphView",
+  "onGraphDepthChange" = "onGraphDepthChange",
 }
 
 export enum CalendarViewMessageType {
@@ -879,6 +880,7 @@ export type GraphViewMessage = DMessage<
     vault?: string;
     graphTheme?: GraphThemeEnum;
     graphType?: GraphTypeEnum;
+    graphDepth?: number;
   }
 >;
 

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -795,7 +795,7 @@ export enum GraphViewMessageEnum {
   "onGetActiveEditor" = "onGetActiveEditor",
   "onReady" = "onReady",
   "onRequestGraphOpts" = "onRequestGraphOpts",
-  "onGraphOptsLoad" = "onGraphOptsLoad",
+  "onGraphLoad" = "onGraphLoad",
   "onGraphThemeChange" = "onGraphThemeChange",
   "configureCustomStyling" = "configureCustomStyling",
   "toggleGraphView" = "toggleGraphView",

--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -27,6 +27,7 @@ type InitialState = {
   lookupModifiers: LookupModifierStatePayload | undefined;
   tree?: TreeMenu;
   graphTheme?: GraphThemeEnum;
+  graphDepth?: number;
 };
 
 const INITIAL_STATE: InitialState = {
@@ -39,6 +40,7 @@ const INITIAL_STATE: InitialState = {
   lookupModifiers: undefined,
   tree: undefined,
   graphTheme: GraphThemeEnum.Classic,
+  graphDepth: 1,
 };
 
 export { InitialState as IDEState };
@@ -78,6 +80,9 @@ export const ideSlice = createSlice({
     },
     setGraphTheme: (state, action: PayloadAction<GraphThemeEnum>) => {
       state.graphTheme = action.payload;
+    },
+    setGraphDepth: (state, action: PayloadAction<number>) => {
+      state.graphDepth = action.payload;
     },
   },
 });

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -98,9 +98,9 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ideDispatch(ideSlice.actions.refreshLookup(msg.data.payload));
         logger.info({ ctx, msg: "refreshLookup:post" });
         break;
-      case GraphViewMessageEnum.onGraphStyleAndThemeLoad: {
+      case GraphViewMessageEnum.onGraphOptsLoad: {
         const cmsg = msg;
-        const { styles, graphTheme } = cmsg.data;
+        const { styles, graphTheme, graphDepth } = cmsg.data;
         logger.info({ ctx, styles, msg: "styles" });
         if (styles) {
           ideDispatch(ideSlice.actions.setGraphStyles(styles));
@@ -111,6 +111,10 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         }
         if (!graphTheme && styles) {
           ideDispatch(ideSlice.actions.setGraphTheme(GraphThemeEnum.Custom));
+        }
+        if (graphDepth) {
+          logger.info({ ctx, graphDepth, msg: "default graph depth" });
+          ideDispatch(ideSlice.actions.setGraphDepth(graphDepth));
         }
         break;
       }

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -98,7 +98,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ideDispatch(ideSlice.actions.refreshLookup(msg.data.payload));
         logger.info({ ctx, msg: "refreshLookup:post" });
         break;
-      case GraphViewMessageEnum.onGraphOptsLoad: {
+      case GraphViewMessageEnum.onGraphLoad: {
         const cmsg = msg;
         const { styles, graphTheme, graphDepth } = cmsg.data;
         logger.info({ ctx, styles, msg: "styles" });

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -124,6 +124,14 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ideDispatch(ideSlice.actions.setSeedsInWorkspace(seeds));
         break;
       }
+
+      case GraphViewMessageEnum.onGraphDepthChange: {
+        const cmsg = msg;
+        const { graphDepth } = cmsg.data;
+        logger.info({ ctx, graphDepth, msg: "onGraphDepthChange" });
+        ideDispatch(ideSlice.actions.setGraphDepth(graphDepth));
+        break;
+      }
       default:
         logger.error({ ctx, msg: "unknown message", payload: msg });
         break;

--- a/packages/dendron-plugin-views/src/components/DendronGraphPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronGraphPanel.tsx
@@ -74,6 +74,20 @@ const DendronGraphPanel: DendronComponent = (props) => {
   }, [ide.graphTheme]);
 
   useEffect(() => {
+    if (ide.graphDepth) {
+      logger.log("updating graph depth in config ", ide.graphDepth);
+      setConfig((c) => ({
+        ...c,
+        "filter.depth": {
+          ...c["filter.depth"],
+          value: ide.graphDepth!,
+        },
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ide.graphDepth]);
+
+  useEffect(() => {
     if (isSidePanel) {
       setConfig((c) => ({
         ...c,

--- a/packages/dendron-plugin-views/src/components/DendronSideGraphPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronSideGraphPanel.tsx
@@ -7,7 +7,10 @@ import DendronGraphPanel from "./DendronGraphPanel";
  * @returns DendronGraphPanel component with ide.isSidePanel set to true
  */
 const DendronSideGraphPanel: DendronComponent = (props) => {
-  props.isSidePanel = true;
+  props = {
+    ...props,
+    isSidePanel: true,
+  };
   return <DendronGraphPanel {...props} />;
 };
 export default DendronSideGraphPanel;

--- a/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
+++ b/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
@@ -188,6 +188,7 @@ const FilterViewStringInput = ({
   );
 };
 
+//TODO: either make this more generic or split it into multiple components.
 const FilterViewSection = ({
   section,
   config,
@@ -349,6 +350,11 @@ const configureCustomStyling = () => {
   } as GraphViewMessage);
 };
 
+/**
+ * vscode message to update graphDepth selected by User.
+ * When the graph panel is disposed, this value is written back to Metadata Service.
+ * @param graphDepth
+ */
 const updateGraphDepth = (graphDepth: number) => {
   postVSCodeMessage({
     type: GraphViewMessageEnum.onGraphDepthChange,

--- a/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
+++ b/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
@@ -247,18 +247,18 @@ const FilterViewSection = ({
                   />
                 </>
               )}
-              {_.isNumber(entry.value) &&
-                entry.label === config["filter.depth"].label &&
+              {entry.label === config["filter.depth"].label &&
                 config["options.show-local-graph"]?.value && (
                   <>
                     <Typography>{label}</Typography>
                     <InputNumber
                       min={1}
                       max={3}
-                      defaultValue={entry.value || 1}
+                      disabled={!entry.mutable}
+                      defaultValue={(entry.value as number) || 1}
                       onChange={(newValue) => {
                         updateConfigField(key, newValue);
-                        updateGraphDepth(newValue);
+                        updateGraphDepth(newValue as number);
                       }}
                     />
                   </>

--- a/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
+++ b/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
@@ -246,16 +246,30 @@ const FilterViewSection = ({
                   />
                 </>
               )}
-              {_.isNumber(entry?.value) && (
-                <>
-                  <Typography>{label}</Typography>
-                  <InputNumber
-                    value={entry?.value}
-                    onChange={(newValue) => updateConfigField(key, newValue)}
-                    disabled={!entry?.mutable}
-                  />
-                </>
-              )}
+              {_.isNumber(entry.value) &&
+                entry.label === config["filter.depth"].label &&
+                config["options.show-local-graph"]?.value && (
+                  <>
+                    <Typography>{label}</Typography>
+                    <InputNumber
+                      min={1}
+                      max={3}
+                      defaultValue={entry.value || 1}
+                      onChange={(newValue) => updateConfigField(key, newValue)}
+                    />
+                  </>
+                )}
+              {_.isNumber(entry?.value) &&
+                entry.label !== config["filter.depth"].label && (
+                  <>
+                    <Typography>{label}</Typography>
+                    <InputNumber
+                      value={entry?.value}
+                      onChange={(newValue) => updateConfigField(key, newValue)}
+                      disabled={!entry?.mutable}
+                    />
+                  </>
+                )}
               {_.isString(entry?.value) &&
                 !_.isUndefined(entry) &&
                 !_.isUndefined(key) &&

--- a/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
+++ b/packages/dendron-plugin-views/src/components/GraphFilterView.tsx
@@ -255,7 +255,10 @@ const FilterViewSection = ({
                       min={1}
                       max={3}
                       defaultValue={entry.value || 1}
-                      onChange={(newValue) => updateConfigField(key, newValue)}
+                      onChange={(newValue) => {
+                        updateConfigField(key, newValue);
+                        updateGraphDepth(newValue);
+                      }}
                     />
                   </>
                 )}
@@ -342,6 +345,14 @@ const updateGraphTheme = (graphTheme: GraphThemeEnum) => {
 const configureCustomStyling = () => {
   postVSCodeMessage({
     type: GraphViewMessageEnum.configureCustomStyling,
+    source: DMessageSource.webClient,
+  } as GraphViewMessage);
+};
+
+const updateGraphDepth = (graphDepth: number) => {
+  postVSCodeMessage({
+    type: GraphViewMessageEnum.onGraphDepthChange,
+    data: { graphDepth },
     source: DMessageSource.webClient,
   } as GraphViewMessage);
 };

--- a/packages/dendron-plugin-views/src/components/graph.tsx
+++ b/packages/dendron-plugin-views/src/components/graph.tsx
@@ -235,10 +235,10 @@ export default function Graph({
   };
 
   useEffect(() => {
-    logger.log("Requesting graph style and theme...");
+    logger.log("Requesting graph opts");
     // Get graph style
     postVSCodeMessage({
-      type: GraphViewMessageEnum.onRequestGraphStyleAndTheme,
+      type: GraphViewMessageEnum.onRequestGraphOpts,
       data: {},
       source: DMessageSource.webClient,
     } as GraphViewMessage);

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -42,6 +42,7 @@ type QueueData = {
    */
   distance: number;
   classes: string;
+  isParent?: boolean;
 };
 
 function computeGraphElements({
@@ -102,9 +103,35 @@ function computeGraphElements({
     });
 
     if (data.distance < maxDistance) {
-      const children = note.children;
-
       const noteVaultClass = getVaultClass(note.vault);
+
+      const parentNote =
+        (data.distance === 0 || data.isParent) && note.parent
+          ? notes[note.parent]
+          : undefined;
+      if (parentNote) {
+        nodesQueue.enqueue({
+          note: parentNote,
+          distance: data.distance + 1,
+          isParent: true,
+          classes: `${DEFAULT_NODE_CLASSES} parent ${getVaultClass(
+            parentNote.vault
+          )}`,
+        });
+        edges.hierarchy.push({
+          data: {
+            group: "edges",
+            id: `${parentNote.id}_${note.id}`,
+            source: parentNote.id,
+            target: note.id,
+            fname: parentNote.fname,
+            stub: _.isUndefined(parentNote.stub) ? false : parentNote.stub,
+          },
+          classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
+        });
+      }
+
+      const children = note.children;
 
       // Setup the edges for children now:
       children.forEach((child: string) => {

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -67,8 +67,6 @@ function computeGraphElements({
   const nodes: GraphNodes = [];
   const activeNote = notes[noteActive.id];
 
-  // TODO: Add parents and grandparents
-
   // Add descendents (children, grandchildren, etc) depending on the specified
   // distance parameter:
   const nodesQueue = new FIFOQueue<QueueData>();
@@ -105,6 +103,7 @@ function computeGraphElements({
     if (data.distance < maxDistance) {
       const noteVaultClass = getVaultClass(note.vault);
 
+      //Add parents and grandparents
       const parentNote =
         (data.distance === 0 || data.isParent) && note.parent
           ? notes[note.parent]
@@ -238,7 +237,7 @@ const getLocalNoteGraphElements = ({
     };
   }
 
-  const hierarchicalElements = computeGraphElements({
+  const graphElements = computeGraphElements({
     notes,
     noteActive,
     maxDistance,
@@ -246,10 +245,7 @@ const getLocalNoteGraphElements = ({
     fNameDict,
   });
 
-  // TODO: Union familialElements, outwardLinkElements, inwardLinkElements. May
-  // need to dedupe nodes if a child is also a link?
-
-  return hierarchicalElements;
+  return graphElements;
 };
 
 function getOutwardLinkedConnections({

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -42,6 +42,9 @@ type QueueData = {
    */
   distance: number;
   classes: string;
+  /**
+   * is node an ancestor of the active note
+   */
   isParent?: boolean;
 };
 
@@ -70,6 +73,8 @@ function computeGraphElements({
   // Add descendents (children, grandchildren, etc) depending on the specified
   // distance parameter:
   const nodesQueue = new FIFOQueue<QueueData>();
+
+  //enqueue active note
   nodesQueue.enqueue({
     note: activeNote,
     distance: 0,
@@ -103,7 +108,7 @@ function computeGraphElements({
     if (data.distance < maxDistance) {
       const noteVaultClass = getVaultClass(note.vault);
 
-      //Add parents and grandparents
+      //Add parents and grandparents. Distance 0 indicates the immediate parent, isParent indicate the ancestor
       const parentNote =
         (data.distance === 0 || data.isParent) && note.parent
           ? notes[note.parent]

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -62,7 +62,6 @@ function computeHierarchicalGraphElements({
     hierarchy: [],
     links: [],
   };
-
   const nodes: GraphNodes = [];
   const activeNote = notes[noteActive.id];
 
@@ -109,7 +108,7 @@ function computeHierarchicalGraphElements({
         (data.distance === 0 || data.isParent) && note.parent
           ? notes[note.parent]
           : undefined;
-      if (parentNote) {
+      if (parentNote && parentNote.id !== activeNote.id) {
         nodesQueue.enqueue({
           note: parentNote,
           distance: data.distance + 1,

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -77,7 +77,7 @@ function computeHierarchicalGraphElements({
     classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(activeNote.vault)}`,
   });
 
-  // Breadth First Search for Descendants
+  // Breadth First Search
   while (nodesQueue.length > 0) {
     const data = nodesQueue.dequeue();
 
@@ -130,34 +130,35 @@ function computeHierarchicalGraphElements({
           classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
         });
       }
+      const children = note.children;
       // do not include children of parent/grandparent
-      const children = data.isParent ? [] : note.children;
+      if (!data.isParent) {
+        // Setup the edges for children now:
+        children.forEach((child: string) => {
+          const childNote = notes[child];
+          if (childNote) {
+            edges.hierarchy.push({
+              data: {
+                group: "edges",
+                id: `${note.id}_${childNote.id}`,
+                source: note.id,
+                target: childNote.id,
+                fname: note.fname,
+                stub: false,
+              },
+              classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
+            });
 
-      // Setup the edges for children now:
-      children.forEach((child: string) => {
-        const childNote = notes[child];
-        if (childNote) {
-          edges.hierarchy.push({
-            data: {
-              group: "edges",
-              id: `${note.id}_${childNote.id}`,
-              source: note.id,
-              target: childNote.id,
-              fname: note.fname,
-              stub: false,
-            },
-            classes: `${DEFAULT_EDGE_CLASSES} hierarchy ${noteVaultClass}`,
-          });
-
-          nodesQueue.enqueue({
-            note: childNote,
-            distance: data.distance + 1,
-            classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(
-              childNote.vault
-            )}`,
-          });
-        }
-      });
+            nodesQueue.enqueue({
+              note: childNote,
+              distance: data.distance + 1,
+              classes: `${DEFAULT_NODE_CLASSES} ${getVaultClass(
+                childNote.vault
+              )}`,
+            });
+          }
+        });
+      }
     }
   }
   return {

--- a/packages/dendron-plugin-views/src/utils/graph.ts
+++ b/packages/dendron-plugin-views/src/utils/graph.ts
@@ -30,6 +30,7 @@ export type CoreGraphConfig = {
 
   "options.allow-relayout": GraphConfigItem<boolean>;
   "options.show-labels": GraphConfigItem<boolean>;
+  "filter.depth": GraphConfigItem<number>;
 
   graphTheme: GraphConfigItem<GraphThemeEnum>;
 };
@@ -88,6 +89,11 @@ const coreGraphConfig: CoreGraphConfig = {
     value: GraphThemeEnum.Classic,
     mutable: true,
     singleSelect: true,
+  },
+  "filter.depth": {
+    value: 1,
+    mutable: true,
+    label: "Depth",
   },
 };
 

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -145,7 +145,7 @@ type Metadata = Partial<{
   /**
    * level set by user for local graph view and graph panel
    */
-  graphDepth?: number;
+  graphDepth: number;
 }>;
 
 export enum InactvieUserMsgStatusEnum {
@@ -252,7 +252,7 @@ export class MetadataService {
     return this.getMeta().recentWorkspaces;
   }
 
-  getGraphDepth(): number | undefined {
+  get graphDepth(): number | undefined {
     return this.getMeta().graphDepth;
   }
 
@@ -342,7 +342,7 @@ export class MetadataService {
       this.setMeta("graphTheme", graphTheme);
     }
   }
-  setGraphDepth(graphDepth: number) {
+  set graphDepth(graphDepth: number | undefined) {
     const meta = this.getMeta();
     if (meta.graphDepth !== graphDepth) {
       this.setMeta("graphDepth", graphDepth);

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -141,6 +141,11 @@ type Metadata = Partial<{
    * message
    */
   v100ReleaseMessageShown: boolean;
+
+  /**
+   * level set by user for local graph view and graph panel
+   */
+  graphDepth?: number;
 }>;
 
 export enum InactvieUserMsgStatusEnum {
@@ -247,6 +252,10 @@ export class MetadataService {
     return this.getMeta().recentWorkspaces;
   }
 
+  getGraphDepth(): number | undefined {
+    return this.getMeta().graphDepth;
+  }
+
   setMeta(key: keyof Metadata, value: any) {
     const stateFromFile = this.getMeta();
     stateFromFile[key] = value;
@@ -331,6 +340,12 @@ export class MetadataService {
     const meta = this.getMeta();
     if (meta.graphTheme !== graphTheme) {
       this.setMeta("graphTheme", graphTheme);
+    }
+  }
+  setGraphDepth(graphDepth: number) {
+    const meta = this.getMeta();
+    if (meta.graphDepth !== graphDepth) {
+      this.setMeta("graphDepth", graphDepth);
     }
   }
 

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -160,6 +160,16 @@
         "icon": "$(expand-all)"
       },
       {
+        "command": "dendron.graph-panel.increaseDepth",
+        "title": "Increase Depth",
+        "icon": "$(arrow-up)"
+      },
+      {
+        "command": "dendron.graph-panel.decreaseDepth",
+        "title": "Decrease Depth",
+        "icon": "$(arrow-down)"
+      },
+      {
         "command": "dendron.browseNote",
         "title": "Dendron: Browse Note"
       },
@@ -892,6 +902,16 @@
         {
           "command": "dendron.treeView.expandAll",
           "when": "view == dendron.treeView && dendron:devMode",
+          "group": "navigation@2"
+        },
+        {
+          "command": "dendron.graph-panel.increaseDepth",
+          "when": "view == dendron.graph-panel",
+          "group": "navigation@2"
+        },
+        {
+          "command": "dendron.graph-panel.decreaseDepth",
+          "when": "view == dendron.graph-panel",
           "group": "navigation@2"
         }
       ],

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -222,7 +222,7 @@ export class NoteGraphPanelFactory {
           this.defaultGraphTheme = undefined;
         }
         if (this.graphDepth) {
-          AnalyticsUtils.track(GraphEvents.GraphThemeChanged, {
+          AnalyticsUtils.track(GraphEvents.GraphDepthChanged, {
             graphDepth: this.graphDepth,
           });
           MetadataService.instance().setGraphDepth(this.graphDepth);

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -39,11 +39,12 @@ export class NoteGraphPanelFactory {
   private static _ext: DendronExtension;
   private static initWithNote: NoteProps | undefined;
   /**
-   * This property temporarily stores the graph theme selected by user and is written
+   * These properties temporarily stores the graph theme and depth selected by user and is written
    * back to MetadataService once the panel is disposed.
    */
   private static defaultGraphTheme: GraphThemeEnum | undefined;
   private static graphDepth: number | undefined;
+
   static create(
     ext: DendronExtension,
     engineEvents: EngineEventEmitter
@@ -221,6 +222,9 @@ export class NoteGraphPanelFactory {
           this.defaultGraphTheme = undefined;
         }
         if (this.graphDepth) {
+          AnalyticsUtils.track(GraphEvents.GraphThemeChanged, {
+            graphDepth: this.graphDepth,
+          });
           MetadataService.instance().setGraphDepth(this.graphDepth);
           this.graphDepth = undefined;
         }

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -122,7 +122,7 @@ export class NoteGraphPanelFactory {
             // Set graph styles
             const styles = GraphStyleService.getParsedStyles();
             const graphTheme = MetadataService.instance().getGraphTheme();
-            const graphDepth = MetadataService.instance().getGraphDepth();
+            const graphDepth = MetadataService.instance().graphDepth;
             if (graphTheme) {
               this.defaultGraphTheme = graphTheme;
             }
@@ -131,7 +131,7 @@ export class NoteGraphPanelFactory {
             }
             if (styles || graphTheme || graphDepth) {
               this._panel!.webview.postMessage({
-                type: GraphViewMessageEnum.onGraphOptsLoad,
+                type: GraphViewMessageEnum.onGraphLoad,
                 data: {
                   styles,
                   graphTheme,
@@ -222,10 +222,10 @@ export class NoteGraphPanelFactory {
           this.defaultGraphTheme = undefined;
         }
         if (this.graphDepth) {
-          AnalyticsUtils.track(GraphEvents.GraphDepthChanged, {
+          AnalyticsUtils.track(GraphEvents.GraphViewUsed, {
             graphDepth: this.graphDepth,
           });
-          MetadataService.instance().setGraphDepth(this.graphDepth);
+          MetadataService.instance().graphDepth = this.graphDepth;
           this.graphDepth = undefined;
         }
       });

--- a/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
@@ -89,7 +89,7 @@ export class SchemaGraphViewFactory {
           break;
         }
         // not handled
-        case GraphViewMessageEnum.onGraphStyleAndThemeLoad: {
+        case GraphViewMessageEnum.onGraphOptsLoad: {
           break;
         }
         // TODO: these should be handled

--- a/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
@@ -89,7 +89,7 @@ export class SchemaGraphViewFactory {
           break;
         }
         // not handled
-        case GraphViewMessageEnum.onGraphOptsLoad: {
+        case GraphViewMessageEnum.onGraphLoad: {
           break;
         }
         // TODO: these should be handled

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -246,6 +246,16 @@ export const DENDRON_MENUS = {
       when: `view == dendron.treeView && ${DendronContext.DEV_MODE}`,
       group: "navigation@2",
     },
+    {
+      command: "dendron.graph-panel.increaseDepth",
+      when: "view == dendron.graph-panel",
+      group: "navigation@2",
+    },
+    {
+      command: "dendron.graph-panel.decreaseDepth",
+      when: "view == dendron.graph-panel",
+      group: "navigation@2",
+    },
   ],
   "explorer/context": [
     {
@@ -339,6 +349,17 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: "Expand All",
     icon: "$(expand-all)",
     when: DendronContext.DEV_MODE,
+  },
+  // graph panel buttons
+  GRAPH_PANEL_INCREASE_DEPTH: {
+    key: "dendron.graph-panel.increaseDepth",
+    title: "Increase Depth",
+    icon: "$(arrow-up)",
+  },
+  GRAPH_PANEL_DECREASE_DEPTH: {
+    key: "dendron.graph-panel.decreaseDepth",
+    title: "Decrease Depth",
+    icon: "$(arrow-down)",
   },
   // --- Notes
   BROWSE_NOTE: {

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -109,10 +109,10 @@ export class GraphPanel implements vscode.WebviewViewProvider {
         // Set graph styles
         const styles = GraphStyleService.getParsedStyles();
         const graphTheme = MetadataService.instance().getGraphTheme();
-        const graphDepth = MetadataService.instance().getGraphDepth();
+        const graphDepth = MetadataService.instance().graphDepth;
         if (this._view && (styles || graphTheme || graphDepth)) {
           this._view.webview.postMessage({
-            type: GraphViewMessageEnum.onGraphOptsLoad,
+            type: GraphViewMessageEnum.onGraphLoad,
             data: {
               styles,
               graphTheme,

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -105,16 +105,18 @@ export class GraphPanel implements vscode.WebviewViewProvider {
         }
         break;
       }
-      case GraphViewMessageEnum.onRequestGraphStyleAndTheme: {
+      case GraphViewMessageEnum.onRequestGraphOpts: {
         // Set graph styles
         const styles = GraphStyleService.getParsedStyles();
         const graphTheme = MetadataService.instance().getGraphTheme();
-        if (this._view && (styles || graphTheme)) {
+        const graphDepth = MetadataService.instance().getGraphDepth();
+        if (this._view && (styles || graphTheme || graphDepth)) {
           this._view.webview.postMessage({
-            type: GraphViewMessageEnum.onGraphStyleAndThemeLoad,
+            type: GraphViewMessageEnum.onGraphOptsLoad,
             data: {
               styles,
               graphTheme,
+              graphDepth,
             },
             source: "vscode",
           });

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -26,13 +26,30 @@ export class GraphPanel implements vscode.WebviewViewProvider {
   public static readonly viewType = DendronTreeViewKey.GRAPH_PANEL;
   private _view?: vscode.WebviewView;
   private _ext: IDendronExtension;
-  private graphDepth: number | undefined;
+  private _graphDepth: number | undefined;
 
   constructor(extension: IDendronExtension) {
     this._ext = extension;
     this._ext.context.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(this.onOpenTextDocument, this)
     );
+  }
+
+  get graphDepth(): number | undefined {
+    return this._graphDepth;
+  }
+
+  set graphDepth(depth: number | undefined) {
+    if (depth) {
+      this._graphDepth = depth;
+      this.postMessage({
+        type: GraphViewMessageEnum.onGraphDepthChange,
+        data: {
+          graphDepth: this._graphDepth,
+        },
+        source: DMessageSource.vscode,
+      });
+    }
   }
 
   private postMessage(msg: DMessage) {
@@ -42,26 +59,12 @@ export class GraphPanel implements vscode.WebviewViewProvider {
   public increaseGraphDepth() {
     if (this._view && this.graphDepth && this.graphDepth < 3) {
       this.graphDepth += 1;
-      this.postMessage({
-        type: GraphViewMessageEnum.onGraphDepthChange,
-        data: {
-          graphDepth: this.graphDepth,
-        },
-        source: DMessageSource.vscode,
-      });
     }
   }
 
   public decreaseGraphDepth() {
     if (this.graphDepth && this.graphDepth > 1) {
       this.graphDepth -= 1;
-      this.postMessage({
-        type: GraphViewMessageEnum.onGraphDepthChange,
-        data: {
-          graphDepth: this.graphDepth,
-        },
-        source: DMessageSource.vscode,
-      });
     }
   }
 

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -87,6 +87,10 @@ export class GraphPanel implements vscode.WebviewViewProvider {
     webviewView.onDidChangeVisibility(() => {
       if (this.graphDepth && !webviewView.visible) {
         MetadataService.instance().graphDepth = this.graphDepth;
+        AnalyticsUtils.track(GraphEvents.GraphPanelUsed, {
+          type: "DepthChanged",
+          state: this.graphDepth,
+        });
       }
       AnalyticsUtils.track(GraphEvents.GraphPanelUsed, {
         type: "VisibilityChanged",

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -35,11 +35,11 @@ export class GraphPanel implements vscode.WebviewViewProvider {
     );
   }
 
-  get graphDepth(): number | undefined {
+  private get graphDepth(): number | undefined {
     return this._graphDepth;
   }
 
-  set graphDepth(depth: number | undefined) {
+  private set graphDepth(depth: number | undefined) {
     if (depth) {
       this._graphDepth = depth;
       this.postMessage({

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -688,14 +688,12 @@ export class DendronExtension implements IDendronExtension {
     vscode.commands.registerCommand(
       DENDRON_COMMANDS.GRAPH_PANEL_INCREASE_DEPTH.key,
       sentryReportingCallback(() => {
-        // post message to DendronGraphPanel
         graphPanel.increaseGraphDepth();
       })
     );
     vscode.commands.registerCommand(
       DENDRON_COMMANDS.GRAPH_PANEL_DECREASE_DEPTH.key,
       sentryReportingCallback(() => {
-        // post message to DendronGraphPanel
         graphPanel.decreaseGraphDepth();
       })
     );

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -513,16 +513,11 @@ export class DendronExtension implements IDendronExtension {
         const tipOfDayView = this.setupTipOfTheDayView();
 
         // Graph panel (side)
-        const graphPanel = new GraphPanel(this);
-        context.subscriptions.push(
-          vscode.window.registerWebviewViewProvider(
-            GraphPanel.viewType,
-            graphPanel
-          )
-        );
+        const graphPanel = this.setupGraphPanel();
 
         context.subscriptions.push(backlinkTreeView);
         context.subscriptions.push(tipOfDayView);
+        context.subscriptions.push(graphPanel);
       }
     });
   }
@@ -685,6 +680,29 @@ export class DendronExtension implements IDendronExtension {
     );
 
     return backlinkTreeView;
+  }
+
+  private setupGraphPanel() {
+    const graphPanel = new GraphPanel(this);
+
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.GRAPH_PANEL_INCREASE_DEPTH.key,
+      sentryReportingCallback(() => {
+        // post message to DendronGraphPanel
+        graphPanel.increaseGraphDepth();
+      })
+    );
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.GRAPH_PANEL_DECREASE_DEPTH.key,
+      sentryReportingCallback(() => {
+        // post message to DendronGraphPanel
+        graphPanel.decreaseGraphDepth();
+      })
+    );
+    return vscode.window.registerWebviewViewProvider(
+      GraphPanel.viewType,
+      graphPanel
+    );
   }
 
   addDisposable(disposable: vscode.Disposable) {


### PR DESCRIPTION
In the Graph Filter menu, an additional filter for "depth" has been added. The depth value varies from 1(default) through 3. This is to improve the usability of the local graph view. This value is also saved so that the graph opens with the same depth the next time.
Use the graph panel buttons to update the graph depth. The depth is saved back to meta.json file when panel is Collapsed

As the graph becomes dense with incoming and outgoing links, it begins to look messy. This may be resolved by adding more filters to show/hide incoming/outgoing links.

Level 1 (default) displays: active note, its parent, children and links
Level 2 displays active note, parent, grandparent, children, grandchildren, active note's links, active note's links' links

Docs link: https://github.com/dendronhq/dendron-site/pull/539

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated
Added a property `graphDepth` for an existing event `GraphViewUsed`

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA


## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)