### PR TITLE
enhance(workspace): validate dendronrc.yml and emit error if invalid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-9
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-10
           restore-keys: |
             ${{ runner.os }}-yarn-8
 

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -276,6 +276,11 @@ export type BooleanResp =
   | { data: true; error: null }
   | { data: false; error: IDendronError };
 
+export type DataWithOptError<T> = {
+  data: T;
+  error?: IDendronError;
+};
+
 export function isDendronResp<T = any>(args: any): args is RespV2<T> {
   return args?.error instanceof DendronError;
 }

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -58,6 +58,7 @@ import {
   SchemaModuleProps,
   SchemaQueryResp,
   StatusCodes,
+  stringifyError,
   VaultUtils,
   WorkspaceOpts,
   WriteNoteResp,
@@ -209,7 +210,11 @@ export class DendronEngineV2 implements DEngine {
 
   static create({ wsRoot, logger }: { logger?: DLogger; wsRoot: string }) {
     const LOGGER = logger || createLogger();
-    const config = DConfig.readConfigAndApplyLocalOverrideSync(wsRoot);
+    const { error, data: config } =
+      DConfig.readConfigAndApplyLocalOverrideSync(wsRoot);
+    if (error) {
+      LOGGER.error(stringifyError(error));
+    }
 
     return new DendronEngineV2({
       wsRoot,

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -24,6 +24,7 @@ import {
   SchemaUtils,
   SeedEntry,
   SelfContainedVault,
+  stringifyError,
   Time,
   VaultUtils,
   WorkspaceSettings,
@@ -198,7 +199,11 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
 
   get config(): IntermediateDendronConfig {
     // TODO: don't read all the time but cache
-    return DConfig.readConfigAndApplyLocalOverrideSync(this.wsRoot);
+    const { error, data } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
+    if (error) this.logger.error(stringifyError(error));
+    return data;
   }
 
   get seedService(): SeedService {

--- a/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
@@ -27,6 +27,12 @@ const stubVaultPick = (vaults: DVault[]) => {
   return vault;
 };
 
+/**
+ * These tests can timeout otherwise
+ * eg. https://github.com/dendronhq/dendron/runs/6942599059?check_suite_focus=true
+ */
+const timeout = 5e3;
+
 suite("Create Daily Journal Suite", function () {
   const TEMPLATE_BODY = "test daily template";
 
@@ -44,6 +50,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -84,6 +91,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and DAILY JOURNAL has already been run before",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -124,6 +132,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and first install is before 5/31/22",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -166,6 +175,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and dailyVault set",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -214,6 +224,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and dailyVault set with lookup Confirm",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -262,6 +273,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and dailyVault not set with lookup Confirm",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",
@@ -310,6 +322,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and dailyDomain set",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".bar",
@@ -351,6 +364,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note and deprecated config",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daisy",
@@ -405,6 +419,7 @@ suite("Create Daily Journal Suite", function () {
     "GIVEN a basic workspace with a daily journal template note",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout,
       preActivateHook: async ({ wsRoot, vaults }) => {
         await NoteTestUtilsV4.createNote({
           fname: CreateDailyJournalCommand.DENDRON_TEMPLATES_FNAME + ".daily",

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -576,6 +576,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
         await wsService.createSelfContainedVault({
           addToConfig: true,
           addToCodeWorkspace: true,
+          newVault: true,
           vault: {
             fsPath: "transitive",
             selfContained: true,

--- a/packages/plugin-core/src/workspace/baseWorkspace.ts
+++ b/packages/plugin-core/src/workspace/baseWorkspace.ts
@@ -9,6 +9,7 @@ import {
 } from "@dendronhq/common-all";
 import { DConfig } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
+import { Logger } from "../logger";
 
 export abstract class DendronBaseWorkspace implements DWorkspaceV2 {
   public wsRoot: string;
@@ -33,7 +34,13 @@ export abstract class DendronBaseWorkspace implements DWorkspaceV2 {
 
   // TODO: optimize to not read every time
   get config(): IntermediateDendronConfig {
-    return DConfig.readConfigAndApplyLocalOverrideSync(this.wsRoot);
+    const { data, error } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
+    if (error) {
+      Logger.error({ error });
+    }
+    return data;
   }
 
   // TODO: optimize to not read every time


### PR DESCRIPTION
enhance(workspace): validate dendronrc.yml and emit error if invalid

dendronrc.yml will prevent the workspace from loading if `workspace` is specified with an empty object or `vaults` is not an array

also fix some issues with tests timing out in plugin