### PR TITLE
chore(pr): refactoring of extension startup logic

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1,13 +1,5 @@
 import {
-  launchv2,
-  ServerUtils,
-  SubProcessExitType,
-} from "@dendronhq/api-server";
-import {
-  ConfigEvents,
-  ConfigUtils,
   CONSTANTS,
-  CURRENT_AB_TESTS,
   DendronError,
   getStage,
   GitEvents,
@@ -16,10 +8,7 @@ import {
   GraphThemeTestGroups,
   GRAPH_THEME_TEST,
   InstallStatus,
-  IntermediateDendronConfig,
   isDisposable,
-  TaskNoteUtils,
-  Time,
   TreeViewItemLabelTypeEnum,
   VaultUtils,
   VSCodeEvents,
@@ -32,14 +21,12 @@ import {
   SegmentClient,
 } from "@dendronhq/common-server";
 import {
-  DConfig,
   HistoryService,
   MetadataService,
   WorkspaceService,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
 import * as Sentry from "@sentry/node";
-import { ExecaChildProcess } from "execa";
 import fs from "fs-extra";
 import _ from "lodash";
 import os from "os";
@@ -62,12 +49,13 @@ import { ShowSchemaGraphCommand } from "./commands/ShowSchemaGraph";
 import { NoteGraphPanelFactory } from "./components/views/NoteGraphViewFactory";
 import { PreviewPanelFactory } from "./components/views/PreviewViewFactory";
 import { SchemaGraphViewFactory } from "./components/views/SchemaGraphViewFactory";
-import { CONFIG, DendronContext, DENDRON_COMMANDS } from "./constants";
+import { DendronContext, DENDRON_COMMANDS } from "./constants";
 import { codeActionProvider } from "./features/codeActionProvider";
 import { completionProvider } from "./features/completionProvider";
 import DefinitionProvider from "./features/DefinitionProvider";
 import FrontmatterFoldingRangeProvider from "./features/FrontmatterFoldingRangeProvider";
 import setupHelpFeedbackTreeView from "./features/HelpFeedbackTreeview";
+import setupRecentWorkspacesTreeView from "./features/RecentWorkspacesTreeview";
 import ReferenceHoverProvider from "./features/ReferenceHoverProvider";
 import ReferenceProvider from "./features/ReferenceProvider";
 import RenameProvider from "./features/RenameProvider";
@@ -78,11 +66,9 @@ import { StateService } from "./services/stateService";
 import { TextDocumentServiceFactory } from "./services/TextDocumentServiceFactory";
 import { Extensions } from "./settings";
 import { FeatureShowcaseToaster } from "./showcase/FeatureShowcaseToaster";
-import { IBaseCommand } from "./types";
-import { GOOGLE_OAUTH_ID, GOOGLE_OAUTH_SECRET } from "./types/global";
 import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
 import { isAutoCompletable } from "./utils/AutoCompletable";
-import { MarkdownUtils } from "./utils/md";
+import { ExtensionUtils } from "./utils/ExtensionUtils";
 import { AutoCompletableRegistrar } from "./utils/registers/AutoCompletableRegistrar";
 import { StartupUtils } from "./utils/StartupUtils";
 import { EngineNoteProvider } from "./views/EngineNoteProvider";
@@ -90,332 +76,13 @@ import { NativeTreeView } from "./views/NativeTreeView";
 import { VSCodeUtils } from "./vsCodeUtils";
 import { showWelcome } from "./WelcomeUtils";
 import { DendronExtension, getDWorkspace, getExtension } from "./workspace";
+import { TutorialInitializer } from "./workspace/tutorialInitializer";
 import { WorkspaceActivator } from "./workspace/workspaceActivater";
 import { WorkspaceInitFactory } from "./workspace/WorkspaceInitFactory";
 import { WSUtils } from "./WSUtils";
-import setupRecentWorkspacesTreeView from "./features/RecentWorkspacesTreeview";
-import { TutorialInitializer } from "./workspace/tutorialInitializer";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
-
-/** Before sending saved telemetry events, wait this long (in ms) to make sure
- * the workspace will likely remain open long enough for us to send everything.
- */
-const DELAY_TO_SEND_SAVED_TELEMETRY = 15 * 1000;
-
-class ExtensionUtils {
-  static addCommand = ({
-    context,
-    key,
-    cmd,
-    existingCommands,
-  }: {
-    context: vscode.ExtensionContext;
-    key: string;
-    cmd: IBaseCommand;
-    existingCommands: string[];
-  }) => {
-    if (!existingCommands.includes(key)) {
-      context.subscriptions.push(
-        vscode.commands.registerCommand(
-          key,
-          sentryReportingCallback(async (args) => {
-            cmd.run(args);
-          })
-        )
-      );
-    }
-  };
-
-  static setWorkspaceContextOnActivate(
-    dendronConfig: IntermediateDendronConfig
-  ) {
-    if (VSCodeUtils.isDevMode()) {
-      vscode.commands.executeCommand(
-        "setContext",
-        DendronContext.DEV_MODE,
-        true
-      );
-    }
-    // used for enablement of legacy show preview command.
-    VSCodeUtils.setContext(
-      DendronContext.HAS_LEGACY_PREVIEW,
-      MarkdownUtils.hasLegacyPreview()
-    );
-
-    //used for enablement of export pod v2 command
-    VSCodeUtils.setContext(
-      DendronContext.ENABLE_EXPORT_PODV2,
-      dendronConfig.dev?.enableExportPodV2 ?? false
-    );
-
-    // @deprecate: should track as property of workspace init instead
-    if (dendronConfig.dev?.enableExportPodV2) {
-      AnalyticsUtils.track(ConfigEvents.EnabledExportPodV2);
-    }
-  }
-
-  /**
-   * Setup segment client
-   * Also setup cache flushing in case of missed uploads
-   */
-
-  static async startServerProcess({
-    context,
-    start,
-    wsService,
-  }: {
-    context: vscode.ExtensionContext;
-    wsService: WorkspaceService;
-    start: [number, number];
-  }) {
-    const ctx = "startServerProcess";
-    const { port, subprocess } = await startServerProcess();
-    if (subprocess) {
-      WSUtils.handleServerProcess({
-        subprocess,
-        context,
-        onExit: (type: SubProcessExitType) => {
-          const txt = "Restart Dendron";
-          vscode.window
-            .showErrorMessage("Dendron engine encountered an error", txt)
-            .then(async (resp) => {
-              if (resp === txt) {
-                AnalyticsUtils.track(VSCodeEvents.ServerCrashed, {
-                  code: type,
-                });
-                _activate(context);
-              }
-            });
-        },
-      });
-    }
-    const durationStartServer = getDurationMilliseconds(start);
-    Logger.info({ ctx, msg: "post-start-server", port, durationStartServer });
-    wsService.writePort(port);
-    return port;
-  }
-
-  static getAndTrackInstallStatus({
-    UUIDPathExists,
-    previousGlobalVersion,
-    currentVersion,
-  }: {
-    UUIDPathExists: boolean;
-    currentVersion: string;
-    previousGlobalVersion: string;
-  }) {
-    const extensionInstallStatus = VSCodeUtils.getInstallStatusForExtension({
-      previousGlobalVersion,
-      currentVersion,
-    });
-
-    // check if this is an install event, but a repeated one on a new instance.
-    let isSecondaryInstall = false;
-
-    // set initial install ^194e5bw7so9g
-    if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
-      // even if it's an initial install for this instance of vscode, it may not be for this machine.
-      // in that case, we should skip setting the initial install time since it's already set.
-      // we also check if we already set uuid for this machine. If so, this is not a true initial install.
-      const metadata = MetadataService.instance().getMeta();
-      if (metadata.firstInstall === undefined && !UUIDPathExists) {
-        MetadataService.instance().setInitialInstall();
-      } else {
-        // we still want to proceed with InstallStatus.INITIAL_INSTALL because we want everything
-        // tied to initial install to happen in this instance of VSCode once for the first time
-        isSecondaryInstall = true;
-      }
-    }
-
-    // TODO: temporary backfill
-    if (_.isUndefined(MetadataService.instance().getMeta().firstInstall)) {
-      const time = Time.DateTime.fromISO("2021-06-22");
-      MetadataService.instance().setInitialInstall(time.toSeconds());
-    }
-    return { extensionInstallStatus, isSecondaryInstall };
-  }
-
-  /**
-   * Analytics related to initializing the workspace
-   * @param param0
-   */
-  static async trackWorkspaceInit({
-    durationReloadWorkspace,
-    ext,
-    activatedSuccess,
-  }: {
-    durationReloadWorkspace: number;
-    ext: DendronExtension;
-    activatedSuccess: boolean;
-  }) {
-    const engine = ext.getEngine();
-    const workspace = ext.getDWorkspace();
-    const {
-      wsRoot,
-      vaults,
-      type: workspaceType,
-      config: dendronConfig,
-    } = workspace;
-    let numNotes = _.size(engine.notes);
-
-    let numNoteRefs = 0;
-    let numWikilinks = 0;
-    let numBacklinks = 0;
-    let numLinkCandidates = 0;
-    let numFrontmatterTags = 0;
-    let numTutorialNotes = 0;
-    let numTaskNotes = 0;
-
-    // Note IDs that are part of our tutorial(s). We want to exclude these from
-    // our 'numNotes' telemetry.
-    const tutorialIds = new Set<string>([
-      "ks3b4u7gnd6yiw68qu6ba4m",
-      "mycf53kz1r7swcttcobwbdl",
-      "kzry3qcy2y4ey1jcf1llajg",
-      "y60h6laqi7w462zjp3jyqtt",
-      "4do06cts1tme9yz7vfp46bu",
-      "5pz82kyfhp2whlzfldxmkzu",
-      "kl6ndok3a1f14be6zv771c9",
-      "iq3ggn67k1u3v6up8ny3kf5",
-      "ie5x2bq5yj7uvenylblnhyr",
-      "rjnqumna1ye82u9u76ni42k",
-      "wmbd5xz40ohjb8rd5b737cq",
-      "epmpyk2kjdxqyvflotan2vt",
-      "yyfpeq3th3h17cgvj8cnjw5",
-      "lxrp006mal1tfsd7nxmsobe",
-      "4u6pv56mnt25d8l2wzfygu7",
-      "khv6u4514vnvvy4njhctfru",
-      "kyjfnf2rnc6vn71iyn9liz7",
-      "c1bs7wsjfbhb0zipaywqfbg", // quickstart-v1
-    ]);
-
-    // Takes about ~10 ms to compute in org-workspace
-    Object.values(engine.notes).forEach((val) => {
-      val.links.forEach((link) => {
-        switch (link.type) {
-          case "ref":
-            numNoteRefs += 1;
-            break;
-          case "wiki":
-            numWikilinks += 1;
-            break;
-          case "backlink":
-            numBacklinks += 1;
-            break;
-          case "linkCandidate":
-            numLinkCandidates += 1;
-            break;
-          case "frontmatterTag":
-            numFrontmatterTags += 1;
-            break;
-          default:
-            break;
-        }
-      });
-
-      if (tutorialIds.has(val.id)) {
-        numTutorialNotes += 1;
-      }
-      if (TaskNoteUtils.isTaskNote(val)) {
-        numTaskNotes += 1;
-      }
-    });
-
-    // These are the values for the original tutorial; approximate is ok here.
-    const tutorialWikiLinkCount = 19;
-    const tutorialNoteRefCount = 1;
-    const tutorialBacklinkCount = 18;
-
-    if (numTutorialNotes > 0) {
-      numNotes -= numTutorialNotes;
-      numWikilinks = Math.max(0, numWikilinks - tutorialWikiLinkCount);
-      numNoteRefs = Math.max(0, numNoteRefs - tutorialNoteRefCount);
-      numBacklinks = Math.max(0, numBacklinks - tutorialBacklinkCount);
-    }
-
-    const numSchemas = _.size(engine.schemas);
-    const codeWorkspacePresent = await fs.pathExists(
-      path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME)
-    );
-    const publishigConfig = ConfigUtils.getPublishingConfig(dendronConfig);
-    const siteUrl = publishigConfig.siteUrl;
-    const publishingTheme = dendronConfig?.publishing?.theme;
-    const previewTheme = dendronConfig?.preview?.theme;
-    const enabledExportPodV2 = dendronConfig.dev?.enableExportPodV2;
-    const workspaceConfig = ConfigUtils.getWorkspace(dendronConfig);
-    const { workspaceFile, workspaceFolders } = vscode.workspace;
-    const trackProps = {
-      duration: durationReloadWorkspace,
-      noCaching: dendronConfig.noCaching || false,
-      numNotes,
-      numNoteRefs,
-      numWikilinks,
-      numBacklinks,
-      numLinkCandidates,
-      numFrontmatterTags,
-      numSchemas,
-      numVaults: vaults.length,
-      numTutorialNotes,
-      numTaskNotes,
-      workspaceType,
-      codeWorkspacePresent,
-      selfContainedVaultsEnabled:
-        dendronConfig.dev?.enableSelfContainedVaults || false,
-      numSelfContainedVaults: vaults.filter(VaultUtils.isSelfContained).length,
-      numRemoteVaults: vaults.filter(VaultUtils.isRemote).length,
-      numWorkspaceVaults: vaults.filter(
-        (vault) => vault.workspace !== undefined
-      ).length,
-      numSeedVaults: vaults.filter((vault) => vault.seed !== undefined).length,
-      activationSucceeded: activatedSuccess,
-      hasLegacyPreview: MarkdownUtils.hasLegacyPreview(),
-      enabledExportPodV2,
-      hasWorkspaceFile: !_.isUndefined(workspaceFile),
-      workspaceFolders: _.isUndefined(workspaceFolders)
-        ? 0
-        : workspaceFolders.length,
-      hasLocalConfig: false,
-      numLocalConfigVaults: 0,
-      enableHandlebarTemplates: workspaceConfig.enableHandlebarTemplates,
-    };
-    if (siteUrl !== undefined) {
-      _.set(trackProps, "siteUrl", siteUrl);
-    }
-    if (publishingTheme !== undefined) {
-      _.set(trackProps, "publishingTheme", publishingTheme);
-    }
-    if (previewTheme !== undefined) {
-      _.set(trackProps, "previewTheme", previewTheme);
-    }
-    const maybeLocalConfig = DConfig.searchLocalConfigSync(wsRoot);
-    if (maybeLocalConfig.data) {
-      trackProps.hasLocalConfig = true;
-      if (maybeLocalConfig.data.workspace.vaults) {
-        trackProps.numLocalConfigVaults =
-          maybeLocalConfig.data.workspace.vaults.length;
-      }
-    }
-
-    AnalyticsUtils.identify({
-      numNotes,
-      // Which side of all currently running tests is this user on?
-      splitTests: CURRENT_AB_TESTS.map(
-        (test) =>
-          // Formatted as `testName.groupName` since group names are not necessarily unique
-          `${test.name}.${test.getUserGroup(
-            SegmentClient.instance().anonymousId
-          )}`
-      ),
-    });
-    AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, trackProps);
-    setTimeout(() => {
-      Logger.info("sendSavedAnalytics"); // TODO
-      AnalyticsUtils.sendSavedAnalytics();
-    }, DELAY_TO_SEND_SAVED_TELEMETRY);
-  }
-}
 
 // this method is called when your extension is activated
 export function activate(
@@ -531,46 +198,6 @@ async function postReloadWorkspace(opts: { extension: DendronExtension }) {
     }
   }
   Logger.info({ ctx, msg: "exit" });
