### PR TITLE
chore(workspace): debounce completion provider trigger to reduce lag when autocompleting wikilinks

### DIFF
--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -185,7 +185,6 @@ export const provideCompletionItems = sentryReportingCallback(
     }
 
     const line = document.lineAt(position).text;
-    console.log({ ctx, line });
     Logger.info({ ctx, position, msg: "enter" });
 
     // get all matches
@@ -341,6 +340,15 @@ export const provideCompletionItems = sentryReportingCallback(
   }
 );
 
+/**
+ * Debounced version of {@link provideCompletionItems}.
+ *
+ * We trigger on both leading and trailing edge of the debounce window because:
+ * 1. without the leading edge we lose focus to the Intellisense
+ * 2. without the trailing edge we may miss some keystrokes from the users at the end.
+ *
+ * related discussion: https://github.com/dendronhq/dendron/pull/3116#discussion_r902075154
+ */
 export const debouncedProvideCompletionItems = _.debounce(
   provideCompletionItems,
   100,

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -341,6 +341,12 @@ export const provideCompletionItems = sentryReportingCallback(
   }
 );
 
+export const debouncedProvideCompletionItems = _.debounce(
+  provideCompletionItems,
+  100,
+  { trailing: false, leading: true }
+);
+
 export const resolveCompletionItem = sentryReportingCallback(
   async (
     item: CompletionItem,
@@ -613,7 +619,8 @@ export const activate = (context: ExtensionContext) => {
     languages.registerCompletionItemProvider(
       "markdown",
       {
-        provideCompletionItems,
+        // we debounce this provider since we don't want lookup to be triggered on every keystroke.
+        provideCompletionItems: debouncedProvideCompletionItems,
       },
 
       "[", // for wikilinks and references
@@ -626,6 +633,10 @@ export const activate = (context: ExtensionContext) => {
     languages.registerCompletionItemProvider(
       "markdown",
       {
+        /**
+         * we don't have to debounce this since it is not triggered on every keystroke
+         * and is ligher than {@link provideCompletionItems} in general.
+         */
         provideCompletionItems: provideBlockCompletionItems,
       },
       "#",

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -179,13 +179,13 @@ export const provideCompletionItems = sentryReportingCallback(
   ): Promise<CompletionList | undefined> => {
     const ctx = "provideCompletionItems";
     const startTime = process.hrtime();
-
     // No-op if we're not in a Dendron Workspace
     if (!ExtensionProvider.getExtension().isActive()) {
       return;
     }
 
     const line = document.lineAt(position).text;
+    console.log({ ctx, line });
     Logger.info({ ctx, position, msg: "enter" });
 
     // get all matches
@@ -344,7 +344,7 @@ export const provideCompletionItems = sentryReportingCallback(
 export const debouncedProvideCompletionItems = _.debounce(
   provideCompletionItems,
   100,
-  { trailing: false, leading: true }
+  { leading: true, trailing: true }
 );
 
 export const resolveCompletionItem = sentryReportingCallback(


### PR DESCRIPTION
# chore(workspace): debounce completion provider trigger to reduce lag when autocompleting wikilinks
This PR:
- register a debounced version of `provideCompletionItem` to avoid triggering lookup (potentially expensive depending on workspace size) on every keystroke.

## Note
- We have another completion item provider for block completions, but this does not get triggered on every keystroke, and doesn't use lookup so it is generally lighter than `provideCompletionItem`. For this reason this is not debounced.

## Testing
This is not straightforward to write a test so confirming manually that it is successfully debounced:

as-is:
![image](https://user-images.githubusercontent.com/1219789/174622166-77b41e6f-72bc-490c-ba19-6899ff1edfe9.png)

to-be:
![image](https://user-images.githubusercontent.com/1219789/174622278-5b2da08f-4960-47a5-9295-8b288b26c98a.png)

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)