### PR TITLE
feat(workspace): smart note refs

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -753,6 +753,9 @@
         "enableEditorDecorations": {
           "type": "boolean"
         },
+        "enableSmartRefs": {
+          "type": "boolean"
+        },
         "feedback": {
           "type": "boolean"
         },

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -224,4 +224,8 @@ export const WORKSPACE: DendronConfigEntryCollection<DendronWorkspaceConfig> = {
     label: "Enable FullHierarchyNoteTitle mode",
     desc: "When enabled, the full hierarchy position of a note is used to generate the note title",
   },
+  enableSmartRefs: {
+    label: "Enable smart references",
+    desc: "When enabled, note references that include a header will transclude said header and all sub headers",
+  },
 };

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -78,6 +78,6 @@ export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
     maxPreviewsCached: 10,
     maxNoteLength: 204800,
     enableFullHierarchyNoteTitle: false,
-    enableSmartRefs: true,
+    enableSmartRefs: false,
   };
 }

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -36,6 +36,7 @@ export type DendronWorkspaceConfig = {
   maxPreviewsCached: number;
   maxNoteLength: number;
   enableEditorDecorations: boolean;
+  enableSmartRefs?: boolean;
   //
   feedback?: boolean;
   apiEndpoint?: string;
@@ -77,5 +78,6 @@ export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
     maxPreviewsCached: 10,
     maxNoteLength: 204800,
     enableFullHierarchyNoteTitle: false,
+    enableSmartRefs: true,
   };
 }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -568,6 +568,32 @@ export class ConfigUtils {
     } as StrictConfigV5;
   }
 
