### PR TITLE
 fix(workspace): duplicate note id detected even after a file is removed

### DIFF
--- a/packages/common-all/src/error.ts
+++ b/packages/common-all/src/error.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from "http-status-codes";
 import _ from "lodash";
 import { AxiosError } from "axios";
 import { ERROR_SEVERITY, ERROR_STATUS } from "./constants";
-import { RespV3 } from "./types";
+import { RespV3, RespV3ErrorResp } from "./types";
 
 export type DendronErrorProps<TCode = StatusCodes | undefined> = {
   /**
@@ -396,8 +396,15 @@ export class ErrorUtils {
   static isDendronError(error: unknown): error is DendronError {
     return _.get(error, "name", "") === "DendronError";
   }
-
-  static isErrorResp(resp: RespV3<any>) {
+  /**
+   * Given a RespV3, ensure it is an error resp.
+   *
+   * This helps typescript properly narrow down the type of the success resp's data as type T where it is called.
+   * Otherwise, because of how union types work, `data` will have the type T | undefined.
+   * @param args
+   * @returns
+   */
+  static isErrorResp(resp: RespV3<any>): resp is RespV3ErrorResp {
     return "error" in resp;
   }
 }

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -262,7 +262,7 @@ export interface BulkResp<T> {
 /**
  * This lets us use a discriminate union to see if result has error or data
  */
-type RespV3ErrorResp = {
+export type RespV3ErrorResp = {
   error: IDendronError;
   data?: never;
 };
@@ -273,20 +273,6 @@ type RespV3SuccessResp<T> = {
 };
 
 export type RespV3<T> = RespV3ErrorResp | RespV3SuccessResp<T>;
-
-/**
- * Given a RespV3, ensure it is a success resp, and that data is of type T.
- *
- * This helps typescript properly narrow down the type of data as type T where it is called.
- * Otherwise, because of how union types work, `data` will have the type T | undefined.
- * @param args
- * @returns
- */
-export function isRespV3SuccessResp<T = any>(
-  args: any
-): args is RespV3SuccessResp<T> {
-  return args?.data !== undefined && args?.error === undefined;
-}
 
 export type BooleanResp =
   | { data: true; error: null }

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -259,9 +259,6 @@ export interface BulkResp<T> {
   error: DendronCompositeError | null;
 }
 
-/**
- * This lets us use a discriminate union to see if result has error or data
- */
 export type RespV3ErrorResp = {
   error: IDendronError;
   data?: never;
@@ -272,6 +269,12 @@ type RespV3SuccessResp<T> = {
   data: T;
 };
 
+/**
+ * This lets us use a discriminated union to see if result has error or data
+ *
+ * If you need to make sure it is an error (or a success),
+ * use {@link ErrorUtils.isErrorResp} type guard to help typescript narrow it down.
+ */
 export type RespV3<T> = RespV3ErrorResp | RespV3SuccessResp<T>;
 
 export type BooleanResp =

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -262,15 +262,31 @@ export interface BulkResp<T> {
 /**
  * This lets us use a discriminate union to see if result has error or data
  */
-export type RespV3<T> =
-  | {
-      error: IDendronError;
-      data?: never;
-    }
-  | {
-      error?: never;
-      data: T;
-    };
+type RespV3ErrorResp = {
+  error: IDendronError;
+  data?: never;
+};
+
+type RespV3SuccessResp<T> = {
+  error?: never;
+  data: T;
+};
+
+export type RespV3<T> = RespV3ErrorResp | RespV3SuccessResp<T>;
+
+/**
+ * Given a RespV3, ensure it is a success resp, and that data is of type T.
+ *
+ * This helps typescript properly narrow down the type of data as type T where it is called.
+ * Otherwise, because of how union types work, `data` will have the type T | undefined.
+ * @param args
+ * @returns
+ */
+export function isRespV3SuccessResp<T = any>(
+  args: any
+): args is RespV3SuccessResp<T> {
+  return args?.data !== undefined && args?.error === undefined;
+}
 
 export type BooleanResp =
   | { data: true; error: null }

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -3,6 +3,7 @@ import {
   DendronError,
   DNodeUtils,
   DVault,
+  ERROR_STATUS,
   FOLDERS,
   isNotUndefined,
   NoteProps,
@@ -195,11 +196,23 @@ export function file2Note(
   fpath: string,
   vault: DVault,
   toLowercase?: boolean
-): NoteProps {
-  const content = fs.readFileSync(fpath, { encoding: "utf8" });
-  const { name } = path.parse(fpath);
-  const fname = toLowercase ? name.toLowerCase() : name;
-  return string2Note({ content, fname, vault });
+): RespV3<NoteProps> {
+  if (!fs.existsSync(fpath)) {
+    const error = DendronError.createFromStatus({
+      status: ERROR_STATUS.INVALID_STATE,
+      message: `${fpath} does not exist`,
+    });
+    return {
+      error,
+    };
+  } else {
+    const content = fs.readFileSync(fpath, { encoding: "utf8" });
+    const { name } = path.parse(fpath);
+    const fname = toLowercase ? name.toLowerCase() : name;
+    return {
+      data: string2Note({ content, fname, vault }),
+    };
+  }
 }
 
 /** Read the contents of a note from the filesystem.

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -9,6 +9,7 @@ import {
   DEngineClient,
   EngineWriteOptsV2,
   SchemaTemplate,
+  isRespV3SuccessResp,
 } from "@dendronhq/common-all";
 import {
   file2Note,
@@ -205,7 +206,11 @@ export class NoteTestUtilsV4 {
   ) {
     const { fname, vault, wsRoot } = opts;
     const npath = path.join(vault2Path({ vault, wsRoot }), fname + ".md");
-    const note = file2Note(npath, vault);
+    const resp = file2Note(npath, vault);
+    if (!isRespV3SuccessResp(resp)) {
+      throw resp.error;
+    }
+    const note = resp.data;
     const newNote = cb(note);
     return note2File({ note: newNote, vault, wsRoot });
   }

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -9,7 +9,7 @@ import {
   DEngineClient,
   EngineWriteOptsV2,
   SchemaTemplate,
-  isRespV3SuccessResp,
+  ErrorUtils,
 } from "@dendronhq/common-all";
 import {
   file2Note,
@@ -207,7 +207,7 @@ export class NoteTestUtilsV4 {
     const { fname, vault, wsRoot } = opts;
     const npath = path.join(vault2Path({ vault, wsRoot }), fname + ".md");
     const resp = file2Note(npath, vault);
-    if (!isRespV3SuccessResp(resp)) {
+    if (ErrorUtils.isErrorResp(resp)) {
       throw resp.error;
     }
     const note = resp.data;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -51,6 +51,7 @@ import {
   NoteFnameDictUtils,
   FindNoteOpts,
   isNotNull,
+  isRespV3SuccessResp,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -713,12 +714,19 @@ export class FileStorage implements DStore {
     oldLoc: DNoteLoc;
     newLoc: DNoteLoc;
   }): Promise<NoteChangeUpdateEntry | undefined> {
+    const ctx = "store:processNoteChangedByRename";
     const prevNote = { ...note };
     const vault = note.vault;
     const vaultPath = vault2Path({ vault, wsRoot: this.wsRoot });
 
     // read note in case its changed
-    const _n = file2Note(path.join(vaultPath, note.fname + ".md"), vault);
+    const resp = file2Note(path.join(vaultPath, note.fname + ".md"), vault);
+    if (!isRespV3SuccessResp(resp)) {
+      // couldn't read note. log it and return.
+      this.logger.error({ ctx, error: stringifyError(resp.error) });
+      return;
+    }
+    const _n = resp.data;
     const foundLinks = LinkUtils.findLinks({
       note: _n,
       engine: this.engine,
@@ -883,7 +891,11 @@ export class FileStorage implements DStore {
 
     // TODO: Move this business logic to engine so we can update metadata
     // read from disk since contents might have changed
-    const noteRaw = file2Note(oldLocPath, oldVault);
+    const resp = file2Note(oldLocPath, oldVault);
+    if (!isRespV3SuccessResp(resp)) {
+      throw new DendronError({ message: "file not found" });
+    }
+    const noteRaw = resp.data;
     const oldNote = NoteUtils.hydrate({
       noteRaw,
       noteHydrated: this.notes[noteRaw.id],

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -51,7 +51,7 @@ import {
   NoteFnameDictUtils,
   FindNoteOpts,
   isNotNull,
-  isRespV3SuccessResp,
+  ErrorUtils,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -721,7 +721,7 @@ export class FileStorage implements DStore {
 
     // read note in case its changed
     const resp = file2Note(path.join(vaultPath, note.fname + ".md"), vault);
-    if (!isRespV3SuccessResp(resp)) {
+    if (ErrorUtils.isErrorResp(resp)) {
       // couldn't read note. log it and return.
       this.logger.error({ ctx, error: stringifyError(resp.error) });
       return;
@@ -892,7 +892,7 @@ export class FileStorage implements DStore {
     // TODO: Move this business logic to engine so we can update metadata
     // read from disk since contents might have changed
     const resp = file2Note(oldLocPath, oldVault);
-    if (!isRespV3SuccessResp(resp)) {
+    if (ErrorUtils.isErrorResp(resp)) {
       throw new DendronError({ message: "file not found" });
     }
     const noteRaw = resp.data;

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -19,6 +19,7 @@ import {
   NoteUtils,
   RespV2,
   VaultUtils,
+  isRespV3SuccessResp,
 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
 import _ from "lodash";
@@ -406,7 +407,11 @@ export function convertNoteRefASTV2(
       });
       let note: NoteProps;
       try {
-        note = file2Note(npath, vault as DVault);
+        const resp = file2Note(npath, vault as DVault);
+        if (!isRespV3SuccessResp(resp)) {
+          throw resp.error;
+        }
+        note = resp.data;
       } catch (err) {
         const msg = `error reading file, ${npath}`;
         return MdastUtils.genMDMsg(msg);

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -19,7 +19,7 @@ import {
   NoteUtils,
   RespV2,
   VaultUtils,
-  isRespV3SuccessResp,
+  ErrorUtils,
 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
 import _ from "lodash";
@@ -408,7 +408,7 @@ export function convertNoteRefASTV2(
       let note: NoteProps;
       try {
         const resp = file2Note(npath, vault as DVault);
-        if (!isRespV3SuccessResp(resp)) {
+        if (ErrorUtils.isErrorResp(resp)) {
           throw resp.error;
         }
         note = resp.data;

--- a/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
@@ -1,7 +1,7 @@
 import {
   DNodeUtils as _du,
   DVault,
-  isRespV3SuccessResp,
+  ErrorUtils,
   SchemaUtils as _su,
 } from "@dendronhq/common-all";
 import {
@@ -102,7 +102,7 @@ config:
 Foo body`
       );
       const resp = file2Note(notePath, vault);
-      expect(isRespV3SuccessResp(resp)).toBeTruthy();
+      expect(ErrorUtils.isErrorResp(resp)).toBeFalsy();
       expect(resp.data).toMatchObject({
         id: "foo",
         title: "foo",

--- a/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-server/filev2.spec.ts
@@ -1,6 +1,7 @@
 import {
   DNodeUtils as _du,
   DVault,
+  isRespV3SuccessResp,
   SchemaUtils as _su,
 } from "@dendronhq/common-all";
 import {
@@ -100,8 +101,9 @@ config:
 ---
 Foo body`
       );
-
-      expect(file2Note(notePath, vault)).toMatchObject({
+      const resp = file2Note(notePath, vault);
+      expect(isRespV3SuccessResp(resp)).toBeTruthy();
+      expect(resp.data).toMatchObject({
         id: "foo",
         title: "foo",
         updated: 1,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
@@ -1,6 +1,6 @@
 import {
   ConfigUtils,
-  isRespV3SuccessResp,
+  ErrorUtils,
   VaultUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
@@ -156,7 +156,7 @@ describe("h1 to h2", () => {
               `${nm.toLowerCase()}.md`
             );
             const resp = file2Note(fpath, vault);
-            if (!isRespV3SuccessResp(resp)) {
+            if (ErrorUtils.isErrorResp(resp)) {
               throw resp.error;
             }
             const note = resp.data;
@@ -197,7 +197,7 @@ describe("h1 to h2", () => {
 
         const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
         const resp1 = file2Note(fpathFoo, vault);
-        if (!isRespV3SuccessResp(resp1)) {
+        if (ErrorUtils.isErrorResp(resp1)) {
           throw resp1.error;
         }
         const noteFoo = resp1.data;
@@ -212,7 +212,7 @@ describe("h1 to h2", () => {
         // bar.md should be untouched.
         const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
         const resp2 = file2Note(fpathBar, vault);
-        if (!isRespV3SuccessResp(resp2)) {
+        if (ErrorUtils.isErrorResp(resp2)) {
           throw resp2.error;
         }
         const note = resp2.data;
@@ -251,7 +251,7 @@ describe("h1 to h2", () => {
               `${nm.toLowerCase()}.md`
             );
             const resp = file2Note(fpath, vault);
-            if (!isRespV3SuccessResp(resp)) {
+            if (ErrorUtils.isErrorResp(resp)) {
               throw resp.error;
             }
             const note = resp.data;
@@ -294,7 +294,7 @@ describe("H1_TO_TITLE", () => {
               `${nm.toLowerCase()}.md`
             );
             const resp = file2Note(fpath, vault);
-            if (!isRespV3SuccessResp(resp)) {
+            if (ErrorUtils.isErrorResp(resp)) {
               throw resp.error;
             }
             const note = resp.data;
@@ -329,7 +329,7 @@ describe("H1_TO_TITLE", () => {
         });
         const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
         const resp1 = file2Note(fpathFoo, vault);
-        if (!isRespV3SuccessResp(resp1)) {
+        if (ErrorUtils.isErrorResp(resp1)) {
           throw resp1.error;
         }
         const noteFoo = resp1.data;
@@ -338,7 +338,7 @@ describe("H1_TO_TITLE", () => {
 
         const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
         const resp2 = file2Note(fpathBar, vault);
-        if (!isRespV3SuccessResp(resp2)) {
+        if (ErrorUtils.isErrorResp(resp2)) {
           throw resp2.error;
         }
         const noteBar = resp2.data;

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
@@ -1,4 +1,9 @@
-import { ConfigUtils, VaultUtils, WorkspaceOpts } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  isRespV3SuccessResp,
+  VaultUtils,
+  WorkspaceOpts,
+} from "@dendronhq/common-all";
 import { file2Note, tmpDir } from "@dendronhq/common-server";
 import {
   BackupService,
@@ -150,7 +155,11 @@ describe("h1 to h2", () => {
               vault.fsPath,
               `${nm.toLowerCase()}.md`
             );
-            const note = file2Note(fpath, vault);
+            const resp = file2Note(fpath, vault);
+            if (!isRespV3SuccessResp(resp)) {
+              throw resp.error;
+            }
+            const note = resp.data;
             expect(note).toMatchSnapshot();
             expect(
               await AssertUtils.assertInString({
@@ -187,7 +196,11 @@ describe("h1 to h2", () => {
         });
 
         const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
-        const noteFoo = file2Note(fpathFoo, vault);
+        const resp1 = file2Note(fpathFoo, vault);
+        if (!isRespV3SuccessResp(resp1)) {
+          throw resp1.error;
+        }
+        const noteFoo = resp1.data;
         expect(noteFoo).toMatchSnapshot();
         expect(
           await AssertUtils.assertInString({
@@ -198,7 +211,11 @@ describe("h1 to h2", () => {
 
         // bar.md should be untouched.
         const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
-        const note = file2Note(fpathBar, vault);
+        const resp2 = file2Note(fpathBar, vault);
+        if (!isRespV3SuccessResp(resp2)) {
+          throw resp2.error;
+        }
+        const note = resp2.data;
         expect(note).toMatchSnapshot();
         expect(
           await AssertUtils.assertInString({
@@ -233,7 +250,11 @@ describe("h1 to h2", () => {
               vault.fsPath,
               `${nm.toLowerCase()}.md`
             );
-            const note = file2Note(fpath, vault);
+            const resp = file2Note(fpath, vault);
+            if (!isRespV3SuccessResp(resp)) {
+              throw resp.error;
+            }
+            const note = resp.data;
             expect(note).toMatchSnapshot();
             expect(
               await AssertUtils.assertInString({
@@ -272,7 +293,11 @@ describe("H1_TO_TITLE", () => {
               vault.fsPath,
               `${nm.toLowerCase()}.md`
             );
-            const note = file2Note(fpath, vault);
+            const resp = file2Note(fpath, vault);
+            if (!isRespV3SuccessResp(resp)) {
+              throw resp.error;
+            }
+            const note = resp.data;
             expect(note).toMatchSnapshot();
             expect(note.title).toEqual(`${nm} Header`);
           })
@@ -303,12 +328,20 @@ describe("H1_TO_TITLE", () => {
           action,
         });
         const fpathFoo = path.join(wsRoot, vault.fsPath, "foo.md");
-        const noteFoo = file2Note(fpathFoo, vault);
+        const resp1 = file2Note(fpathFoo, vault);
+        if (!isRespV3SuccessResp(resp1)) {
+          throw resp1.error;
+        }
+        const noteFoo = resp1.data;
         expect(noteFoo).toMatchSnapshot();
         expect(noteFoo.title).toEqual("Foo Header");
 
         const fpathBar = path.join(wsRoot, vault.fsPath, "bar.md");
-        const noteBar = file2Note(fpathBar, vault);
+        const resp2 = file2Note(fpathBar, vault);
+        if (!isRespV3SuccessResp(resp2)) {
+          throw resp2.error;
+        }
+        const noteBar = resp2.data;
         expect(noteBar).toMatchSnapshot();
         expect(noteBar.title).toEqual("Bar");
       },

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -2,6 +2,7 @@ import {
   ConfigUtils,
   ContextualUIEvents,
   DNodeUtils,
+  isRespV3SuccessResp,
   NoteUtils,
   SchemaUtils,
   Time,
@@ -450,7 +451,11 @@ export class WorkspaceWatcher {
       });
       const vpath = vault2Path({ wsRoot, vault: newVault });
       const newLocPath = path.join(vpath, fname + ".md");
-      const noteRaw = file2Note(newLocPath, newVault);
+      const resp = file2Note(newLocPath, newVault);
+      if (!isRespV3SuccessResp(resp)) {
+        throw resp.error;
+      }
+      const noteRaw = resp.data;
       const newNote = NoteUtils.hydrate({
         noteRaw,
         noteHydrated: engine.notes[noteRaw.id],

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -2,7 +2,7 @@ import {
   ConfigUtils,
   ContextualUIEvents,
   DNodeUtils,
-  isRespV3SuccessResp,
+  ErrorUtils,
   NoteUtils,
   SchemaUtils,
   Time,
@@ -452,7 +452,7 @@ export class WorkspaceWatcher {
       const vpath = vault2Path({ wsRoot, vault: newVault });
       const newLocPath = path.join(vpath, fname + ".md");
       const resp = file2Note(newLocPath, newVault);
-      if (!isRespV3SuccessResp(resp)) {
+      if (ErrorUtils.isErrorResp(resp)) {
         throw resp.error;
       }
       const noteRaw = resp.data;

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -6,11 +6,11 @@ import {
   DNoteHeaderAnchor,
   DNoteLink,
   DVault,
+  ErrorUtils,
   ERROR_SEVERITY,
   extractNoteChangeEntryCounts,
   getSlugger,
   NoteChangeEntry,
-  isRespV3SuccessResp,
   NoteProps,
   NoteQuickInput,
   NoteUtils,
@@ -505,7 +505,7 @@ export class MoveHeaderCommand extends BasicCommand<
           path.join(vaultPath, note!.fname + ".md"),
           note!.vault
         );
-        if (!isRespV3SuccessResp<NoteProps>(resp)) {
+        if (ErrorUtils.isErrorResp(resp)) {
           throw error;
         }
         const _note = resp.data;

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -1,6 +1,6 @@
 import {
   DuplicateNoteError,
-  isRespV3SuccessResp,
+  ErrorUtils,
   VaultUtils,
   WorkspaceEvents,
 } from "@dendronhq/common-all";
@@ -34,7 +34,7 @@ export class DoctorUtils {
     // we do this because the note in document would _not_ be in our store
     // if it is a duplicate note.
     const resp = file2Note(fsPath, vault);
-    if (!isRespV3SuccessResp(resp)) {
+    if (ErrorUtils.isErrorResp(resp)) {
       // not in file system, we do nothing.
       Logger.error({ ctx, error: resp.error });
       return;

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -1,6 +1,7 @@
 import {
   ContextualUIEvents,
   DVault,
+  isRespV3SuccessResp,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -114,7 +115,11 @@ export class FileWatcher {
         fsPath,
         wsRoot,
       });
-      note = file2Note(fsPath, vault);
+      const resp = file2Note(fsPath, vault);
+      if (!isRespV3SuccessResp<NoteProps>(resp)) {
+        throw resp.error;
+      }
+      note = resp.data;
 
       // check if note exist as
       const maybeNote = NoteUtils.getNoteByFnameFromEngine({

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -1,7 +1,7 @@
 import {
   ContextualUIEvents,
   DVault,
-  isRespV3SuccessResp,
+  ErrorUtils,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -116,7 +116,7 @@ export class FileWatcher {
         wsRoot,
       });
       const resp = file2Note(fsPath, vault);
-      if (!isRespV3SuccessResp<NoteProps>(resp)) {
+      if (ErrorUtils.isErrorResp(resp)) {
         throw resp.error;
       }
       note = resp.data;

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -1,7 +1,7 @@
 import {
   DNodeUtils,
   DVault,
-  isRespV3SuccessResp,
+  ErrorUtils,
   NoteProps,
   VaultUtils,
   WorkspaceOpts,
@@ -129,7 +129,7 @@ export const getNoteFromTextEditor = (): NoteProps => {
     basename: path.basename(txtPath),
   });
   const resp = file2Note(fullPath, vault);
-  if (!isRespV3SuccessResp(resp)) {
+  if (ErrorUtils.isErrorResp(resp)) {
     throw resp.error;
   }
   return resp.data;

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -1,6 +1,7 @@
 import {
   DNodeUtils,
   DVault,
+  isRespV3SuccessResp,
   NoteProps,
   VaultUtils,
   WorkspaceOpts,
@@ -127,8 +128,11 @@ export const getNoteFromTextEditor = (): NoteProps => {
     vault,
     basename: path.basename(txtPath),
   });
-  const node = file2Note(fullPath, vault);
-  return node;
+  const resp = file2Note(fullPath, vault);
+  if (!isRespV3SuccessResp(resp)) {
+    throw resp.error;
+  }
+  return resp.data;
 };
 
 export class LocationTestUtils {

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -8,6 +8,7 @@ import {
   MAIN_TUTORIAL_TYPE_NAME,
   TutorialNoteViewedPayload,
   isABTest,
+  isRespV3SuccessResp,
 } from "@dendronhq/common-all";
 import { file2Note, SegmentClient, vault2Path } from "@dendronhq/common-server";
 import {
@@ -93,7 +94,11 @@ export class TutorialInitializer
     const fsPath = document.uri.fsPath;
     const { vaults, wsRoot } = ws;
     const vault = VaultUtils.getVaultByFilePath({ vaults, wsRoot, fsPath });
-    const note = file2Note(fsPath, vault);
+    const resp = file2Note(fsPath, vault);
+    if (!isRespV3SuccessResp(resp)) {
+      throw resp.error;
+    }
+    const note = resp.data;
     const { fname, custom } = note;
     const { currentStep, totalSteps } = custom;
     return {

--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -8,7 +8,7 @@ import {
   MAIN_TUTORIAL_TYPE_NAME,
   TutorialNoteViewedPayload,
   isABTest,
-  isRespV3SuccessResp,
+  ErrorUtils,
 } from "@dendronhq/common-all";
 import { file2Note, SegmentClient, vault2Path } from "@dendronhq/common-server";
 import {
@@ -95,7 +95,7 @@ export class TutorialInitializer
     const { vaults, wsRoot } = ws;
     const vault = VaultUtils.getVaultByFilePath({ vaults, wsRoot, fsPath });
     const resp = file2Note(fsPath, vault);
-    if (!isRespV3SuccessResp(resp)) {
+    if (ErrorUtils.isErrorResp(resp)) {
       throw resp.error;
     }
     const note = resp.data;


### PR DESCRIPTION
# fix(workspace): duplicate note id detected even after a file is removed

This PR:
- Handles the case where duplicate note id detection is triggered for a file that is opened in the editor, but is already removed (VSCode keeps the editor open even after a file system delete).
- This also covers some cases where the note is temporarily removed from the file system during workspace sync (caused by git stashing)
- ~~Adds a custom type guard `isRespV3SuccessResp` for `RespV3` that can be used to help typescript properly narrow the type of the response.~~ Changes `ErrorUtils.isErrorResp` to be a user defined type guard that can be used to help typescript properly narrow the type of the response.
- change `file2Note` to return a `RespV3` in cases where the file path does not exist.
- refactors all usage of `file2Note`.

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)