### PR TITLE
fix(workspace): removing vault with a name different than their `fsPath` doesn't remove them from `duplicateNoteBehavior`

### DIFF
--- a/.github/workflows/ci-windows-test.yml
+++ b/.github/workflows/ci-windows-test.yml
@@ -49,9 +49,9 @@ jobs:
         id: node-modules-cache-windows
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}-17
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-yarn-
+            ${{ runner.os }}-${{ matrix.node-version }}-yarn-8
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-11
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-17
           restore-keys: |
-            ${{ runner.os }}-yarn-8
+            ${{ runner.os }}-yarn-9
 
       - name: Sets env vars for publish test
         run: |

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -501,8 +501,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       // Unsupported vaults are filtered in the commands that use this function,
       // but also adding a sanity check here.
       throw new DendronError({
-        message:
-          "Seed vaults are not yet supported for automated migration.",
+        message: "Seed vaults are not yet supported for automated migration.",
       });
     }
     const newVault: SelfContainedVault = {
@@ -986,7 +985,10 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
         const updatedDuplicateNoteBehavior =
           publishingConfig.duplicateNoteBehavior;
 
-        _.pull(updatedDuplicateNoteBehavior.payload as string[], vault.fsPath);
+        _.pull(
+          updatedDuplicateNoteBehavior.payload as string[],
+          VaultUtils.getName(vault)
+        );
 
         ConfigUtils.setDuplicateNoteBehavior(
           config,

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -798,7 +798,6 @@ publishing:
             - vault1
             - vault2
             - vaultThree
-            - dendron.foo
 "
 `;
 
@@ -920,6 +919,5 @@ publishing:
             - vault1
             - vault2
             - vaultThree
-            - dendron.foo
 "
 `;

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -218,52 +218,42 @@ suite("GIVEN VaultRemoveCommand", function () {
     }
   );
 
-  // This test has been skipped because the checks were not working with self
-  // contained vaults. This should be fixed later.
-  describeSingleWS.skip(
-    "WHEN there's only one vault left after remove",
-    {},
-    () => {
-      test("THEN duplicateNoteBehavior is omitted", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-        const configPath = DConfig.configPath(wsRoot as string);
+  describeSingleWS("WHEN there's only one vault left after remove", {}, () => {
+    test("THEN duplicateNoteBehavior is omitted", async () => {
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
+      const configPath = DConfig.configPath(wsRoot as string);
 
-        // add a second vault
-        const vault2 = VaultUtils.getRelPath(vaults[1]);
-        const vpath2 = path.join(wsRoot, vault2);
+      // add a second vault
+      const vault2 = "vault2";
 
-        stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
-        await new VaultAddCommand().run();
+      stubVaultInput({ sourceType: "local", sourcePath: vault2 });
+      await new VaultAddCommand().run();
 
-        const config = readYAML(configPath) as IntermediateDendronConfig;
-        // confirm that duplicateNoteBehavior option exists
-        const publishingConfig = ConfigUtils.getPublishingConfig(config);
-        expect(publishingConfig.duplicateNoteBehavior).toBeTruthy();
+      const config = readYAML(configPath) as IntermediateDendronConfig;
+      // confirm that duplicateNoteBehavior option exists
+      const publishingConfig = ConfigUtils.getPublishingConfig(config);
+      expect(publishingConfig.duplicateNoteBehavior).toBeTruthy();
 
-        const vaultsAfter = ExtensionProvider.getDWorkspace().vaults;
-        // @ts-ignore
-        VSCodeUtils.showQuickPick = () => {
-          return { data: vaultsAfter[1] };
-        };
-        await new VaultRemoveCommand().run();
+      const vaultsAfter = ExtensionProvider.getDWorkspace().vaults;
+      // @ts-ignore
+      VSCodeUtils.showQuickPick = () => {
+        return { data: vaultsAfter[1] };
+      };
+      await new VaultRemoveCommand().run();
 
-        const configNew = readYAML(configPath) as IntermediateDendronConfig;
-        // confirm that duplicateNoteBehavior setting is gone
-        const publishingConfigNew = ConfigUtils.getPublishingConfig(configNew);
-        expect(publishingConfigNew.duplicateNoteBehavior).toBeFalsy();
-      });
-    }
-  );
-
-  // This test has been skipped because the checks were not working with self
-  // contained vaults. This should be fixed later.
-  describeSingleWS.skip("WHEN a published vault is removed", {}, () => {
+      const configNew = readYAML(configPath) as IntermediateDendronConfig;
+      // confirm that duplicateNoteBehavior setting is gone
+      const publishingConfigNew = ConfigUtils.getPublishingConfig(configNew);
+      expect(publishingConfigNew.duplicateNoteBehavior).toBeFalsy();
+    });
+  });
+  describeSingleWS("WHEN a published vault is removed", {}, () => {
     test("THEN the vault is removed from duplicateNoteBehavior payload", async () => {
       const { wsRoot } = ExtensionProvider.getDWorkspace();
       // add two more vaults
 
-      const vpath2 = path.join(wsRoot, "vault2");
-      const vpath3 = path.join(wsRoot, "vault3");
+      const vpath2 = "vault2";
+      const vpath3 = "vault3";
 
       stubVaultInput({ sourceType: "local", sourcePath: vpath2 });
       await new VaultAddCommand().run();
@@ -293,8 +283,8 @@ suite("GIVEN VaultRemoveCommand", function () {
       // check that "vault2" is gone from payload
       const publishingConfig = ConfigUtils.getPublishingConfig(config);
       expect(publishingConfig.duplicateNoteBehavior!.payload).toEqual([
-        vaultsAfter[0].fsPath,
-        vaultsAfter[2].fsPath,
+        VaultUtils.getName(vaultsAfter[2]),
+        VaultUtils.getName(vaultsAfter[0]),
       ]);
     });
   });


### PR DESCRIPTION
It also re-enables the tests related to duplicate note behavior settings when a vault is removed, which were skipped when switching the default vault type for tests to self contained.

The issue affects all vaults that have a `name`, where their name is different from the `fsPath`. The issue was "dormant" until self contained vaults since old style vaults would typically use the same name as their fsPath or wouldn't use a name at all, while self contained vaults have longer `fsPath`s and they set their `name` different than `fsPath` by default.