### PR TITLE
fix(structure): hot reload in note traits + no template by default

### DIFF
--- a/packages/engine-server/src/topics/webpack-require-hack.ts
+++ b/packages/engine-server/src/topics/webpack-require-hack.ts
@@ -1,5 +1,11 @@
 // @ts-ignore
+// NOTE: This file is ONLY used during debugging. In the webpacked production
+// build, the file that is used is the version located at
+// PROJECT_ROOT/packages/plugin-core/webpack-require-hack.js
 const webpackRequire = (importPath) => {
+  // First delete the import from the node module cache in case it exists. This
+  // allows us to do 'hot-reloading' of the .js files in Traits.
+  delete require.cache[require.resolve(importPath)];
   const module = require(importPath);
   return module;
 };

--- a/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
+++ b/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
@@ -78,13 +78,13 @@ module.exports = {
       return props.currentNoteName.split(".").slice(-3).join("-");
     },
     /**
-     * Set a note template to be applied. This method is optional, if you don't
-     * want to apply a template, simply delete this 'setTemplate' property.
+     * Set a note template to be applied. This method is optional, uncomment out
+     * the lines below if you want to apply a template.
      * @returns the name of the desired template note from this function
      */
-    setTemplate: () => {
-      return "root";
-    },
+    // setTemplate: () => {
+    //   return "root";
+    // },
   },
 };
 `;

--- a/packages/plugin-core/src/traits/webpack-require-hack.ts
+++ b/packages/plugin-core/src/traits/webpack-require-hack.ts
@@ -1,6 +1,10 @@
 /* eslint-disable global-require */
 /* eslint-disable import/no-dynamic-require */
 // @ts-ignore
+
+// NOTE: This file is ONLY used during debugging. In the webpacked production
+// build, the file that is used is the version located at
+// PROJECT_ROOT/packages/plugin-core/webpack-require-hack.js
 const webpackRequire = (importPath) => {
   // First delete the import from the node module cache in case it exists. This
   // allows us to do 'hot-reloading' of the .js files in Traits.

--- a/packages/plugin-core/webpack-require-hack.js
+++ b/packages/plugin-core/webpack-require-hack.js
@@ -1,4 +1,8 @@
 const webpackRequire = (importPath) => {
+  // First delete the import from the node module cache in case it exists. This
+  // allows us to do 'hot-reloading' of the .js files in Traits.
+  delete require.cache[require.resolve(importPath)];
+
   const module = require(importPath);
   return module;
 };


### PR DESCRIPTION
## fix(structure): hot reload in note traits + no template by default

Fixing two issues with the note traits updates:
- Hot reloading wasn't working in the webpacked build because the wrong `webpack-require-hack` file was being modified.
- Commenting out the `applyTemplate` function of the default trait template.