### PR TITLE
fix(workspace): improve phrasing of sync message

### DIFF
--- a/packages/plugin-core/src/commands/Sync.ts
+++ b/packages/plugin-core/src/commands/Sync.ts
@@ -265,8 +265,8 @@ export class SyncCommand extends BasicCommand<CommandOpts, CommandReturns> {
     const pushedDone = WorkspaceUtils.getCountForStatusDone(pushed);
     const repos = (count: number) => (count === 1 ? "repo" : "repos");
     message.push(`Committed ${committedDone} ${repos(committedDone)},`);
-    message.push(`tried pulling ${pulledDone}`);
-    message.push(`and pushing ${pushedDone} ${repos(pushedDone)}.`);
+    message.push(`pulled ${pulledDone}`);
+    message.push(`and pushed ${pushedDone} ${repos(pushedDone)}.`);
     const finalMessage = message.join(" ");
 
     VSCodeUtils.showMessage(maxMessageSeverity, finalMessage, {});


### PR DESCRIPTION
# Workspace sync message phrasing improved

only thing changed is the wording of the message, no logic altered.
see issue here: https://github.com/dendronhq/dendron/issues/2816

discord username: avhb#0567