### PR TITLE
enhance(sync): adding import hint to tutorial

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.conclusion.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/main/tutorial.conclusion.md
@@ -15,6 +15,8 @@ With fast lookup, flexible hierarchies, note linking, and rich formatting, you'r
 
 From here, you can start adding your notes to this workspace or, if you'd like to start fresh, you can create a new workspace for your notes with the `Dendron: Initialize Workspace` Command.
 
+> Coming from Obsidian? Click [here](command:dendron.importObsidianPod) to import your Obsidian notes (or any markdown notes) into Dendron to see how they look.
+
 ## Join the Dendron Community
 
 Dendron wouldn't be what it is today without our wonderful set of members and supporters.

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
@@ -83,6 +83,8 @@ Depending on your needs, here are some common next steps:
 - I want to use Dendron for managing my tasks and todos: See the [Getting Things Done (GTD), Bullet Journaling, and Other Task Management Workflows](https://wiki.dendron.so/notes/ordz7r99w1v099v14hrwgnp) for how the founder of Dendron uses it to manage his work.
 - I want to dive deeper into Dendron: See [next steps](https://wiki.dendron.so/notes/TflY5kn29HOLpp1pWT9tP) for longer walkthroughs and advanced functionality!
 
+> Coming from Obsidian? Click [here](command:dendron.importObsidianPod) to import your Obsidian notes (or any markdown notes) into Dendron to see how they look.
+
 ## Community
 
 Dendron is more that just a tool - we are also a community of individuals that are passionate about knowledge management. If you need help or want to connect with the community, join us in the [Discords](https://link.dendron.so/discord).

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -73,10 +73,10 @@ export class TutorialInitializer
       vpath
     );
 
-    // 10 minutes after setup, try to show this toast if we haven't already tried
+    // 3 minutes after setup, try to show this toast if we haven't already tried
     setTimeout(() => {
       this.tryShowImportNotesFeatureToaster();
-    }, 1000 * 60 * 10);
+    }, 1000 * 60 * 3);
   }
 
   private getAnalyticsPayloadFromDocument(opts: {


### PR DESCRIPTION
## enhance(sync): Adding Import Hint to Tutorial

- Adding a small tip about Obsidian Import to the tutorial
- Shortening the duration for the feature toaster to show up after 3 minutes instead of 10

Corresponding PR for dendron-site: https://github.com/dendronhq/dendron-site/pull/561