-}
-
-async function startServerProcess(): Promise<{
-  port: number;
-  subprocess?: ExecaChildProcess;
-}> {
-  const { nextServerUrl, nextStaticRoot, engineServerPort } =
-    getDWorkspace().config.dev || {};
-  // const ctx = "startServer";
-  const maybePort =
-    DendronExtension.configuration().get<number | undefined>(
-      CONFIG.SERVER_PORT.key
-    ) || engineServerPort;
-  const port = maybePort;
-  if (port) {
-    return { port };
-  }
-
-  // if in dev mode, simplify debugging without going multi process
-  if (getStage() !== "prod") {
-    const out = await launchv2({
-      logPath: path.join(__dirname, "..", "..", "dendron.server.log"),
-      googleOauthClientId: GOOGLE_OAUTH_ID,
-      googleOauthClientSecret: GOOGLE_OAUTH_SECRET,
-    });
-    return { port: out.port };
-  }
-
-  // start server is separate process ^pyiildtq4tdx
-  const logPath = getDWorkspace().logUri.fsPath;
-  const out = await ServerUtils.execServerNode({
-    scriptPath: path.join(__dirname, "server.js"),
-    logPath,
-    nextServerUrl,
-    nextStaticRoot,
-    port,
-    googleOauthClientId: GOOGLE_OAUTH_ID,
-    googleOauthClientSecret: GOOGLE_OAUTH_SECRET,
-  });
-  return out;
 }
 
 // Only exported for test purposes ^jtm6bf7utsxy

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -1,3 +1,4 @@
+import { SubProcessExitType } from "@dendronhq/api-server";
 import {
   CONSTANTS,
   DendronError,
@@ -514,6 +515,19 @@ export async function _activate(
         context,
         start,
         wsService,
+        onExit: (type: SubProcessExitType) => {
+          const txt = "Restart Dendron";
+          vscode.window
+            .showErrorMessage("Dendron engine encountered an error", txt)
+            .then(async (resp) => {
+              if (resp === txt) {
+                AnalyticsUtils.track(VSCodeEvents.ServerCrashed, {
+                  code: type,
+                });
+                _activate(context);
+              }
+            });
+        },
       });
 
       // Setup the Engine API Service and the tree view

