### PR TITLE
fix(retrieve): bad parsing of xvault wikilink with space

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -983,6 +983,11 @@ export class NoteUtils {
     return props.title === NoteUtils.genTitle(props.fname);
   }
 
+  /**
+   * Remove `.md` extension if exists and remove spaces
+   * @param nodePath
+   * @returns
+   */
   static normalizeFname(nodePath: string) {
     nodePath = _.trim(nodePath);
     if (nodePath.endsWith(".md")) {

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -474,12 +474,13 @@ export class LinkUtils {
       if (!value && !anchor) return null; // Does not actually link to anything
       let vaultName: string | undefined;
       if (value) {
+        // remove spaces
+        value = _.trim(value);
         ({ vaultName, link: value } = parseDendronURI(value));
         if (!alias && !explicitAlias) {
           alias = value;
         }
         alias = _.trim(alias);
-        value = _.trim(value);
       }
       return {
         alias,

--- a/packages/engine-server/src/markdown/remark/wikiLinks.ts
+++ b/packages/engine-server/src/markdown/remark/wikiLinks.ts
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 import {
   ConfigUtils,
   CONSTANTS,

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/wikiLink.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/wikiLink.spec.ts.snap
@@ -547,6 +547,32 @@ VFile {
 }
 `;
 
+exports[`wikiLinks parse cross vault wikilink with spaces 1`] = `
+Object {
+  "data": Object {
+    "alias": "foo",
+    "anchorHeader": undefined,
+    "sameFile": false,
+    "vaultName": "vault1",
+  },
+  "position": Position {
+    "end": Object {
+      "column": 31,
+      "line": 1,
+      "offset": 30,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "wikiLink",
+  "value": "foo",
+}
+`;
+
 exports[`wikiLinks parse fail: bad format 1`] = `
 Object {
   "children": Array [

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/wikiLink.spec.ts
@@ -52,6 +52,15 @@ describe("wikiLinks", () => {
       });
     });
 
+    test("cross vault wikilink with spaces", () => {
+      const resp = proc().parse(`[[foo | dendron://vault1/foo]]`);
+      expect(getWikiLink(resp)).toMatchSnapshot();
+      expect(_.pick(getWikiLink(resp), ["type", "value"])).toEqual({
+        type: DendronASTTypes.WIKI_LINK,
+        value: "foo",
+      });
+    });
+
     test("fail: bad format", () => {
       const resp = proc().parse(`[[[foo bar]]]`);
       expect(resp).toMatchSnapshot();


### PR DESCRIPTION
`[[foo | dendron://vault/foo]]` is parsed incorrectly, with `dendron://vault/foo` taken as the name of the note (vs being identified as a vault prefix).

First brought up in https://github.com/dendronhq/dendron/issues/3179
