### PR TITLE
feat(plugin-core): command for local override config

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -226,6 +226,10 @@
         "title": "Dendron: Random Note"
       },
       {
+        "command": "dendron.renameNoteV2a",
+        "title": "Dendron: Rename Note V2a"
+      },
+      {
         "command": "dendron.renameNote",
         "title": "Dendron: Rename Note"
       },
@@ -486,6 +490,10 @@
         "title": "Dendron: Configure Graph Style (css)"
       },
       {
+        "command": "dendron.configureLocalOverride",
+        "title": "Dendron: Configure Local Override"
+      },
+      {
         "command": "dendron.seedAdd",
         "title": "Dendron: Add Seed to Workspace"
       },
@@ -603,6 +611,10 @@
         {
           "command": "dendron.randomNote",
           "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.renameNoteV2a",
+          "when": "false"
         },
         {
           "command": "dendron.renameNote",
@@ -818,6 +830,10 @@
         },
         {
           "command": "dendron.configureGraphStyle",
+          "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.configureLocalOverride",
           "when": "dendron:pluginActive"
         },
         {

--- a/packages/plugin-core/src/commands/ConfigureLocalOverride.ts
+++ b/packages/plugin-core/src/commands/ConfigureLocalOverride.ts
@@ -60,8 +60,7 @@ const getConfigScope = async (): Promise<LocalConfigScope | undefined> => {
     },
     {
       label: LocalConfigScope.GLOBAL,
-      detail:
-        "Configure dendronrc.yml for all local dendron workspaces of the current user",
+      detail: "Configure dendronrc.yml for all dendron workspaces",
     },
   ];
 

--- a/packages/plugin-core/src/commands/ConfigureLocalOverride.ts
+++ b/packages/plugin-core/src/commands/ConfigureLocalOverride.ts
@@ -1,0 +1,54 @@
+import { DENDRON_COMMANDS } from "../constants";
+import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {};
+
+type CommandOutput = {};
+
+enum Scopes {
+  Vault = "vault",
+  Global = "global",
+}
+
+export class ConfigureLocalOverride extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CONFIGURE_LOCAL_OVERRIDE.key;
+
+  async execute() {
+    const configScope = await getConfigScope();
+    if (configScope === undefined) {
+      VSCodeUtils.showMessage(
+        MessageSeverity.ERROR,
+        "Configuration scope needs to be selected to open dendronrc.yml file",
+        {}
+      );
+      return {};
+    }
+
+    return {};
+  }
+}
+
+const getConfigScope = async (): Promise<Scopes | undefined> => {
+  const options = [
+    {
+      label: Scopes.Vault,
+      detail: "Configure dendronrc.yml for current local vault",
+    },
+    {
+      label: Scopes.Global,
+      detail: "Configure dendronrc.yml for all local dendron workspaces",
+    },
+  ];
+
+  const scope = await VSCodeUtils.showQuickPick(options, {
+    title: "Select configuration scope",
+    placeHolder: "vault",
+    ignoreFocusOut: true,
+  });
+
+  return scope ? (scope.label as Scopes) : undefined;
+};

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -5,6 +5,7 @@ import { CodeCommandConstructor } from "./base";
 import { BrowseNoteCommand } from "./BrowseNoteCommand";
 import { ChangeWorkspaceCommand } from "./ChangeWorkspace";
 import { ConfigureCommand } from "./ConfigureCommand";
+import { ConfigureLocalOverride } from "./ConfigureLocalOverride";
 import { ConfigureGraphStylesCommand } from "./ConfigureGraphStyles";
 import { ConfigureNoteTraitsCommand } from "./ConfigureNoteTraitsCommand";
 import { ConfigurePodCommand } from "./ConfigurePodCommand";
