### PR TITLE
enhance(workspace): make vault add command warn for transitive deps

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -149,6 +149,7 @@ export enum ContextualUIEvents {
 export enum WorkspaceEvents {
   AutoFix = "AutoFix",
   DuplicateNoteFound = "DuplicateNoteFound",
+  TransitiveDepsWarningShow = "TransitiveDepsWarningShow",
 }
 
 export enum NativeWorkspaceEvents {

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -32,6 +32,7 @@ import { DENDRON_COMMANDS, DENDRON_REMOTE_VAULTS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { AnalyticsUtils } from "../utils/analytics";
+import { PluginFileUtils } from "../utils/files";
 import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
@@ -384,19 +385,28 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
           );
           // Wait for the user to accept the prompt, otherwise window will
           // reload before they see the warning
-          await VSCodeUtils.showMessage(
+          const openDocsOption = "Open documentation & continue";
+          const select = await VSCodeUtils.showMessage(
             MessageSeverity.WARN,
             "The vault you added depends on other vaults, which is not supported.",
             {
               modal: true,
               detail:
-                "You may be unable to access these transitive vaults. The vault itself should continue to work.",
+                "You may be unable to access these transitive vaults. The vault itself should continue to work. Please see for [details]()",
             },
             {
               title: "Continue",
               isCloseAffordance: true,
-            }
+            },
+            { title: openDocsOption }
           );
+          if (select?.title === openDocsOption) {
+            // Open a page in the default browser that describes what transitive
+            // dependencies are, and how to add them.
+            await PluginFileUtils.openWithDefaultApp(
+              "https://wiki.dendron.so/notes/q9yo0y7czv8mxlkbnw1ugj1"
+            );
+          }
         }
       }
     } catch (err) {

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -10,6 +10,7 @@ import {
   SelfContainedVault,
   VaultRemoteSource,
   VaultUtils,
+  WorkspaceEvents,
 } from "@dendronhq/common-all";
 import {
   GitUtils,
@@ -30,6 +31,7 @@ import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS, DENDRON_REMOTE_VAULTS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
+import { AnalyticsUtils } from "../utils/analytics";
 import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
@@ -377,7 +379,11 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
           vaultRootPath
         ) as IntermediateDendronConfig;
         if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
-          // Wait for the user to accept the
+          await AnalyticsUtils.trackForNextRun(
+            WorkspaceEvents.TransitiveDepsWarningShow
+          );
+          // Wait for the user to accept the prompt, otherwise window will
+          // reload before they see the warning
           await VSCodeUtils.showMessage(
             MessageSeverity.WARN,
             "The vault you added depends on other vaults, which is not supported.",

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -377,10 +377,19 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
           vaultRootPath
         ) as IntermediateDendronConfig;
         if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
-          VSCodeUtils.showMessage(
+          // Wait for the user to accept the
+          await VSCodeUtils.showMessage(
             MessageSeverity.WARN,
-            "The vault you added depends on other vaults. You may not be able to access these transitive vaults.",
-            {}
+            "The vault you added depends on other vaults, which is not supported.",
+            {
+              modal: true,
+              detail:
+                "You may be unable to access these transitive vaults. The vault itself should continue to work.",
+            },
+            {
+              title: "Continue",
+              isCloseAffordance: true,
+            }
           );
         }
       }


### PR DESCRIPTION
This PR adds a check when a self contained vault is being added to the workspace. If the self contained vault has transitive dependencies, the user will be warned with a prompt which they'll need to acknowledge before we continue. I opted to have this blocking prompt because the user otherwise won't have enough time to see the prompt before the window reloads.

Docs: https://github.com/dendronhq/dendron-site/pull/545

![2022-06-14-17-18-52-360630604](https://user-images.githubusercontent.com/1008124/173690913-fc54dcca-71b9-444c-9ccc-804268df83fa.png)

