### PR TITLE
fix(publish): issue publishing note with ref without a `code-worksapce` file

### DIFF
--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -440,7 +440,12 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     const resp = await this.api.engineUpdateNote({ ws: this.ws, note, opts });
     const noteClean = resp.data;
     if (_.isUndefined(noteClean)) {
-      throw new DendronError({ message: "error updating note", payload: resp });
+      throw new DendronError({
+        message: `error updating note: ${JSON.stringify(
+          NoteUtils.toNoteLoc(note)
+        )}`,
+        payload: resp,
+      });
     }
 
     // If no note existed, treat this as a create.

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -728,19 +728,31 @@ export class DendronEngineV2 implements DEngine {
   }
 
   /**
+   * TODO: this should return a ERROR
    * See {@link FileStorageV2.updateNote}
    * @param note
    * @param opts
    * @returns
    */
   async updateNote(note: NoteProps, opts?: EngineUpdateNodesOptsV2) {
-    const noteWithLinks = await EngineUtils.refreshNoteLinksAndAnchors({
-      note,
-      engine: this,
-    });
-    const out = this.store.updateNote(noteWithLinks, opts);
-    await this.updateIndex("note");
-    return out;
+    const ctx = "updateNote";
+    this.logger.debug({ ctx, msg: "enter", note: NoteUtils.toNoteLoc(note) });
+    const engine = this as DEngineClient;
+    try {
+      const noteWithLinks = await EngineUtils.refreshNoteLinksAndAnchors({
+        note,
+        engine,
+      });
+      this.logger.debug({ ctx, msg: "post:refreshed note links and anchors" });
+      const out = this.store.updateNote(noteWithLinks, opts);
+      this.logger.debug({ ctx, msg: "post:updateNote" });
+      await this.updateIndex("note");
+      this.logger.debug({ ctx, msg: "post:updateIndex" });
+      return out;
+    } catch (err) {
+      this.logger.error({ ctx, msg: error2PlainObject(err as Error) });
+      throw err;
+    }
   }
 
   async updateIndex(mode: DNodeType) {

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -843,8 +843,7 @@ function convertNoteRefHelperAST(
     MDUtilsV5.getProcOpts(proc)
   );
 
-  const wsRoot = engine.wsRoot;
-  noteRefProc = noteRefProc.data("fm", MDUtilsV5.getFM({ note, wsRoot }));
+  noteRefProc = noteRefProc.data("fm", MDUtilsV5.getFM({ note }));
   MDUtilsV5.setNoteRefLvl(noteRefProc, refLvl);
 
   const bodyAST: DendronASTNode = noteRefProc.parse(

--- a/packages/engine-server/src/markdown/utilsv5.ts
+++ b/packages/engine-server/src/markdown/utilsv5.ts
@@ -1,15 +1,14 @@
 import {
   assertUnreachable,
-  IntermediateDendronConfig,
+  ConfigUtils,
   DendronError,
   DEngineClient,
   DVault,
   ERROR_STATUS,
+  IntermediateDendronConfig,
+  NoteProps,
   NotePropsByIdDict,
   NoteUtils,
-  NoteProps,
-  DateTime,
-  ConfigUtils,
   ProcFlavor,
 } from "@dendronhq/common-all";
 // @ts-ignore
@@ -17,8 +16,8 @@ import rehypePrism from "@mapbox/rehype-prism";
 // @ts-ignore
 import mermaid from "@dendronhq/remark-mermaid";
 import _ from "lodash";
-import math from "remark-math";
 import link from "rehype-autolink-headings";
+import math from "remark-math";
 // @ts-ignore
 import variables from "remark-variables";
 // @ts-ignore
@@ -33,21 +32,19 @@ import frontmatterPlugin from "remark-frontmatter";
 import remarkParse from "remark-parse";
 import remark2rehype from "remark-rehype";
 import { Processor } from "unified";
+import { hierarchies } from "./remark";
+import { backlinks } from "./remark/backlinks";
+import { BacklinkOpts, backlinksHover } from "./remark/backlinksHover";
 import { blockAnchors } from "./remark/blockAnchors";
 import { dendronHoverPreview } from "./remark/dendronPreview";
 import { dendronPub, DendronPubOpts } from "./remark/dendronPub";
+import { extendedImage } from "./remark/extendedImage";
+import { hashtags } from "./remark/hashtag";
 import { noteRefsV2 } from "./remark/noteRefsV2";
+import { userTags } from "./remark/userTags";
 import { wikiLinks, WikiLinksOpts } from "./remark/wikiLinks";
 import { DendronASTDest } from "./types";
 import { MDUtilsV4 } from "./utils";
-import { hashtags } from "./remark/hashtag";
-import { userTags } from "./remark/userTags";
-import { backlinks } from "./remark/backlinks";
-import { hierarchies } from "./remark";
-import { extendedImage } from "./remark/extendedImage";
-import { WorkspaceService } from "../workspace";
-import { DateTimeFormatOptions } from "luxon";
-import { backlinksHover, BacklinkOpts } from "./remark/backlinksHover";
 
 export { ProcFlavor };
 
@@ -217,29 +214,16 @@ export class MDUtilsV5 {
     );
   }
 
-  static getFM(opts: { note: NoteProps; wsRoot: string }) {
-    const { note, wsRoot } = opts;
-
+  static getFM(opts: { note: NoteProps }) {
+    const { note } = opts;
     const custom = note.custom ? note.custom : undefined;
-
-    const ws = new WorkspaceService({ wsRoot });
-    const wsConfig = ws.getCodeWorkspaceSettingsSync();
-    ws.dispose();
-    const timestampConfig: keyof typeof DateTime =
-      wsConfig?.settings["dendron.defaultTimestampDecorationFormat"];
-    const formatOption = DateTime[timestampConfig] as
-      | DateTimeFormatOptions
-      | undefined;
-    const created = DateTime.fromMillis(_.toInteger(note.created));
-    const updated = DateTime.fromMillis(_.toInteger(note.updated));
-
     return {
       ...custom,
       id: note.id,
       title: note.title,
       desc: note.desc,
-      created: created.toLocaleString(formatOption),
-      updated: updated.toLocaleString(formatOption),
+      created: note.created,
+      updated: note.updated,
     };
   }
 
@@ -301,7 +285,7 @@ export class MDUtilsV5 {
           });
 
           if (!_.isUndefined(note)) {
-            proc = proc.data("fm", this.getFM({ note, wsRoot: data.wsRoot }));
+            proc = proc.data("fm", this.getFM({ note }));
           }
 
           // backwards compatibility, default to v4 values

--- a/packages/engine-server/src/workspace/vscode.ts
+++ b/packages/engine-server/src/workspace/vscode.ts
@@ -88,6 +88,14 @@ export type WriteConfigOpts = {
 };
 
 export class WorkspaceConfig {
+  static genDefaults(): WorkspaceSettings {
+    return {
+      folders: [],
+      settings: Settings.defaults(),
+      extensions: Extensions.defaults(),
+    };
+  }
+
   static workspaceFile(wsRoot: string) {
     return path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME);
   }
@@ -104,7 +112,9 @@ export class WorkspaceConfig {
       vaults,
       overrides: {},
     });
+    const defaultSettings = this.genDefaults();
     const jsonBody: WorkspaceSettings = _.merge(
+      defaultSettings,
       {
         folders: cleanOpts.vaults
           ? cleanOpts.vaults.map((ent) => ({
@@ -112,8 +122,6 @@ export class WorkspaceConfig {
               name: ent.name,
             }))
           : [],
-        settings: Settings.defaults(),
-        extensions: Extensions.defaults(),
       },
       cleanOpts.overrides
     );


### PR DESCRIPTION
Dendron will try to format `created`/`updated` according to `dendron.defaultTimestampDecorationFormat` option from `dendron.code-workspace` when processing note references. This will fail on any workspace that does not have `dendron.code-workspace`. This leads to an error on publish (see https://github.com/dendronhq/dendron/issues/2988) and probably errors in other places

For frontmatter variable substitution, we never meant for `created`/`updated` to actually be formatted. To simplify the method call, remove the requirement to parse `dendron.code-workspace`
