### PR TITLE
fix(workspace): proper handling of invalid data for write note ops

### DIFF
--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -69,7 +69,7 @@ interface IRequestArgs {
 }
 
 interface IAPIPayload {
-  data: null | any | any[];
+  data?: null | any | any[];
   error: null | DendronError | DendronCompositeError;
 }
 

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -435,8 +435,8 @@ export type NoteBlock = {
 /**
  * Returns list of notes that were changed
  */
-export type WriteNoteResp = Required<RespV2<NoteChangeEntry[]>>;
-export type BulkWriteNoteResp = Required<BulkResp<NoteChangeEntry[]>>;
+export type WriteNoteResp = RespV2<NoteChangeEntry[]>;
+export type BulkWriteNoteResp = BulkResp<NoteChangeEntry[]>;
 
 // --- Common
 export type ConfigGetPayload = IntermediateDendronConfig;
@@ -444,7 +444,7 @@ export type ConfigGetPayload = IntermediateDendronConfig;
 export type DCommonMethods = {
   bulkWriteNotes: (
     opts: BulkWriteNotesOpts
-  ) => Promise<Required<BulkResp<NoteChangeEntry[]>>>;
+  ) => Promise<BulkResp<NoteChangeEntry[]>>;
   // TODO
   // configGet(): RespV2<ConfigGetPayload>
   /**
@@ -520,7 +520,7 @@ export type WorkspaceExtensionSetting = {
 // --- KLUDGE END
 
 export type EngineDeleteNoteResp = Required<RespV2<EngineDeleteNotePayload>>;
-export type NoteQueryResp = Required<RespV2<NoteProps[]>>;
+export type NoteQueryResp = RespV2<NoteProps[]>;
 export type SchemaQueryResp = Required<RespV2<SchemaModuleProps[]>>;
 export type StoreDeleteNoteResp = EngineDeleteNotePayload;
 /**

--- a/packages/common-all/src/utils/lookup.ts
+++ b/packages/common-all/src/utils/lookup.ts
@@ -107,6 +107,11 @@ export class NoteLookupUtils {
     // limit number of results. currently, this is hardcoded and we don't paginate
     // this is okay because we rely on user refining query to get more results
     let nodes = resp.data;
+
+    if (!nodes) {
+      return [];
+    }
+
     if (nodes.length > PAGINATE_LIMIT) {
       nodes = nodes.slice(0, PAGINATE_LIMIT);
     }

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -197,13 +197,16 @@ export class DoctorService implements Disposable {
 
     let notes: NoteProps[];
     if (_.isUndefined(candidates)) {
-      notes = query
-        ? engine.queryNotesSync({ qs: query, originalQS: query }).data
-        : _.values(engine.notes);
+      notes =
+        (query
+          ? engine.queryNotesSync({ qs: query, originalQS: query }).data
+          : _.values(engine.notes)) ?? [];
     } else {
       notes = candidates;
     }
-    notes = notes.filter((n) => !n.stub);
+    if (notes) {
+      notes = notes.filter((n) => !n.stub);
+    }
     const notesById = NoteDictsUtils.createNotePropsByIdDict(notes);
     const notesByFname =
       NoteFnameDictUtils.createNotePropsByFnameDict(notesById);

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -227,9 +227,11 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   async bulkWriteNotes(opts: BulkWriteNotesOpts) {
     const resp = await this.api.engineBulkAdd({ opts, ws: this.ws });
     const changed = resp.data;
-    await this.refreshNotesV2(changed);
 
-    this._onNoteChangedEmitter.fire(resp.data);
+    if (changed) {
+      await this.refreshNotesV2(changed);
+      this._onNoteChangedEmitter.fire(changed);
+    }
 
     return resp;
   }
@@ -349,6 +351,10 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   }
 
   async refreshNotesV2(notes: NoteChangeEntry[]) {
+    if (_.isUndefined(notes)) {
+      return;
+    }
+
     const noteDicts = {
       notesById: this.notes,
       notesByFname: this.noteFnames,
@@ -486,9 +492,11 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     if (opts?.updateExisting) {
       changed = _.reject(changed, (ent) => ent.status === "delete");
     }
-    await this.refreshNotesV2(changed);
 
-    this._onNoteChangedEmitter.fire(resp.data);
+    if (changed) {
+      await this.refreshNotesV2(changed);
+      this._onNoteChangedEmitter.fire(changed);
+    }
 
     return resp;
   }

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -129,7 +129,7 @@ const NOTES = {
       });
       return [
         {
-          actual: data.length,
+          actual: data?.length,
           expected: 4,
         },
       ];
@@ -155,11 +155,11 @@ const NOTES = {
       )[0];
       return [
         {
-          actual: data[0],
+          actual: data ? data[0] : undefined,
           expected: expectedNote,
         },
         {
-          actual: data[0].schema,
+          actual: data ? data[0].schema : undefined,
           expected: {
             moduleId: SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.fname,
             schemaId: SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.fname,

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -909,13 +909,13 @@ const NOTES = {
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
-            { status: "update", fname: "bar" },
           ],
         },
         {
-          actual: _.trim(changed![4].note.body),
+          actual: _.trim(changed![2].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[1])}/baz]]`,
         },
         {
@@ -971,14 +971,14 @@ const NOTES = {
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
+            { status: "update", fname: "bar" },
             // this is a diff vault
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
-            { status: "update", fname: "bar" },
           ],
         },
         {
-          actual: _.trim(changed![4].note.body),
+          actual: _.trim(changed![2].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[2])}/baz]]`,
         },
         {
@@ -1038,9 +1038,9 @@ const NOTES = {
           expected: [
             { status: "update", fname: "root" },
             { status: "delete", fname: "alpha" },
+            { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
             { status: "create", fname: "gamma" },
-            { status: "update", fname: "beta" },
           ],
         },
         {

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -204,12 +204,12 @@ const NOTES = {
       originalQS: "bar",
       vault,
     });
-    const note = resp.data[0];
+    const note = resp.data![0];
 
     return [
       {
         actual: note,
-        expected: engine.notes[note.id],
+        expected: engine.notes["note.id"],
         msg: "bar should be written in engine",
       },
       {
@@ -495,7 +495,7 @@ const NOTES_MULTI = {
       originalQS: "bar",
       vault,
     });
-    const note = resp.data[0];
+    const note = resp.data![0];
 
     return [
       {
@@ -527,7 +527,7 @@ const NOTES_MULTI = {
         originalQS: "bar",
         vault,
       });
-      const note = resp.data[0];
+      const note = resp.data![0];
 
       return [
         {
@@ -549,17 +549,17 @@ const NOTES_MULTI = {
       fooUpdated.id = "updatedID";
       const changes = await engine.writeNote(fooUpdated);
       const createEntries = extractNoteChangeEntriesByType(
-        changes.data,
+        changes.data!,
         "create"
       );
 
       const deleteEntries = extractNoteChangeEntriesByType(
-        changes.data,
+        changes.data!,
         "delete"
       );
 
       const updateEntries = extractNoteChangeEntriesByType(
-        changes.data,
+        changes.data!,
         "update"
       ) as NoteChangeUpdateEntry[];
 

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -209,7 +209,7 @@ const NOTES = {
     return [
       {
         actual: note,
-        expected: engine.notes["note.id"],
+        expected: engine.notes[note.id],
         msg: "bar should be written in engine",
       },
       {

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -525,7 +525,9 @@ export class MoveHeaderCommand extends BasicCommand<
         const writeResp = await engine.writeNote(note!, {
           updateExisting: true,
         });
-        noteChangeEntries = noteChangeEntries.concat(writeResp.data);
+        if (writeResp.data) {
+          noteChangeEntries = noteChangeEntries.concat(writeResp.data);
+        }
       } catch (error) {
         // TODO: should notify which one we failed during update.
         this.L.error({ ctx, error });

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -170,7 +170,11 @@ export class NotePickerUtils {
       onlyDirectChildren: transformedQuery.onlyDirectChildren,
       originalQS,
     });
-    let nodes: NoteProps[] = resp.data;
+    let nodes = resp.data;
+
+    if (!nodes) {
+      return [];
+    }
 
     // We need to filter our results to abide by different variations of our
     // transformed query. We should do filtering prior to doing pagination cut off.

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -532,16 +532,18 @@ export class PickerUtilsV2 {
 
     const vaultsWithMatchingHierarchy: VaultPickerItem[] | undefined =
       queryResponse.data
-        .filter((value) => value.fname === newQs)
-        .map((value) => value.vault)
-        .sort(sortByPathNameFn)
-        .map((value) => {
-          return {
-            vault: value,
-            detail: HIERARCHY_MATCH_DETAIL,
-            label: VaultUtils.getName(value),
-          };
-        });
+        ? queryResponse.data
+            .filter((value) => value.fname === newQs)
+            .map((value) => value.vault)
+            .sort(sortByPathNameFn)
+            .map((value) => {
+              return {
+                vault: value,
+                detail: HIERARCHY_MATCH_DETAIL,
+                label: VaultUtils.getName(value),
+              };
+            })
+        : undefined;
 
     if (!vaultsWithMatchingHierarchy) {
       // Suggest current vault context as top suggestion

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -233,7 +233,7 @@ export class EngineAPIService
   writeNote(
     note: NoteProps,
     opts?: EngineWriteOptsV2 | undefined
-  ): Promise<Required<RespV2<NoteChangeEntry[]>>> {
+  ): Promise<RespV2<NoteChangeEntry[]>> {
     if (!this._trustedWorkspace) {
       if (!opts) {
         opts = { runHooks: false };
@@ -283,7 +283,7 @@ export class EngineAPIService
     return this._internalEngine.querySchema(qs);
   }
 
-  queryNotes(opts: QueryNotesOpts): Promise<Required<RespV2<NoteProps[]>>> {
+  queryNotes(opts: QueryNotesOpts): Promise<RespV2<NoteProps[]>> {
     return this._internalEngine.queryNotes(opts);
   }
 
@@ -295,7 +295,7 @@ export class EngineAPIService
     qs: string;
     originalQS: string;
     vault?: DVault | undefined;
-  }): Required<RespV2<NoteProps[]>> {
+  }): RespV2<NoteProps[]> {
     return this._internalEngine.queryNotesSync({ qs, originalQS, vault });
   }
 

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -73,7 +73,7 @@ export interface IEngineAPIService {
 
   bulkWriteNotes(
     opts: BulkWriteNotesOpts
-  ): Promise<Required<BulkResp<NoteChangeEntry[]>>>;
+  ): Promise<BulkResp<NoteChangeEntry[]>>;
 
   updateNote(
     note: NoteProps,
@@ -85,7 +85,7 @@ export interface IEngineAPIService {
   writeNote(
     note: NoteProps,
     opts?: EngineWriteOptsV2 | undefined
-  ): Promise<Required<RespV2<NoteChangeEntry[]>>>;
+  ): Promise<RespV2<NoteChangeEntry[]>>;
 
   writeSchema(schema: SchemaModuleProps): Promise<void>;
 
@@ -109,7 +109,7 @@ export interface IEngineAPIService {
 
   querySchema(qs: string): Promise<Required<RespV2<SchemaModuleProps[]>>>;
 
-  queryNotes(opts: QueryNotesOpts): Promise<Required<RespV2<NoteProps[]>>>;
+  queryNotes(opts: QueryNotesOpts): Promise<RespV2<NoteProps[]>>;
 
   queryNotesSync({
     qs,
@@ -119,7 +119,7 @@ export interface IEngineAPIService {
     qs: string;
     originalQS: string;
     vault?: DVault | undefined;
-  }): Required<RespV2<NoteProps[]>>;
+  }): RespV2<NoteProps[]>;
 
   renameNote(opts: RenameNoteOpts): Promise<RespV2<RenameNotePayload>>;
 


### PR DESCRIPTION
## fix(workspace): proper handling of invalid data for write note ops

We have some improperly typed responses in API.ts that make the data prop of `Resp` be `Required`.  The server was not passing back Data in some cases due to exceptions, which led to cascading issues on the plugin side because the type definitions on the responses were not accurate.

The main way I found this manifesting itself is with Doctor Fix:Frontmatter, which was always showing a modal dialog error because we try to re-write root as part of that operation, which store doesn't permit right now (another separate issue).

Example errors that we were getting below: 

```log
"TypeError: Cannot read properties of undefined (reading 'forEach')
    at DendronEngineClient.refreshNotesV2 (/Users/jyeung/code/dendron/dendron/packages/engine-server/src/engineClient.ts:356:11)
    at DendronEngineClient.bulkWriteNotes (/Users/jyeung/code/dendron/dendron/packages/engine-server/src/engineClient.ts:230:16)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at BackfillService.updateNotes (/Users/jyeung/code/dendron/dendron/packages/engine-server/src/backfillV2/service.ts:43:5)
    at DoctorCommand.execute (/Users/jyeung/code/dendron/dendron/packages/plugin-core/src/commands/Doctor.ts:412:9)
    at DoctorCommand.run (/Users/jyeung/code/dendron/dendron/packages/plugin-core/src/commands/base.ts:113:14)
    at /Users/jyeung/code/dendron/dendron/packages/plugin-core/src/_extension.ts:1149:13
    at o._executeContributedCommand (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:83:62513)"


    "TypeError: Cannot read properties of undefined (reading 'filter')
    at extractNoteChangeEntriesByType (/Users/jyeung/code/dendron/dendron/packages/common-all/lib/utils/index.js:935:20)
    at EventEmitter.<anonymous> (/Users/jyeung/code/dendron/dendron/packages/plugin-core/out/src/services/EngineAPIService.js:211:81)
    at EventEmitter.emit (node:events:402:35)
    at EventEmitter.emit (node:domain:475:12)
    at EventEmitter.fire (/Users/jyeung/code/dendron/dendron/packages/common-all/lib/types/events.js:40:23)
    at DendronEngineClient.bulkWriteNotes (/Users/jyeung/code/dendron/dendron/packages/engine-server/lib/engineClient.js:126:36)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async BackfillService.updateNotes (/Users/jyeung/code/dendron/dendron/packages/engine-server/lib/backfillV2/service.js:36:9)
    at async DoctorCommand.execute (/Users/jyeung/code/dendron/dendron/packages/plugin-core/out/src/commands/Doctor.js:269:17)
    at async DoctorCommand.run (/Users/jyeung/code/dendron/dendron/packages/plugin-core/out/src/commands/base.js:69:20)
    at async /Users/jyeung/code/dendron/dendron/packages/plugin-core/out/src/_extension.js:892:17
    at async o._executeContributedCommand (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:83:62513)"
```

---

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)