### PR TITLE
fix(views): double click issue on help and feedback panel

### DIFF
--- a/packages/plugin-core/src/features/HelpFeedbackTreeview.ts
+++ b/packages/plugin-core/src/features/HelpFeedbackTreeview.ts
@@ -1,4 +1,10 @@
 import {
+  assertUnreachable,
+  DendronTreeViewKey,
+  VSCodeEvents,
+} from "@dendronhq/common-all";
+import * as vscode from "vscode";
+import {
   Event,
   ProviderResult,
   ThemeIcon,
@@ -6,17 +12,12 @@ import {
   TreeItem,
   TreeItemCollapsibleState,
 } from "vscode";
-import * as vscode from "vscode";
-import {
-  assertUnreachable,
-  DendronTreeViewKey,
-  VSCodeEvents,
-} from "@dendronhq/common-all";
-import { AnalyticsUtils } from "../utils/analytics";
+import { InstrumentedWrapperCommand } from "../commands/InstrumentedWrapperCommand";
 
 enum MenuItem {
   getStarted = "Get Started",
   readDocs = "Read Documentation",
+  seeFaqs = "See FAQ's",
   reviewIssues = "Review Issues",
   reportIssue = "Report Issue",
   joinCommunity = "Join our Community!",
@@ -30,40 +31,67 @@ class HelpFeedbackTreeDataProvider implements TreeDataProvider<MenuItem> {
 
   getTreeItem(element: MenuItem): TreeItem {
     let iconPath: vscode.ThemeIcon;
+    let url = "";
 
     switch (element) {
       case MenuItem.getStarted:
         iconPath = new ThemeIcon("star");
+        url =
+          "https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/";
         break;
 
       case MenuItem.readDocs:
         iconPath = new ThemeIcon("book");
+        url = "https://wiki.dendron.so/notes/FWtrGfE4YJc3j0yMNjBn5/";
+        break;
+
+      case MenuItem.seeFaqs:
+        iconPath = new ThemeIcon("question");
+        url =
+          "https://wiki.dendron.so/notes/683740e3-70ce-4a47-a1f4-1f140e80b558/";
         break;
 
       case MenuItem.reviewIssues:
         iconPath = new ThemeIcon("issues");
+        url = "https://github.com/dendronhq/dendron/issues";
         break;
 
       case MenuItem.reportIssue:
         iconPath = new ThemeIcon("comment");
+        url = "https://github.com/dendronhq/dendron/issues/new/choose";
         break;
 
       case MenuItem.joinCommunity:
         iconPath = new ThemeIcon("organization");
+        url = "https://discord.com/invite/xrKTUStHNZ";
         break;
 
       case MenuItem.followUs:
         iconPath = new ThemeIcon("twitter");
+        url = "https://twitter.com/dendronhq";
         break;
 
       default:
         assertUnreachable(element);
     }
 
+    const command = InstrumentedWrapperCommand.createVSCodeCommand({
+      command: {
+        title: "Help and Feedback",
+        command: "vscode.open",
+        arguments: [url],
+      },
+      event: VSCodeEvents.HelpAndFeedbackItemClicked,
+      customProps: {
+        menuItem: element,
+      },
+    });
+
     return {
       label: element.toString(),
       collapsibleState: TreeItemCollapsibleState.None,
       iconPath,
+      command,
     };
   }
   getChildren(element?: MenuItem): ProviderResult<MenuItem[]> {
@@ -76,61 +104,13 @@ class HelpFeedbackTreeDataProvider implements TreeDataProvider<MenuItem> {
   }
 }
 
-function openUrl(url: string) {
-  vscode.commands.executeCommand("vscode.open", url);
-}
-
 /**
  * Creates a tree view for the basic 'Help and Feedback' panel in the Dendron
  * Custom View Container
  * @returns
  */
 export default function setupHelpFeedbackTreeView(): vscode.TreeView<MenuItem> {
-  const treeView = vscode.window.createTreeView(
-    DendronTreeViewKey.HELP_AND_FEEDBACK,
-    {
-      treeDataProvider: new HelpFeedbackTreeDataProvider(),
-    }
-  );
-
-  treeView.onDidChangeSelection((e) => {
-    const item = e.selection[0];
-
-    AnalyticsUtils.track(VSCodeEvents.HelpAndFeedbackItemClicked, {
-      menuItem: item,
-    });
-
-    switch (item) {
-      case MenuItem.getStarted:
-        openUrl(
-          "https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/"
-        );
-        break;
-
-      case MenuItem.readDocs:
-        openUrl("https://wiki.dendron.so/notes/FWtrGfE4YJc3j0yMNjBn5/");
-        break;
-
-      case MenuItem.reviewIssues:
-        openUrl("https://github.com/dendronhq/dendron/issues");
-        break;
-
-      case MenuItem.reportIssue:
-        openUrl("https://github.com/dendronhq/dendron/issues/new/choose");
-        break;
-
-      case MenuItem.joinCommunity:
-        openUrl("https://discord.com/invite/xrKTUStHNZ");
-        break;
-
-      case MenuItem.followUs:
-        openUrl("https://twitter.com/dendronhq");
-        break;
-
-      default:
-        assertUnreachable(item);
-    }
+  return vscode.window.createTreeView(DendronTreeViewKey.HELP_AND_FEEDBACK, {
+    treeDataProvider: new HelpFeedbackTreeDataProvider(),
   });
-
-  return treeView;
 }

--- a/packages/plugin-core/src/features/HelpFeedbackTreeview.ts
+++ b/packages/plugin-core/src/features/HelpFeedbackTreeview.ts
@@ -17,7 +17,7 @@ import { InstrumentedWrapperCommand } from "../commands/InstrumentedWrapperComma
 enum MenuItem {
   getStarted = "Get Started",
   readDocs = "Read Documentation",
-  seeFaqs = "See FAQ's",
+  seeFaq = "See FAQ",
   reviewIssues = "Review Issues",
   reportIssue = "Report Issue",
   joinCommunity = "Join our Community!",
@@ -45,7 +45,7 @@ class HelpFeedbackTreeDataProvider implements TreeDataProvider<MenuItem> {
         url = "https://wiki.dendron.so/notes/FWtrGfE4YJc3j0yMNjBn5/";
         break;
 
-      case MenuItem.seeFaqs:
+      case MenuItem.seeFaq:
         iconPath = new ThemeIcon("question");
         url =
           "https://wiki.dendron.so/notes/683740e3-70ce-4a47-a1f4-1f140e80b558/";


### PR DESCRIPTION
## fix(views): double click issue on help and feedback panel

There's an issue with the Help and Feedback panel where if you click an item multiple times, it'll only launch the link once.  This may make it feel like the button is broken. This change addresses that issue.

I also added an additional link to our FAQ page.

