### PR TITLE
enhance(workspace): Prompt to update seed vault configuration during sync if the seed configuration changed

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -130,6 +130,8 @@ export enum ConfigEvents {
   DuplicateConfigEntryMessageConfirm = "DuplicateConfigEntryMessageConfirm",
   MissingSelfContainedVaultsMessageShow = "MissingSelfContainedVaultsMessageShow",
   MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",
+  OutdatedSeedVaultMessageShow = "OutdatedSeedVaultMessageShow",
+  OutdatedSeedVaultMessageAccept = "OutdatedSeedVaultMessageAccept",
 }
 
 export enum MigrationEvents {

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -4,10 +4,13 @@ import { FOLDERS, normalizeUnixPath } from ".";
 import { CONSTANTS } from "./constants";
 import { DendronError } from "./error";
 import { DVault, WorkspaceFolderRaw } from "./types";
+import { NonOptional } from "./utils";
 
 export type SelfContainedVault = Omit<DVault, "selfContained"> & {
   selfContained: true;
 };
+
+export type SeedVault = NonOptional<DVault, "seed">;
 
 export class VaultUtils {
   static getName(vault: DVault): string {
@@ -40,6 +43,10 @@ export class VaultUtils {
 
   static isSelfContained(vault: DVault): vault is SelfContainedVault {
     return vault.selfContained === true;
+  }
+
+  static isSeed(vault: DVault): vault is SeedVault {
+    return vault.seed !== undefined;
   }
 
   static isRemote(vault: DVault): boolean {

--- a/packages/engine-server/src/seed/service.ts
+++ b/packages/engine-server/src/seed/service.ts
@@ -8,6 +8,7 @@ import {
   VaultUtils,
   WorkspaceType,
   ConfigUtils,
+  SeedVault,
 } from "@dendronhq/common-all";
 import { simpleGit, writeYAML } from "@dendronhq/common-server";
 import fs from "fs-extra";
@@ -296,11 +297,13 @@ export class SeedService {
     return undefined !== vaults.find((vault) => vault.seed === id);
   }
 
-  getSeedsInWorkspace(): string[] {
+  getSeedVaultsInWorkspace(): SeedVault[] {
     const config = WorkspaceService.getOrCreateConfig(this.wsRoot);
     const vaults = ConfigUtils.getVaults(config);
-    return vaults
-      .filter((vault) => vault.seed !== undefined)
-      .map((vault) => vault.seed!);
+    return vaults.filter(VaultUtils.isSeed);
+  }
+
+  getSeedsInWorkspace(): string[] {
+    return this.getSeedVaultsInWorkspace().map((vault) => vault.seed!);
   }
 }

--- a/packages/plugin-core/src/commands/Sync.ts
+++ b/packages/plugin-core/src/commands/Sync.ts
@@ -61,7 +61,7 @@ export async function detectOutOfDateSeeds({
           }
         );
         if (select?.title === UPDATE_SEED_CONFIG_PROMPT) {
-          AnalyticsUtils.trackForNextRun(
+          await AnalyticsUtils.trackForNextRun(
             ConfigEvents.OutdatedSeedVaultMessageAccept
           );
           await DConfig.createBackup(wsRoot, "update-seed");
@@ -70,7 +70,7 @@ export async function detectOutOfDateSeeds({
             vault.fsPath = info.root;
             return vault;
           });
-          DConfig.writeConfig({ wsRoot, config });
+          await DConfig.writeConfig({ wsRoot, config });
           VSCodeUtils.reloadWindow();
         }
       }

--- a/packages/plugin-core/src/test/suite-integ/OutOfDateSeedCheck.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OutOfDateSeedCheck.test.ts
@@ -57,6 +57,7 @@ suite("GIVEN out of date seed check", function () {
         wsRoot,
         registryFile: modifiedTestSeeds.registryFile,
       });
+      sinon.stub(VSCodeUtils, "reloadWindow");
       await detectOutOfDateSeeds({ wsRoot, seedSvc: modifiedSeedService });
     });
 

--- a/packages/plugin-core/src/test/suite-integ/OutOfDateSeedCheck.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/OutOfDateSeedCheck.test.ts
@@ -1,0 +1,76 @@
+import { tmpDir } from "@dendronhq/common-server";
+import { before } from "mocha";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS } from "../testUtilsV3";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { SinonStubbedFn } from "@dendronhq/common-test-utils";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { TestSeedUtils } from "@dendronhq/engine-test-utils";
+import { DConfig, SeedService } from "@dendronhq/engine-server";
+import sinon from "sinon";
+import {
+  detectOutOfDateSeeds,
+  UPDATE_SEED_CONFIG_PROMPT,
+} from "../../commands/Sync";
+import {
+  ConfigUtils,
+  FOLDERS,
+  IntermediateDendronConfig,
+} from "@dendronhq/common-all";
+import { PluginTestSeedUtils } from "../utils/TestSeedUtils";
+
+suite("GIVEN out of date seed check", function () {
+  describeSingleWS("WHEN there's a seed with an out-of-date path", {}, () => {
+    const seedKey = "dendron.foo";
+    let showMessage: SinonStubbedFn<typeof VSCodeUtils["showMessage"]>;
+    before(async () => {
+      const { engine } = ExtensionProvider.getDWorkspace();
+      const wsRoot = engine.wsRoot;
+
+      // Create the seed and add it into the workspace
+      const seedRoot = tmpDir().name;
+      const testSeeds = await TestSeedUtils.createSeedRegistry({
+        engine,
+        wsRoot: seedRoot,
+      });
+      const seedService = new SeedService({
+        wsRoot,
+        registryFile: testSeeds.registryFile,
+      });
+      showMessage = sinon.stub(VSCodeUtils, "showMessage").resolves({
+        title: UPDATE_SEED_CONFIG_PROMPT,
+      });
+      await PluginTestSeedUtils.getFakedAddCommand(seedService).cmd.execute({
+        seedId: "dendron.foo",
+      });
+
+      // Swap the seed registry stub with one where the seed path is modified
+      const modifiedTestSeeds = await TestSeedUtils.createSeedRegistry({
+        engine,
+        wsRoot: seedRoot,
+        modifySeed: (seed) => {
+          seed.root = FOLDERS.NOTES;
+          return seed;
+        },
+      });
+      const modifiedSeedService = new SeedService({
+        wsRoot,
+        registryFile: modifiedTestSeeds.registryFile,
+      });
+      await detectOutOfDateSeeds({ wsRoot, seedSvc: modifiedSeedService });
+    });
+
+    test("THEN Dendron prompts to update the seed config", () => {
+      expect(showMessage.calledOnce).toBeTruthy();
+    });
+
+    test("THEN seed config is correctly updated", async () => {
+      const wsRoot = ExtensionProvider.getDWorkspace().wsRoot;
+      const conf = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
+      const seed = ConfigUtils.getVaults(conf).find(
+        (vault) => vault.seed === seedKey
+      );
+      expect(seed?.fsPath).toEqual(FOLDERS.NOTES);
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/SeedCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SeedCommand.test.ts
@@ -1,36 +1,10 @@
 import { tmpDir } from "@dendronhq/common-server";
 import { SeedService } from "@dendronhq/engine-server";
 import { TestSeedUtils } from "@dendronhq/engine-test-utils";
-import sinon from "sinon";
-import { SeedAddCommand } from "../../commands/SeedAddCommand";
-import { SeedRemoveCommand } from "../../commands/SeedRemoveCommand";
 import { DENDRON_COMMANDS } from "../../constants";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-
-function getFakedAddCommand(svc: SeedService) {
-  const cmd = new SeedAddCommand(svc);
-
-  const fakedOnUpdating = sinon.fake.resolves(null);
-  const fakedOnUpdated = sinon.fake.resolves(null);
-
-  sinon.replace(cmd, <any>"onUpdatingWorkspace", fakedOnUpdating);
-  sinon.replace(cmd, <any>"onUpdatedWorkspace", fakedOnUpdated);
-
-  return { cmd, fakedOnUpdating, fakedOnUpdated };
-}
-
-function getFakedRemoveCommand(svc: SeedService) {
-  const cmd = new SeedRemoveCommand(svc);
-
-  const fakedOnUpdating = sinon.fake.resolves(null);
-  const fakedOnUpdated = sinon.fake.resolves(null);
-
-  sinon.replace(cmd, <any>"onUpdatingWorkspace", fakedOnUpdating);
-  sinon.replace(cmd, <any>"onUpdatedWorkspace", fakedOnUpdated);
-
-  return { cmd, fakedOnUpdating, fakedOnUpdated };
-}
+import { PluginTestSeedUtils } from "../utils/TestSeedUtils";
 
 suite(DENDRON_COMMANDS.SEED_ADD.key, function seedAddTests() {
   const ctx = setupBeforeAfter(this, {});
@@ -47,7 +21,7 @@ suite(DENDRON_COMMANDS.SEED_ADD.key, function seedAddTests() {
         const id = TestSeedUtils.defaultSeedId();
         const seedService = new SeedService({ wsRoot, registryFile });
         const { cmd, fakedOnUpdating, fakedOnUpdated } =
-          getFakedAddCommand(seedService);
+          PluginTestSeedUtils.getFakedAddCommand(seedService);
 
         const resp = await cmd.execute({ seedId: id });
         expect(resp.error).toBeFalsy();
@@ -75,7 +49,7 @@ suite(DENDRON_COMMANDS.SEED_ADD.key, function seedAddTests() {
         await seedService.addSeed({ id });
 
         const { cmd, fakedOnUpdating, fakedOnUpdated } =
-          getFakedAddCommand(seedService);
+          PluginTestSeedUtils.getFakedAddCommand(seedService);
 
         const resp = await cmd.execute({ seedId: id });
         expect(resp.error).toBeTruthy();
@@ -106,7 +80,7 @@ suite(DENDRON_COMMANDS.SEED_REMOVE.key, function seedRemoveTests() {
         await seedService.addSeed({ id });
 
         const { cmd, fakedOnUpdating, fakedOnUpdated } =
-          getFakedRemoveCommand(seedService);
+          PluginTestSeedUtils.getFakedRemoveCommand(seedService);
 
         const resp = await cmd.execute({ seedId: id });
         expect(resp.error).toBeFalsy();
@@ -132,7 +106,7 @@ suite(DENDRON_COMMANDS.SEED_REMOVE.key, function seedRemoveTests() {
         const seedService = new SeedService({ wsRoot, registryFile });
 
         const { cmd, fakedOnUpdating, fakedOnUpdated } =
-          getFakedRemoveCommand(seedService);
+          PluginTestSeedUtils.getFakedRemoveCommand(seedService);
 
         const resp = await cmd.execute({ seedId: id });
         expect(resp.error).toBeTruthy();

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -4,26 +4,18 @@ import {
   ConfigUtils,
   NoteUtils,
   VaultUtils,
-  FOLDERS,
 } from "@dendronhq/common-all";
 import { tmpDir } from "@dendronhq/common-server";
+import { FileTestUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import {
-  FileTestUtils,
-  NoteTestUtilsV4,
-  SinonStubbedFn,
-} from "@dendronhq/common-test-utils";
-import {
-  DConfig,
   Git,
-  SeedRegistry,
-  SeedService,
   SyncActionStatus,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
-import { GitTestUtils, TestSeedUtils } from "@dendronhq/engine-test-utils";
+import { GitTestUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
-import { describe, before } from "mocha";
-import { SyncCommand, UPDATE_SEED_CONFIG_PROMPT } from "../../commands/Sync";
+import { describe } from "mocha";
+import { SyncCommand } from "../../commands/Sync";
 import { getExtension } from "../../workspace";
 import { expect } from "../testUtilsv2";
 import {
@@ -34,9 +26,6 @@ import {
 import fs from "fs-extra";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import path from "path";
-import sinon from "sinon";
-import { VSCodeUtils } from "../../vsCodeUtils";
-import { SeedAddCommand } from "../../commands/SeedAddCommand";
 
 suite("workspace sync command", function () {
   const ctx = setupBeforeAfter(this, {});
@@ -44,7 +33,7 @@ suite("workspace sync command", function () {
   describe("no repo", () => {
     test("do nothing", (done) => {
       runLegacyMultiWorkspaceTest({
-        onInit: async ({}) => {
+        onInit: async () => {
           const out = await new SyncCommand().execute();
           expect(out).toBeTruthy();
           const { committed, pulled, pushed } = out;
@@ -1310,63 +1299,6 @@ suite("workspace sync command", function () {
         // Should push
         expect(WorkspaceUtils.getCountForStatusDone(pushed)).toEqual(1);
         expect(pushed[0].status).toEqual(SyncActionStatus.DONE);
-      });
-    }
-  );
-
-  describeSingleWS(
-    "WHEN there's a seed with an out-of-date path",
-    {
-      ctx,
-    },
-    () => {
-      const seedKey = "dendron.foo";
-      let wsRoot: string;
-      let showMessage: SinonStubbedFn<typeof VSCodeUtils["showMessage"]>;
-      before(async () => {
-        const { engine } = ExtensionProvider.getDWorkspace();
-        wsRoot = engine.wsRoot;
-
-        // Create the seed and add it into the workspace
-        const seedRoot = tmpDir().name;
-        const testSeeds = await TestSeedUtils.createSeedRegistry({
-          engine,
-          wsRoot: seedRoot,
-        });
-        const seedService = new SeedService({
-          wsRoot,
-          registryFile: testSeeds.registryFile,
-        });
-        await new SeedAddCommand(seedService).run({
-          seedId: "dendron-foo",
-        });
-
-        // Swap the seed registry stub with one where the seed path is modified
-        const modifiedTestSeeds = await TestSeedUtils.createSeedRegistry({
-          engine,
-          wsRoot: seedRoot,
-          modifySeed: (seed) => {
-            seed.root = FOLDERS.NOTES;
-            return seed;
-          },
-        });
-        const modifiedTestRegistry = new SeedRegistry(
-          modifiedTestSeeds.seedDict
-        );
-        sinon.stub(SeedRegistry, "create").returns(modifiedTestRegistry);
-
-        await new SyncCommand().run();
-      });
-
-      test("THEN Dendron prompts to update the seed config", () => {
-        // Once for sync status, once for the prompt
-        expect(showMessage.calledTwice).toBeTruthy();
-      });
-
-      test("THEN seed config is correctly updated", async () => {
-        const conf = DConfig.getRaw(wsRoot);
-        const seed = conf.vaults?.find((vault) => vault.seed === seedKey);
-        expect(seed?.fsPath).toEqual(FOLDERS.NOTES);
       });
     }
   );

--- a/packages/plugin-core/src/test/utils/TestSeedUtils.ts
+++ b/packages/plugin-core/src/test/utils/TestSeedUtils.ts
@@ -1,0 +1,30 @@
+import { SeedService } from "@dendronhq/engine-server";
+import sinon from "sinon";
+import { SeedAddCommand } from "../../commands/SeedAddCommand";
+import { SeedRemoveCommand } from "../../commands/SeedRemoveCommand";
+
+export class PluginTestSeedUtils {
+  static getFakedAddCommand(svc: SeedService) {
+    const cmd = new SeedAddCommand(svc);
+
+    const fakedOnUpdating = sinon.fake.resolves(null);
+    const fakedOnUpdated = sinon.fake.resolves(null);
+
+    sinon.replace(cmd, <any>"onUpdatingWorkspace", fakedOnUpdating);
+    sinon.replace(cmd, <any>"onUpdatedWorkspace", fakedOnUpdated);
+
+    return { cmd, fakedOnUpdating, fakedOnUpdated };
+  }
+
+  static getFakedRemoveCommand(svc: SeedService) {
+    const cmd = new SeedRemoveCommand(svc);
+
+    const fakedOnUpdating = sinon.fake.resolves(null);
+    const fakedOnUpdated = sinon.fake.resolves(null);
+
+    sinon.replace(cmd, <any>"onUpdatingWorkspace", fakedOnUpdating);
+    sinon.replace(cmd, <any>"onUpdatedWorkspace", fakedOnUpdated);
+
+    return { cmd, fakedOnUpdating, fakedOnUpdated };
+  }
+}


### PR DESCRIPTION
The `root` path of a seed configuration is added to the users config file as the `fsPath` of the corresponding seed vault. However, if the `root` configuration of the seed vault changes, the `fsPath` is not updated.

This PR adds a check during workspace sync where we'll check if the path has changed, and prompt the user to update their configuration file. I added this to the sync since that's when the user will hit an issue with the change: the vault will continue to work until the user pulls in an update with the sync.

This is required to migrate seed vaults to self contained without causing significant impact to users. Without this feature, we'd have to rely on users to manually update the configuration or remove and re-add the vault.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](https://wiki.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e.html)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](https://wiki.dendron.so/notes/pMS27sHxbWeKMoPRrWEzs.html).
- [x] sticking to existing conventions instead of creating new ones 
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended

- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed 
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)



## Instrumentation

### Basics

- [x] if you are adding analytics related changes, make sure you [Document](https://wiki.dendron.so/notes/8ThPaB9iXXm2Szk3C9kFt.html) changes in airtable

### Extended

- [x] can we track the performance of this change to know if it is _successful_? 
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## 



## Tests

### Basics

- [x] [Write Tests](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [x] [Confirm existing tests pass](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)
- [x] [Confirm manual testing](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](https://wiki.dendron.so/notes/99q7A73uGmCwu2KvSHZro.html)

### Extended

- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](https://wiki.dendron.so/notes/dtMsF12SF2SUhLN10sYe2.html)

- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome



## Docs

### Basics

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR

## 


### Basics

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/3489b652-cd0e-4ac8-a734-08094dc043eb.html) or [Packages](https://wiki.dendron.so/notes/32cdd4aa-d9f6-4582-8d0c-07f64a00299b.html)

## 



## Close the Loop

### Basics

### Extended

- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](https://wiki.dendron.so/notes/iZ8vpfY0n1E3Nq3IC1Y7X.html)
  - eg. [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)