### PR TITLE
enhance(workspace): Vaults always use UNIX style separators in config files & Adding an existing remote vault avoids creating workspace files

### DIFF
--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -1238,7 +1238,7 @@ export function cleanName(name: string): string {
 
 /** Given a path on any platform, convert it to a unix style path. Avoid using this with absolute paths. */
 export function normalizeUnixPath(fsPath: string): string {
-  return path.posix.format(path.parse(fsPath));
+  return path.posix.normalize(fsPath.replace(/\\/g, "/"));
 }
 
 /** Wrapper(s) for easier testing, to wrap functions where we don't want to mock the global function. */

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -232,10 +232,13 @@ export class VaultUtils {
 
   static toWorkspaceFolder(vault: DVault): WorkspaceFolderRaw {
     const name = VaultUtils.getName(vault);
-    const _path = VaultUtils.getRelPath(vault);
+    const vaultPath = VaultUtils.getRelPath(vault);
     return {
-      path: _path,
-      name: name === _path || path.basename(_path) === name ? undefined : name,
+      path: normalizeUnixPath(vaultPath),
+      name:
+        name === vaultPath || path.basename(vaultPath) === name
+          ? undefined
+          : name,
     };
   }
 

--- a/packages/dendron-cli/src/commands/vaultCLICommand.ts
+++ b/packages/dendron-cli/src/commands/vaultCLICommand.ts
@@ -88,6 +88,7 @@ export class VaultCLICommand extends CLICommand<CommandOpts> {
               vault,
               addToConfig: true,
               addToCodeWorkspace: true,
+              newVault: true,
             });
           } else {
             const vault: DVault = {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -19,6 +19,7 @@ import {
   IntermediateDendronConfig,
   isNotUndefined,
   isWebUri,
+  normalizeUnixPath,
   NoteUtils,
   SchemaUtils,
   SeedEntry,
@@ -281,6 +282,8 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       updateWorkspace: false,
     });
 
+    // Normalize the vault path to unix style (forward slashes) which is better for cross-compatibility
+    vault.fsPath = normalizeUnixPath(vault.fsPath);
     const vaults = ConfigUtils.getVaults(config);
     vaults.unshift(vault);
     ConfigUtils.setVaults(config, vaults);

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -396,12 +396,15 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
    * for the current workspace.
    * @param addToCodeWorkspace If true, the created vault will be added to the
    * `code-workspace` file for the current workspace.
+   * @param newVault If true, the root note and schema files, and workspace
+   * files will be created inside the vault.
    */
   async createSelfContainedVault(opts: {
     addToConfig?: boolean;
     addToCodeWorkspace?: boolean;
     // Must be created with a self-contained vault
     vault: SelfContainedVault;
+    newVault: boolean;
   }) {
     const { vault, addToConfig, addToCodeWorkspace } = opts;
     /** The `vault` folder */
@@ -412,65 +415,67 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     await fs.mkdirp(notesPath);
     await fs.mkdirp(path.join(notesPath, "assets"));
 
-    // Create root note and schema
-    const note = NoteUtils.createRoot({
-      vault,
-      body: ROOT_NOTE_TEMPLATE,
-    });
-    const schema = SchemaUtils.createRootModule({ vault });
-    if (
-      !(await fs.pathExists(
-        NoteUtils.getFullPath({ note, wsRoot: this.wsRoot })
-      ))
-    ) {
-      await note2File({ note, vault, wsRoot: this.wsRoot });
-    }
-    if (
-      !(await fs.pathExists(
-        SchemaUtils.getPath({ root: notesPath, fname: "root" })
-      ))
-    ) {
-      await schemaModuleOpts2File(schema, notesPath, "root");
-    }
+    if (opts.newVault) {
+      // Create root note and schema
+      const note = NoteUtils.createRoot({
+        vault,
+        body: ROOT_NOTE_TEMPLATE,
+      });
+      const schema = SchemaUtils.createRootModule({ vault });
+      if (
+        !(await fs.pathExists(
+          NoteUtils.getFullPath({ note, wsRoot: this.wsRoot })
+        ))
+      ) {
+        await note2File({ note, vault, wsRoot: this.wsRoot });
+      }
+      if (
+        !(await fs.pathExists(
+          SchemaUtils.getPath({ root: notesPath, fname: "root" })
+        ))
+      ) {
+        await schemaModuleOpts2File(schema, notesPath, "root");
+      }
 
-    // Create the config and code-workspace for the vault, which make it self contained.
-    // This is the config that goes inside the vault itself
-    const selfContainedVaultConfig: DVault = {
-      fsPath: ".",
-      selfContained: true,
-    };
-    if (vault.name) selfContainedVaultConfig.name = vault.name;
+      // Create the config and code-workspace for the vault, which make it self contained.
+      // This is the config that goes inside the vault itself
+      const selfContainedVaultConfig: DVault = {
+        fsPath: ".",
+        selfContained: true,
+      };
+      if (vault.name) selfContainedVaultConfig.name = vault.name;
 
-    // create dendron.yml
-    DConfig.getOrCreate(vaultPath, {
-      dev: {
-        enableSelfContainedVaults: true,
-      },
-      workspace: {
-        vaults: [selfContainedVaultConfig],
-      },
-    });
-    // create dendron.code-workspace
-    WorkspaceConfig.write(vaultPath, [], {
-      overrides: {
-        folders: [
-          {
-            // Following how we set up workspace config for workspaces, where
-            // the root is the `vault` directory
-            path: "notes",
-            name: VaultUtils.getName(vault),
-          },
-        ],
-        settings: {
-          // Also enable the self contained vault workspaces when inside the self contained vault
-          [DENDRON_VSCODE_CONFIG_KEYS.ENABLE_SELF_CONTAINED_VAULTS_WORKSPACE]:
-            true,
+      // create dendron.yml
+      DConfig.getOrCreate(vaultPath, {
+        dev: {
+          enableSelfContainedVaults: true,
         },
-      },
-    });
-    // Also add a gitignore, so files like `.dendron.port` are ignored if the
-    // self contained vault is opened on its own
-    await WorkspaceService.createGitIgnore(vaultPath);
+        workspace: {
+          vaults: [selfContainedVaultConfig],
+        },
+      });
+      // create dendron.code-workspace
+      WorkspaceConfig.write(vaultPath, [], {
+        overrides: {
+          folders: [
+            {
+              // Following how we set up workspace config for workspaces, where
+              // the root is the `vault` directory
+              path: "notes",
+              name: VaultUtils.getName(vault),
+            },
+          ],
+          settings: {
+            // Also enable the self contained vault workspaces when inside the self contained vault
+            [DENDRON_VSCODE_CONFIG_KEYS.ENABLE_SELF_CONTAINED_VAULTS_WORKSPACE]:
+              true,
+          },
+        },
+      });
+      // Also add a gitignore, so files like `.dendron.port` are ignored if the
+      // self contained vault is opened on its own
+      await WorkspaceService.createGitIgnore(vaultPath);
+    }
 
     // Update the config and code-workspace for the current workspace
     if (addToConfig) {
@@ -1086,6 +1091,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
         vault: wsVault as SelfContainedVault,
         addToCodeWorkspace: false,
         addToConfig: false,
+        newVault: true,
       });
     }
 
@@ -1103,6 +1109,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
           vault,
           addToCodeWorkspace: false,
           addToConfig: true,
+          newVault: true,
         });
       });
     }

