### PR TITLE
fix(workspace): try to patch `EPERM` issues for windows

### DIFF
--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -93,6 +93,14 @@ export class NoteController {
     getLogger().info({ ctx, msg: "enter" });
     try {
       const version = NodeJSUtils.getVersionFromPkg();
+      if (!version) {
+        return {
+          data: undefined,
+          error: DendronError.createPlainError({
+            message: "Unable to read the Dendron version",
+          }),
+        };
+      }
       return {
         data: {
           version,

--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -13,7 +13,6 @@ import {
   NoteQueryResp,
   RenderNoteOpts,
   RenderNotePayload,
-  RespRequired,
   RespV2,
 } from "@dendronhq/common-all";
 import { NodeJSUtils } from "@dendronhq/common-server";
@@ -88,7 +87,7 @@ export class NoteController {
     }
   }
 
-  async info(): Promise<RespRequired<EngineInfoResp>> {
+  async info(): Promise<RespV2<EngineInfoResp>> {
     const ctx = "NoteController:info";
     getLogger().info({ ctx, msg: "enter" });
     try {
@@ -105,7 +104,7 @@ export class NoteController {
         data: {
           version,
         },
-        error: undefined,
+        error: null,
       };
     } catch (err) {
       getLogger().error({ ctx, err });

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -19,7 +19,6 @@ import {
   NoteProps,
   RenameNoteOpts,
   RenameNotePayload,
-  RespRequired,
   RespV2,
   SchemaModuleProps,
   WriteNoteResp,
@@ -437,7 +436,7 @@ export class DendronAPI extends API {
     });
   }
 
-  engineInfo(): Promise<RespRequired<EngineInfoResp>> {
+  engineInfo(): Promise<RespV2<EngineInfoResp>> {
     return this._makeRequest({
       path: "note/info",
       method: "get",

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -280,16 +280,6 @@ export function isDendronResp<T = any>(args: any): args is RespV2<T> {
   return args?.error instanceof DendronError;
 }
 
-/**
- * @deprecated - use RespV2<T> instead.
- */
-export type RespRequired<T> =
-  | {
-      error: null | undefined;
-      data: T;
-    }
-  | { error: IDendronError; data: undefined };
-
 export interface QueryOptsV2 {
   /**
    * Should add to full nodes
@@ -608,7 +598,7 @@ export type DEngine = DCommonProps &
       id: string,
       opts?: EngineDeleteOptsV2
     ) => Promise<DEngineDeleteSchemaResp>;
-    info: () => Promise<RespRequired<EngineInfoResp>>;
+    info: () => Promise<RespV2<EngineInfoResp>>;
     sync: (opts?: DEngineSyncOpts) => Promise<DEngineInitResp>;
 
     getNoteByPath: (opts: GetNoteOptsV2) => Promise<RespV2<GetNotePayload>>;

--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -1,16 +1,22 @@
 import fs from "fs-extra";
-import path from "path";
-import { goUpTo } from "./filesv2";
+import { findUpTo } from "./filesv2";
 
 export class NodeJSUtils {
-  static getVersionFromPkg(): string {
-    const pkgJSON = fs.readJSONSync(
-      path.join(
-        goUpTo({ base: __dirname, fname: "package.json" }),
-        "package.json"
-      )
-    );
-    return `${pkgJSON.version}`;
+  static getVersionFromPkg(): string | undefined {
+    const packageJsonPath = findUpTo({
+      base: __dirname,
+      fname: "package.json",
+      maxLvl: 5,
+    });
+    if (!packageJsonPath) return undefined;
+    try {
+      const pkgJSON = fs.readJSONSync(packageJsonPath);
+      if (!pkgJSON?.version) return undefined;
+      return `${pkgJSON.version}`;
+    } catch {
+      // There may be errors if we couldn't read the file
+      return undefined;
+    }
   }
 }
 

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -46,7 +46,6 @@ import {
   RenameNoteOpts,
   RenameNotePayload,
   RenderNoteOpts,
-  RespRequired,
   RespV2,
   SchemaModuleDict,
   SchemaModuleProps,
@@ -298,7 +297,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     return resp;
   }
 
-  async info(): Promise<RespRequired<EngineInfoResp>> {
+  async info(): Promise<RespV2<EngineInfoResp>> {
     const resp = await this.api.engineInfo();
     return resp;
   }

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -18,6 +18,7 @@ import {
   DStore,
   DVault,
   EngineDeleteOptsV2,
+  EngineInfoResp,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
   error2PlainObject,
@@ -508,10 +509,19 @@ export class DendronEngineV2 implements DEngine {
     };
   }
 
-  async info() {
+  async info(): Promise<RespV2<EngineInfoResp>> {
+    const version = NodeJSUtils.getVersionFromPkg();
+    if (!version) {
+      return {
+        data: undefined,
+        error: DendronError.createPlainError({
+          message: "Unable to read Dendron version",
+        }),
+      };
+    }
     return {
       data: {
-        version: NodeJSUtils.getVersionFromPkg(),
+        version,
       },
       error: null,
     };

--- a/packages/engine-server/src/topics/connector.ts
+++ b/packages/engine-server/src/topics/connector.ts
@@ -154,7 +154,7 @@ export class EngineConnector {
       logger: this.logger,
     });
     const resp = await dendronEngine.info();
-    if (!_.isUndefined(resp.error)) {
+    if (resp.error) {
       this.logger.info({ ctx, msg: "can't connect", error: resp.error });
       return false;
     } else {

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -40,7 +40,6 @@ import {
   RenameNotePayload,
   RenderNoteOpts,
   RenderNotePayload,
-  RespRequired,
   RespV2,
   SchemaModuleDict,
   SchemaModuleProps,
@@ -270,7 +269,7 @@ export class EngineAPIService
     return this._internalEngine.deleteSchema(id, opts);
   }
 
-  info(): Promise<RespRequired<EngineInfoResp>> {
+  info(): Promise<RespV2<EngineInfoResp>> {
     return this._internalEngine.info();
   }
 

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -35,7 +35,6 @@ import {
   RenameNotePayload,
   RenderNoteOpts,
   RenderNotePayload,
-  RespRequired,
   RespV2,
   SchemaModuleDict,
   SchemaModuleProps,
@@ -104,7 +103,7 @@ export interface IEngineAPIService {
     opts?: EngineDeleteOpts | undefined
   ): Promise<DEngineInitResp>;
 
-  info(): Promise<RespRequired<EngineInfoResp>>;
+  info(): Promise<RespV2<EngineInfoResp>>;
 
   sync(opts?: DEngineSyncOpts | undefined): Promise<DEngineInitResp>;
 

--- a/packages/plugin-core/src/views/utils.ts
+++ b/packages/plugin-core/src/views/utils.ts
@@ -2,6 +2,7 @@ import {
   APIUtils,
   CONSTANTS,
   DendronEditorViewKey,
+  DendronError,
   DendronTreeViewKey,
   DUtils,
   getStage,
@@ -32,9 +33,17 @@ export class WebViewUtils {
     const assetUri = VSCodeUtils.getAssetUri(
       ExtensionProvider.getExtension().context
     );
-    const pkgRoot = path.dirname(
-      findUpTo({ base: __dirname, fname: "package.json", maxLvl: 5 })!
-    );
+    const pkgRoot = findUpTo({
+      base: __dirname,
+      fname: "package.json",
+      maxLvl: 5,
+      returnDirPath: true,
+    });
+    if (!pkgRoot) {
+      throw new DendronError({
+        message: "Unable to find the folder where Dendron assets are stored",
+      });
+    }
     return getStage() === "dev"
       ? vscode.Uri.file(
           path.join(pkgRoot, "..", "dendron-plugin-views", "build")

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -190,25 +190,6 @@ export class VSCodeUtils {
     return { text, selection, editor };
   }
 
-  static createWSContext(): vscode.ExtensionContext {
-    const pkgRoot = goUpTo({ base: __dirname, fname: "package.json" });
-    return {
-      extensionMode: vscode.ExtensionMode.Development,
-      logPath: tmpDir().name,
-      subscriptions: [] as any[],
-      extensionPath: pkgRoot,
-      globalState: VSCodeUtils.createMockState({
-        [GLOBAL_STATE.VERSION]: "0.0.1",
-      }),
-      workspaceState: VSCodeUtils.createMockState({}),
-      extensionUri: vscode.Uri.file(pkgRoot),
-      environmentVariableCollection: {} as any,
-      storagePath: tmpDir().name,
-      globalStoragePath: tmpDir().name,
-      asAbsolutePath: {} as any, //vscode.Uri.file(wsPath)
-    } as unknown as vscode.ExtensionContext;
-  }
-
   // create mock context for testing ^7a83pznb91c8
   static getOrCreateMockContext(): vscode.ExtensionContext {
     if (!_MOCK_CONTEXT) {


### PR DESCRIPTION
This PR tries to patch the `EPERM` issues some users reported on Windows. I can't reproduce the bug, but I patched all places that are likely to cause issues.

Looking at Sentry, it looks like the issue happens inside `_activate`, but that's as much as Sentry gives me because the real stack trace seems to get lost.

Also removed the deprecated `RespRequired` type, and updated the `info()` engine interface which was the only place where it was used.