### PR TITLE
chore(internal): find duplicate note only for md files

### DIFF
--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -13,6 +13,8 @@ import { MessageSeverity, VSCodeUtils } from "../../vsCodeUtils";
 export class DoctorUtils {
   static async findDuplicateNoteFromDocument(document: vscode.TextDocument) {
     const fsPath = document.uri.fsPath;
+    // return if file is not a markdown
+    if (!fsPath.endsWith(".md")) return;
     const extension = ExtensionProvider.getExtension();
     const { vaults, wsRoot, engine } = extension.getDWorkspace();
     let vault;


### PR DESCRIPTION
This is to fix the following error that appears in debug console repeatedly :
```
rejected promise not handled within 1 second: Error: ENOENT: no such file or directory, open 'e:\dendron-code\dendron\test-workspace\vault\dendron.journal.md.git'
internal/timers:557
stack trace: Error: ENOENT: no such file or directory, open 'e:\dendron-code\dendron\test-workspace\vault\dendron.journal.md.git'
	at Object.openSync (node:fs:585:3)
	at Object.func [as openSync] (node:electron/js2c/asar_bundle:5:1812)
	at Object.readFileSync (node:fs:453:35)
	at Object.readFileSync (node:electron/js2c/asar_bundle:5:9160)
	at file2Note (E:\dendron-code\dendron\packages\common-server\lib\filesv2.js:158:40)
	at Function.findDuplicateNoteFromDocument (e:\dendron-code\dendron\packages\plugin-core\out\src\components\doctor\utils.js:29:59)
```

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.