+  /**
+   * This is different from {@link genDefaultConfig}
+   * as it includes updated settings that we don't want to set as
+   * defaults for backward compatibility reasons
+   */
+  static genLatestConfig(
+    defaults?: DeepPartial<StrictConfigV5>
+  ): StrictConfigV5 {
+    const common = {
+      dev: {
+        enablePreviewV2: true,
+      },
+    };
+    return _.merge(
+      {
+        version: 5,
+        ...common,
+        commands: genDefaultCommandConfig(),
+        workspace: { ...genDefaultWorkspaceConfig(), enableSmartRefs: true },
+        preview: genDefaultPreviewConfig(),
+        publishing: genDefaultPublishingConfig(),
+      } as StrictConfigV5,
+      defaults
+    );
+  }
+
   // get
   static getProp<K extends keyof StrictConfigV5>(
     config: IntermediateDendronConfig,

--- a/packages/engine-server/src/config.ts
+++ b/packages/engine-server/src/config.ts
@@ -32,6 +32,20 @@ export enum LocalConfigScope {
 }
 
 export class DConfig {
+  static createSync({
+    wsRoot,
+    defaults,
+  }: {
+    wsRoot: string;
+    defaults?: DeepPartial<StrictConfigV5>;
+  }) {
+    const configPath = DConfig.configPath(wsRoot);
+    const config: IntermediateDendronConfig =
+      ConfigUtils.genLatestConfig(defaults);
+    writeYAML(configPath, config);
+    return config;
+  }
+
   static configPath(configRoot: string): string {
     return path.join(configRoot, CONSTANTS.DENDRON_CONFIG_FILE);
   }

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -639,7 +639,6 @@ function prepareNoteRefIndices<T>({
     end = { ...start };
   }
 
-  // TODO: check for smark blocks
   if (!anchorEnd && start.type === "header" && start.node && enableSmartRef) {
     // anchor end is next header that is smaller or equal
     const nodes = RemarkUtils.extractHeaderBlock(

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -574,11 +574,13 @@ function prepareNoteRefIndices<T>({
   anchorEnd,
   bodyAST,
   makeErrorData,
+  enableSmartRef,
 }: {
   anchorStart?: string;
   anchorEnd?: string;
   bodyAST: DendronASTNode;
   makeErrorData: (anchorName: string, anchorType: "Start" | "End") => T;
+  enableSmartRef?: boolean;
 }): {
   start: FindAnchorResult;
   end: FindAnchorResult;
@@ -638,7 +640,7 @@ function prepareNoteRefIndices<T>({
   }
 
   // TODO: check for smark blocks
-  if (!anchorEnd && start.type === "header" && start.node) {
+  if (!anchorEnd && start.type === "header" && start.node && enableSmartRef) {
     // anchor end is next header that is smaller or equal
     const nodes = RemarkUtils.extractHeaderBlock(
       bodyAST,
@@ -688,7 +690,7 @@ function convertNoteRefHelperAST(
   const { proc, refLvl, link, note } = opts;
   let noteRefProc: Processor;
   // Workaround until all usages of MDUtilsV4 are removed
-  const engine = MDUtilsV5.getProcData(proc).engine;
+  const { engine, config } = MDUtilsV5.getProcData(proc);
 
   // Create a new proc to parse the reference; set the fname accordingly.
   // NOTE: a new proc is created here instead of using the proc() copy
@@ -719,6 +721,7 @@ function convertNoteRefHelperAST(
 
   const { start, end, data, error } = prepareNoteRefIndices({
     anchorStart,
+    enableSmartRef: ConfigUtils.getWorkspace(config).enableSmartRefs,
     anchorEnd,
     bodyAST,
     makeErrorData: (anchorName, anchorType) => {

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -1330,7 +1330,7 @@ export class RemarkUtils {
           }
         }
       } else if (node.type === DendronASTTypes.HEADING) {
-        if (foundHeaderIndex) {
+        if (!_.isUndefined(foundHeaderIndex)) {
           if (depth <= targetHeader!.depth) nextHeaderIndex = index;
         }
       }
@@ -1340,7 +1340,7 @@ export class RemarkUtils {
       return [];
     }
     const nodesToExtract = nextHeaderIndex
-      ? tree.children.slice(foundHeaderIndex!, nextHeaderIndex!)
+      ? tree.children.slice(foundHeaderIndex!, nextHeaderIndex)
       : tree.children.slice(foundHeaderIndex!);
     return nodesToExtract;
   }

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -1340,11 +1340,8 @@ export class RemarkUtils {
       return [];
     }
     const nodesToExtract = nextHeaderIndex
-      ? tree.children.splice(
-          foundHeaderIndex!,
-          nextHeaderIndex! - foundHeaderIndex!
-        )
-      : tree.children.splice(foundHeaderIndex!);
+      ? tree.children.slice(foundHeaderIndex!, nextHeaderIndex!)
+      : tree.children.slice(foundHeaderIndex!);
     return nodesToExtract;
   }
 

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -193,6 +193,9 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     }
   }
 
+  /**
+   * @deprecated: not applicable for self cotnained vaults
+   */
   static getOrCreateConfig(wsRoot: string) {
     return DConfig.getOrCreate(wsRoot);
   }
@@ -454,12 +457,15 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       if (vault.name) selfContainedVaultConfig.name = vault.name;
 
       // create dendron.yml
-      DConfig.getOrCreate(vaultPath, {
-        dev: {
-          enableSelfContainedVaults: true,
-        },
-        workspace: {
-          vaults: [selfContainedVaultConfig],
+      DConfig.createSync({
+        wsRoot: vaultPath,
+        defaults: {
+          dev: {
+            enableSelfContainedVaults: true,
+          },
+          workspace: {
+            vaults: [selfContainedVaultConfig],
+          },
         },
       });
       // create dendron.code-workspace
@@ -1083,7 +1089,9 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     const ws = new WorkspaceService({ wsRoot });
     fs.ensureDirSync(wsRoot);
     // this creates `dendron.yml`
-    ws.createConfig();
+    DConfig.createSync({
+      wsRoot,
+    });
     // add gitignore
     WorkspaceService.createGitIgnore(wsRoot);
     if (opts.createCodeWorkspace) {

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -91,6 +91,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds:
         dendron.foo: {}
 preview:
@@ -245,6 +246,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds:
         dendron.foo:
             site:
@@ -389,6 +391,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -500,6 +503,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -628,6 +632,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -91,7 +91,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds:
         dendron.foo: {}
 preview:
@@ -246,7 +246,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds:
         dendron.foo:
             site:
@@ -391,7 +391,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -503,7 +503,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -85,6 +85,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds:
         dendron.foo: {}
 preview:
@@ -239,6 +240,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds:
         dendron.foo:
             site:
@@ -383,6 +385,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -494,6 +497,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -622,6 +626,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -757,6 +762,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds: {}
 preview:
     enableFMTitle: true
@@ -878,6 +884,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
+    enableSmartRefs: true
     seeds: {}
 preview:
     enableFMTitle: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -85,7 +85,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds:
         dendron.foo: {}
 preview:
@@ -240,7 +240,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds:
         dendron.foo:
             site:
@@ -385,7 +385,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -497,7 +497,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -762,7 +762,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds: {}
 preview:
     enableFMTitle: true
@@ -884,7 +884,7 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
+    enableSmartRefs: false
     seeds: {}
 preview:
     enableFMTitle: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/dconfig.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/dconfig.spec.ts
@@ -8,7 +8,7 @@ import { TestWorkspaceUtils } from "../../utils/workspace";
 
 function getDefaultConfig() {
   const defaultConfig: IntermediateDendronConfig = {
-    ...ConfigUtils.genDefaultConfig(),
+    ...ConfigUtils.genLatestConfig(),
   };
   defaultConfig.publishing.duplicateNoteBehavior = {
     action: "useVault",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`legacy note ref compile "MD_DENDRON: BAD_REF" 1`] = `
+exports[`noteRefV2 WHEN parse section AND section header has space "MD_DENDRON: THEN header is parsed correctly: REGULAR" 1`] = `
 VFile {
   "contents": "# Foo
 
-((foo))
+# Foo Bar
+
+![[foo#header-2]]
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -14,11 +16,43 @@ VFile {
 }
 `;
 
-exports[`legacy note ref compile "MD_DENDRON: BAD_REF" 2`] = `
+exports[`noteRefV2 WHEN parse section AND section header has space "MD_REGULAR: THEN header is parsed correctly: REGULAR" 1`] = `
 VFile {
   "contents": "# Foo
 
-((foo))
+# Foo Bar
+
+## Header 2
+
+task2
+
+### Header 2.1
+
+task2.1
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 WHEN parse section AND section header has space "MD_REGULAR: THEN header is parsed correctly: REGULAR" 2`] = `
+VFile {
+  "contents": "# Foo
+
+# Foo Bar
+
+## Header 2
+
+task2
+
+### Header 2.1
+
+task2.1
+
 
 ",
   "cwd": "<PROJECT_ROOT>",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -1,12 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`noteRefV2 WHEN parse section AND section header has space "MD_DENDRON: THEN header is parsed correctly: REGULAR" 1`] = `
+exports[`noteRefV2 WHEN parse header AND parse from end header "MD_REGULAR: THEN parse end header and sub headers: REGULAR" 1`] = `
 VFile {
   "contents": "# Foo
 
 # Foo Bar
 
-![[foo#header-2]]
+## Header 3
+
+task3
+
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -16,7 +19,26 @@ VFile {
 }
 `;
 
-exports[`noteRefV2 WHEN parse section AND section header has space "MD_REGULAR: THEN header is parsed correctly: REGULAR" 1`] = `
+exports[`noteRefV2 WHEN parse header AND parse from end header "MD_REGULAR: THEN parse end header and sub headers: REGULAR" 2`] = `
+VFile {
+  "contents": "# Foo
+
+# Foo Bar
+
+## Header 3
+
+task3
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 WHEN parse header AND parse from middle header "MD_REGULAR: THEN parse middle header and sub headers: REGULAR" 1`] = `
 VFile {
   "contents": "# Foo
 
@@ -39,7 +61,7 @@ task2.1
 }
 `;
 
-exports[`noteRefV2 WHEN parse section AND section header has space "MD_REGULAR: THEN header is parsed correctly: REGULAR" 2`] = `
+exports[`noteRefV2 WHEN parse header AND parse from middle header "MD_REGULAR: THEN parse middle header and sub headers: REGULAR" 2`] = `
 VFile {
   "contents": "# Foo
 
@@ -52,6 +74,52 @@ task2
 ### Header 2.1
 
 task2.1
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 WHEN parse header AND parse from start header "MD_REGULAR: THEN parse start header and sub headers: REGULAR" 1`] = `
+VFile {
+  "contents": "# Foo
+
+# Foo Bar
+
+## Header 1
+
+task1
+
+### Header 1.1
+
+task1.1
+
+
+",
+  "cwd": "<PROJECT_ROOT>",
+  "data": Object {},
+  "history": Array [],
+  "messages": Array [],
+}
+`;
+
+exports[`noteRefV2 WHEN parse header AND parse from start header "MD_REGULAR: THEN parse start header and sub headers: REGULAR" 2`] = `
+VFile {
+  "contents": "# Foo
+
+# Foo Bar
+
+## Header 1
+
+task1
+
+### Header 1.1
+
+task1.1
 
 
 ",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -1,7 +1,9 @@
 import {
   ConfigUtils,
+  DendronASTDest,
   IntermediateDendronConfig,
   NoteProps,
+  ProcFlavor,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import {
@@ -9,19 +11,21 @@ import {
   NoteTestUtilsV4,
   TestPresetEntryV4,
 } from "@dendronhq/common-test-utils";
-import { DendronASTDest, MDUtilsV5 } from "@dendronhq/engine-server";
+import { MDUtilsV5 } from "@dendronhq/engine-server";
 import { TestConfigUtils } from "../../../config";
 import { runEngineTestV5 } from "../../../engine";
 import { ENGINE_HOOKS, ENGINE_SERVER } from "../../../presets";
 import {
   checkNotInVFile,
   checkVFile,
+  createProcCompileTests,
   createProcTests,
   generateVerifyFunction,
   processNote,
   processTextV2,
   ProcTests,
 } from "./utils";
+import { getOpts, runTestCases } from "./v5/utils";
 
 function runAllTests(opts: {
   name: string;
@@ -55,38 +59,63 @@ export const modifyNote = async (
   );
 };
 
-describe("legacy note ref", () => {
-  const badRef = "((foo))";
-  const BAD_REF = createProcTests({
-    name: "BAD_REF",
-    setupFunc: async ({ engine, vaults, extra }) => {
-      const proc2 = MDUtilsV5.procRemarkFull({
-        config: {
-          ...engine.config,
-        },
-        engine,
-        fname: "foo",
-        wikiLinksOpts: { useId: true },
-        dest: extra.dest,
-        vault: vaults[0],
-      });
-      const resp = await proc2.process(badRef);
-      return { resp };
-    },
-    verifyFuncDict: {
-      [DendronASTDest.MD_DENDRON]: async ({ extra }) => {
-        const { resp } = extra;
-        expect(resp).toMatchSnapshot();
-        checkVFile(resp, badRef);
-      },
-    },
-    preSetupHook: ENGINE_HOOKS.setupBasic,
+describe("noteRefV2", () => {
+  const ANCHOR_WITH_SPACE_PRE_SETUP = async (opts: WorkspaceOpts) => {
+    await ENGINE_HOOKS.setupBasic(opts);
+    await modifyNote(opts, "foo", (note: NoteProps) => {
+      const txt = [
+        "---",
+        "id: foo",
+        "---",
+        "## Header 1",
+        "task1",
+        "### Header 1.1",
+        "task1.1",
+        "## Header 2",
+        "task2",
+        "### Header 2.1",
+        "task2.1",
+        "## Header 3",
+        "task3",
+      ];
+      note.body = txt.join("\n");
+      return note;
+    });
+  };
+
+  describe.only("WHEN parse section", () => {
+    describe("AND section header has space", () => {
+      runTestCases(
+        createProcCompileTests({
+          name: "THEN header is parsed correctly",
+          fname: "foo",
+          setup: async (opts) => {
+            const text = "# Foo Bar\n![[foo#header-2]]";
+            const { proc } = getOpts(opts);
+            const resp = await proc.process(text);
+            return { resp, proc };
+          },
+          verify: {
+            [DendronASTDest.MD_REGULAR]: {
+              [ProcFlavor.REGULAR]: async ({ extra }) => {
+                const { resp } = extra;
+                await checkVFile(resp, "task2", "task2.1");
+                await checkNotInVFile(resp, "task1", "task3");
+              },
+            },
+            [DendronASTDest.MD_DENDRON]: {
+              [ProcFlavor.REGULAR]: async ({ extra }) => {
+                const { resp } = extra;
+                await checkVFile(resp, "![[foo#header-2]]");
+              },
+            },
+          },
+          preSetupHook: ANCHOR_WITH_SPACE_PRE_SETUP,
+        })
+      );
+    });
   });
 
-  runAllTests({ name: "compile", testCases: BAD_REF });
-});
-
-describe("noteRefV2", () => {
   describe("common cases", () => {
     const linkWithNoExtension = "![[foo]]";
 
@@ -152,24 +181,6 @@ describe("noteRefV2", () => {
           "## Header1",
           "task1",
           "## Header2",
-          "task2",
-        ];
-        note.body = txt.join("\n");
-        return note;
-      });
-    };
-
-    const ANCHOR_WITH_SPACE_PRE_SETUP = async (opts: WorkspaceOpts) => {
-      await ENGINE_HOOKS.setupBasic(opts);
-      await modifyNote(opts, "foo", (note: NoteProps) => {
-        const txt = [
-          "---",
-          "id: foo",
-          "---",
-          `# Tasks`,
-          "## Header 1",
-          "task1",
-          "## HeadeR 2",
           "task2",
         ];
         note.body = txt.join("\n");
@@ -263,46 +274,6 @@ describe("noteRefV2", () => {
           const { resp } = extra;
           await checkVFile(resp, `<span class="portal-text-title">Ch1</span>`);
         },
-      },
-    });
-
-    const WITH_ANCHOR_WITH_SPACE = createProcTests({
-      name: "WITH_ANCHOR_WITH_SPACE",
-      setupFunc: async (opts) => {
-        const { engine, vaults } = opts;
-        return processTextV2({
-          text: "# Foo Bar\n![[foo#header-2]]",
-          dest: opts.extra.dest,
-          engine,
-          vault: vaults[0],
-          fname: "foo",
-        });
-      },
-      preSetupHook: ANCHOR_WITH_SPACE_PRE_SETUP,
-      verifyFuncDict: {
-        [DendronASTDest.MD_REGULAR]: async ({ extra }) => {
-          const { resp } = extra;
-          expect(
-            await AssertUtils.assertInString({
-              body: resp.toString(),
-              match: ["task2"],
-              nomatch: ["task1"],
-            })
-          ).toBeTruthy();
-        },
-        [DendronASTDest.MD_DENDRON]: async ({ extra }) => {
-          const { resp } = extra;
-          expect(
-            await AssertUtils.assertInString({
-              body: resp.toString(),
-              match: ["![[foo#header-2]]"],
-            })
-          ).toBeTruthy();
-        },
-        ...generateVerifyFunction({
-          target: DendronASTDest.MD_REGULAR,
-          exclude: [DendronASTDest.MD_DENDRON],
-        }),
       },
     });
 
@@ -922,7 +893,6 @@ describe("noteRefV2", () => {
       ...RECURSIVE_TEST_CASES,
       ...WITH_ANCHOR,
       ...WITH_FM_TITLE,
-      ...WITH_ANCHOR_WITH_SPACE,
       ...WITH_START_ANCHOR_INVALID,
       ...WITH_END_ANCHOR_INVALID,
       ...WITH_START_ANCHOR_OFFSET,

--- a/packages/engine-test-utils/src/utils/seed.ts
+++ b/packages/engine-test-utils/src/utils/seed.ts
@@ -70,7 +70,10 @@ export class TestSeedUtils {
       mode: SeedInitMode.CREATE_WORKSPACE,
       ...opts,
     });
-    await GitTestUtils.addRepoToWorkspace(opts.wsRoot);
+    try {
+      await GitTestUtils.addRepoToWorkspace(opts.wsRoot);
+      // eslint-disable-next-line no-empty
+    } catch (err) {}
     return seed;
   }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -226,6 +226,10 @@
         "title": "Dendron: Random Note"
       },
       {
+        "command": "dendron.renameNoteV2a",
+        "title": "Dendron: Rename Note V2a"
+      },
+      {
         "command": "dendron.renameNote",
         "title": "Dendron: Rename Note"
       },
@@ -603,6 +607,10 @@
         {
           "command": "dendron.randomNote",
           "when": "dendron:pluginActive"
+        },
+        {
+          "command": "dendron.renameNoteV2a",
+          "when": "false"
         },
         {
           "command": "dendron.renameNote",

--- a/packages/plugin-core/src/commands/CopyNoteRef.ts
+++ b/packages/plugin-core/src/commands/CopyNoteRef.ts
@@ -77,7 +77,9 @@ export class CopyNoteRefCommand extends BasicCommand<
       if (!_.isUndefined(startAnchor) && !isBlockAnchor(startAnchor)) {
         // if a header is selected, skip the header itself
         linkData.anchorStart = slugger.slug(startAnchor);
-        linkData.anchorStartOffset = 1;
+        if (!opts.enableSmartRefs) {
+          linkData.anchorStartOffset = 1;
+        }
       }
       linkData.anchorEnd = endAnchor;
       if (!_.isUndefined(endAnchor) && !isBlockAnchor(endAnchor)) {

--- a/packages/plugin-core/src/commands/CopyNoteRef.ts
+++ b/packages/plugin-core/src/commands/CopyNoteRef.ts
@@ -14,6 +14,7 @@ import { Position, Range, Selection, TextEditor, window } from "vscode";
 import { DendronClientUtilsV2 } from "../clientUtils";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { clipboard } from "../utils";
 import { getSelectionAnchors } from "../utils/editor";
 import { VSCodeUtils } from "../vsCodeUtils";
@@ -57,6 +58,7 @@ export class CopyNoteRefCommand extends BasicCommand<
     note: NoteProps;
     useVaultPrefix?: boolean;
     editor: TextEditor;
+    enableSmartRefs?: boolean;
   }) {
     const { note, useVaultPrefix, editor } = opts;
     const { fname, vault } = note;
@@ -84,7 +86,8 @@ export class CopyNoteRefCommand extends BasicCommand<
       if (
         _.isUndefined(endAnchor) &&
         !_.isUndefined(startAnchor) &&
-        this.hasNextHeader({ selection })
+        this.hasNextHeader({ selection }) &&
+        !opts.enableSmartRefs
       ) {
         // if a header is selected for the start, and nothing for the end, and there's a next anchor, then use the wildcard
         linkData.anchorEnd = "*";
@@ -110,7 +113,8 @@ export class CopyNoteRefCommand extends BasicCommand<
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
     const fname = NoteUtils.uri2Fname(editor.document.uri);
     const vault = PickerUtilsV2.getVaultForOpenEditor();
-    const engine = getEngine();
+    const { config, engine } = ExtensionProvider.getDWorkspace();
+    const enableSmartRefs = config.workspace.enableSmartRefs;
     const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
       engine,
@@ -118,7 +122,12 @@ export class CopyNoteRefCommand extends BasicCommand<
     });
     if (note) {
       const useVaultPrefix = DendronClientUtilsV2.shouldUseVaultPrefix(engine);
-      const link = await this.buildLink({ note, useVaultPrefix, editor });
+      const link = await this.buildLink({
+        note,
+        useVaultPrefix,
+        editor,
+        enableSmartRefs,
+      });
       try {
         clipboard.writeText(link);
       } catch (err) {

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -1,7 +1,11 @@
 import { ConfigUtils, IntermediateDendronConfig } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
-import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
-import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import {
+  AssertUtils,
+  NoteTestUtilsV4,
+  PreSetupHookFunction,
+} from "@dendronhq/common-test-utils";
+import { ENGINE_HOOKS, TestConfigUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import { describe } from "mocha";
 import path from "path";
@@ -11,16 +15,196 @@ import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
-import {
-  describeMultiWS,
-  runLegacyMultiWorkspaceTest,
-  setupBeforeAfter,
-} from "../testUtilsV3";
+import { describeMultiWS } from "../testUtilsV3";
 
 suite("CopyNoteRef", function () {
-  const ctx = setupBeforeAfter(this, {});
+  describe("WHEN referencing a header", () => {
+    [true, false].forEach((enableSmartRef) => {
+      const preSetupHook: PreSetupHookFunction = async (opts) => {
+        await ENGINE_HOOKS.setupBasic(opts);
+        const rootName = "bar";
+        await NoteTestUtilsV4.createNote({
+          fname: `${rootName}`,
+          body: "## Foo\nfoo text\n## Header\n Header text",
+          vault: opts.vaults[0],
+          props: {
+            id: `${rootName}`,
+          },
+          wsRoot: opts.wsRoot,
+        });
+      };
+      const postSetupHook = async (opts: { wsRoot: string }) => {
+        TestConfigUtils.withConfig((config) => {
+          config.workspace.enableSmartRefs = enableSmartRef;
+          return config;
+        }, opts);
+      };
 
-  describe("multi", () => {
+      describe("WHEN enableSmartRef is " + enableSmartRef, () => {
+        describeMultiWS(
+          "AND WHEN with header selected",
+          {
+            preSetupHook,
+            preActivateHook: postSetupHook,
+          },
+          () => {
+            test("THEN generate note ref", async () => {
+              const engine = ExtensionProvider.getEngine();
+              const note = engine.notes["bar"];
+              const editor = await WSUtils.openNote(note);
+              editor.selection = new vscode.Selection(7, 0, 7, 12);
+              const link = await new CopyNoteRefCommand().run();
+              const suffix = enableSmartRef ? "" : ":#*";
+              expect(link).toEqual(`![[bar#foo,1${suffix}]]`);
+            });
+          }
+        );
+
+        describeMultiWS(
+          "AND WHEN with partial selection",
+          {
+            preSetupHook,
+            preActivateHook: postSetupHook,
+          },
+          () => {
+            test("THEN generate note ref", async () => {
+              const engine = ExtensionProvider.getEngine();
+              const note = engine.notes["bar"];
+              const editor = await WSUtils.openNote(note);
+              editor.selection = new vscode.Selection(7, 0, 7, 4);
+              const link = await new CopyNoteRefCommand().run();
+              const suffix = enableSmartRef ? "" : ":#*";
+              expect(link).toEqual(`![[bar#foo,1${suffix}]]`);
+            });
+          }
+        );
+
+        describeMultiWS(
+          "AND WHEN no next header",
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              const rootName = "bar";
+              await NoteTestUtilsV4.createNote({
+                fname: `${rootName}`,
+                body: "## Foo\nfoo text\n",
+                vault: opts.vaults[0],
+                props: {
+                  id: `${rootName}`,
+                },
+                wsRoot: opts.wsRoot,
+              });
+            },
+            preActivateHook: postSetupHook,
+          },
+          () => {
+            test("THEN generate note ref", async () => {
+              const engine = ExtensionProvider.getEngine();
+              const note = engine.notes["bar"];
+              const editor = await WSUtils.openNote(note);
+              editor.selection = new vscode.Selection(7, 0, 7, 12);
+              const link = await new CopyNoteRefCommand().run();
+              expect(link).toEqual(`![[bar#foo,1]]`);
+            });
+          }
+        );
+
+        describeMultiWS(
+          "AND WHEN existing block anchor selection",
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              const rootName = "bar";
+              await NoteTestUtilsV4.createNote({
+                fname: `${rootName}`,
+                body: [
+                  "Sint est quis sint sed.",
+                  "Dicta vel nihil tempora. ^test-anchor",
+                  "",
+                  "A est alias unde quia quas.",
+                  "Laborum corrupti porro iure.",
+                  "",
+                  "Id perspiciatis est adipisci.",
+                ].join("\n"),
+                vault: opts.vaults[0],
+                props: {
+                  id: `${rootName}`,
+                },
+                wsRoot: opts.wsRoot,
+              });
+            },
+            preActivateHook: postSetupHook,
+          },
+          () => {
+            test("THEN generate note ref", async () => {
+              const engine = ExtensionProvider.getEngine();
+              const note = engine.notes["bar"];
+              const editor = await WSUtils.openNote(note);
+              editor.selection = new vscode.Selection(8, 0, 8, 0);
+              const link = await new CopyNoteRefCommand().run();
+              expect(link).toEqual("![[bar#^test-anchor]]");
+            });
+          }
+        );
+
+        describeMultiWS(
+          "AND WHEN generated block anchors",
+          {
+            preSetupHook: async (opts) => {
+              await ENGINE_HOOKS.setupBasic(opts);
+              const rootName = "bar";
+              await NoteTestUtilsV4.createNote({
+                fname: `${rootName}`,
+                body: [
+                  "Sint est quis sint sed.",
+                  "Dicta vel nihil tempora. ^test-anchor",
+                  "",
+                  "A est alias unde quia quas.",
+                  "Laborum corrupti porro iure.",
+                  "",
+                  "Id perspiciatis est adipisci.",
+                ].join("\n"),
+                vault: opts.vaults[0],
+                props: {
+                  id: `${rootName}`,
+                },
+                wsRoot: opts.wsRoot,
+              });
+            },
+            preActivateHook: postSetupHook,
+          },
+          () => {
+            test("THEN generate note ref", async () => {
+              const engine = ExtensionProvider.getEngine();
+              const note = engine.notes["bar"];
+              const editor = await WSUtils.openNote(note);
+              editor.selection = new vscode.Selection(8, 0, 11, 0);
+              const link = await new CopyNoteRefCommand().run();
+
+              // make sure the link is correct
+              expect(link!.startsWith("![[bar#^test-anchor:#^"));
+              expect(link!.endsWith("]]"));
+
+              // make sure we only added 1 block anchor (there should be 2 now)
+              AssertUtils.assertTimesInString({
+                body: editor.document.getText(),
+                match: [[2, /\^[a-zA-Z0-9-_]+/]],
+              });
+
+              // make sure the anchor in the link has been inserted into the document
+              const anchor = getAnchorsFromLink(link!, 2)[1];
+              AssertUtils.assertTimesInString({
+                body: editor.document.getText(),
+                match: [[1, anchor]],
+              });
+            });
+          }
+        );
+      });
+    });
+  });
+
+  describe("GIVEN multi vault", () => {
     describeMultiWS(
       "WHEN xvault link when allowed in config",
       {
@@ -66,135 +250,52 @@ suite("CopyNoteRef", function () {
         });
       }
     );
-  });
 
-  test("basic", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async ({ engine }) => {
-        const note = engine.notes["foo"];
-        await WSUtils.openNote(note);
-        const link = await new CopyNoteRefCommand().run();
-        expect(link).toEqual("![[foo]]");
-        done();
+    describeMultiWS(
+      "AND WHEN reference entire note",
+      {
+        preSetupHook: ENGINE_HOOKS.setupBasic,
       },
-    });
-  });
-
-  test("with selection", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: "## Foo\nfoo text\n## Header\n Header text",
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
-          },
-          wsRoot: opts.wsRoot,
+      () => {
+        test("THEN generate note to note", async () => {
+          const engine = ExtensionProvider.getEngine();
+          const note = engine.notes["foo"];
+          await WSUtils.openNote(note);
+          const link = await new CopyNoteRefCommand().run();
+          expect(link).toEqual("![[foo]]");
         });
-      },
-      onInit: async ({ engine }) => {
-        const note = engine.notes["bar"];
-        const editor = await WSUtils.openNote(note);
-        editor.selection = new vscode.Selection(7, 0, 7, 12);
-        const link = await new CopyNoteRefCommand().run();
-        expect(link).toEqual("![[bar#foo,1:#*]]");
-        done();
-      },
-    });
-  });
+      }
+    );
 
-  test("with partial selection", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: "## Foo\nfoo text\n## Header\n Header text",
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
+    describe("AND WHEN reference with config", () => {
+      describeMultiWS(
+        "AND WHEN with header selected",
+        {
+          preSetupHook: async (opts) => {
+            await ENGINE_HOOKS.setupBasic(opts);
+            const rootName = "bar";
+            await NoteTestUtilsV4.createNote({
+              fname: `${rootName}`,
+              body: "## Foo\nfoo text\n## Header\n Header text",
+              vault: opts.vaults[0],
+              props: {
+                id: `${rootName}`,
+              },
+              wsRoot: opts.wsRoot,
+            });
           },
-          wsRoot: opts.wsRoot,
-        });
-      },
-      onInit: async ({ engine }) => {
-        const note = engine.notes["bar"];
-        const editor = await WSUtils.openNote(note);
-        editor.selection = new vscode.Selection(7, 0, 7, 4);
-        const link = await new CopyNoteRefCommand().run();
-        expect(link).toEqual("![[bar#foo,1:#*]]");
-        done();
-      },
-    });
-  });
-
-  test("with selection and no next header", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: "## Foo\nfoo text\n",
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
-          },
-          wsRoot: opts.wsRoot,
-        });
-      },
-      onInit: async ({ engine }) => {
-        const note = engine.notes["bar"];
-        const editor = await WSUtils.openNote(note);
-        editor.selection = new vscode.Selection(7, 0, 7, 12);
-        const link = await new CopyNoteRefCommand().run();
-        expect(link).toEqual("![[bar#foo,1]]");
-        done();
-      },
-    });
-  });
-
-  test("with existing block anchor selection", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: [
-            "Sint est quis sint sed.",
-            "Dicta vel nihil tempora. ^test-anchor",
-            "",
-            "A est alias unde quia quas.",
-            "Laborum corrupti porro iure.",
-            "",
-            "Id perspiciatis est adipisci.",
-          ].join("\n"),
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
-          },
-          wsRoot: opts.wsRoot,
-        });
-      },
-      onInit: async ({ engine }) => {
-        const note = engine.notes["bar"];
-        const editor = await WSUtils.openNote(note);
-        editor.selection = new vscode.Selection(8, 0, 8, 0);
-        const link = await new CopyNoteRefCommand().run();
-        expect(link).toEqual("![[bar#^test-anchor]]");
-        done();
-      },
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(7, 0, 7, 12);
+            const link = await new CopyNoteRefCommand().run();
+            expect(link).toEqual("![[bar#foo,1]]");
+          });
+        }
+      );
     });
   });
 
