### PR TITLE
enhance: autocomplete Lookup based on cursor position when no text is selected

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/utils.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/utils.test.ts
@@ -6,6 +6,7 @@ import { PickerUtilsV2, VaultPickerItem } from "../../components/lookup/utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
+import * as assert from "assert";
 
 suite("Plugin Utils", function () {
   describe("PickerUtils", function () {
@@ -28,6 +29,49 @@ suite("Plugin Utils", function () {
           done();
         },
       });
+    });
+  });
+
+  describe("When there is no selection, try to parse a wiki link from the cursor's position", function () {
+    test("THEN a wiki link is recognized", function () {
+      assert.deepStrictEqual(
+        { label: "", link: "dendron.note.vegetable.tomato" },
+        VSCodeUtils.parseWikiLink("[[ dendron.note.vegetable.tomato ]]")
+      );
+    });
+    test("THEN a labelled wiki link is recognized", function () {
+      assert.deepStrictEqual(
+        { label: "label", link: "link" },
+        VSCodeUtils.parseWikiLink("[[label|link]]")
+      );
+    });
+    test("THEN multi-word label is ok", function () {
+      assert.deepStrictEqual(
+        { label: "this is a label", link: "dendron.note.fruit.tomato" },
+        VSCodeUtils.parseWikiLink(
+          "[[     this is a label  |     dendron.note.fruit.tomato ]]"
+        )
+      );
+    });
+    test("THEN a markdown link is rejected", function () {
+      assert.deepStrictEqual(
+        { label: "", link: "" },
+        VSCodeUtils.parseWikiLink("[link text](dendron.note.name.md)")
+      );
+    });
+    test("THEN an image link is rejected", function () {
+      assert.deepStrictEqual(
+        { label: "", link: "" },
+        VSCodeUtils.parseWikiLink(
+          "![image alt text](http://image.url/or/path/to/image)"
+        )
+      );
+    });
+    test("THEN if the cursor is not in a link, the parsing also fails", function () {
+      assert.deepStrictEqual(
+        { label: "", link: "" },
+        VSCodeUtils.parseWikiLink("someRandomWord")
+      );
     });
   });
 });

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -93,6 +93,45 @@ export class VSCodeUtils {
     return { document, range };
   };
 
+  static getWikiLinkFromCursor = (
+    documentParam?: vscode.TextDocument
+  ): { label: string; link: string } => {
+    const document = documentParam || vscode.window.activeTextEditor?.document;
+
+    if (!document || (document && document.languageId !== "markdown")) {
+      return { label: "", link: "" };
+    }
+
+    const active = vscode.window.activeTextEditor!.selection.active;
+    const range = document.getWordRangeAtPosition(active, /\[\[.*\]\]/);
+
+    if (!range || (range && range.isEmpty)) {
+      return { label: "", link: "" };
+    }
+
+    return this.parseWikiLink(document.getText(range));
+  };
+
+  // split [[  label | link]]
+  static parseWikiLink = (
+    input: string
+  ): {
+    label: string;
+    link: string;
+  } => {
+    const regex = /^\[\[(?:(?=.+\|)(.+)\|(.+)|(.+))\]\]$/;
+    const m = regex.exec(input);
+    if (m === null) {
+      return { label: "", link: "" };
+    }
+
+    if (m[1] === undefined) {
+      return { label: "", link: m[3].trim() };
+    } else {
+      return { label: m[1].trim(), link: m[2].trim() };
+    }
+  };
+
   static deleteRange = async (
     document: vscode.TextDocument,
     range: vscode.Range


### PR DESCRIPTION
## Enhancement

Remove the need to select a word so as to create a note, VSCode can recognize a word from the cursor's position, and that recognized word is possibly a link, in the case of a link, the users can create the note directly without further editing the name in the lookup dialog box. 

Selecting a word is less efficient and often distracting, double clicks and shortcuts are less economic than not doing anything at all, Dendron could be smart enough to help reduce the burden.

## Implementation

- Get the word from the cursor's current position, with the pattern of a wiki link `\[\[.*\]\]`
- If no text is selected by the users, then set the value of `quickPicker` to that link, if there is one.
- else if the user intended to use the selected text, Dendron will handle the situation the way it used to do.

## Usecase

I have been using Dendron a lot. When jotting down ideas, at some point I will have to refer to other notes. But some of the notes do not exist at the time, so I have to create them, but I find creating notes is not so convenient, and the hint provided on the lookup dialog box is not so helpful, in both modes:  selectionExtract and selection2link. In the latter mode, I still need to edit the name a lot. If I need to change the preset name a lot, I would prefer to do it in the editor, on the fly, to avoid switching focus to somewhere else. And If I decide to create that note later, I can continue the writing and then move the cursor back to the link of the non-existent note and, without selection, which often fails to select a link if no complicated shortcuts are applied, I can quickly prompt the lookup window and jump directly to that note.

## Effect

https://imgur.com/a/BuOrEFA