@@ -93,6 +94,7 @@ const ALL_COMMANDS = [
   BrowseNoteCommand,
   ChangeWorkspaceCommand,
   ConfigureCommand,
+  ConfigureLocalOverride,
   ConfigurePodCommand,
   ConfigureServiceConnection,
   ConfigureExportPodV2,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -867,6 +867,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Configure Graph Style (css)`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
+  CONFIGURE_LOCAL_OVERRIDE: {
+    key: "dendron.configureLocalOverride",
+    title: `${CMD_PREFIX} Configure Local Override`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
   //-- Seeds
   SEED_ADD: {
     key: "dendron.seedAdd",

--- a/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
@@ -1,0 +1,50 @@
+import { DConfig, LocalConfigScope } from "@dendronhq/engine-server";
+import { describe } from "mocha";
+import { ConfigureLocalOverride } from "../../commands/ConfigureLocalOverride";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS } from "../testUtilsV3";
+
+suite("ConfigureLocalOverrideCommand", function () {
+  describeSingleWS("WHEN run", {}, () => {
+    let cmd: ConfigureLocalOverride;
+
+    this.beforeEach(() => {
+      const ext = ExtensionProvider.getExtension();
+      cmd = new ConfigureLocalOverride(ext);
+    });
+
+    describe("AND scopoe is GLOBAL", () => {
+      test("THEN the configuration file for the user should open", async () => {
+        await cmd.run({ configScope: LocalConfigScope.GLOBAL });
+
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        expect(
+          VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
+        ).toEqual(
+          DConfig.configOverridePath(
+            wsRoot,
+            LocalConfigScope.GLOBAL
+          ).toLowerCase()
+        );
+      });
+    });
+
+    describe("AND scope is LOCAL", () => {
+      test("THEN the configuration file for the workspace should open", async () => {
+        await cmd.run({ configScope: LocalConfigScope.WORKSPACE });
+
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        expect(
+          VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.toLowerCase()
+        ).toEqual(
+          DConfig.configOverridePath(
+            wsRoot,
+            LocalConfigScope.WORKSPACE
+          ).toLowerCase()
+        );
+      });
+    });
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
@@ -1,4 +1,5 @@
 import { DConfig, LocalConfigScope } from "@dendronhq/engine-server";
+import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import { describe } from "mocha";
 import { ConfigureLocalOverride } from "../../commands/ConfigureLocalOverride";
 import { ExtensionProvider } from "../../ExtensionProvider";
@@ -10,7 +11,7 @@ suite("ConfigureLocalOverrideCommand", function () {
   describeSingleWS("WHEN run", {}, () => {
     let cmd: ConfigureLocalOverride;
 
-    this.beforeEach(() => {
+    beforeEach(() => {
       const ext = ExtensionProvider.getExtension();
       cmd = new ConfigureLocalOverride(ext);
     });
@@ -32,6 +33,10 @@ suite("ConfigureLocalOverrideCommand", function () {
     });
 
     describe("AND scope is LOCAL", () => {
+      beforeEach(() => {
+        TestEngineUtils.mockHomeDir();
+      });
+
       test("THEN the configuration file for the workspace should open", async () => {
         await cmd.run({ configScope: LocalConfigScope.WORKSPACE });
 

--- a/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureLocalOverride.test.ts
@@ -1,6 +1,6 @@
 import { DConfig, LocalConfigScope } from "@dendronhq/engine-server";
 import { TestEngineUtils } from "@dendronhq/engine-test-utils";
-import { describe } from "mocha";
+import { describe, beforeEach } from "mocha";
 import { ConfigureLocalOverride } from "../../commands/ConfigureLocalOverride";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";


### PR DESCRIPTION
# Add `Dendron: Configure Local Override` command to show `dendronrc.yml` file for either current workspace or current user

task: `[[task.2022.06.29.configure-local-config]]`
doc pr: [570](https://github.com/dendronhq/dendron-site/pull/570)

When run, the command opens up quick pickup to ask if user wants to configure overrides for the current workspace or all local workspaces of that user.

When `dendronrc.yml` doesn't exist for the specified scope, the command creates one.