### PR TITLE
enhance(structure): improved note traits

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -30,6 +30,7 @@ export enum VSCodeEvents {
   BacklinksPanelUsed = "BacklinksPanelUsed",
   RecentWorkspacesPanelUsed = "RecentWorkspacesPanelUsed",
   V100ReleaseNotesShown = "V100ReleaseNotesShown",
+  NoteTraitsInitialized = "NoteTraitsInitialized",
 }
 
 export enum CLIEvents {

--- a/packages/common-all/src/types/noteTrait.ts
+++ b/packages/common-all/src/types/noteTrait.ts
@@ -60,15 +60,21 @@ export type onWillCreateProps = {
 };
 
 export type onCreateProps = {
-  //TODO: Should these be combined into one? Is String the right type for vault, probably not. Should we use DNoteProps for note?
-  //configurable_level_1
+  /**
+   * Function whose return value will be used as the title of the note
+   * @param props
+   */
   setTitle?(props: OnCreateContext): string;
 
-  // We shouldn't choose apply template; should be more generic
-  // applyTemplate(templateName: string): void;
+  /**
+   * Set a note template to be applied. Return the fname of the desired template
+   * note from this function
+   */
+  setTemplate?(): string;
 
-  //TODO: What are the arguments?
-  //configurable_level_1 - via a template
+  //TODO: What are the arguments? Also - reconcile this functionality with
+  //setTemplate, as both modify body contents.
+  // configurable_level_1 - via a template
   setBody?(): Promise<string>;
 
   //TODO: needs to return a prop array of some sort

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -399,6 +399,10 @@
         "title": "Dendron: Register Note Trait"
       },
       {
+        "command": "dendron.configureNoteTraits",
+        "title": "Dendron: Configure Note Traits"
+      },
+      {
         "command": "dendron.createNoteWithTraits",
         "title": "Dendron: Create Note with Custom Traits"
       },
@@ -748,6 +752,10 @@
         },
         {
           "command": "dendron.registerNoteTrait",
+          "when": "false"
+        },
+        {
+          "command": "dendron.configureNoteTraits",
           "when": "dendron:pluginActive"
         },
         {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -420,7 +420,10 @@ export function activate(context: vscode.ExtensionContext) {
   });
   if (stage !== "test") {
     _activate(context).catch((err) => {
-      Logger.error(err);
+      Logger.error({
+        ctx: "activate",
+        error: err,
+      });
       HistoryService.instance().add({
         action: "not_initialized",
         source: "extension",

--- a/packages/plugin-core/src/commands/ConfigureNoteTraitsCommand.ts
+++ b/packages/plugin-core/src/commands/ConfigureNoteTraitsCommand.ts
@@ -1,0 +1,74 @@
+import { CONSTANTS, DendronError } from "@dendronhq/common-all";
+import fs from "fs-extra";
+import path from "path";
+import * as vscode from "vscode";
+import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+import { RegisterNoteTraitCommand } from "./RegisterNoteTraitCommand";
+
+type CommandOpts = { traitId: string };
+
+type CommandOutput = {} | undefined;
+
+/**
+ * Command for a user to register a new note type with custom functionality
+ */
+export class ConfigureNoteTraitsCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CONFIGURE_NOTE_TRAITS.key;
+  private readonly createNewOption = "Create New";
+
+  async gatherInputs() {
+    const registeredTraits =
+      ExtensionProvider.getExtension().traitRegistrar.registeredTraits;
+
+    const items: string[] = Array.from(registeredTraits.keys());
+
+    items.unshift(this.createNewOption);
+
+    const picked = await vscode.window.showQuickPick(items, {
+      canPickMany: false,
+      title: "Select which Note Trait to Configure",
+    });
+
+    if (
+      (!picked || !registeredTraits.get(picked)) &&
+      picked !== this.createNewOption
+    ) {
+      return;
+    }
+
+    return { traitId: picked };
+  }
+
+  async execute(opts: CommandOpts): Promise<CommandOutput> {
+    if (opts.traitId === this.createNewOption) {
+      new RegisterNoteTraitCommand().run();
+      return;
+    }
+
+    const engine = ExtensionProvider.getEngine();
+    const { wsRoot } = engine;
+    const scriptPath = path.join(
+      wsRoot,
+      CONSTANTS.DENDRON_USER_NOTE_TRAITS_BASE,
+      opts.traitId + ".js"
+    );
+
+    if (await fs.pathExists(scriptPath)) {
+      await VSCodeUtils.openFileInEditor(vscode.Uri.file(scriptPath));
+    } else {
+      const error = DendronError.createPlainError({
+        message: `${scriptPath} doesn't exist.`,
+      });
+      this.L.error({ error });
+      return { error };
+    }
+
+    return;
+  }
+}

--- a/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
@@ -182,7 +182,7 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
           vault: vault!,
         });
 
-        if (notes) {
+        if (notes && notes.length > 0) {
           // Only apply schema if note is found
           TemplateUtils.applyTemplate({
             templateNote: notes[0], // Ok to use [0] here because we specified a vault in findNotes()

--- a/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteWithTraitCommand.ts
@@ -22,6 +22,7 @@ import { VaultSelectionModeConfigUtils } from "../components/lookup/vaultSelecti
 import { NoteLookupProviderUtils } from "../components/lookup/NoteLookupProviderUtils";
 import { TemplateUtils } from "@dendronhq/common-server";
 import { AnalyticsUtils } from "../utils/analytics";
+import { TraitUtils } from "../traits/TraitUtils";
 
 export type CommandOpts = {
   fname: string;
@@ -49,6 +50,10 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
   }
 
   async gatherInputs(): Promise<CommandInput | undefined> {
+    if (!TraitUtils.checkWorkspaceTrustAndWarn()) {
+      return;
+    }
+
     // If there's no modifier, provide a regular lookup UI.
     if (!this.trait.OnWillCreate?.setNameModifier) {
       const resp = await this.getNoteNameFromLookup();
@@ -63,10 +68,6 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
     }
 
     try {
-      if (!this.checkWorkspaceTrustAndWarn()) {
-        return;
-      }
-
       const context = await this.getCreateContext();
 
       // Default settings in case something goes wrong.
@@ -117,8 +118,13 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
 
     this.L.info({ ctx, msg: "enter", opts });
 
+    if (!TraitUtils.checkWorkspaceTrustAndWarn()) {
+      return;
+    }
+
     let title;
     let body;
+    let custom;
 
     // TODO: GoToNoteCommand() needs to have its arg behavior fixed, and then
     // this vault logic can be deferred there.
@@ -143,71 +149,70 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
     }
 
     // Handle Trait Behavior
-    if (this.checkWorkspaceTrustAndWarn()) {
-      if (this.trait.OnCreate?.setTitle) {
-        const context = await this.getCreateContext();
-        context.currentNoteName = fname;
+    if (this.trait.OnCreate?.setTitle) {
+      const context = await this.getCreateContext();
+      context.currentNoteName = fname;
 
-        try {
-          title = this.trait.OnCreate.setTitle(context);
-        } catch (Error: any) {
-          this.L.error({ ctx: "trait.OnCreate.setTitle", msg: Error });
-        }
+      try {
+        title = this.trait.OnCreate.setTitle(context);
+      } catch (Error: any) {
+        this.L.error({ ctx: "trait.OnCreate.setTitle", msg: Error });
+      }
+    }
+
+    if (this.trait.OnCreate?.setBody) {
+      try {
+        body = await this.trait.OnCreate.setBody();
+      } catch (Error: any) {
+        this.L.error({ ctx: "trait.OnCreate.setBody", msg: Error });
+      }
+    } else if (this.trait.OnCreate?.setTemplate) {
+      // Check if we should apply a template from any traits:
+      let templateNoteName = "";
+      try {
+        templateNoteName = this.trait.OnCreate.setTemplate();
+      } catch (Error: any) {
+        this.L.error({ ctx: "trait.OnCreate.setTemplate", msg: Error });
       }
 
-      if (this.trait.OnCreate?.setBody) {
-        try {
-          body = await this.trait.OnCreate.setBody();
-        } catch (Error: any) {
-          this.L.error({ ctx: "trait.OnCreate.setBody", msg: Error });
-        }
-      } else if (this.trait.OnCreate?.setTemplate) {
-        // Check if we should apply a template from any traits:
-        let templateNoteName = "";
-        try {
-          templateNoteName = this.trait.OnCreate.setTemplate();
-        } catch (Error: any) {
-          this.L.error({ ctx: "trait.OnCreate.setTemplate", msg: Error });
-        }
+      const notes = await ExtensionProvider.getEngine().findNotes({
+        fname: templateNoteName,
+        vault,
+      });
 
-        const notes = await ExtensionProvider.getEngine().findNotes({
-          fname: templateNoteName,
-          vault,
+      const dummy = NoteUtils.createForFake({
+        contents: "",
+        fname: "trait-tmp",
+        id: "trait-tmp",
+        vault: vault!,
+      });
+
+      if (notes && notes.length > 0) {
+        // Only apply schema if note is found
+        TemplateUtils.applyTemplate({
+          templateNote: notes[0], // Ok to use [0] here because we specified a vault in findNotes()
+          targetNote: dummy,
+          engine: this._extension.getEngine(),
         });
 
-        const dummy = NoteUtils.createForFake({
-          contents: "",
-          fname: "trait-tmp",
-          id: "trait-tmp",
-          vault: vault!,
+        body = dummy.body;
+        custom = dummy.custom;
+
+        AnalyticsUtils.track(EngagementEvents.TemplateApplied, {
+          source: "Trait",
         });
-
-        if (notes && notes.length > 0) {
-          // Only apply schema if note is found
-          TemplateUtils.applyTemplate({
-            templateNote: notes[0], // Ok to use [0] here because we specified a vault in findNotes()
-            targetNote: dummy,
-            engine: this._extension.getEngine(),
-          });
-
-          body = dummy.body;
-
-          AnalyticsUtils.track(EngagementEvents.TemplateApplied, {
-            source: "Trait",
-          });
-        } else {
-          this.L.error({
-            ctx: "trait.OnCreate.setTemplate",
-            msg: `Unable to find note with name ${templateNoteName} to use as template.`,
-          });
-        }
+      } else {
+        this.L.error({
+          ctx: "trait.OnCreate.setTemplate",
+          msg: `Unable to find note with name ${templateNoteName} to use as template.`,
+        });
       }
     }
 
     await new GotoNoteCommand(this._extension).execute({
       qs: fname,
       vault,
-      overrides: { title, traits: [this.trait.id], body },
+      overrides: { title, traits: [this.trait.id], body, custom },
     });
 
     this.L.info({ ctx, msg: "exit" });
@@ -299,17 +304,5 @@ export class CreateNoteWithTraitCommand extends BaseCommand<
       clipboard,
       currentNoteName: openNoteName,
     };
-  }
-
-  private checkWorkspaceTrustAndWarn(): boolean {
-    const engine = this._extension.getEngine();
-
-    if (!engine.trustedWorkspace) {
-      vscode.window.showWarningMessage(
-        "Workspace Trust has been disabled for this workspace. Note Trait behavior will not be applied."
-      );
-    }
-
-    return engine.trustedWorkspace;
   }
 }

--- a/packages/plugin-core/src/commands/CreateNoteWithUserDefinedTrait.ts
+++ b/packages/plugin-core/src/commands/CreateNoteWithUserDefinedTrait.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { BaseCommand } from "./base";
+import { RegisterNoteTraitCommand } from "./RegisterNoteTraitCommand";
 
 type CommandOpts = {
   trait: NoteTrait;
@@ -28,9 +29,23 @@ export class CreateNoteWithUserDefinedTrait extends BaseCommand<
   async gatherInputs(): Promise<CommandInput | undefined> {
     const registeredTraits =
       ExtensionProvider.getExtension().traitRegistrar.registeredTraits;
+
+    if (registeredTraits.size === 0) {
+      const createOption = "Create Trait";
+      const response = await vscode.window.showErrorMessage(
+        "No registered traits. Create a trait first before running this command.",
+        createOption
+      );
+
+      if (response === createOption) {
+        const cmd = new RegisterNoteTraitCommand();
+        cmd.run();
+      }
+    }
     const items = registeredTraits.keys();
     const picked = await vscode.window.showQuickPick(Array.from(items), {
       canPickMany: false,
+      title: "Select a Note Trait",
     });
 
     if (!picked || !registeredTraits.get(picked)) {

--- a/packages/plugin-core/src/commands/CreateNoteWithUserDefinedTrait.ts
+++ b/packages/plugin-core/src/commands/CreateNoteWithUserDefinedTrait.ts
@@ -2,6 +2,7 @@ import { DendronError, NoteTrait } from "@dendronhq/common-all";
 import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
+import { TraitUtils } from "../traits/TraitUtils";
 import { BaseCommand } from "./base";
 import { RegisterNoteTraitCommand } from "./RegisterNoteTraitCommand";
 
@@ -27,6 +28,10 @@ export class CreateNoteWithUserDefinedTrait extends BaseCommand<
   key = DENDRON_COMMANDS.CREATE_USER_DEFINED_NOTE.key;
 
   async gatherInputs(): Promise<CommandInput | undefined> {
+    if (!TraitUtils.checkWorkspaceTrustAndWarn()) {
+      return;
+    }
+
     const registeredTraits =
       ExtensionProvider.getExtension().traitRegistrar.registeredTraits;
 

--- a/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
+++ b/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
@@ -3,9 +3,9 @@ import fs from "fs-extra";
 import path from "path";
 import * as vscode from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { UserDefinedTraitV1 } from "../traits/UserDefinedTraitV1";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getEngine, getExtension } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = { traitId: string };
@@ -14,33 +14,88 @@ type CommandOutput = {} | undefined;
 
 const noteTraitTemplate = `
 /**
- * Note: you must reload your window after each file change for it to take into
- * effect. We are working to improve this behavior.
+ * Define your custom trait behavior in this file by modifying the functions in
+ * 'module.exports' below. See
+ * https://wiki.dendron.so/notes/EQoaBI8A0ZcswKQC3UMpO/ for examples and
+ * documentation.
+ *
+ * NOTE: This is an alpha feature, so this API may have breaking changes in
+ * future releases.
  */
+
+/**
+ * @typedef OnCreateContext Properties that can be utilized during note creation
+ * @type {object}
+ * @property {string} currentNoteName The name of the currently opened Dendron
+ * note, or the specified name of the note about to be created
+ * @property {string} selectedText Any currently selected text in the editor
+ * @property {number} clipboard The current contents of the clipboard
+ */
+
+/**
+ * @typedef SetNameModifierReturnType Properties that can be utilized during
+ * note creation
+ * @type {object}
+ * @property {string} name The name to use for the note
+ * @property {boolean} promptUserForModification if true, the modified name will
+ * appear in a lookup control to allow the user to further edit the note name
+ * before confirming.
+ */
+
+/**
+ * lodash module is available. See https://lodash.com/docs for documentation.
+ */
+const _ = module.require("lodash");
+
+/**
+ * luxon is available for Date functions. See
+ * https://moment.github.io/luxon/api-docs/index.html for documentation
+ */
+const luxon = module.require("luxon");
+
 module.exports = {
-  /**
-   * Specify behavior to modify the name of the note. If
-   * promptUserForModification is true, the modified name will appear in a
-   * lookup control to allow the user to further edit the note name before
-   * confirming.
-   */
   OnWillCreate: {
+    /**
+     * Specify behavior to modify the name of the note.
+     * @param {OnCreateContext} props
+     * @returns {SetNameModifierReturnType} the name to use for the note. If
+     * promptUserForModification is true, the modified name will appear in a
+     * lookup control to allow the user to further edit the note name before
+     * confirming.
+     */
     setNameModifier(props) {
+      // This example sets a prefix of 'my-hierarchy', and then adds a date
+      // hierarchy using the luxon module. PromptUserForModification is set to
+      // true so that the user has the option to alter the title name before
+      // creating the note.
       return {
-        name: [props.currentNoteName, props.selectedText, props.clipboard].join(','),
-        promptUserForModification: true
+        name: "my-hierarchy." + luxon.DateTime.local().toFormat("yyyy.MM.dd"),
+        promptUserForModification: true,
       };
-    }
+    },
   },
-  /**
-   * Specify behavior for altering the title of the note when it is created.
-   */
   OnCreate: {
+    /**
+     * Specify behavior for altering the title of the note when it is created.
+     * @param {OnCreateContext} props
+     * @returns {string} the title to set for the note
+     */
     setTitle(props) {
-      return [props.currentNoteName, props.selectedText, props.clipboard].join(',');
-    }
-  }
-}
+      // This example will use the currentNoteName property, extract the
+      // yyyy.MM.dd date portion of the note name, and then reformat it with
+      // dashes.
+      return props.currentNoteName.split(".").slice(-3).join("-");
+    },
+    /**
+     * Set a note template to be applied. This method is optional, if you don't
+     * want to apply a template, simply delete this 'setTemplate' property.
+     * @returns the name of the desired template note from this function
+     */
+    setTemplate: () => {
+      return "root";
+    },
+  },
+};
 `;
 
 /**
@@ -66,7 +121,7 @@ export class RegisterNoteTraitCommand extends BasicCommand<
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     vscode.window.showInformationMessage("Enter Your Trait Functionality");
 
-    const engine = getEngine();
+    const engine = ExtensionProvider.getEngine();
     const { wsRoot } = engine;
     const scriptPath = path.join(
       wsRoot,
@@ -85,7 +140,7 @@ export class RegisterNoteTraitCommand extends BasicCommand<
     fs.writeFileSync(scriptPath, noteTraitTemplate);
 
     const newNoteTrait = new UserDefinedTraitV1(opts.traitId, scriptPath);
-    getExtension().traitRegistrar.registerTrait(newNoteTrait);
+    ExtensionProvider.getExtension().traitRegistrar.registerTrait(newNoteTrait);
 
     await VSCodeUtils.openFileInEditor(vscode.Uri.file(scriptPath));
     return;

--- a/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
+++ b/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
@@ -140,7 +140,29 @@ export class RegisterNoteTraitCommand extends BasicCommand<
     fs.writeFileSync(scriptPath, noteTraitTemplate);
 
     const newNoteTrait = new UserDefinedTraitV1(opts.traitId, scriptPath);
-    ExtensionProvider.getExtension().traitRegistrar.registerTrait(newNoteTrait);
+
+    try {
+      await newNoteTrait.initialize();
+    } catch (error: any) {
+      const msg = `Error registering note trait ${opts.traitId}\n${error.stack}`;
+
+      this.L.error({
+        msg,
+      });
+    }
+
+    const resp =
+      ExtensionProvider.getExtension().traitRegistrar.registerTrait(
+        newNoteTrait
+      );
+
+    if (resp.error) {
+      const msg = `Error registering note trait ${opts.traitId}\n${resp.error.innerError?.stack}`;
+
+      this.L.error({
+        msg,
+      });
+    }
 
     await VSCodeUtils.openFileInEditor(vscode.Uri.file(scriptPath));
     return;

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -6,6 +6,7 @@ import { BrowseNoteCommand } from "./BrowseNoteCommand";
 import { ChangeWorkspaceCommand } from "./ChangeWorkspace";
 import { ConfigureCommand } from "./ConfigureCommand";
 import { ConfigureGraphStylesCommand } from "./ConfigureGraphStyles";
+import { ConfigureNoteTraitsCommand } from "./ConfigureNoteTraitsCommand";
 import { ConfigurePodCommand } from "./ConfigurePodCommand";
 import { ConfigureWithUICommand } from "./ConfigureWithUI";
 import { ContributeCommand } from "./Contribute";
@@ -164,6 +165,7 @@ const ALL_COMMANDS = [
   TaskStatusCommand,
   TaskCompleteCommand,
   RegisterNoteTraitCommand,
+  ConfigureNoteTraitsCommand,
   CreateNoteWithUserDefinedTrait,
   OpenBackupCommand,
   InstrumentedWrapperCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -733,6 +733,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   REGISTER_NOTE_TRAIT: {
     key: "dendron.registerNoteTrait",
     title: `${CMD_PREFIX} Register Note Trait`,
+    when: "false",
+  },
+  CONFIGURE_NOTE_TRAITS: {
+    key: "dendron.configureNoteTraits",
+    title: `${CMD_PREFIX} Configure Note Traits`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
   CREATE_USER_DEFINED_NOTE: {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -12,6 +12,7 @@ import {
 } from "./components/lookup/LookupProviderV3Interface";
 import { FileWatcher } from "./fileWatcher";
 import { IEngineAPIService } from "./services/EngineAPIServiceInterface";
+import { NoteTraitService } from "./services/NoteTraitService";
 import { ISchemaSyncService } from "./services/SchemaSyncServiceInterface";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
 
@@ -119,4 +120,10 @@ export interface IDendronExtension {
   getWorkspaceConfig(
     section?: string | undefined
   ): vscode.WorkspaceConfiguration;
+
+  /**
+   * Gets an instance of the trait Registrar service, which contains information
+   * about registered Note Traits
+   */
+  get traitRegistrar(): NoteTraitService;
 }

--- a/packages/plugin-core/src/services/NoteTraitManager.ts
+++ b/packages/plugin-core/src/services/NoteTraitManager.ts
@@ -1,19 +1,40 @@
 import {
+  CONSTANTS,
   DendronError,
   ERROR_SEVERITY,
   NoteTrait,
+  OnCreateContext,
   ResponseUtil,
   RespV2,
+  VSCodeEvents,
 } from "@dendronhq/common-all";
+import path from "path";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { UserDefinedTraitV1 } from "../traits/UserDefinedTraitV1";
 import { CommandRegistrar } from "./CommandRegistrar";
 import { NoteTraitService } from "./NoteTraitService";
+import fs from "fs-extra";
+import { Logger } from "../logger";
+import * as vscode from "vscode";
+import { AnalyticsUtils } from "../utils/analytics";
+import _ from "lodash";
 
-export class NoteTraitManager implements NoteTraitService {
+export class NoteTraitManager implements NoteTraitService, vscode.Disposable {
   private cmdRegistar: CommandRegistrar;
+  private L = Logger;
+  private _watcher: vscode.FileSystemWatcher | undefined;
 
-  constructor(registrar: CommandRegistrar) {
+  constructor(private _wsRoot: string, registrar: CommandRegistrar) {
     this.cmdRegistar = registrar;
     this.registeredTraits = new Map<string, NoteTrait>();
+  }
+
+  /**
+   * Loads up saved note traits and sets up a filewatcher on trait .js files
+   */
+  async initialize(): Promise<void> {
+    await this.setupSavedTraitsFromFS();
+    await this.setupFileWatcherForTraitFileChanges();
   }
 
   registeredTraits: Map<string, NoteTrait>;
@@ -28,14 +49,64 @@ export class NoteTraitManager implements NoteTraitService {
       });
     }
 
+    // During registration, do a test execution of each function to make sure
+    // it's valid TS/JS and doesn't throw.
+    const testContext: OnCreateContext = {
+      currentNoteName: "foo.bar",
+      selectedText: "text",
+      clipboard: "clipboard",
+    };
+
+    if (trait.OnCreate?.setTitle) {
+      try {
+        trait.OnCreate.setTitle(testContext);
+      } catch (error: any) {
+        return ResponseUtil.createUnhappyResponse({
+          error: new DendronError({
+            message: `Error in OnCreate.setTitle function.`,
+            innerError: error,
+          }),
+        });
+      }
+    }
+
+    if (trait.OnCreate?.setTemplate) {
+      try {
+        trait.OnCreate.setTemplate();
+      } catch (error: any) {
+        return ResponseUtil.createUnhappyResponse({
+          error: new DendronError({
+            message: `Error in OnCreate.setTemplate function.`,
+            innerError: error,
+          }),
+        });
+      }
+    }
+
+    if (trait.OnWillCreate?.setNameModifier) {
+      try {
+        trait.OnWillCreate.setNameModifier(testContext);
+      } catch (error: any) {
+        return ResponseUtil.createUnhappyResponse({
+          error: new DendronError({
+            message: `Error in OnWillCreate.setNameModifier function.`,
+            innerError: error,
+          }),
+        });
+      }
+    }
+
     this.registeredTraits.set(trait.id, trait);
 
     this.cmdRegistar.registerCommandForTrait(trait);
     return { error: null };
   }
 
-  unregisterTrait(_trait: NoteTrait): RespV2<void> {
-    throw new Error("Method not implemented.");
+  unregisterTrait(trait: NoteTrait): RespV2<void> {
+    this.cmdRegistar.unregisterTrait(trait);
+    this.registeredTraits.delete(trait.id);
+
+    return { error: null };
   }
 
   getTypesWithRegisteredCallback(_callbackType: callbackType): NoteTrait[] {
@@ -48,6 +119,138 @@ export class NoteTraitManager implements NoteTraitService {
     }
 
     return undefined;
+  }
+
+  dispose() {
+    if (this._watcher) {
+      this._watcher.dispose();
+    }
+  }
+
+  // ^6fjseznl6au4
+  private async setupSavedTraitsFromFS() {
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+
+    const userTraitsPath = wsRoot
+      ? path.join(wsRoot, CONSTANTS.DENDRON_USER_NOTE_TRAITS_BASE)
+      : undefined;
+
+    if (userTraitsPath && fs.pathExistsSync(userTraitsPath)) {
+      const files = fs.readdirSync(userTraitsPath);
+
+      // Track some info about how many and what kind of traits users have
+      let traitJSFileCount = 0;
+      let traitInitializedCount = 0;
+      let traitHasSetTitleImplCount = 0;
+      let traitHasSetNameModifierImplCount = 0;
+      let traitHasSetTemplateImplCount = 0;
+
+      files.forEach((file) => {
+        if (file.endsWith(".js")) {
+          traitJSFileCount += 1;
+
+          const resp = this.setupTraitFromJSFile(
+            path.join(userTraitsPath, file)
+          );
+
+          // Don't log an error at this point since we're just initializing - if
+          // a user has some old trait files with errors in their workspace,
+          // don't warn about trait errors until they try to actually use it.
+          if (!ResponseUtil.hasError(resp)) {
+            traitInitializedCount += 1;
+
+            const newNoteTrait = resp.data;
+
+            if (newNoteTrait?.OnCreate?.setTitle) {
+              traitHasSetTitleImplCount += 1;
+            }
+
+            if (newNoteTrait?.OnCreate?.setTemplate) {
+              traitHasSetTemplateImplCount += 1;
+            }
+
+            if (newNoteTrait?.OnWillCreate?.setNameModifier) {
+              traitHasSetNameModifierImplCount += 1;
+            }
+          }
+        }
+      });
+
+      if (traitJSFileCount > 0) {
+        AnalyticsUtils.track(VSCodeEvents.NoteTraitsInitialized, {
+          traitJSFileCount,
+          traitInitializedCount,
+          traitHasSetTitleImplCount,
+          traitHasSetNameModifierImplCount,
+          traitHasSetTemplateImplCount,
+        });
+      }
+    }
+  }
+
+  private setupTraitFromJSFile(fsPath: string): RespV2<NoteTrait> {
+    const traitId = path.basename(fsPath, ".js");
+
+    this.L.info("Registering User Defined Note Trait with ID " + traitId);
+    const newNoteTrait = new UserDefinedTraitV1(traitId, fsPath);
+
+    const resp = this.registerTrait(newNoteTrait);
+
+    return {
+      data: newNoteTrait,
+      error: resp.error,
+    };
+  }
+
+  private async setupFileWatcherForTraitFileChanges() {
+    const userTraitsPath = this._wsRoot
+      ? path.join(this._wsRoot, CONSTANTS.DENDRON_USER_NOTE_TRAITS_BASE)
+      : undefined;
+
+    if (!userTraitsPath) {
+      return;
+    }
+
+    const pattern = new vscode.RelativePattern(userTraitsPath, "*.js");
+
+    this._watcher = vscode.workspace.createFileSystemWatcher(
+      pattern,
+      false,
+      false,
+      false
+    );
+
+    this._watcher.onDidCreate((uri) => {
+      this.setupTraitFromJSFile(uri.fsPath);
+    });
+
+    this._watcher.onDidChange(
+      // Need to debounce this, for some reason it fires 4 times each save
+      _.debounce((uri) => {
+        const traitId = path.basename(uri.fsPath, ".js");
+
+        // First unregister if it exists already (and then re-register)
+        if (this.registeredTraits.has(traitId)) {
+          this.unregisterTrait(this.registeredTraits.get(traitId)!);
+        }
+
+        const resp = this.setupTraitFromJSFile(uri.fsPath);
+
+        if (ResponseUtil.hasError(resp)) {
+          const errMessage = `${resp.error?.message}\n${resp.error?.innerError?.stack}`;
+          vscode.window.showErrorMessage(errMessage);
+        }
+      }),
+      250 // 250 ms debounce interval
+    );
+
+    this._watcher.onDidDelete((uri) => {
+      const traitId = path.basename(uri.fsPath, ".js");
+
+      if (this.registeredTraits.has(traitId)) {
+        this.unregisterTrait(this.registeredTraits.get(traitId)!);
+      }
+    });
   }
 }
 

--- a/packages/plugin-core/src/services/NoteTraitManager.ts
+++ b/packages/plugin-core/src/services/NoteTraitManager.ts
@@ -258,8 +258,7 @@ export class NoteTraitManager implements NoteTraitService, vscode.Disposable {
             `Note trait ${traitId} successfully registered.`
           );
         }
-      }),
-      250 // 250 ms debounce interval
+      }, 500) // 500 ms debounce interval
     );
 
     this._watcher.onDidDelete((uri) => {

--- a/packages/plugin-core/src/services/NoteTraitManager.ts
+++ b/packages/plugin-core/src/services/NoteTraitManager.ts
@@ -1,0 +1,60 @@
+import {
+  DendronError,
+  ERROR_SEVERITY,
+  NoteTrait,
+  ResponseUtil,
+  RespV2,
+} from "@dendronhq/common-all";
+import { CommandRegistrar } from "./CommandRegistrar";
+import { NoteTraitService } from "./NoteTraitService";
+
+export class NoteTraitManager implements NoteTraitService {
+  private cmdRegistar: CommandRegistrar;
+
+  constructor(registrar: CommandRegistrar) {
+    this.cmdRegistar = registrar;
+    this.registeredTraits = new Map<string, NoteTrait>();
+  }
+
+  registeredTraits: Map<string, NoteTrait>;
+
+  registerTrait(trait: NoteTrait): RespV2<void> {
+    if (this.registeredTraits.has(trait.id)) {
+      return ResponseUtil.createUnhappyResponse({
+        error: new DendronError({
+          message: `Type with ID ${trait.id} has already been registered`,
+          severity: ERROR_SEVERITY.MINOR,
+        }),
+      });
+    }
+
+    this.registeredTraits.set(trait.id, trait);
+
+    this.cmdRegistar.registerCommandForTrait(trait);
+    return { error: null };
+  }
+
+  unregisterTrait(_trait: NoteTrait): RespV2<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  getTypesWithRegisteredCallback(_callbackType: callbackType): NoteTrait[] {
+    throw new Error("Method not implemented.");
+  }
+
+  getRegisteredCommandForTrait(trait: NoteTrait): string | undefined {
+    if (trait.id in this.cmdRegistar.registeredCommands) {
+      return this.cmdRegistar.registeredCommands[trait.id];
+    }
+
+    return undefined;
+  }
+}
+
+/**
+ * Not used yet
+ */
+enum callbackType {
+  onDescendantLifecycleEvent,
+  onSiblingLifecycleEvent,
+}

--- a/packages/plugin-core/src/services/NoteTraitService.ts
+++ b/packages/plugin-core/src/services/NoteTraitService.ts
@@ -1,15 +1,21 @@
 import { NoteTrait, RespV2 } from "@dendronhq/common-all";
+import * as vscode from "vscode";
 
 /**
  * Interface for a service that manages Note Traits
  * TODO: Figure out how to split functionality here such that some can move to engine-server while plugin-specific func stays in plugin-core
  * TODO: Expand functionality to cover more advanced typed functionality such as note lifecycle events
  */
-export type NoteTraitService = {
+export type NoteTraitService = vscode.Disposable & {
   /**
    * Contains list of registered Note Traits
    */
   readonly registeredTraits: Map<string, NoteTrait>;
+
+  /**
+   * Method for any intialization logic
+   */
+  initialize(): Promise<void>;
 
   /**
    * Register a New Note Trait

--- a/packages/plugin-core/src/services/NoteTraitService.ts
+++ b/packages/plugin-core/src/services/NoteTraitService.ts
@@ -1,11 +1,4 @@
-import {
-  DendronError,
-  ERROR_SEVERITY,
-  NoteTrait,
-  ResponseUtil,
-  RespV2,
-} from "@dendronhq/common-all";
-import { CommandRegistrar } from "./CommandRegistrar";
+import { NoteTrait, RespV2 } from "@dendronhq/common-all";
 
 /**
  * Interface for a service that manages Note Traits
@@ -37,54 +30,3 @@ export type NoteTraitService = {
    */
   getRegisteredCommandForTrait(trait: NoteTrait): string | undefined;
 };
-
-export class NoteTraitManager implements NoteTraitService {
-  private cmdRegistar: CommandRegistrar;
-
-  constructor(registrar: CommandRegistrar) {
-    this.cmdRegistar = registrar;
-    this.registeredTraits = new Map<string, NoteTrait>();
-  }
-
-  registeredTraits: Map<string, NoteTrait>;
-
-  registerTrait(trait: NoteTrait): RespV2<void> {
-    if (this.registeredTraits.has(trait.id)) {
-      return ResponseUtil.createUnhappyResponse({
-        error: new DendronError({
-          message: `Type with ID ${trait.id} has already been registered`,
-          severity: ERROR_SEVERITY.MINOR,
-        }),
-      });
-    }
-
-    this.registeredTraits.set(trait.id, trait);
-
-    this.cmdRegistar.registerCommandForTrait(trait);
-    return { error: null };
-  }
-
-  unregisterTrait(_trait: NoteTrait): RespV2<void> {
-    throw new Error("Method not implemented.");
-  }
-
-  getTypesWithRegisteredCallback(_callbackType: callbackType): NoteTrait[] {
-    throw new Error("Method not implemented.");
-  }
-
-  getRegisteredCommandForTrait(trait: NoteTrait): string | undefined {
-    if (trait.id in this.cmdRegistar.registeredCommands) {
-      return this.cmdRegistar.registeredCommands[trait.id];
-    }
-
-    return undefined;
-  }
-}
-
-/**
- * Not used yet
- */
-export enum callbackType {
-  onDescendantLifecycleEvent,
-  onSiblingLifecycleEvent,
-}

--- a/packages/plugin-core/src/services/NoteTraitService.ts
+++ b/packages/plugin-core/src/services/NoteTraitService.ts
@@ -16,7 +16,7 @@ export type NoteTraitService = {
   /**
    * Contains list of registered Note Traits
    */
-  readonly registeredTraits: NoteTrait[];
+  readonly registeredTraits: Map<string, NoteTrait>;
 
   /**
    * Register a New Note Trait
@@ -40,17 +40,16 @@ export type NoteTraitService = {
 
 export class NoteTraitManager implements NoteTraitService {
   private cmdRegistar: CommandRegistrar;
-  registeredTraits: NoteTrait[] = [];
 
   constructor(registrar: CommandRegistrar) {
     this.cmdRegistar = registrar;
+    this.registeredTraits = new Map<string, NoteTrait>();
   }
 
+  registeredTraits: Map<string, NoteTrait>;
+
   registerTrait(trait: NoteTrait): RespV2<void> {
-    if (
-      this.registeredTraits.find((registered) => registered.id === trait.id) !==
-      undefined
-    ) {
+    if (this.registeredTraits.has(trait.id)) {
       return ResponseUtil.createUnhappyResponse({
         error: new DendronError({
           message: `Type with ID ${trait.id} has already been registered`,
@@ -59,7 +58,8 @@ export class NoteTraitManager implements NoteTraitService {
       });
     }
 
-    this.registeredTraits = this.registeredTraits.concat(trait);
+    this.registeredTraits.set(trait.id, trait);
+
     this.cmdRegistar.registerCommandForTrait(trait);
     return { error: null };
   }

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -18,7 +18,6 @@ import {
   ISchemaLookupProviderFactory,
 } from "../components/lookup/LookupProviderV3Interface";
 import { IDendronExtension } from "../dendronExtensionInterface";
-import { FileWatcher } from "../fileWatcher";
 import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
 import { NoteTraitService } from "../services/NoteTraitService";
 import { ISchemaSyncService } from "../services/SchemaSyncServiceInterface";

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -18,7 +18,9 @@ import {
   ISchemaLookupProviderFactory,
 } from "../components/lookup/LookupProviderV3Interface";
 import { IDendronExtension } from "../dendronExtensionInterface";
+import { FileWatcher } from "../fileWatcher";
 import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
+import { NoteTraitService } from "../services/NoteTraitService";
 import { ISchemaSyncService } from "../services/SchemaSyncServiceInterface";
 import { WSUtilsV2 } from "../WSUtilsV2";
 import { IWSUtilsV2 } from "../WSUtilsV2Interface";
@@ -49,6 +51,9 @@ export class MockDendronExtension implements IDendronExtension {
     this._context = context;
     this._wsRoot = wsRoot;
     this._vaults = vaults;
+  }
+  get traitRegistrar(): NoteTraitService {
+    throw new Error("Method not implemented.");
   }
 
   port?: number | undefined;

--- a/packages/plugin-core/src/test/suite-integ/components/traits/CreateNoteWithTraitCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/CreateNoteWithTraitCommand.test.ts
@@ -1,62 +1,71 @@
 import { VaultUtils } from "@dendronhq/common-all";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import path from "path";
 import { CreateNoteWithTraitCommand } from "../../../../commands/CreateNoteWithTraitCommand";
+import { ExtensionProvider } from "../../../../ExtensionProvider";
 import { VSCodeUtils } from "../../../../vsCodeUtils";
-import { getDWorkspace } from "../../../../workspace";
 import { MockDendronExtension } from "../../../MockDendronExtension";
 import { expect } from "../../../testUtilsv2";
-import { describeSingleWS } from "../../../testUtilsV3";
+import { describeMultiWS } from "../../../testUtilsV3";
 import { TestTrait } from "./TestTrait";
 
 suite("CreateNoteWithTraitCommand tests", () => {
-  describeSingleWS("GIVEN a Note Trait", {}, (ctx) => {
-    describe(`WHEN creating a note with that trait applied`, () => {
-      beforeEach(() => {
-        VSCodeUtils.closeAllEditors();
-      });
-
-      afterEach(() => {
-        VSCodeUtils.closeAllEditors();
-      });
-
-      test(`THEN expect the title to have been modified`, async () => {
-        const { engine, wsRoot, vaults } = getDWorkspace();
-        const testTrait = new TestTrait();
-
-        const mockExtension = new MockDendronExtension({
-          engine,
-          wsRoot,
-          context: ctx,
+  describeMultiWS(
+    "GIVEN a Note Trait",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    (ctx) => {
+      describe(`WHEN creating a note with that trait applied`, () => {
+        beforeEach(() => {
+          VSCodeUtils.closeAllEditors();
         });
 
-        const cmd = new CreateNoteWithTraitCommand(
-          mockExtension,
-          "test-create-note-with-trait",
-          testTrait
-        );
+        afterEach(() => {
+          VSCodeUtils.closeAllEditors();
+        });
 
-        await cmd.execute({ fname: "test" });
+        test(`THEN expect the title to have been modified AND have the foo template applied`, async () => {
+          const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const testTrait = new TestTrait();
 
-        const expectedFName = path.join(
-          wsRoot,
-          VaultUtils.getRelPath(vaults[0]),
-          "test.md"
-        );
+          const mockExtension = new MockDendronExtension({
+            engine,
+            wsRoot,
+            context: ctx,
+            vaults,
+          });
 
-        expect(VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath).toEqual(
-          expectedFName
-        );
+          const cmd = new CreateNoteWithTraitCommand(
+            mockExtension,
+            "test-create-note-with-trait",
+            testTrait
+          );
 
-        const props = (
-          await engine.findNotes({
-            fname: "test",
-            vault: vaults[0],
-          })
-        )[0];
+          await cmd.execute({ fname: "test" });
 
-        expect(props?.title).toEqual(testTrait.TEST_TITLE_MODIFIER);
+          const expectedFName = path.join(
+            wsRoot,
+            VaultUtils.getRelPath(vaults[0]),
+            "test.md"
+          );
+
+          expect(
+            VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath
+          ).toEqual(expectedFName);
+
+          const props = (
+            await engine.findNotes({
+              fname: "test",
+              vault: vaults[0],
+            })
+          )[0];
+
+          expect(props?.title).toEqual(testTrait.TEST_TITLE_MODIFIER);
+          expect(props?.body).toEqual("foo body\n");
+        });
       });
-    });
-  });
+    }
+  );
 });

--- a/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
@@ -1,5 +1,5 @@
-import { NoteTrait } from "@dendronhq/common-all";
-import { afterEach, describe } from "mocha";
+import { NoteTrait, OnCreateContext } from "@dendronhq/common-all";
+import { beforeEach, afterEach, describe } from "mocha";
 import sinon from "sinon";
 import vscode from "vscode";
 import { ExtensionProvider } from "../../../../ExtensionProvider";
@@ -8,9 +8,16 @@ import { NoteTraitManager } from "../../../../services/NoteTraitManager";
 import { MockDendronExtension } from "../../../MockDendronExtension";
 import { expect } from "../../../testUtilsv2";
 import { describeSingleWS } from "../../../testUtilsV3";
+import { UserDefinedTraitV1 } from "../../../../traits/UserDefinedTraitV1";
+import * as path from "path";
 
 //TODO: Expand coverage once other methods of NoteTraitManager are implemented
 suite("NoteTraitManager tests", () => {
+  const createContext: OnCreateContext = {
+    clipboard: "clipboard-text",
+    currentNoteName: "current.note.name",
+  };
+
   describe(`GIVEN a NoteTraitManager`, () => {
     const TRAIT_ID = "test-trait";
 
@@ -20,6 +27,7 @@ suite("NoteTraitManager tests", () => {
 
     describeSingleWS("WHEN registering a new trait", {}, (ctx) => {
       let registrar: CommandRegistrar;
+
       afterEach(() => {
         if (registrar) {
           registrar.unregisterTrait(trait);
@@ -36,7 +44,7 @@ suite("NoteTraitManager tests", () => {
         });
         registrar = new CommandRegistrar(mockExtension);
 
-        const traitManager = new NoteTraitManager(registrar);
+        const traitManager = new NoteTraitManager(wsRoot, registrar);
         const resp = traitManager.registerTrait(trait);
         expect(resp.error).toBeFalsy();
         expect(registerCommand.calledOnce).toBeTruthy();
@@ -44,6 +52,83 @@ suite("NoteTraitManager tests", () => {
           "dendron.customCommand.test-trait"
         );
         registerCommand.restore();
+      });
+    });
+  });
+
+  describe(`GIVEN a user defined trait in a JS file`, () => {
+    describeSingleWS("WHEN registering the trait", {}, () => {
+      let trait: NoteTrait;
+
+      beforeEach(() => {
+        trait = new UserDefinedTraitV1(
+          "foo",
+          path.resolve(
+            __dirname,
+            "../../../../../../src/test/suite-integ/components/traits/testJSTraits/UserTestTrait.js"
+          )
+        );
+      });
+
+      test(`THEN setNameModifier can be properly invoked AND context props can be accessed`, () => {
+        const nameModifierResp =
+          trait.OnWillCreate!.setNameModifier!(createContext);
+
+        expect(nameModifierResp.name).toEqual("clipboard-text");
+        expect(nameModifierResp.promptUserForModification).toBeTruthy();
+      });
+
+      test(`THEN setTitle can be properly invoked AND context props can be accessed`, () => {
+        const modifiedTitle = trait.OnCreate!.setTitle!(createContext);
+        expect(modifiedTitle).toEqual("current.note.name");
+      });
+
+      test(`THEN setTemplate can be properly invoked`, () => {
+        expect(trait.OnCreate!.setTemplate!()).toEqual("foo");
+      });
+    });
+  });
+
+  describe(`GIVEN a user defined trait with module requires`, () => {
+    describeSingleWS("WHEN registering the trait", {}, (ctx) => {
+      let registrar: CommandRegistrar;
+      let trait: NoteTrait;
+
+      afterEach(() => {
+        if (registrar && trait) {
+          registrar.unregisterTrait(trait);
+        }
+      });
+
+      test(`THEN registration succeeds and lodash and luxon modules can be invoked`, () => {
+        const { wsRoot, engine } = ExtensionProvider.getDWorkspace();
+        const mockExtension = new MockDendronExtension({
+          engine,
+          wsRoot,
+          context: ctx,
+        });
+        registrar = new CommandRegistrar(mockExtension);
+
+        trait = new UserDefinedTraitV1(
+          "foo",
+          path.resolve(
+            __dirname,
+            "../../../../../../src/test/suite-integ/components/traits/testJSTraits/TestTraitUsingModules.js"
+          )
+        );
+
+        const traitManager = new NoteTraitManager(wsRoot, registrar);
+        const resp = traitManager.registerTrait(trait);
+
+        expect(resp.error).toBeFalsy();
+
+        // setTitle uses lodash
+        expect(trait.OnCreate!.setTitle!(createContext)).toEqual(2);
+
+        // setTemplate uses luxon
+        expect(trait.OnCreate!.setTemplate!()).toEqual(
+          "2022-01-01T00:00:00.000+08:00"
+        );
       });
     });
   });

--- a/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
@@ -173,9 +173,9 @@ suite("NoteTraitManager tests", () => {
         expect(trait.OnCreate!.setTitle!(createContext)).toEqual(2);
 
         // setTemplate uses luxon
-        expect(trait.OnCreate!.setTemplate!()).toEqual(
-          "2022-01-01T00:00:00.000+08:00"
-        );
+        expect(
+          trait.OnCreate!.setTemplate!().startsWith("2022-01-01")
+        ).toBeTruthy();
       });
     });
   });

--- a/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/NoteTraitService.test.ts
@@ -4,7 +4,7 @@ import sinon from "sinon";
 import vscode from "vscode";
 import { ExtensionProvider } from "../../../../ExtensionProvider";
 import { CommandRegistrar } from "../../../../services/CommandRegistrar";
-import { NoteTraitManager } from "../../../../services/NoteTraitService";
+import { NoteTraitManager } from "../../../../services/NoteTraitManager";
 import { MockDendronExtension } from "../../../MockDendronExtension";
 import { expect } from "../../../testUtilsv2";
 import { describeSingleWS } from "../../../testUtilsV3";

--- a/packages/plugin-core/src/test/suite-integ/components/traits/TestTrait.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/TestTrait.ts
@@ -24,5 +24,8 @@ export class TestTrait implements NoteTrait {
     setTitle: () => {
       return this.TEST_TITLE_MODIFIER;
     },
+    setTemplate: () => {
+      return "foo";
+    },
   };
 }

--- a/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/InvalidTestTrait.js
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/InvalidTestTrait.js
@@ -1,0 +1,8 @@
+module.exports = {
+  OnWillCreate: {
+    setNameModifier() {
+      // eslint-disable-next-line no-undef
+      notAValidFunction();
+    },
+  },
+};

--- a/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/TestTraitUsingModules.js
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/TestTraitUsingModules.js
@@ -1,0 +1,22 @@
+const _ = module.require("lodash");
+const luxon = module.require("luxon");
+
+module.exports = {
+  OnWillCreate: {
+    setNameModifier(props) {
+      return {
+        name: props.clipboard,
+        promptUserForModification: true,
+      };
+    },
+  },
+  OnCreate: {
+    setTitle() {
+      return _.add(1, 1);
+    },
+    setTemplate: () => {
+      const date = luxon.DateTime.fromFormat("2022-01-01", "yyyy-MM-dd");
+      return date.toString();
+    },
+  },
+};

--- a/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/UserTestTrait.js
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/testJSTraits/UserTestTrait.js
@@ -1,0 +1,18 @@
+module.exports = {
+  OnWillCreate: {
+    setNameModifier(props) {
+      return {
+        name: props.clipboard,
+        promptUserForModification: true,
+      };
+    },
+  },
+  OnCreate: {
+    setTitle(props) {
+      return props.currentNoteName;
+    },
+    setTemplate: () => {
+      return "foo";
+    },
+  },
+};

--- a/packages/plugin-core/src/traits/TraitUtils.ts
+++ b/packages/plugin-core/src/traits/TraitUtils.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+import { ExtensionProvider } from "../ExtensionProvider";
+
+export class TraitUtils {
+  /**
+   * Shows a warning to user's about needing to enable workspace trust for traits.
+   * @returns true if the workspace is trusted.
+   */
+  static checkWorkspaceTrustAndWarn(): boolean {
+    const engine = ExtensionProvider.getEngine();
+
+    const moreInfoBtn = "More Info";
+
+    if (!engine.trustedWorkspace) {
+      vscode.window
+        .showErrorMessage(
+          "Workspace Trust has been disabled for this workspace. Turn on workspace trust before using note traits.",
+          moreInfoBtn
+        )
+        .then((resp) => {
+          if (resp === moreInfoBtn) {
+            vscode.commands.executeCommand(
+              "vscode.open",
+              "https://code.visualstudio.com/docs/editor/workspace-trust"
+            );
+          }
+        });
+    }
+
+    return engine.trustedWorkspace;
+  }
+}

--- a/packages/plugin-core/src/traits/UserDefinedTraitV1.ts
+++ b/packages/plugin-core/src/traits/UserDefinedTraitV1.ts
@@ -1,15 +1,12 @@
-/* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 import {
   NoteTrait,
   onCreateProps,
   onWillCreateProps,
 } from "@dendronhq/common-all";
-import fs from "fs-extra";
-import path from "path";
 
 /**
- * A NoteTrait that will execute end-user defined javascript code.
+ * A Note Trait that will execute end-user defined javascript code.
  */
 export class UserDefinedTraitV1 implements NoteTrait {
   id: string;
@@ -34,20 +31,52 @@ export class UserDefinedTraitV1 implements NoteTrait {
    * methods will be invoked.
    */
   async initialize() {
-    // Copy the user's JS file to somewhere in the current node execution path.
-    // This allows any module.requires (such as lodash, luxon) in the user's JS
-    // file to properly resolve and gives the user full access to any node
-    // modules Dendron is using.
-    const userTraitsPath = path.join(__dirname, "user-traits");
-    const destPath = path.join(userTraitsPath, path.basename(this.scriptPath));
-
-    fs.ensureDirSync(userTraitsPath);
-    fs.copyFileSync(this.scriptPath, destPath);
-
     const hack = require(`./webpack-require-hack.js`);
-    const trait = hack(destPath);
+    const trait: UserDefinedTraitV1 = hack(this.scriptPath);
 
-    this.OnCreate = trait.OnCreate;
-    this.OnWillCreate = trait.OnWillCreate;
+    this.OnWillCreate = {
+      setNameModifier: trait.OnWillCreate?.setNameModifier
+        ? this.wrapFnWithRequiredModules(trait.OnWillCreate!.setNameModifier)
+        : undefined,
+    };
+
+    this.OnCreate = {
+      setTitle: trait.OnCreate?.setTitle
+        ? this.wrapFnWithRequiredModules(trait.OnCreate!.setTitle)
+        : undefined,
+      setTemplate: trait.OnCreate?.setTemplate
+        ? this.wrapFnWithRequiredModules(trait.OnCreate!.setTemplate)
+        : undefined,
+    };
+  }
+
+  /**
+   * Helper method that returns a modified form of the passed in function. The
+   * modified form allows the function to access lodash and luxon modules as if
+   * they were imported modules. It does this by temporarily modifying the
+   * global Object prototype, which allows module access with '_.*' or 'luxon.*'
+   * syntax
+   * @param fn
+   * @returns
+   */
+  private wrapFnWithRequiredModules(
+    fn: (args?: any) => any
+  ): (args?: any) => any {
+    return function (args: any) {
+      const objectPrototype = Object.prototype as any;
+
+      const _ = require("lodash");
+      const luxon = require("luxon");
+
+      try {
+        objectPrototype._ = _;
+        objectPrototype.luxon = luxon;
+        return fn(args);
+      } finally {
+        // Make sure to clean up the global object after we're done.
+        delete objectPrototype._;
+        delete objectPrototype.luxon;
+      }
+    };
   }
 }

--- a/packages/plugin-core/src/traits/webpack-require-hack.ts
+++ b/packages/plugin-core/src/traits/webpack-require-hack.ts
@@ -2,6 +2,10 @@
 /* eslint-disable import/no-dynamic-require */
 // @ts-ignore
 const webpackRequire = (importPath) => {
+  // First delete the import from the node module cache in case it exists. This
+  // allows us to do 'hot-reloading' of the .js files in Traits.
+  delete require.cache[require.resolve(importPath)];
+
   const module = require(importPath);
   return module;
 };

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -50,10 +50,8 @@ import { FileWatcher } from "./fileWatcher";
 import { Logger } from "./logger";
 import { CommandRegistrar } from "./services/CommandRegistrar";
 import { EngineAPIService } from "./services/EngineAPIService";
-import {
-  NoteTraitManager,
-  NoteTraitService,
-} from "./services/NoteTraitService";
+import { NoteTraitManager } from "./services/NoteTraitManager";
+import { NoteTraitService } from "./services/NoteTraitService";
 import { SchemaSyncService } from "./services/SchemaSyncService";
 import { ISchemaSyncService } from "./services/SchemaSyncServiceInterface";
 import { ALL_FEATURE_SHOWCASES } from "./showcase/AllFeatureShowcases";

--- a/packages/plugin-core/src/workspace/workspaceActivater.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivater.ts
@@ -60,11 +60,11 @@ export class WorkspaceActivator {
       workspace = await this.activateCodeWorkspace({ ext, context });
     }
 
-    // --- Setup Traits
     ext.workspaceImpl = workspace;
-    // Only set up note traits after workspaceImpl has been set, so that the
-    // wsRoot path is known for locating the note trait definition location.
-    ext.setupTraits();
+
+    // HACK: Only set up note traits after workspaceImpl has been set, so that
+    // the wsRoot path is known for locating the note trait definition location.
+    ext.traitRegistrar.initialize();
     return workspace;
   }
 

--- a/packages/plugin-core/src/workspace/workspaceActivater.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivater.ts
@@ -64,7 +64,13 @@ export class WorkspaceActivator {
 
     // HACK: Only set up note traits after workspaceImpl has been set, so that
     // the wsRoot path is known for locating the note trait definition location.
-    ext.traitRegistrar.initialize();
+    if (vscode.workspace.isTrusted) {
+      ext.traitRegistrar.initialize();
+    } else {
+      Logger.info({
+        msg: "User specified note traits not initialized because workspace is not trusted.",
+      });
+    }
     return workspace;
   }
 


### PR DESCRIPTION
## enhance(structure): improved note traits

Various improvements to Note Traits:
- Note Traits now supports application of a template
- 'Adding' support for lodash, luxon access in the trait definition JS.  It turns out that it was already accessible via Node JS' `module.require`, but just completely undiscoverable.  I've added require statements to the traits template.
- Revamping the traits template to include more thorough documentation, including rudimentary Intellisense support via JSDoc strings
- Allows traits to 'hot' reload, so you no longer need to reload window to test if your code is working
- Add a watch-like compile capability - when a user saves their JS file, the code does a test run of each function during the traits registration process.  If any of the functions have errors, we'll provide a helpful error toast pointing directly at the error source.
- Fixes some usability issues with the note traits related commands, such as when you try to create a note with a trait but have no traits defined.

Docs: https://github.com/dendronhq/dendron-site/pull/560

---

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs

https://github.com/dendronhq/dendron-site/pull/560

- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