--- a/packages/plugin-core/src/commands/SetupWorkspace.ts
+++ b/packages/plugin-core/src/commands/SetupWorkspace.ts
@@ -11,11 +11,9 @@ import _ from "lodash";
 import path from "path";
 import vscode, { Uri } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BlankInitializer } from "../workspace/blankInitializer";
-import { WorkspaceActivator } from "../workspace/workspaceActivater";
 import { WorkspaceInitializer } from "../workspace/workspaceInitializer";
 import { BasicCommand } from "./base";
 import PathLike = fs.PathLike;
@@ -255,13 +253,8 @@ export class SetupWorkspaceCommand extends BasicCommand<
           vscode.Uri.file(path.join(rootDir, CONSTANTS.DENDRON_WS_NAME)).fsPath
         );
       } else if (workspaceType === WorkspaceType.NATIVE) {
-        const ext = ExtensionProvider.getExtension();
-        const { context } = ext;
-        new WorkspaceActivator().activateNativeWorkspace({
-          context,
-          ext,
-          wsRoot: rootDir,
-        });
+        // For native workspaces, we just need to reload the existing workspace because we want to keep the same workspace.
+        VSCodeUtils.reloadWindow();
       }
     }
     return { wsVault, additionalVaults };

--- a/packages/plugin-core/src/commands/SetupWorkspace.ts
+++ b/packages/plugin-core/src/commands/SetupWorkspace.ts
@@ -11,9 +11,11 @@ import _ from "lodash";
 import path from "path";
 import vscode, { Uri } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { BlankInitializer } from "../workspace/blankInitializer";