@@ -208,55 +309,4 @@ suite("CopyNoteRef", function () {
     }
     return anchors!;
   }
-
-  test("with generated block anchors", (done) => {
-    runLegacyMultiWorkspaceTest({
-      ctx,
-      preSetupHook: async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: [
-            "Sint est quis sint sed.",
-            "Dicta vel nihil tempora. ^test-anchor",
-            "",
-            "A est alias unde quia quas.",
-            "Laborum corrupti porro iure.",
-            "",
-            "Id perspiciatis est adipisci.",
-          ].join("\n"),
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
-          },
-          wsRoot: opts.wsRoot,
-        });
-      },
-      onInit: async ({ engine }) => {
-        const note = engine.notes["bar"];
-        const editor = await WSUtils.openNote(note);
-        editor.selection = new vscode.Selection(8, 0, 11, 0);
-        const link = await new CopyNoteRefCommand().run();
-
-        // make sure the link is correct
-        expect(link!.startsWith("![[bar#^test-anchor:#^"));
-        expect(link!.endsWith("]]"));
-
-        // make sure we only added 1 block anchor (there should be 2 now)
-        AssertUtils.assertTimesInString({
-          body: editor.document.getText(),
-          match: [[2, /\^[a-zA-Z0-9-_]+/]],
-        });
-
-        // make sure the anchor in the link has been inserted into the document
-        const anchor = getAnchorsFromLink(link!, 2)[1];
-        AssertUtils.assertTimesInString({
-          body: editor.document.getText(),
-          match: [[1, anchor]],
-        });
-        done();
-      },
-    });
-  });
 });

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -39,6 +39,7 @@ suite("CopyNoteRef", function () {
           return config;
         }, opts);
       };
