### PR TITLE
fix(publish): slow rendering of sidebar in published site

### DIFF
--- a/packages/nextjs-template/components/DendronBreadCrumb.tsx
+++ b/packages/nextjs-template/components/DendronBreadCrumb.tsx
@@ -1,11 +1,10 @@
 import { Breadcrumb } from "antd";
 import _ from "lodash";
 import React from "react";
-import { NoteUtils, NoteProps } from "@dendronhq/common-all";
+import { NoteUtils } from "@dendronhq/common-all";
 import { useNoteActive } from "../utils/hooks";
 import { getNoteUrl } from "../utils/links";
 import { DendronCommonProps, verifyNoteData } from "../utils/types";
-import DendronSpinner from "./DendronSpinner";
 import Link from "next/link";
 
 export function DendronBreadCrumb(props: DendronCommonProps) {
@@ -29,14 +28,12 @@ export function DendronBreadCrumb(props: DendronCommonProps) {
   return (
     <Breadcrumb style={{ margin: "16px 0" }}>
       {_.map(noteParents, (note) => {
-        const dest = getNoteUrl({note, noteIndex: props.noteIndex})
+        const dest = getNoteUrl({ note, noteIndex: props.noteIndex });
         return (
           <Breadcrumb.Item key={note.id}>
-            <Link href={dest}>
-              {note.title}
-            </Link>
+            <Link href={dest}>{note.title}</Link>
           </Breadcrumb.Item>
-        )
+        );
       })}
     </Breadcrumb>
   );

--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -1,5 +1,5 @@
 import { MenuOutlined } from "@ant-design/icons";
-import { ConfigUtils, IntermediateDendronConfig } from "@dendronhq/common-all";
+import { ConfigUtils } from "@dendronhq/common-all";
 import { Col, Divider, Layout, Row } from "antd";
 import Script from "next/script";
 import * as React from "react";
@@ -103,6 +103,7 @@ export default function DendronLayout(
             // initialize
             mermaid.init();
           }}
+          strategy="lazyOnload"
         />
       )}
       <Header

--- a/packages/nextjs-template/components/DendronLogoOrTitle.tsx
+++ b/packages/nextjs-template/components/DendronLogoOrTitle.tsx
@@ -1,8 +1,6 @@
 import { ConfigUtils, PublishUtils } from "@dendronhq/common-all";
 import { verifyEngineSliceState } from "@dendronhq/common-frontend";
-import { Col } from "antd";
 import Link from "next/link";
-import path from "path";
 import React from "react";
 import { useEngineAppSelector } from "../features/engine/hooks";
 import { DENDRON_STYLE_CONSTANTS } from "../styles/constants";

--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import {
   ConfigUtils,
-  DVault,
   IntermediateDendronConfig,
   NoteProps,
   RESERVED_KEYS,

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -6,7 +6,7 @@ import {
 import { LoadingStatus } from "@dendronhq/common-frontend";
 import { AutoComplete, Alert, Row, Col, Typography } from "antd";
 import React, { useCallback, useEffect } from "react";
-import { useCombinedDispatch, useCombinedSelector } from "../features";
+import { useCombinedDispatch } from "../features";
 import { browserEngineSlice } from "../features/engine";
 import { useFetchFuse } from "../utils/fuse";
 import type Fuse from "fuse.js";
@@ -85,7 +85,6 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
   );
   const [results, setResults] = React.useState<SearchMode>();
   const dispatch = useCombinedDispatch();
-  //const notes = useCombinedSelector((state) => state.engine.notes);
   const { noteBodies, requestNotes } = useNoteBodies();
   const lookup = useDendronLookup(props.notes);
   const { noteActive } = useNoteActive(dendronRouter.getActiveNoteId());

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -5,8 +5,8 @@ import {
 } from "@dendronhq/common-all";
 import { LoadingStatus } from "@dendronhq/common-frontend";
 import { AutoComplete, Alert, Row, Col, Typography } from "antd";
-import React, { useCallback, useEffect, useRef } from "react";
-import { useCombinedDispatch } from "../features";
+import React, { useCallback, useEffect } from "react";
+import { useCombinedDispatch, useCombinedSelector } from "../features";
 import { browserEngineSlice } from "../features/engine";
 import { useFetchFuse } from "../utils/fuse";
 import type Fuse from "fuse.js";
@@ -85,8 +85,9 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
   );
   const [results, setResults] = React.useState<SearchMode>();
   const dispatch = useCombinedDispatch();
+  //const notes = useCombinedSelector((state) => state.engine.notes);
   const { noteBodies, requestNotes } = useNoteBodies();
-  const lookup = useDendronLookup();
+  const lookup = useDendronLookup(props.notes);
   const { noteActive } = useNoteActive(dendronRouter.getActiveNoteId());
   const initValue = noteActive?.fname || "";
   const [searchQueryValue, setSearchQueryValue] = React.useState(initValue);

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -57,7 +57,7 @@ export default function DendronTreeMenu(
     });
 
     setActiveNoteIds(activeNoteIds);
-  }, [props.notes, props.noteIndex, dendronRouter.query.id, noteActiveId]);
+  }, [props.noteIndex, dendronRouter.query.id, noteActiveId]);
 
   const { notes, collapsed, setCollapsed } = props;
 

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -61,7 +61,7 @@ export function useDendronRouter() {
  * Get instance of fuse js
  * @param setNoteIndex
  */
-export function useDendronLookup() {
+export function useDendronLookup(notes?: NotePropsByIdDict) {
   const engine = useEngineAppSelector((state) => state.engine);
   const config = engine.config as IntermediateDendronConfig;
   const fuzzThreshold = ConfigUtils.getLookup(config).note.fuzzThreshold;
@@ -70,13 +70,12 @@ export function useDendronLookup() {
     undefined
   );
   React.useEffect(() => {
-    fetchNotes().then(async (noteData) => {
-      const { notes } = noteData;
+    if (notes) {
       const noteIndex = new FuseEngine({ mode: "fuzzy", fuzzThreshold });
       noteIndex.updateNotesIndex(notes);
       setNoteIndex(noteIndex);
-    });
-  }, []);
+    }
+  }, [notes]);
   return noteIndex;
 }
 


### PR DESCRIPTION
This PR aims to reduce the load time of Dendron sidebar in a published site.
- Removed unnecessary dependencies on load, unused imports and duplicate fetch request.

Tested by commenting out the custom BannerAlert code

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
NA

### Extended
NA

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
NA

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)