+import { WorkspaceActivator } from "../workspace/workspaceActivater";
 import { WorkspaceInitializer } from "../workspace/workspaceInitializer";
 import { BasicCommand } from "./base";
 import PathLike = fs.PathLike;
@@ -253,8 +255,13 @@ export class SetupWorkspaceCommand extends BasicCommand<
           vscode.Uri.file(path.join(rootDir, CONSTANTS.DENDRON_WS_NAME)).fsPath
         );
       } else if (workspaceType === WorkspaceType.NATIVE) {
-        // For native workspaces, we just need to reload the existing workspace because we want to keep the same workspace.
-        VSCodeUtils.reloadWindow();
+        const ext = ExtensionProvider.getExtension();
+        const { context } = ext;
+        new WorkspaceActivator().activateNativeWorkspace({
+          context,
+          ext,
+          wsRoot: rootDir,
+        });
       }
     }
     return { wsVault, additionalVaults };

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -127,5 +127,4 @@ export interface IDendronExtension {
    * about registered Note Traits
    */
   get traitRegistrar(): NoteTraitService;
-  setupTraits(): Promise<void>;
 }

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -65,6 +65,7 @@ export interface IDendronExtension {
   lookupControllerFactory: ILookupControllerV3Factory;
   noteLookupProviderFactory: INoteLookupProviderFactory;
   schemaLookupProviderFactory: ISchemaLookupProviderFactory;
+  workspaceImpl?: DWorkspaceV2;
 
   activateWatchers(): Promise<void>;
   /**
@@ -126,4 +127,5 @@ export interface IDendronExtension {
    * about registered Note Traits
    */
   get traitRegistrar(): NoteTraitService;
+  setupTraits(): Promise<void>;
 }

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -57,9 +57,6 @@ export class MockDendronExtension implements IDendronExtension {
   }
   fileWatcher?: FileWatcher | undefined;
   workspaceImpl?: DWorkspaceV2 | undefined;
