### PR TITLE
chore: add sponsorship link

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -5,6 +5,9 @@
   "description": "Dendron is a hierarchal note taking tool that grows as you do. ",
   "publisher": "dendron",
   "version": "0.98.0",
+  "sponsor": {
+    "url": "https://accounts.dendron.so/account/subscribe"
+  },
   "engines": {
     "vscode": "^1.62.0"
   },


### PR DESCRIPTION
VSCode now supports displaying a "Sponsor" button on the extension store. This PR adds the required `package.json` config for Dendron.

See docs: https://code.visualstudio.com/updates/v1_68#_extension-sponsorship

What the button looks like: https://code.visualstudio.com/updates/v1_68#_sponsoring-extensions