### PR TITLE
fix(workspace): error when native workspaces are initializing

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -942,10 +942,11 @@ export async function _activate(
         showcase.showToast();
       }, ONE_MINUTE_IN_MS);
 
-      // Add the current workspace to the recent workspace list.
-      MetadataService.instance().addToRecentWorkspaces(
-        DendronExtension.workspaceFile().fsPath
-      );
+      // Add the current workspace to the recent workspace list. The current
+      // workspace is either the workspace file (Code Workspace) or the current
+      // folder (Native Workspace)
+      const workspace = DendronExtension.tryWorkspaceFile()?.fsPath || wsRoot;
+      MetadataService.instance().addToRecentWorkspaces(workspace);
 
       Logger.info({ ctx, msg: "fin startClient", durationReloadWorkspace });
     } else {

--- a/packages/plugin-core/src/commands/DiagnosticsReport.ts
+++ b/packages/plugin-core/src/commands/DiagnosticsReport.ts
@@ -40,8 +40,14 @@ export class DiagnosticsReportCommand extends BasicCommand<
     const port = EngineUtils.getPortFilePathForWorkspace({ wsRoot });
     const portFromFile = fs.readFileSync(port, { encoding: "utf8" });
 
-    const workspaceFile = DendronExtension.workspaceFile().fsPath;
-    const wsFile = fs.readFileSync(workspaceFile, { encoding: "utf8" });
+    let wsFile: string;
+    try {
+      const workspaceFile = DendronExtension.workspaceFile().fsPath;
+      wsFile = await fs.readFile(workspaceFile, { encoding: "utf8" });
+    } catch {
+      // Workspace file is missing, may be a native workspace
+      wsFile = "<!-- workspace file doesn't exist -->";
+    }
 
     const content = [
       "# Plugin Logs",


### PR DESCRIPTION
Fixes an issue that causes an error during initialization if a native workspace is used, or if a code workspace is opened without opening the workspace file.

#3122