-  setupTraits(): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
 
   port?: number | undefined;
   get context(): ExtensionContext {

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -18,6 +18,7 @@ import {
   ISchemaLookupProviderFactory,
 } from "../components/lookup/LookupProviderV3Interface";
 import { IDendronExtension } from "../dendronExtensionInterface";
+import { FileWatcher } from "../fileWatcher";
 import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
 import { NoteTraitService } from "../services/NoteTraitService";
 import { ISchemaSyncService } from "../services/SchemaSyncServiceInterface";
@@ -52,6 +53,11 @@ export class MockDendronExtension implements IDendronExtension {
     this._vaults = vaults;
   }
   get traitRegistrar(): NoteTraitService {
+    throw new Error("Method not implemented.");
+  }
+  fileWatcher?: FileWatcher | undefined;
+  workspaceImpl?: DWorkspaceV2 | undefined;
+  setupTraits(): Promise<void> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -71,6 +71,7 @@ suite("GIVEN a text document with decorations", function () {
   const CREATED = "1625648278263";
   const UPDATED = "1625758878263";
   const FNAME = "bar";
+  this.timeout(5e3);
 
   describe("AND GIVEN links ", () => {
     function checkTimestampsDecorated({

--- a/packages/plugin-core/src/utils/ExtensionUtils.ts
+++ b/packages/plugin-core/src/utils/ExtensionUtils.ts
@@ -1,0 +1,400 @@
+import {
+  launchv2,
+  ServerUtils,
+  SubProcessExitType,
+} from "@dendronhq/api-server";
+import {
+  ConfigEvents,
+  ConfigUtils,
+  CONSTANTS,
+  CURRENT_AB_TESTS,
+  getStage,
+  InstallStatus,
+  IntermediateDendronConfig,
+  TaskNoteUtils,
+  Time,
+  VaultUtils,
+  VSCodeEvents,
+} from "@dendronhq/common-all";
+import {
+  getDurationMilliseconds,
+  SegmentClient,
+} from "@dendronhq/common-server";
+import {
+  DConfig,
+  MetadataService,
+  WorkspaceService,
+} from "@dendronhq/engine-server";
+import { ExecaChildProcess } from "execa";
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
+import * as vscode from "vscode";
+import { CONFIG, DendronContext } from "../constants";
+import { Logger } from "../logger";
+import { IBaseCommand } from "../types";
+import { GOOGLE_OAUTH_ID, GOOGLE_OAUTH_SECRET } from "../types/global";
+import { AnalyticsUtils, sentryReportingCallback } from "../utils/analytics";
+import { MarkdownUtils } from "../utils/md";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { DendronExtension, getDWorkspace } from "../workspace";
+import { WSUtils } from "../WSUtils";
+import { _activate } from "../_extension";
+
+/** Before sending saved telemetry events, wait this long (in ms) to make sure
+ * the workspace will likely remain open long enough for us to send everything.
+ */
+const DELAY_TO_SEND_SAVED_TELEMETRY = 15 * 1000;
+
+async function startServerProcess(): Promise<{
+  port: number;
+  subprocess?: ExecaChildProcess;
+}> {
+  const { nextServerUrl, nextStaticRoot, engineServerPort } =
+    getDWorkspace().config.dev || {};
+  // const ctx = "startServer";
+  const maybePort =
+    DendronExtension.configuration().get<number | undefined>(
+      CONFIG.SERVER_PORT.key
+    ) || engineServerPort;
+  const port = maybePort;
+  if (port) {
+    return { port };
+  }
+
+  // if in dev mode, simplify debugging without going multi process
+  if (getStage() !== "prod") {
+    const out = await launchv2({
+      logPath: path.join(__dirname, "..", "..", "dendron.server.log"),
+      googleOauthClientId: GOOGLE_OAUTH_ID,
+      googleOauthClientSecret: GOOGLE_OAUTH_SECRET,
+    });
+    return { port: out.port };
+  }
+
+  // start server is separate process ^pyiildtq4tdx
+  const logPath = getDWorkspace().logUri.fsPath;
+  const out = await ServerUtils.execServerNode({
+    scriptPath: path.join(__dirname, "server.js"),
+    logPath,
+    nextServerUrl,
+    nextStaticRoot,
+    port,
+    googleOauthClientId: GOOGLE_OAUTH_ID,
+    googleOauthClientSecret: GOOGLE_OAUTH_SECRET,
+  });
+  return out;
+}
+
+export class ExtensionUtils {
+  static addCommand = ({
+    context,
+    key,
+    cmd,
+    existingCommands,
+  }: {
+    context: vscode.ExtensionContext;
+    key: string;
+    cmd: IBaseCommand;
+    existingCommands: string[];
+  }) => {
+    if (!existingCommands.includes(key)) {
+      context.subscriptions.push(
+        vscode.commands.registerCommand(
+          key,
+          sentryReportingCallback(async (args) => {
+            cmd.run(args);
+          })
+        )
+      );
+    }
+  };
+
+  static setWorkspaceContextOnActivate(
+    dendronConfig: IntermediateDendronConfig
+  ) {
+    if (VSCodeUtils.isDevMode()) {
+      vscode.commands.executeCommand(
+        "setContext",
+        DendronContext.DEV_MODE,
+        true
+      );
+    }
+    // used for enablement of legacy show preview command.
+    VSCodeUtils.setContext(
+      DendronContext.HAS_LEGACY_PREVIEW,
+      MarkdownUtils.hasLegacyPreview()
+    );
+
+    //used for enablement of export pod v2 command
+    VSCodeUtils.setContext(
+      DendronContext.ENABLE_EXPORT_PODV2,
+      dendronConfig.dev?.enableExportPodV2 ?? false
+    );
+
+    // @deprecate: should track as property of workspace init instead
+    if (dendronConfig.dev?.enableExportPodV2) {
+      AnalyticsUtils.track(ConfigEvents.EnabledExportPodV2);
+    }
+  }
+
+  /**
+   * Setup segment client
+   * Also setup cache flushing in case of missed uploads
+   */
+
+  static async startServerProcess({
+    context,
+    start,
+    wsService,
+  }: {
+    context: vscode.ExtensionContext;
+    wsService: WorkspaceService;
+    start: [number, number];
+  }) {
+    const ctx = "startServerProcess";
+    const { port, subprocess } = await startServerProcess();
+    if (subprocess) {
+      WSUtils.handleServerProcess({
+        subprocess,
+        context,
+        onExit: (type: SubProcessExitType) => {
+          const txt = "Restart Dendron";
+          vscode.window
+            .showErrorMessage("Dendron engine encountered an error", txt)
+            .then(async (resp) => {
+              if (resp === txt) {
+                AnalyticsUtils.track(VSCodeEvents.ServerCrashed, {
+                  code: type,
+                });
+                _activate(context);
+              }
+            });
+        },
+      });
+    }
+    const durationStartServer = getDurationMilliseconds(start);
+    Logger.info({ ctx, msg: "post-start-server", port, durationStartServer });
+    wsService.writePort(port);
+    return port;
+  }
+
+  static getAndTrackInstallStatus({
+    UUIDPathExists,
+    previousGlobalVersion,
+    currentVersion,
+  }: {
+    UUIDPathExists: boolean;
+    currentVersion: string;
+    previousGlobalVersion: string;
+  }) {
+    const extensionInstallStatus = VSCodeUtils.getInstallStatusForExtension({
+      previousGlobalVersion,
+      currentVersion,
+    });
+
+    // check if this is an install event, but a repeated one on a new instance.
+    let isSecondaryInstall = false;
+
+    // set initial install ^194e5bw7so9g
+    if (extensionInstallStatus === InstallStatus.INITIAL_INSTALL) {
+      // even if it's an initial install for this instance of vscode, it may not be for this machine.
+      // in that case, we should skip setting the initial install time since it's already set.
+      // we also check if we already set uuid for this machine. If so, this is not a true initial install.
+      const metadata = MetadataService.instance().getMeta();
+      if (metadata.firstInstall === undefined && !UUIDPathExists) {
+        MetadataService.instance().setInitialInstall();
+      } else {
+        // we still want to proceed with InstallStatus.INITIAL_INSTALL because we want everything
+        // tied to initial install to happen in this instance of VSCode once for the first time
+        isSecondaryInstall = true;
+      }
+    }
+
+    // TODO: temporary backfill
+    if (_.isUndefined(MetadataService.instance().getMeta().firstInstall)) {
+      const time = Time.DateTime.fromISO("2021-06-22");
+      MetadataService.instance().setInitialInstall(time.toSeconds());
+    }
+    return { extensionInstallStatus, isSecondaryInstall };
+  }
+
+  /**
+   * Analytics related to initializing the workspace
+   * @param param0
+   */
+  static async trackWorkspaceInit({
+    durationReloadWorkspace,
+    ext,
+    activatedSuccess,
+  }: {
+    durationReloadWorkspace: number;
+    ext: DendronExtension;
+    activatedSuccess: boolean;
+  }) {
+    const engine = ext.getEngine();
+    const workspace = ext.getDWorkspace();
+    const {
+      wsRoot,
+      vaults,
+      type: workspaceType,
+      config: dendronConfig,
+    } = workspace;
+    let numNotes = _.size(engine.notes);
+
+    let numNoteRefs = 0;
+    let numWikilinks = 0;
+    let numBacklinks = 0;
+    let numLinkCandidates = 0;
+    let numFrontmatterTags = 0;
+    let numTutorialNotes = 0;
+    let numTaskNotes = 0;
+
+    // Note IDs that are part of our tutorial(s). We want to exclude these from
+    // our 'numNotes' telemetry.
+    const tutorialIds = new Set<string>([
+      "ks3b4u7gnd6yiw68qu6ba4m",
+      "mycf53kz1r7swcttcobwbdl",
+      "kzry3qcy2y4ey1jcf1llajg",
+      "y60h6laqi7w462zjp3jyqtt",
+      "4do06cts1tme9yz7vfp46bu",
+      "5pz82kyfhp2whlzfldxmkzu",
+      "kl6ndok3a1f14be6zv771c9",
+      "iq3ggn67k1u3v6up8ny3kf5",
+      "ie5x2bq5yj7uvenylblnhyr",
+      "rjnqumna1ye82u9u76ni42k",
+      "wmbd5xz40ohjb8rd5b737cq",
+      "epmpyk2kjdxqyvflotan2vt",
+      "yyfpeq3th3h17cgvj8cnjw5",
+      "lxrp006mal1tfsd7nxmsobe",
+      "4u6pv56mnt25d8l2wzfygu7",
+      "khv6u4514vnvvy4njhctfru",
+      "kyjfnf2rnc6vn71iyn9liz7",
+      "c1bs7wsjfbhb0zipaywqfbg", // quickstart-v1
+    ]);
+
+    // Takes about ~10 ms to compute in org-workspace
+    Object.values(engine.notes).forEach((val) => {
+      val.links.forEach((link) => {
+        switch (link.type) {
+          case "ref":
+            numNoteRefs += 1;
+            break;
+          case "wiki":
+            numWikilinks += 1;
+            break;
+          case "backlink":
+            numBacklinks += 1;
+            break;
+          case "linkCandidate":
+            numLinkCandidates += 1;
+            break;
+          case "frontmatterTag":
+            numFrontmatterTags += 1;
+            break;
+          default:
+            break;
+        }
+      });
+
+      if (tutorialIds.has(val.id)) {
+        numTutorialNotes += 1;
+      }
+      if (TaskNoteUtils.isTaskNote(val)) {
+        numTaskNotes += 1;
+      }
+    });
+
+    // These are the values for the original tutorial; approximate is ok here.
+    const tutorialWikiLinkCount = 19;
+    const tutorialNoteRefCount = 1;
+    const tutorialBacklinkCount = 18;
+
+    if (numTutorialNotes > 0) {
+      numNotes -= numTutorialNotes;
+      numWikilinks = Math.max(0, numWikilinks - tutorialWikiLinkCount);
+      numNoteRefs = Math.max(0, numNoteRefs - tutorialNoteRefCount);
+      numBacklinks = Math.max(0, numBacklinks - tutorialBacklinkCount);
+    }
+
+    const numSchemas = _.size(engine.schemas);
+    const codeWorkspacePresent = await fs.pathExists(
+      path.join(wsRoot, CONSTANTS.DENDRON_WS_NAME)
+    );
+    const publishigConfig = ConfigUtils.getPublishingConfig(dendronConfig);
+    const siteUrl = publishigConfig.siteUrl;
+    const publishingTheme = dendronConfig?.publishing?.theme;
+    const previewTheme = dendronConfig?.preview?.theme;
+    const enabledExportPodV2 = dendronConfig.dev?.enableExportPodV2;
+    const workspaceConfig = ConfigUtils.getWorkspace(dendronConfig);
+    const { workspaceFile, workspaceFolders } = vscode.workspace;
+    const trackProps = {
+      duration: durationReloadWorkspace,
+      noCaching: dendronConfig.noCaching || false,
+      numNotes,
+      numNoteRefs,
+      numWikilinks,
+      numBacklinks,
+      numLinkCandidates,
+      numFrontmatterTags,
+      numSchemas,
+      numVaults: vaults.length,
+      numTutorialNotes,
+      numTaskNotes,
+      workspaceType,
+      codeWorkspacePresent,
+      selfContainedVaultsEnabled:
+        dendronConfig.dev?.enableSelfContainedVaults || false,
+      numSelfContainedVaults: vaults.filter(VaultUtils.isSelfContained).length,
+      numRemoteVaults: vaults.filter(VaultUtils.isRemote).length,
+      numWorkspaceVaults: vaults.filter(
+        (vault) => vault.workspace !== undefined
+      ).length,
+      numSeedVaults: vaults.filter((vault) => vault.seed !== undefined).length,
+      activationSucceeded: activatedSuccess,
+      hasLegacyPreview: MarkdownUtils.hasLegacyPreview(),
+      enabledExportPodV2,
+      hasWorkspaceFile: !_.isUndefined(workspaceFile),
+      workspaceFolders: _.isUndefined(workspaceFolders)
+        ? 0
+        : workspaceFolders.length,
+      hasLocalConfig: false,
+      numLocalConfigVaults: 0,
+      enableHandlebarTemplates: workspaceConfig.enableHandlebarTemplates,
+    };
+    if (siteUrl !== undefined) {
+      _.set(trackProps, "siteUrl", siteUrl);
+    }
+    if (publishingTheme !== undefined) {
+      _.set(trackProps, "publishingTheme", publishingTheme);
+    }
+    if (previewTheme !== undefined) {
+      _.set(trackProps, "previewTheme", previewTheme);
+    }
+    const maybeLocalConfig = DConfig.searchLocalConfigSync(wsRoot);
+    if (maybeLocalConfig.data) {
+      trackProps.hasLocalConfig = true;
+      if (maybeLocalConfig.data.workspace.vaults) {
+        trackProps.numLocalConfigVaults =
+          maybeLocalConfig.data.workspace.vaults.length;
+      }
+    }
+
+    AnalyticsUtils.identify({
+      numNotes,
+      // Which side of all currently running tests is this user on?
+      splitTests: CURRENT_AB_TESTS.map(
+        (test) =>
+          // Formatted as `testName.groupName` since group names are not necessarily unique
+          `${test.name}.${test.getUserGroup(
+            SegmentClient.instance().anonymousId
+          )}`
+      ),
+    });
+    AnalyticsUtils.track(VSCodeEvents.InitializeWorkspace, trackProps);
+    setTimeout(() => {
+      Logger.info("sendSavedAnalytics"); // TODO
+      AnalyticsUtils.sendSavedAnalytics();
+    }, DELAY_TO_SEND_SAVED_TELEMETRY);
+  }
+}


### PR DESCRIPTION
chore(pr): refactoring of extension startup logic

Some prep work to enable enabling workspace initialization without reloading
- move ExtensionUtils into own file
- workspace activator shouldn't require user input