### PR TITLE
enhance(workspace): upgrade page for v100

### DIFF
--- a/packages/common-all/src/constants/views.ts
+++ b/packages/common-all/src/constants/views.ts
@@ -19,7 +19,7 @@ export enum DendronEditorViewKey {
   NOTE_GRAPH = "dendron.graph-note",
   SCHEMA_GRAPH = "dendron.graph-schema",
   NOTE_PREVIEW = "dendron.note-preview",
-  CHANGELOG = "dendron.changelog",
+  RELEASE_NOTES = "dendron.release-notes",
   SEED_BROWSER = "dendron.seed-browser",
 }
 
@@ -42,9 +42,9 @@ export const EDITOR_VIEWS: Record<DendronEditorViewKey, DendronViewEntry> = {
     bundleName: "DendronNotePreview",
     type: "webview",
   },
-  [DendronEditorViewKey.CHANGELOG]: {
-    desc: "Changelog",
-    label: "Changelog",
+  [DendronEditorViewKey.RELEASE_NOTES]: {
+    desc: "Dendron Release Notes",
+    label: "Dendron Release Notes",
     bundleName: "DendronNotePreview",
     type: "webview",
   },

--- a/packages/common-all/src/constants/views.ts
+++ b/packages/common-all/src/constants/views.ts
@@ -19,6 +19,7 @@ export enum DendronEditorViewKey {
   NOTE_GRAPH = "dendron.graph-note",
   SCHEMA_GRAPH = "dendron.graph-schema",
   NOTE_PREVIEW = "dendron.note-preview",
+  CHANGELOG = "dendron.changelog",
   SEED_BROWSER = "dendron.seed-browser",
 }
 
@@ -38,6 +39,12 @@ export const EDITOR_VIEWS: Record<DendronEditorViewKey, DendronViewEntry> = {
   [DendronEditorViewKey.NOTE_PREVIEW]: {
     desc: "Note Preview",
     label: "Note Preview",
+    bundleName: "DendronNotePreview",
+    type: "webview",
+  },
+  [DendronEditorViewKey.CHANGELOG]: {
+    desc: "Changelog",
+    label: "Changelog",
     bundleName: "DendronNotePreview",
     type: "webview",
   },

--- a/packages/plugin-core/assets/dendron-ws/vault/v100.md
+++ b/packages/plugin-core/assets/dendron-ws/vault/v100.md
@@ -1,0 +1,76 @@
+---
+id: q69fyod4ey0a716b69b64fb
+title: Latest
+desc: ""
+updated: 1655327146166
+created: 1654447362351
+documentId: 11cbvNLFHBMK4_4XOAAIaV7WpUHhqxgfgY0xrG2Exubw
+revisionId: >-
+  ALm37BWKnOzlGRBLQnqxfd3v6bUF2R9lo04_bddygMFGLt40sErKXnku7Is_vdSH52YwpLM7eHoJWPjLP6xLuA
+---
+
+> Dendron is launching on product hunt today! If Dendron has been of use to you, please leave feedback on our [launch page](TODO).
+
+### Context
+
+Two years ago, we launched Dendron because we believed there was a [better way of managing knowledge](https://www.kevinslin.com/notes/e1455752-b052-4212-ac6e-cc054659f2bb.html).
+
+The problem - we are all drowning in information! Existing tools (try) to make it easy to get knowledge in but fail at getting that information back out when needed.
+
+Dendron is a developer-focused, open-source, note-taking tool. It combines the simplicity of markdown with the power of VSCode. To manage information at scale, Dendron applies the insights we've learned from five decades of developer tooling and brings it to general knowledge.
+
+Since 2020, we've been iterating on this thesis with weekly releases to make Dendron better, faster and stronger! With the v100 release, we'll take a moment to go over some highlights.
+
+### Better
+
+In a well-designed system, easy things should be easy and hard things possible.
+
+This hasn't always been the case at Dendron and it's something we've put in a lot of effort addressing through improved documentation, feature work, and better defaults.
+
+Besides creating a catalogue of [[talks|dendron://dendron.dendron-site/community.events.greenhouse.2022-02-25-gtd-bullet-journals-task-management-workflow-demos]] and [[guides|dendron://dendron.dendron-site/dendron.guides.workflows]] of how Dendron is used in the wild, we've also kicked off a [[standardization effort|dendron://dendron.handbook/leaflet.journal.2022.05.10.standard-documentation]] across all our docs so that any feature, command, or config is just a [[lookup|dendron://dendron.dendron-site/dendron.topic.lookup]] away!
+
+Feature wise, the following are some areas we've invested in to make common workflows easy:
+
+- the [[Dendron Sidebar|dendron://dendron.dendron-site/dendron.topic.sidebar#summary]] provides one click access to most frequently used features like backlinks and the tree view
+- the [[Import Obsidian Vault|dendron://dendron.dendron-site/dendron.topic.pod-v2.commands.import-obsidian-vault]] command provides a one click method for importing your notes
+- the [[Help and Feedback|dendron://dendron.dendron-site/dendron.topic.sidebar.help-and-feedback]] panel provides a cheatsheet of useful resources and docs
+- the [[Tip of the Day|dendron://dendron.dendron-site/dendron.topic.sidebar.tip-of-the-day]] panel highlights new features and enhancements
+
+Finally, many of Dendron's core use cases now come with better defauts. For example, [[daily journals|dendron://dendron.dendron-site/dendron.topic.daily-journal-note]] and [[meeting notes|dendron://dendron.dendron-site/dendron.topic.special-notes#meeting-note]] have built-in [[templates|dendron://dendron.dendron-site/dendron.topic.templates]] that get created the firist time these commands are invoked.
+
+### Faster
+
+Life is too short to wait for your notes to load.
+
+Dendron has always been fast - much of this we get for free because your notes are just local plaintext files stored in your computer.
+Over the past year, we've optimized all the parts of Dendron's lifecycle, which include initialization, lookup, publishing, and autocomplete just to name a few.
+
+These changes resulted in orders of magnitude better performance across the board and <100ms of latency for the most common actions in Dendron 🚀 🚀 🚀
+
+### Stronger
+
+Our goal is to make Dendron an IDE for knowledge.
+Since 2020, we've released **over 600 features** to augment what you can do with plaintext.
+
+Some highlights:
+
+- [[Handlebar Templates|dendron://dendron.dendron-site/dendron.topic.templates.handlebars]] that allow augmentation of your templates with conditions, variables, and for loops
+- [[Hovers|dendron://dendron.dendron-site/dendron.topic.workbench.contextual-ui#hovers]] over links and backlinks
+- [[Note Traits|dendron://dendron.dendron-site/dendron.topic.traits]] that allow you to create notes with custom behavior
+- [[Publishing using NextJS|dendron://dendron.dendron-site/dendron.topic.publish]] with selective publishing
+
+For the full changelog of all features, see the [[release notes|dendron://dendron.dendron-site/changelog.release]].
+
+### Conclusion
+
+Prior to Dendron, I worked at Amazon for over half a decade.
+Something that stuck with me from my time there is the mindset of it [always being day one](https://aws.amazon.com/executive-insights/content/how-amazon-defines-and-operationalizes-a-day-1-culture/).
+
+This is especially relevant when dealing with knowledge management today because how humans manage information in the age of the internet is fundamentally an unsolved problem.
+At Dendron, we think we have something that works.
+Whether you are an individual managing a handful of notes or a team with tens of thousands of notes, Dendron helps you stay organized and on top of it all.
+
+We've spent the past 100 releases iterating on our [[hierarchy first approach to note taking|dendron://dendron.blog/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking]] and we'll spend a few hundred more building on top of this foundation.
+
+A ginormous thank you to our team, our community, and our investors that helped us reach today's milestone - we couldn't have done it without your support.
+Here's to the next 100 releases!

--- a/packages/plugin-core/assets/dendron-ws/vault/v100.md
+++ b/packages/plugin-core/assets/dendron-ws/vault/v100.md
@@ -1,6 +1,6 @@
 ---
 id: q69fyod4ey0a716b69b64fb
-title: Latest
+title: Release Notes 0.100.0
 desc: ""
 updated: 1655327146166
 created: 1654447362351
@@ -9,7 +9,48 @@ revisionId: >-
   ALm37BWKnOzlGRBLQnqxfd3v6bUF2R9lo04_bddygMFGLt40sErKXnku7Is_vdSH52YwpLM7eHoJWPjLP6xLuA
 ---
 
-> Dendron is launching on product hunt today! If Dendron has been of use to you, please leave feedback on our [launch page](TODO).
+<html lang="en">
+  <style>
+    body {
+      margin: 0;
+    }
+    .container {
+      text-align: center;
+      background-color: #4da167;
+      padding-top: 30px;
+      padding-bottom: 30px;
+    }
+    #header-block {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+    }
+    .inline-header {
+      display: inline-block;
+    }
+    .inline-header > p {
+      color: white;
+      font-size: larger;
+      margin-bottom: 0;
+      margin-left: 30;
+      margin-right: 30;
+    }
+  </style>
+  <body>
+    <div class="container">
+      <div id="header-block">
+        <div class="inline-header">
+          <p><b>
+            Dendron is launching on Product Hunt today! If Dendron has been of
+            use to you, please help us out by leaving feedback on our launch page. 
+            </b>
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>
 
 ### Context
 

--- a/packages/plugin-core/assets/dendron-ws/vault/v100.md
+++ b/packages/plugin-core/assets/dendron-ws/vault/v100.md
@@ -9,54 +9,163 @@ revisionId: >-
   ALm37BWKnOzlGRBLQnqxfd3v6bUF2R9lo04_bddygMFGLt40sErKXnku7Is_vdSH52YwpLM7eHoJWPjLP6xLuA
 ---
 
-<html lang="en">
-  <style>
-    body {
-      margin: 0;
-    }
-    .container {
-      text-align: center;
-      background-color: #4da167;
-      padding-top: 30px;
-      padding-bottom: 30px;
-    }
-    #header-block {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      vertical-align: middle;
-    }
-    .inline-header {
-      display: inline-block;
-    }
-    .inline-header > p {
-      color: white;
-      font-size: larger;
-      margin-bottom: 0;
-      margin-left: 30;
-      margin-right: 30;
-    }
-  </style>
-  <body>
-    <div class="container">
-      <div id="header-block">
-        <div class="inline-header">
-          <p><b>
-            Dendron is launching on Product Hunt today! If Dendron has been of
-            use to you, please help us out by leaving feedback on our launch page. 
-            </b>
-          </p>
-        </div>
-      </div>
-    </div>
-  </body>
-</html>
+<style>
+.alert {
+--docsearch-text-color: #1c1e21;
+--docsearch-spacing: 12px;
+--docsearch-icon-stroke-width: 1.4;
+--docsearch-highlight-color: var(--docsearch-primary-color);
+--docsearch-muted-color: #969faf;
+--docsearch-container-background: rgba(101,108,133,0.8);
+--docsearch-modal-width: 560px;
+--docsearch-modal-height: 600px;
+--docsearch-modal-background: #f5f6f7;
+--docsearch-modal-shadow: inset 1px 1px 0 0 hsla(0,0%,100%,0.5),0 3px 8px 0 #555a64;
+--docsearch-searchbox-height: 56px;
+--docsearch-searchbox-background: #ebedf0;
+--docsearch-searchbox-focus-background: #fff;
+--docsearch-searchbox-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
+--docsearch-hit-height: 56px;
+--docsearch-hit-color: #444950;
+--docsearch-hit-active-color: #fff;
+--docsearch-hit-background: #fff;
+--docsearch-hit-shadow: 0 1px 3px 0 #d4d9e1;
+--docsearch-key-gradient: linear-gradient(-225deg,#d5dbe4,#f8f8f8);
+--docsearch-key-shadow: inset 0 -2px 0 0 #cdcde6,inset 0 0 1px 1px #fff,0 1px 2px 1px rgba(30,35,90,0.4);
+--docsearch-footer-height: 44px;
+--docsearch-footer-background: #fff;
+--docsearch-footer-shadow: 0 -1px 0 0 #e0e3e8,0 -3px 6px 0 rgba(69,98,155,0.12);
+--bs-blue: #0d6efd;
+--bs-indigo: #6610f2;
+--bs-purple: #6f42c1;
+--bs-pink: #d63384;
+--bs-red: #dc3545;
+--bs-orange: #fd7e14;
+--bs-yellow: #ffc107;
+--bs-green: #198754;
+--bs-teal: #20c997;
+--bs-cyan: #0dcaf0;
+--bs-black: #000;
+--bs-white: #fff;
+--bs-gray: #6c757d;
+--bs-gray-dark: #343a40;
+--bs-gray-100: #f8f9fa;
+--bs-gray-200: #e9ecef;
+--bs-gray-300: #dee2e6;
+--bs-gray-400: #ced4da;
+--bs-gray-500: #adb5bd;
+--bs-gray-600: #6c757d;
+--bs-gray-700: #495057;
+--bs-gray-800: #343a40;
+--bs-gray-900: #212529;
+--bs-primary: #0d6efd;
+--bs-secondary: #6c757d;
+--bs-success: #198754;
+--bs-info: #0dcaf0;
+--bs-warning: #ffc107;
+--bs-danger: #dc3545;
+--bs-light: #f8f9fa;
+--bs-dark: #212529;
+--bs-primary-rgb: 13,110,253;
+--bs-secondary-rgb: 108,117,125;
+--bs-success-rgb: 25,135,84;
+--bs-info-rgb: 13,202,240;
+--bs-warning-rgb: 255,193,7;
+--bs-danger-rgb: 220,53,69;
+--bs-light-rgb: 248,249,250;
+--bs-dark-rgb: 33,37,41;
+--bs-white-rgb: 255,255,255;
+--bs-black-rgb: 0,0,0;
+--bs-body-color-rgb: 33,37,41;
+--bs-body-bg-rgb: 255,255,255;
+--bs-font-sans-serif: system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+--bs-font-monospace: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+--bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+--bs-body-font-family: var(--bs-font-sans-serif);
+--bs-body-font-size: 1rem;
+--bs-body-font-weight: 400;
+--bs-body-line-height: 1.5;
+--bs-body-color: #212529;
+--bs-body-bg: #fff;
+--bs-border-width: 1px;
+--bs-border-style: solid;
+--bs-border-color: #dee2e6;
+--bs-border-color-translucent: rgba(0, 0, 0, 0.175);
+--bs-border-radius: 0.375rem;
+--bs-border-radius-sm: 0.25rem;
+--bs-border-radius-lg: 0.5rem;
+--bs-border-radius-xl: 1rem;
+--bs-border-radius-2xl: 2rem;
+--bs-border-radius-pill: 50rem;
+--bs-heading-color: ;
+--bs-link-color: #0d6efd;
+--bs-link-hover-color: #0a58ca;
+--bs-code-color: #d63384;
+--bs-highlight-bg: #fff3cd;
+--bd-purple: #4c0bce;
+--bd-violet: #712cf9;
+--bd-accent: #ffe484;
+--bd-violet-rgb: 112.520718,44.062154,249.437846;
+--bd-accent-rgb: 255,228,132;
+--bd-pink-rgb: 214,51,132;
+--bd-teal-rgb: 32,201,151;
+--docsearch-primary-color: var(--bd-violet);
+--docsearch-logo-color: var(--bd-violet);
+--base00: #fff;
+--base01: #f5f5f5;
+--base02: #c8c8fa;
+--base03: #565c64;
+--base04: #030303;
+--base05: #333;
+--base06: #fff;
+--base07: #9a6700;
+--base08: #bc4c00;
+--base09: #087990;
+--base0A: #795da3;
+--base0B: #183691;
+--base0C: #183691;
+--base0D: #795da3;
+--base0E: #a71d5d;
+--base0F: #333;
+font-family: var(--bs-body-font-family);
+font-size: var(--bs-body-font-size);
+font-weight: var(--bs-body-font-weight);
+line-height: var(--bs-body-line-height);
+text-align: var(--bs-body-text-align);
+-webkit-text-size-adjust: 100%;
+-webkit-tap-highlight-color: transparent;
+--bs-gutter-y: 0;
+--bs-gutter-x: 3rem;
+--bd-example-padding: 1.5rem;
+box-sizing: border-box;
+--bs-alert-padding-x: 1rem;
+--bs-alert-padding-y: 1rem;
+--bs-alert-margin-bottom: 1rem;
+--bs-alert-border: 1px solid var(--bs-alert-border-color);
+--bs-alert-border-radius: 0.375rem;
+position: relative;
+padding: var(--bs-alert-padding-y) var(--bs-alert-padding-x);
+margin-bottom: var(--bs-alert-margin-bottom);
+color: var(--bs-alert-color);
+background-color: var(--bs-alert-bg);
+border: var(--bs-alert-border);
+border-radius: var(--bs-alert-border-radius,0);
+--bs-alert-color: #0f5132;
+--bs-alert-bg: #d1e7dd;
+--bs-alert-border-color: #badbcc;
+margin-top: 1rem;
+}
+</style>
+
+<div class="alert alert-primary" role="alert">
+Dendron is launching on product hunt today. If you've found Dendron useful, please leave feedback on our <a href="https://www.producthunt.com/posts/dendron-v100">launch page</a> - this would help us out a lot! 🙏
+</div>
 
 ### Context
 
 Two years ago, we launched Dendron because we believed there was a [better way of managing knowledge](https://www.kevinslin.com/notes/e1455752-b052-4212-ac6e-cc054659f2bb.html).
 
-The problem - we are all drowning in information! Existing tools (try) to make it easy to get knowledge in but fail at getting that information back out when needed.
+The problem - we are all drowning in information! Existing tools try to make it easy to get knowledge in but fail at getting that information back out when needed.
 
 Dendron is a developer-focused, open-source, note-taking tool. It combines the simplicity of markdown with the power of VSCode. To manage information at scale, Dendron applies the insights we've learned from five decades of developer tooling and brings it to general knowledge.
 
@@ -68,16 +177,16 @@ In a well-designed system, easy things should be easy and hard things possible.
 
 This hasn't always been the case at Dendron and it's something we've put in a lot of effort addressing through improved documentation, feature work, and better defaults.
 
-Besides creating a catalogue of [[talks|dendron://dendron.dendron-site/community.events.greenhouse.2022-02-25-gtd-bullet-journals-task-management-workflow-demos]] and [[guides|dendron://dendron.dendron-site/dendron.guides.workflows]] of how Dendron is used in the wild, we've also kicked off a [[standardization effort|dendron://dendron.handbook/leaflet.journal.2022.05.10.standard-documentation]] across all our docs so that any feature, command, or config is just a [[lookup|dendron://dendron.dendron-site/dendron.topic.lookup]] away!
+Besides creating a catalog of [talks](https://wiki.dendron.so/notes/ordz7r99w1v099v14hrwgnp) and [guides](https://wiki.dendron.so/notes/9313b845-d9bf-42c9-aad1-0da34794ce26) of how Dendron is used in the wild, we've also kicked off a [standardization effort](https://handbook.dendron.so/notes/ebpudfrf6rg5uut75d29lhg) across all our docs so that any feature, command, or config is just a [lookup](https://wiki.dendron.so/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3) away!
 
 Feature wise, the following are some areas we've invested in to make common workflows easy:
 
-- the [[Dendron Sidebar|dendron://dendron.dendron-site/dendron.topic.sidebar#summary]] provides one click access to most frequently used features like backlinks and the tree view
-- the [[Import Obsidian Vault|dendron://dendron.dendron-site/dendron.topic.pod-v2.commands.import-obsidian-vault]] command provides a one click method for importing your notes
-- the [[Help and Feedback|dendron://dendron.dendron-site/dendron.topic.sidebar.help-and-feedback]] panel provides a cheatsheet of useful resources and docs
-- the [[Tip of the Day|dendron://dendron.dendron-site/dendron.topic.sidebar.tip-of-the-day]] panel highlights new features and enhancements
+- the [Dendron Sidebar](https://wiki.dendron.so/notes/9b059u38o0b7fydjgoazt06) provides one click access to most frequently used features like backlinks and the tree view
+- the [Import Obsidian Vault](https://wiki.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47/#import-obsidian-vault) command provides a one click method for importing your notes
+- the [Help and Feedback](https://wiki.dendron.so/notes/c877f1204xn2ev5djgwc7do) panel provides a cheatsheet of useful resources and docs
+- the [Tip of the Day](https://wiki.dendron.so/notes/te9obzegtn5vjrsdf4sp5xx) panel highlights new features and enhancements
 
-Finally, many of Dendron's core use cases now come with better defauts. For example, [[daily journals|dendron://dendron.dendron-site/dendron.topic.daily-journal-note]] and [[meeting notes|dendron://dendron.dendron-site/dendron.topic.special-notes#meeting-note]] have built-in [[templates|dendron://dendron.dendron-site/dendron.topic.templates]] that get created the firist time these commands are invoked.
+Finally, many of Dendron's core use cases now come with better defaults. For example, [daily journals](https://wiki.dendron.so/notes/ogIUqY5VDCJP28G3cAJhd) and [meeting notes](https://wiki.dendron.so/notes/5c213aa6-e4ba-49e8-85c5-1bdcb33ce202/#meeting-note) have built-in [templates](https://wiki.dendron.so/notes/861cbdf8-102e-4633-9933-1f3d74df53d2) that get created the first time these commands are invoked.
 
 ### Faster
 
@@ -86,7 +195,7 @@ Life is too short to wait for your notes to load.
 Dendron has always been fast - much of this we get for free because your notes are just local plaintext files stored in your computer.
 Over the past year, we've optimized all the parts of Dendron's lifecycle, which include initialization, lookup, publishing, and autocomplete just to name a few.
 
-These changes resulted in orders of magnitude better performance across the board and <100ms of latency for the most common actions in Dendron 🚀 🚀 🚀
+These changes resulted in orders of magnitude better performance across the board and &lt;100ms of latency for the most common actions in Dendron 🚀 🚀 🚀
 
 ### Stronger
 
@@ -95,23 +204,20 @@ Since 2020, we've released **over 600 features** to augment what you can do with
 
 Some highlights:
 
-- [[Handlebar Templates|dendron://dendron.dendron-site/dendron.topic.templates.handlebars]] that allow augmentation of your templates with conditions, variables, and for loops
-- [[Hovers|dendron://dendron.dendron-site/dendron.topic.workbench.contextual-ui#hovers]] over links and backlinks
-- [[Note Traits|dendron://dendron.dendron-site/dendron.topic.traits]] that allow you to create notes with custom behavior
-- [[Publishing using NextJS|dendron://dendron.dendron-site/dendron.topic.publish]] with selective publishing
+- [Handlebar Templates](https://wiki.dendron.so/notes/1mu1qb1vilhqr7tlatwyqxm) that allow augmentation of your templates with conditions, variables, and for loops
+- [Hovers](https://wiki.dendron.so/notes/ckkmesn09bye11sdnaoqcut) over links and backlinks
+- [Note Traits](https://wiki.dendron.so/notes/bdZhT3nF8Yz3WDzKp7hqh) that allow you to create notes with custom behavior
+- [Publishing using NextJS](https://wiki.dendron.so/notes/4ushYTDoX0TYQ1FDtGQSg) with selective publishing
 
-For the full changelog of all features, see the [[release notes|dendron://dendron.dendron-site/changelog.release]].
+For the full changelog of all features, see the [release notes](https://wiki.dendron.so/notes/FPXeGgv44ZlJHVoXmU8Ku).
 
 ### Conclusion
 
 Prior to Dendron, I worked at Amazon for over half a decade.
-Something that stuck with me from my time there is the mindset of it [always being day one](https://aws.amazon.com/executive-insights/content/how-amazon-defines-and-operationalizes-a-day-1-culture/).
+Something that stuck with me from my time there is that it's always [day one](https://aws.amazon.com/executive-insights/content/how-amazon-defines-and-operationalizes-a-day-1-culture/).
 
 This is especially relevant when dealing with knowledge management today because how humans manage information in the age of the internet is fundamentally an unsolved problem.
-At Dendron, we think we have something that works.
+With Dendron, we think we have something that works.
 Whether you are an individual managing a handful of notes or a team with tens of thousands of notes, Dendron helps you stay organized and on top of it all.
 
-We've spent the past 100 releases iterating on our [[hierarchy first approach to note taking|dendron://dendron.blog/blog.2020.2020-08-24-a-hierarchy-first-approach-to-note-taking]] and we'll spend a few hundred more building on top of this foundation.
-
-A ginormous thank you to our team, our community, and our investors that helped us reach today's milestone - we couldn't have done it without your support.
-Here's to the next 100 releases!
+We've spent the past 100 releases iterating on our [hierarchy first approach to note taking](https://blog.dendron.so/notes/3dd58f62-fee5-4f93-b9f1-b0f0f59a9b64) and we'll spend a few hundred more building on top of this foundation. On behalf of the entire Dendron team, I would like to say thanks to everyone that helped make this happen - chiefly our wonderful community and our steadfast investors. Here's to the next 100 releases!

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -456,6 +456,10 @@
         "icon": "$(open-preview)"
       },
       {
+        "command": "dendron.showReleaseNotes",
+        "title": "Dendron: Show Release Notes"
+      },
+      {
         "command": "dendron.pasteFile",
         "title": "Dendron: Paste File"
       },
@@ -784,6 +788,10 @@
         },
         {
           "command": "dendron.showPreview",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.showReleaseNotes",
           "when": "dendron:pluginActive"
         },
         {

--- a/packages/plugin-core/src/commands/ShowReleaseNotes.ts
+++ b/packages/plugin-core/src/commands/ShowReleaseNotes.ts
@@ -1,0 +1,84 @@
+import { NoteUtils } from "@dendronhq/common-all";
+import fs from "fs-extra";
+import _ from "lodash";
+import { PreviewProxy } from "../components/views/PreviewProxy";
+import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { InputArgCommand } from "./base";
+import {
+  ShowPreviewCommandOpts,
+  ShowPreviewCommandOutput,
+} from "./ShowPreviewInterface";
+
+/**
+ * Command to show the preview. If the desire is to programmatically show the
+ * preview webview, then prefer to get an instance of {@link PreviewProxy}
+ * instead of creating an instance of this command.
+ */
+export class ShowReleaseNotesCommand extends InputArgCommand<
+  ShowPreviewCommandOpts,
+  ShowPreviewCommandOutput
+> {
+  key = DENDRON_COMMANDS.SHOW_RELEASE_NOTES.key;
+
+  _panel: PreviewProxy;
+  constructor(changelogPanel: PreviewProxy) {
+    super();
+    this._panel = changelogPanel;
+  }
+
+  // async sanityCheck(opts?: ShowPreviewCommandOpts) {
+  //   if (_.isEmpty(opts)) {
+  //     return "No release note selected to open.";
+  //   }
+  //   return;
+  // }
+
+  // addAnalyticsPayload(opts?: ShowPreviewCommandOpts) {
+  //   return { providedFile: !_.isEmpty(opts) };
+  // }
+
+  /**
+   *
+   * @param opts if a Uri is defined through this parameter, then that Uri will
+   * be shown in preview. If unspecified, then preview will follow default
+   * behavior of showing the contents of the currently in-focus Dendron note.
+   */
+  async execute(opts?: ShowPreviewCommandOpts) {
+    let fsPath;
+    if (_.isEmpty(opts) || !opts) {
+      const uri = VSCodeUtils.joinPath(
+        VSCodeUtils.getAssetUri(ExtensionProvider.getExtension().context),
+        "dendron-ws",
+        "vault",
+        "v100.md"
+      );
+
+      fsPath = uri.fsPath;
+    } else {
+      fsPath = opts.fsPath;
+    }
+
+    await this.openFileInPreview(fsPath);
+    return { fsPath };
+  }
+
+  /**
+   * Show a file in the preview. Only use this for files that are not notes,
+   * like a markdown file outside any vault.
+   * @param filePath
+   * @returns
+   */
+  private async openFileInPreview(filePath: string) {
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const contents = await fs.readFile(filePath, { encoding: "utf-8" });
+    const dummyFileNote = NoteUtils.createForFile({
+      filePath,
+      wsRoot,
+      contents,
+    });
+
+    await this._panel.show(dummyFileNote);
+  }
+}

--- a/packages/plugin-core/src/commands/ShowReleaseNotes.ts
+++ b/packages/plugin-core/src/commands/ShowReleaseNotes.ts
@@ -26,6 +26,10 @@ export class ShowReleaseNotesCommand extends InputArgCommand<
     this._panel = changelogPanel;
   }
 
+  addAnalyticsPayload(_opts?: ShowPreviewCommandOpts) {
+    return { page: "v0.100.0" };
+  }
+
   /**
    *
    * @param opts if a Uri is defined through this parameter, then that Uri will

--- a/packages/plugin-core/src/commands/ShowReleaseNotes.ts
+++ b/packages/plugin-core/src/commands/ShowReleaseNotes.ts
@@ -12,9 +12,7 @@ import {
 } from "./ShowPreviewInterface";
 
 /**
- * Command to show the preview. If the desire is to programmatically show the
- * preview webview, then prefer to get an instance of {@link PreviewProxy}
- * instead of creating an instance of this command.
+ * Command to show the Release Notes webview
  */
 export class ShowReleaseNotesCommand extends InputArgCommand<
   ShowPreviewCommandOpts,
@@ -28,22 +26,11 @@ export class ShowReleaseNotesCommand extends InputArgCommand<
     this._panel = changelogPanel;
   }
 
-  // async sanityCheck(opts?: ShowPreviewCommandOpts) {
-  //   if (_.isEmpty(opts)) {
-  //     return "No release note selected to open.";
-  //   }
-  //   return;
-  // }
-
-  // addAnalyticsPayload(opts?: ShowPreviewCommandOpts) {
-  //   return { providedFile: !_.isEmpty(opts) };
-  // }
-
   /**
    *
    * @param opts if a Uri is defined through this parameter, then that Uri will
-   * be shown in preview. If unspecified, then preview will follow default
-   * behavior of showing the contents of the currently in-focus Dendron note.
+   * be shown in preview. Otherwise, show the hard-coded release notes markdown
+   * file. (This can be cleaned up later)
    */
   async execute(opts?: ShowPreviewCommandOpts) {
     let fsPath;
@@ -64,12 +51,6 @@ export class ShowReleaseNotesCommand extends InputArgCommand<
     return { fsPath };
   }
 
-  /**
-   * Show a file in the preview. Only use this for files that are not notes,
-   * like a markdown file outside any vault.
-   * @param filePath
-   * @returns
-   */
   private async openFileInPreview(filePath: string) {
     const { wsRoot } = ExtensionProvider.getDWorkspace();
     const contents = await fs.readFile(filePath, { encoding: "utf-8" });
@@ -78,6 +59,9 @@ export class ShowReleaseNotesCommand extends InputArgCommand<
       wsRoot,
       contents,
     });
+
+    // Tmp Override
+    dummyFileNote.title = "Release Notes 0.100.0";
 
     await this._panel.show(dummyFileNote);
   }

--- a/packages/plugin-core/src/components/views/ReleaseNotesPanel.ts
+++ b/packages/plugin-core/src/components/views/ReleaseNotesPanel.ts
@@ -1,90 +1,62 @@
 import {
-  assertUnreachable,
   ConfigUtils,
-  DendronASTDest,
   DendronEditorViewKey,
-  DendronError,
   DMessageEnum,
   getWebEditorViewEntry,
-  isWebUri,
-  memoize,
   NoteProps,
-  NoteUtils,
   NoteViewMessage,
   NoteViewMessageEnum,
   OnDidChangeActiveTextEditorMsg,
 } from "@dendronhq/common-all";
-import {
-  DendronASTTypes,
-  Image,
-  makeImageUrlFullPath,
-  MDUtilsV5,
-  visit,
-} from "@dendronhq/engine-server";
 import * as vscode from "vscode";
 import { IDendronExtension } from "../../dendronExtensionInterface";
-import { ITextDocumentService } from "../../services/TextDocumentService";
+import { Logger } from "../../logger";
 import { WebViewUtils } from "../../views/utils";
-import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtilsV2 } from "../../WSUtilsV2";
 import { IPreviewLinkHandler } from "./PreviewLinkHandler";
 import { PreviewProxy } from "./PreviewProxy";
-import { Logger } from "../../logger";
-import _ from "lodash";
 
 /**
- * This is the default implementation of PreviewProxy. It contains a singleton
- * of a vscode webviewPanel that renders the note preview. Furthermore, it will
- * automatically handle event subscriptions to know when to update the preview,
- * as well as properly dispose of the resources when the preview has been
- * closed.
+ * An implementation of PreviewProxy specific for displaying Release Notes in a
+ * webview. This is a stripped down version of PreviewPanel that only displays
+ * an unchanging page.
  */
 export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
   private _ext: IDendronExtension;
   private _panel: vscode.WebviewPanel | undefined;
-  private _textDocumentService: ITextDocumentService;
   private _linkHandler: IPreviewLinkHandler;
 
-  /**
-   *
-   * @param param0 extension - IDendronExtension implementation. linkHandler -
-   * Implementation to handle preview link clicked events
-   */
+  private _note: NoteProps | undefined;
+
   constructor({
     extension,
     linkHandler,
-    textDocumentService,
   }: {
     extension: IDendronExtension;
     linkHandler: IPreviewLinkHandler;
-    textDocumentService: ITextDocumentService;
   }) {
     this._ext = extension;
     this._linkHandler = linkHandler;
-    this._textDocumentService = textDocumentService;
   }
 
   /**
-   * Show the preview.
-   * @param note - if specified, this will override the preview contents with
-   * the contents specified in this parameter. Otherwise, the contents of the
-   * preview will follow default behavior (it will show the currently in-focus
-   * Dendron note).
+   * Show the specified release note page.
    */
-  async show(note?: NoteProps): Promise<void> {
+  async show(note: NoteProps): Promise<void> {
+    this._note = note;
+
     if (this._panel) {
       if (!this.isVisible()) {
         this._panel.reveal();
       }
     } else {
-      const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
+      const viewColumn = vscode.ViewColumn.One;
       const preserveFocus = true;
       const port = this._ext.port!;
       const engine = this._ext.getEngine();
       const { wsRoot } = engine;
 
       const { bundleName: name, label } = getWebEditorViewEntry(
-        DendronEditorViewKey.CHANGELOG
+        DendronEditorViewKey.RELEASE_NOTES
       );
 
       this._panel = vscode.window.createWebviewPanel(
@@ -128,9 +100,8 @@ export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
       this._panel.reveal(viewColumn, preserveFocus);
     }
 
-    if (note && this.isVisible()) {
-      this.sendRefreshMessage(this._panel, note, false);
-      this.initWithNote = note;
+    if (this.isVisible()) {
+      this.sendRefreshMessage(this._panel, note);
     }
   }
   hide(): void {
@@ -150,35 +121,14 @@ export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
   }
 
   private setupCallbacks(): void {
-    const wsUtils = new WSUtilsV2(this._ext);
-
     // Callback on getting a message back from the webview
     this._panel!.webview.onDidReceiveMessage(async (msg: NoteViewMessage) => {
       const ctx = "ShowPreview:onDidReceiveMessage";
       Logger.debug({ ctx, msgType: msg.type });
       switch (msg.type) {
         case DMessageEnum.MESSAGE_DISPATCHER_READY: {
-          // if ready, get current note
-          let note: NoteProps | undefined;
-          if (this.initWithNote !== undefined) {
-            note = this.initWithNote;
-            Logger.debug({
-              ctx,
-              msg: "got pre-set note",
-              note: NoteUtils.toLogObj(note),
-            });
-          } else {
-            note = wsUtils.getActiveNote();
-            if (note) {
-              Logger.debug({
-                ctx,
-                msg: "got active note",
-                note: NoteUtils.toLogObj(note),
-              });
-            }
-          }
-          if (note) {
-            this.sendRefreshMessage(this._panel!, note, false);
+          if (this._note) {
+            this.sendRefreshMessage(this._panel!, this._note);
           }
           break;
         }
@@ -194,71 +144,13 @@ export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
     });
   }
 
-  /** Rewrites the image URLs to use VSCode's webview URIs, which is required to
-   * access files from the preview.
-   *
-   * The results of this is cached based on the note content hash, so repeated
-   * calls should not be excessively expensive.
-   */
-  private rewriteImageUrls = memoize({
-    fn: (note: NoteProps, panel: vscode.WebviewPanel) => {
-      const parser = MDUtilsV5.procRemarkFull({
-        dest: DendronASTDest.MD_DENDRON,
-        engine: this._ext.getEngine(),
-        fname: note.fname,
-        vault: note.vault,
-      });
-      const tree = parser.parse(note.body);
-      // ^preview-rewrites-images
-      visit(
-        tree,
-        [DendronASTTypes.IMAGE, DendronASTTypes.EXTENDED_IMAGE],
-        (image: Image) => {
-          if (!isWebUri(image.url)) {
-            makeImageUrlFullPath({ node: image, proc: parser });
-            image.url = panel.webview
-              .asWebviewUri(vscode.Uri.file(image.url))
-              .toString();
-          }
-        }
-      );
-      return {
-        ...note,
-        body: parser.stringify(tree),
-      };
-    },
-    keyFn: (note) => note.id,
-    shouldUpdate: (previous, current) =>
-      previous.contentHash !== current.contentHash,
-  });
-
-  /**
-   * Notify preview webview panel to display latest contents
-   *
-   * @param panel panel to notify
-   * @param note note to display
-   * @param isFullRefresh If true, sync contents of note with what's being seen in active editor.
-   * This will be true in cases where user switches between tabs or opens/closes notes without saving, as contents of notes may not match engine notes.
-   * Otherwise display contents of note
-   */
   private async sendRefreshMessage(
     panel: vscode.WebviewPanel,
-    note: NoteProps,
-    isFullRefresh: boolean
+    note: NoteProps
   ) {
     if (this.isVisible()) {
-      // Engine state has not changed so do not sync. This is for displaying updated text only
+      // This page is static.  Don't do any syncing.
       const syncChangedNote = false;
-
-      // If full refresh is required, sync note with contents in active text editor
-      const textDocument = VSCodeUtils.getActiveTextEditor()?.document;
-      if (textDocument && isFullRefresh) {
-        note = await this._textDocumentService.applyTextDocumentToNoteProps(
-          note,
-          textDocument
-        );
-      }
-      note = this.rewriteImageUrls(note, panel);
 
       return panel.webview.postMessage({
         type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
@@ -270,41 +162,5 @@ export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
       } as OnDidChangeActiveTextEditorMsg);
     }
     return;
-  }
-
-  /**
-   * If panel is visible, update preview panel with text document changes
-   */
-  private async updatePreviewPanel(
-    textDocument: vscode.TextDocumentChangeEvent
-  ) {
-    if (textDocument.document.isDirty === false) {
-      return;
-    }
-    if (this.isVisible()) {
-      const note =
-        await this._textDocumentService.processTextDocumentChangeEvent(
-          textDocument
-        );
-      if (note) {
-        return this.sendRefreshMessage(this._panel!, note, false);
-      }
-    }
-    return undefined;
-  }
-
-  private initWithNote: NoteProps | undefined;
-
-  // eslint-disable-next-line camelcase
-  __DO_NOT_USE_IN_PROD_exposePropsForTesting() {
-    return {
-      rewriteImageUrls: (note: NoteProps) => {
-        if (!this._panel)
-          throw new DendronError({
-            message: "Panel used before being initalized",
-          });
-        return this.rewriteImageUrls(note, this._panel);
-      },
-    };
   }
 }

--- a/packages/plugin-core/src/components/views/ReleaseNotesPanel.ts
+++ b/packages/plugin-core/src/components/views/ReleaseNotesPanel.ts
@@ -1,0 +1,310 @@
+import {
+  assertUnreachable,
+  ConfigUtils,
+  DendronASTDest,
+  DendronEditorViewKey,
+  DendronError,
+  DMessageEnum,
+  getWebEditorViewEntry,
+  isWebUri,
+  memoize,
+  NoteProps,
+  NoteUtils,
+  NoteViewMessage,
+  NoteViewMessageEnum,
+  OnDidChangeActiveTextEditorMsg,
+} from "@dendronhq/common-all";
+import {
+  DendronASTTypes,
+  Image,
+  makeImageUrlFullPath,
+  MDUtilsV5,
+  visit,
+} from "@dendronhq/engine-server";
+import * as vscode from "vscode";
+import { IDendronExtension } from "../../dendronExtensionInterface";
+import { ITextDocumentService } from "../../services/TextDocumentService";
+import { WebViewUtils } from "../../views/utils";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { WSUtilsV2 } from "../../WSUtilsV2";
+import { IPreviewLinkHandler } from "./PreviewLinkHandler";
+import { PreviewProxy } from "./PreviewProxy";
+import { Logger } from "../../logger";
+import _ from "lodash";
+
+/**
+ * This is the default implementation of PreviewProxy. It contains a singleton
+ * of a vscode webviewPanel that renders the note preview. Furthermore, it will
+ * automatically handle event subscriptions to know when to update the preview,
+ * as well as properly dispose of the resources when the preview has been
+ * closed.
+ */
+export class ReleaseNotesPanel implements PreviewProxy, vscode.Disposable {
+  private _ext: IDendronExtension;
+  private _panel: vscode.WebviewPanel | undefined;
+  private _textDocumentService: ITextDocumentService;
+  private _linkHandler: IPreviewLinkHandler;
+
+  /**
+   *
+   * @param param0 extension - IDendronExtension implementation. linkHandler -
+   * Implementation to handle preview link clicked events
+   */
+  constructor({
+    extension,
+    linkHandler,
+    textDocumentService,
+  }: {
+    extension: IDendronExtension;
+    linkHandler: IPreviewLinkHandler;
+    textDocumentService: ITextDocumentService;
+  }) {
+    this._ext = extension;
+    this._linkHandler = linkHandler;
+    this._textDocumentService = textDocumentService;
+  }
+
+  /**
+   * Show the preview.
+   * @param note - if specified, this will override the preview contents with
+   * the contents specified in this parameter. Otherwise, the contents of the
+   * preview will follow default behavior (it will show the currently in-focus
+   * Dendron note).
+   */
+  async show(note?: NoteProps): Promise<void> {
+    if (this._panel) {
+      if (!this.isVisible()) {
+        this._panel.reveal();
+      }
+    } else {
+      const viewColumn = vscode.ViewColumn.Beside; // Editor column to show the new webview panel in.
+      const preserveFocus = true;
+      const port = this._ext.port!;
+      const engine = this._ext.getEngine();
+      const { wsRoot } = engine;
+
+      const { bundleName: name, label } = getWebEditorViewEntry(
+        DendronEditorViewKey.CHANGELOG
+      );
+
+      this._panel = vscode.window.createWebviewPanel(
+        name,
+        label,
+        {
+          viewColumn,
+          preserveFocus,
+        },
+        {
+          enableScripts: true,
+          enableCommandUris: true,
+          retainContextWhenHidden: true,
+          enableFindWidget: true,
+          localResourceRoots: WebViewUtils.getLocalResourceRoots(
+            this._ext.context
+          ).concat(vscode.Uri.file(wsRoot)),
+        }
+      );
+
+      const webViewAssets = WebViewUtils.getJsAndCss();
+      const initialTheme =
+        ConfigUtils.getPreview(this._ext.getDWorkspace().config).theme || "";
+      const html = await WebViewUtils.getWebviewContent({
+        ...webViewAssets,
+        name,
+        port,
+        wsRoot,
+        panel: this._panel,
+        initialTheme,
+      });
+
+      this._panel.webview.html = html;
+
+      this.setupCallbacks();
+
+      this._panel.onDidDispose(() => {
+        this._panel = undefined;
+      });
+
+      this._panel.reveal(viewColumn, preserveFocus);
+    }
+
+    if (note && this.isVisible()) {
+      this.sendRefreshMessage(this._panel, note, false);
+      this.initWithNote = note;
+    }
+  }
+  hide(): void {
+    this.dispose();
+  }
+  isOpen(): boolean {
+    return this._panel !== undefined;
+  }
+  isVisible(): boolean {
+    return this._panel !== undefined && this._panel.visible;
+  }
+  dispose() {
+    if (this._panel) {
+      this._panel.dispose();
+      this._panel = undefined;
+    }
+  }
+
+  private setupCallbacks(): void {
+    const wsUtils = new WSUtilsV2(this._ext);
+
+    // Callback on getting a message back from the webview
+    this._panel!.webview.onDidReceiveMessage(async (msg: NoteViewMessage) => {
+      const ctx = "ShowPreview:onDidReceiveMessage";
+      Logger.debug({ ctx, msgType: msg.type });
+      switch (msg.type) {
+        case DMessageEnum.MESSAGE_DISPATCHER_READY: {
+          // if ready, get current note
+          let note: NoteProps | undefined;
+          if (this.initWithNote !== undefined) {
+            note = this.initWithNote;
+            Logger.debug({
+              ctx,
+              msg: "got pre-set note",
+              note: NoteUtils.toLogObj(note),
+            });
+          } else {
+            note = wsUtils.getActiveNote();
+            if (note) {
+              Logger.debug({
+                ctx,
+                msg: "got active note",
+                note: NoteUtils.toLogObj(note),
+              });
+            }
+          }
+          if (note) {
+            this.sendRefreshMessage(this._panel!, note, false);
+          }
+          break;
+        }
+        case NoteViewMessageEnum.onClick: {
+          const { data } = msg;
+          this._linkHandler.onLinkClicked({ data });
+          break;
+        }
+
+        default:
+          break;
+      }
+    });
+  }
+
+  /** Rewrites the image URLs to use VSCode's webview URIs, which is required to
+   * access files from the preview.
+   *
+   * The results of this is cached based on the note content hash, so repeated
+   * calls should not be excessively expensive.
+   */
+  private rewriteImageUrls = memoize({
+    fn: (note: NoteProps, panel: vscode.WebviewPanel) => {
+      const parser = MDUtilsV5.procRemarkFull({
+        dest: DendronASTDest.MD_DENDRON,
+        engine: this._ext.getEngine(),
+        fname: note.fname,
+        vault: note.vault,
+      });
+      const tree = parser.parse(note.body);
+      // ^preview-rewrites-images
+      visit(
+        tree,
+        [DendronASTTypes.IMAGE, DendronASTTypes.EXTENDED_IMAGE],
+        (image: Image) => {
+          if (!isWebUri(image.url)) {
+            makeImageUrlFullPath({ node: image, proc: parser });
+            image.url = panel.webview
+              .asWebviewUri(vscode.Uri.file(image.url))
+              .toString();
+          }
+        }
+      );
+      return {
+        ...note,
+        body: parser.stringify(tree),
+      };
+    },
+    keyFn: (note) => note.id,
+    shouldUpdate: (previous, current) =>
+      previous.contentHash !== current.contentHash,
+  });
+
+  /**
+   * Notify preview webview panel to display latest contents
+   *
+   * @param panel panel to notify
+   * @param note note to display
+   * @param isFullRefresh If true, sync contents of note with what's being seen in active editor.
+   * This will be true in cases where user switches between tabs or opens/closes notes without saving, as contents of notes may not match engine notes.
+   * Otherwise display contents of note
+   */
+  private async sendRefreshMessage(
+    panel: vscode.WebviewPanel,
+    note: NoteProps,
+    isFullRefresh: boolean
+  ) {
+    if (this.isVisible()) {
+      // Engine state has not changed so do not sync. This is for displaying updated text only
+      const syncChangedNote = false;
+
+      // If full refresh is required, sync note with contents in active text editor
+      const textDocument = VSCodeUtils.getActiveTextEditor()?.document;
+      if (textDocument && isFullRefresh) {
+        note = await this._textDocumentService.applyTextDocumentToNoteProps(
+          note,
+          textDocument
+        );
+      }
+      note = this.rewriteImageUrls(note, panel);
+
+      return panel.webview.postMessage({
+        type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
+        data: {
+          note,
+          syncChangedNote,
+        },
+        source: "vscode",
+      } as OnDidChangeActiveTextEditorMsg);
+    }
+    return;
+  }
+
+  /**
+   * If panel is visible, update preview panel with text document changes
+   */
+  private async updatePreviewPanel(
+    textDocument: vscode.TextDocumentChangeEvent
+  ) {
+    if (textDocument.document.isDirty === false) {
+      return;
+    }
+    if (this.isVisible()) {
+      const note =
+        await this._textDocumentService.processTextDocumentChangeEvent(
+          textDocument
+        );
+      if (note) {
+        return this.sendRefreshMessage(this._panel!, note, false);
+      }
+    }
+    return undefined;
+  }
+
+  private initWithNote: NoteProps | undefined;
+
+  // eslint-disable-next-line camelcase
+  __DO_NOT_USE_IN_PROD_exposePropsForTesting() {
+    return {
+      rewriteImageUrls: (note: NoteProps) => {
+        if (!this._panel)
+          throw new DendronError({
+            message: "Panel used before being initalized",
+          });
+        return this.rewriteImageUrls(note, this._panel);
+      },
+    };
+  }
+}

--- a/packages/plugin-core/src/components/views/ReleaseNotesViewFactory.ts
+++ b/packages/plugin-core/src/components/views/ReleaseNotesViewFactory.ts
@@ -1,8 +1,7 @@
 import { IDendronExtension } from "../../dendronExtensionInterface";
-import { TextDocumentServiceFactory } from "../../services/TextDocumentServiceFactory";
-import { ReleaseNotesPanel } from "./ReleaseNotesPanel";
 import { PreviewLinkHandler } from "./PreviewLinkHandler";
 import { PreviewProxy } from "./PreviewProxy";
+import { ReleaseNotesPanel } from "./ReleaseNotesPanel";
 
 /**
  * Creates a singleton PreviewProxy intended for use for displaying release
@@ -23,7 +22,6 @@ export class ReleaseNotesViewFactory {
       ReleaseNotesViewFactory._view = new ReleaseNotesPanel({
         extension,
         linkHandler: new PreviewLinkHandler(extension),
-        textDocumentService: TextDocumentServiceFactory.create(extension),
       });
     }
 

--- a/packages/plugin-core/src/components/views/ReleaseNotesViewFactory.ts
+++ b/packages/plugin-core/src/components/views/ReleaseNotesViewFactory.ts
@@ -1,0 +1,32 @@
+import { IDendronExtension } from "../../dendronExtensionInterface";
+import { TextDocumentServiceFactory } from "../../services/TextDocumentServiceFactory";
+import { ReleaseNotesPanel } from "./ReleaseNotesPanel";
+import { PreviewLinkHandler } from "./PreviewLinkHandler";
+import { PreviewProxy } from "./PreviewProxy";
+
+/**
+ * Creates a singleton PreviewProxy intended for use for displaying release
+ * notes
+ */
+export class ReleaseNotesViewFactory {
+  private static _view: ReleaseNotesPanel | undefined;
+
+  /**
+   * Get a usable PreviewProxy for showing the release notes
+   */
+  public static create(extension: IDendronExtension): PreviewProxy {
+    // Simple singleton implementation, since we only want one release notes
+    // panel at any given time.
+
+    // if view doesn't exist yet, create a new one.
+    if (!ReleaseNotesViewFactory._view) {
+      ReleaseNotesViewFactory._view = new ReleaseNotesPanel({
+        extension,
+        linkHandler: new PreviewLinkHandler(extension),
+        textDocumentService: TextDocumentServiceFactory.create(extension),
+      });
+    }
+
+    return ReleaseNotesViewFactory._view;
+  }
+}

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -814,6 +814,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     },
     when: "dendron:pluginActive",
   },
+  SHOW_RELEASE_NOTES: {
+    key: "dendron.showReleaseNotes",
+    title: `${CMD_PREFIX} Show Release Notes`,
+    when: "dendron:pluginActive",
+  },
   PASTE_FILE: {
     key: "dendron.pasteFile",
     title: `${CMD_PREFIX} Paste File`,

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -36,6 +36,7 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { showWelcome } from "../WelcomeUtils";
 import { AnalyticsUtils } from "./analytics";
 import { ConfigMigrationUtils } from "./ConfigMigration";
+import semver from "semver";
 
 export class StartupUtils {
   static async runMigrationsIfNecessary({
@@ -517,5 +518,21 @@ export class StartupUtils {
           }
         });
     }
+  }
+
+  static shouldShowFullPageUpgradeWebview(
+    previousExtensionVersion: string,
+    currentVersion: string
+  ): boolean {
+    const threshold = "0.100.0";
+
+    if (!currentVersion) {
+      return false;
+    }
+
+    return (
+      semver.lt(previousExtensionVersion, threshold) &&
+      semver.gte(currentVersion, threshold)
+    );
   }
 }


### PR DESCRIPTION
## enhance(workspace): upgrade page for v100

Some scaffolding to allow us to show a full page webview when users upgrade to v100. 

NOTE: implementation is a bit hacky right now (lot of duplicated logic with PreviewPanel), but I'm just trying to get something functioning quickly.  We can clean up in the next iteration.

Still TODO: 

- Update contents of the v100.md notes with the latest edits + a working Product Hunt link (pending)
- Add PH link click telemetry