### PR TITLE
chore(internal): add tutorial group prop to install event

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -8,6 +8,7 @@ import {
   ConfigUtils,
   CONSTANTS,
   CURRENT_AB_TESTS,
+  CURRENT_TUTORIAL_TEST,
   DendronError,
   getStage,
   GitEvents,
@@ -1028,10 +1029,19 @@ async function showWelcomeOrWhatsNew({
             : "secondary install on new vscode instance"
         }`,
       });
+
+      // Explicitly set the tutorial split test group in the Install event as
+      // well, since Amplitude may not have the user props splitTest setup in time
+      // before this install event reaches their backend.
+      const group = CURRENT_TUTORIAL_TEST.getUserGroup(
+        SegmentClient.instance().anonymousId
+      );
+
       // track how long install process took ^e8itkyfj2rn3
       AnalyticsUtils.track(VSCodeEvents.Install, {
         duration: getDurationMilliseconds(start),
         isSecondaryInstall,
+        tutorialGroup: group,
       });
 
       metadataService.setGlobalVersion(version);


### PR DESCRIPTION
## chore(internal): add tutorial group prop to install event

This fixes a race condition in our telemetry where properties being added in an identify call were not getting associated with the user quickly enough for some events that happened right afterward. This is causing a problem in our tutorial analysis, since a lot of users aren't properly getting marked in the right split test group for the tutorial.