+      let suffix = enableSmartRef ? "" : ",1:#*";
 
       describe("WHEN enableSmartRef is " + enableSmartRef, () => {
         describeMultiWS(
@@ -54,8 +55,7 @@ suite("CopyNoteRef", function () {
               const editor = await WSUtils.openNote(note);
               editor.selection = new vscode.Selection(7, 0, 7, 12);
               const link = await new CopyNoteRefCommand().run();
-              const suffix = enableSmartRef ? "" : ":#*";
-              expect(link).toEqual(`![[bar#foo,1${suffix}]]`);
+              expect(link).toEqual(`![[bar#foo${suffix}]]`);
             });
           }
         );
@@ -73,8 +73,7 @@ suite("CopyNoteRef", function () {
               const editor = await WSUtils.openNote(note);
               editor.selection = new vscode.Selection(7, 0, 7, 4);
               const link = await new CopyNoteRefCommand().run();
-              const suffix = enableSmartRef ? "" : ":#*";
-              expect(link).toEqual(`![[bar#foo,1${suffix}]]`);
+              expect(link).toEqual(`![[bar#foo${suffix}]]`);
             });
           }
         );
@@ -104,7 +103,8 @@ suite("CopyNoteRef", function () {
               const editor = await WSUtils.openNote(note);
               editor.selection = new vscode.Selection(7, 0, 7, 12);
               const link = await new CopyNoteRefCommand().run();
-              expect(link).toEqual(`![[bar#foo,1]]`);
+              suffix = enableSmartRef ? "" : ",1";
+              expect(link).toEqual(`![[bar#foo${suffix}]]`);
             });
           }
         );
@@ -292,7 +292,7 @@ suite("CopyNoteRef", function () {
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
             const link = await new CopyNoteRefCommand().run();
-            expect(link).toEqual("![[bar#foo,1]]");
+            expect(link).toEqual("![[bar#foo,1:#*]]");
           });
         }
       );

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -97,6 +97,7 @@ export class WorkspaceTestUtils {
         maxPreviewsCached: 10,
         maxNoteLength: 204800,
         enableFullHierarchyNoteTitle: false,
+        enableSmartRefs: true,
       },
       preview: {
         enableFMTitle: true,


### PR DESCRIPTION
- introduce smart note references as described in [[smart header references|dendron://dendron.docs/rfc.47-better-note-references#smart-header-references]]
- introduce `enableSmartRef` config option with default set to true
    - NOTE: decided to go with this instead of `enableLegacyRef` - the plan is to manually migrate everyone to the new syntax and remove legacy ref syntax
- fix bug in `extractHeader` (was mutating the block when extracting)
- copy note ref behavior update, if using `enableSmartRef` and a header is selected, don't generate `#{header},1:#*` but `#{header}` instead

Docs: https://github.com/dendronhq/dendron-site/pull/573
