### PR TITLE
chore: clean up some DeleteNodeCommand tests

### DIFF
--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -251,7 +251,7 @@ export class FileStorage implements DStore {
     // remove from fs
     if (!opts?.metaOnly) {
       this.logger.info({ ctx, noteAsLog, msg: "removing from disk", fpath });
-      fs.unlinkSync(fpath);
+      await fs.unlink(fpath);
     }
 
     // if have children, keep this node around as a stub

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -243,7 +243,10 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     const ws = this.ws;
     const resp = await this.api.engineDelete({ id, opts, ws });
     if (!resp.data) {
-      throw new DendronError({ message: "no data" });
+      throw new DendronError({
+        message: `Failed to delete note with id ${id}`,
+        payload: resp.error,
+      });
     }
     await this.refreshNotesV2(resp.data);
 

--- a/packages/plugin-core/src/commands/DeleteNodeCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteNodeCommand.ts
@@ -28,6 +28,7 @@ type CommandOpts = {
 };
 
 type CommandOutput = EngineDeletePayload | void;
+export type { CommandOutput as DeleteNodeCommandOutput };
 
 function formatDeletedMsg({
   fsPath,


### PR DESCRIPTION
The tests fail on Windows only, and only when running the entire test suite. It seems like a race condition (the tests sometimes pass and sometimes fail when running locally, although they seem to consistently fail on CI), but I wasn't able to find any issues with the code or any common mistakes like not awaiting a promise.

I can't figure out why the tests are failing when running the entire suite, but I did some cleanup which would be useful to merge.