--- a/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts
@@ -156,7 +156,7 @@ describe("WorkspaceService", () => {
               snapshot: false,
             },
             // Necessary for windows test-compat:
-            path.join(`seeds`, `${id}`, `vault`).replace(/\\/g, "\\\\")
+            path.posix.join(`seeds`, `${id}`, `vault`)
           );
           await checkVaults(
             {

--- a/packages/engine-test-utils/src/utils/index.ts
+++ b/packages/engine-test-utils/src/utils/index.ts
@@ -7,6 +7,7 @@ import {
   WorkspaceOpts,
   WorkspaceSettings,
   WorkspaceType,
+  normalizeUnixPath,
 } from "@dendronhq/common-all";
 import { readYAML } from "@dendronhq/common-server";
 import { AssertUtils } from "@dendronhq/common-test-utils";
@@ -110,7 +111,9 @@ export async function checkVaults(opts: WorkspaceOpts, expect: any) {
     const wsFolders = getWorkspaceFolders(wsRoot);
     expect(wsFolders).toEqual(
       vaults.map((ent) => {
-        const out: WorkspaceFolderRaw = { path: VaultUtils.getRelPath(ent) };
+        const out: WorkspaceFolderRaw = {
+          path: normalizeUnixPath(VaultUtils.getRelPath(ent)),
+        };
         if (ent.name) {
           out.name = ent.name;
         }

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -333,6 +333,7 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
               await wsService.createSelfContainedVault({
                 vault,
                 addToConfig: true,
+                newVault: false,
               });
             } else {
               // eslint-disable-next-line no-await-in-loop
@@ -417,6 +418,7 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
           vault,
           addToConfig: true,
           addToCodeWorkspace: false,
+          newVault: true,
         });
       } else {
         await wsService.createVault({ vault });

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -4,6 +4,7 @@ import {
   DVault,
   FOLDERS,
   IntermediateDendronConfig,
+  normalizeUnixPath,
   NoteUtils,
   SchemaUtils,
   VaultUtils,
@@ -211,7 +212,7 @@ suite("VaultAddCommand", function () {
               wsRoot,
               vaults: [
                 {
-                  fsPath: vaultPath,
+                  fsPath: normalizeUnixPath(vaultPath),
                   workspace: wsName,
                   name: "dendron",
                 },
@@ -455,7 +456,12 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
         expect(vault?.selfContained).toBeTruthy();
         expect(vault?.name).toEqual(vaultName);
         expect(vault?.fsPath).toEqual(
-          path.join(FOLDERS.DEPENDENCIES, FOLDERS.LOCAL_DEPENDENCY, vaultName)
+          // vault paths always use UNIX style
+          path.posix.join(
+            FOLDERS.DEPENDENCIES,
+            FOLDERS.LOCAL_DEPENDENCY,
+            vaultName
+          )
         );
       });
 
@@ -525,7 +531,8 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
         expect(vault?.selfContained).toBeTruthy();
         expect(vault?.name).toEqual(vaultName);
         expect(vault?.fsPath).toEqual(
-          path.join(FOLDERS.DEPENDENCIES, vaultName)
+          // vault paths always use UNIX style
+          path.posix.join(FOLDERS.DEPENDENCIES, vaultName)
         );
         expect(vault?.remote?.url).toEqual(remoteDir);
       });
@@ -604,7 +611,8 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           expect(vault?.selfContained).toBeTruthy();
           expect(vault?.name).toEqual(vaultName);
           expect(vault?.fsPath).toEqual(
-            path.join(FOLDERS.DEPENDENCIES, vaultName)
+            // vault paths always use UNIX style
+            path.posix.join(FOLDERS.DEPENDENCIES, vaultName)
           );
         });
 
@@ -749,7 +757,8 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
 
         expect(vault?.selfContained).toBeFalsy();
         expect(vault?.fsPath).toEqual(
-          path.join(FOLDERS.DEPENDENCIES, vaultName)
+          // vault paths always use UNIX style
+          path.posix.join(FOLDERS.DEPENDENCIES, vaultName)
         );
         expect(vault?.remote?.url).toEqual(remoteDir);
       });


### PR DESCRIPTION
This PR does 2 things:

1. Newly added vaults will always use UNIX style paths, as opposed to platform specific paths. This is required for cross compatibility for vaults created in Windows. Dendron will continue to correctly read these paths on Windows. #3040 
2. When adding an existing vault as a remote vault to a workspace, Dendron will no longer try to create `.gitignore` and `dendron.yml` files inside the added vault.