### PR TITLE
chore(analytics): end quickstart tutorial ab test

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -2,6 +2,10 @@
 import { ABTest } from "./abTesting";
 import { GraphThemeEnum } from "./types/typesv2";
 
+export const isABTest = (value: any): value is ABTest<any> => {
+  return value instanceof ABTest;
+};
+
 /**
  * Section: Tests (Active or soon to be active)
  *
@@ -46,31 +50,6 @@ export const GRAPH_THEME_TEST = new ABTest("GraphThemeTest", [
   },
 ]);
 
-export enum QuickstartTutorialTestGroups {
-  "main" = "main",
-  "quickstart-v1" = "quickstart-v1",
-}
-
-/**
- * Experiment to test the impact of a short-form tutorial vs 5-step tutorial on the onboarding funnel.
- *
- * main:          full 5-step tutorial
- * quickstart-v1: one pager tutorial
- */
-const _2022_06_QUICKSTART_TUTORIAL_TEST = new ABTest(
-  "2022-06-QuickstartTutorialTest",
-  [
-    {
-      name: QuickstartTutorialTestGroups["main"],
-      weight: 1,
-    },
-    {
-      name: QuickstartTutorialTestGroups["quickstart-v1"],
-      weight: 1,
-    },
-  ]
-);
-
 export enum DailyJournalTestGroups {
   withTemplate = "withTemplate",
   withoutTemplate = "withoutTemplate",
@@ -96,20 +75,29 @@ export const _2022_05_DAILY_JOURNAL_TEMPLATE_TEST = new ABTest(
   ]
 );
 
+/**
+ * Tutorial type of our ever-running / up to date main tutorial.
+ * This should never change.
+ *
+ * If after an a/b test we find out that some treatment of the tutorial works better,
+ * that treatment should be escalated as the "main", and be synced to the extension as such.
+ */
 export const MAIN_TUTORIAL_TYPE_NAME = "main";
 
-/**
+/** ^480iitgzeq5w
  * Currently running tutorial AB test group.
  * If we are not running any A/B testing, explicitly set this to `undefined`
  */
-export const CURRENT_TUTORIAL_TEST = _2022_06_QUICKSTART_TUTORIAL_TEST;
+export const CURRENT_TUTORIAL_TEST: ABTest<any> | undefined = undefined;
 
 /** All A/B tests that are currently running.
  *
+ * We apply a filter here before exporting because {@link CURRENT_TUTORIAL_TEST} can be undefined
+ * when there is no active tutorial AB test running.
  * ^tkqhy45hflfd
  */
 export const CURRENT_AB_TESTS = [
   GRAPH_THEME_TEST,
   _2022_05_DAILY_JOURNAL_TEMPLATE_TEST,
   CURRENT_TUTORIAL_TEST,
-];
+].filter((entry): entry is ABTest<any> => !!entry);

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -8,7 +8,6 @@ import {
   ConfigUtils,
   CONSTANTS,
   CURRENT_AB_TESTS,
-  CURRENT_TUTORIAL_TEST,
   DendronError,
   getStage,
   GitEvents,
@@ -94,6 +93,7 @@ import { WorkspaceActivator } from "./workspace/workspaceActivater";
 import { WorkspaceInitFactory } from "./workspace/WorkspaceInitFactory";
 import { WSUtils } from "./WSUtils";
 import setupRecentWorkspacesTreeView from "./features/RecentWorkspacesTreeview";
+import { TutorialInitializer } from "./workspace/tutorialInitializer";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -1038,9 +1038,7 @@ async function showWelcomeOrWhatsNew({
       // Explicitly set the tutorial split test group in the Install event as
       // well, since Amplitude may not have the user props splitTest setup in time
       // before this install event reaches their backend.
-      const group = CURRENT_TUTORIAL_TEST.getUserGroup(
-        SegmentClient.instance().anonymousId
-      );
+      const group = TutorialInitializer.getTutorialType();
 
       // track how long install process took ^e8itkyfj2rn3
       AnalyticsUtils.track(VSCodeEvents.Install, {

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -7,6 +7,7 @@ import {
   CURRENT_TUTORIAL_TEST,
   MAIN_TUTORIAL_TYPE_NAME,
   TutorialNoteViewedPayload,
+  isABTest,
 } from "@dendronhq/common-all";
 import { file2Note, SegmentClient, vault2Path } from "@dendronhq/common-server";
 import {
@@ -43,10 +44,14 @@ export class TutorialInitializer
   extends BlankInitializer
   implements WorkspaceInitializer
 {
-  private getTutorialType() {
-    return CURRENT_TUTORIAL_TEST !== undefined
-      ? CURRENT_TUTORIAL_TEST.getUserGroup(SegmentClient.instance().anonymousId)
-      : MAIN_TUTORIAL_TYPE_NAME;
+  static getTutorialType() {
+    if (isABTest(CURRENT_TUTORIAL_TEST)) {
+      return CURRENT_TUTORIAL_TEST.getUserGroup(
+        SegmentClient.instance().anonymousId
+      );
+    } else {
+      return MAIN_TUTORIAL_TYPE_NAME;
+    }
   }
 
   async onWorkspaceCreation(opts: OnWorkspaceCreationOpts): Promise<void> {
@@ -61,7 +66,7 @@ export class TutorialInitializer
 
     const vpath = vault2Path({ vault: opts.wsVault!, wsRoot: opts.wsRoot });
 
-    const tutorialDir = this.getTutorialType();
+    const tutorialDir = TutorialInitializer.getTutorialType();
 
     fs.copySync(
       path.join(
@@ -84,7 +89,7 @@ export class TutorialInitializer
     ws: DWorkspaceV2;
   }): TutorialNoteViewedPayload {
     const { document, ws } = opts;
-    const tutorialType = this.getTutorialType();
+    const tutorialType = TutorialInitializer.getTutorialType();
     const fsPath = document.uri.fsPath;
     const { vaults, wsRoot } = ws;
     const vault = VaultUtils.getVaultByFilePath({ vaults, wsRoot, fsPath });


### PR DESCRIPTION
# chore(analytics): end quickstart tutorial ab test

This PR:
- Ends the quickstart tutorial AB test in preparation of other tutorial related ab tests.
- Fixes `TutorialInitializer` to properly recognize that there are no active running tutorial ab tests.

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)