### PR TITLE
Enhance/delete and close

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -210,6 +210,10 @@
         "title": "Dendron: Delete Node"
       },
       {
+        "command": "dendron.delete",
+        "title": "Dendron: Delete"
+      },
+      {
         "command": "dendron.insertNoteLink",
         "title": "Dendron: Insert Note Link"
       },
@@ -597,6 +601,10 @@
           "when": "dendron:pluginActive"
         },
         {
+          "command": "dendron.delete",
+          "when": "dendron:pluginActive"
+        },
+        {
           "command": "dendron.insertNoteLink",
           "when": "dendron:pluginActive"
         },
@@ -956,6 +964,11 @@
           "group": "2_workspace"
         },
         {
+          "when": "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive",
+          "command": "dendron.delete",
+          "group": "2_workspace"
+        },
+        {
           "when": "resourceExtname == .md && dendron:pluginActive",
           "command": "dendron.moveNote",
           "group": "2_workspace"
@@ -1162,7 +1175,7 @@
         "when": "editorFocus && dendron:pluginActive"
       },
       {
-        "command": "dendron.deleteNode",
+        "command": "dendron.delete",
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "dendron:pluginActive"

--- a/packages/plugin-core/src/commands/DeleteCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteCommand.ts
@@ -1,0 +1,195 @@
+import {
+  DLink,
+  DVault,
+  EngineDeletePayload,
+  NoteProps,
+  NoteUtils,
+  Position,
+  SchemaUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import { RemarkUtils } from "@dendronhq/engine-server";
+import fs from "fs-extra";
+import _ from "lodash";
+import _md from "markdown-it";
+import path from "path";
+import { TextEditor, ViewColumn, window } from "vscode";
+import { DendronClientUtilsV2 } from "../clientUtils";
+import { PickerUtilsV2 } from "../components/lookup/utils";
+import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
+import { Logger } from "../logger";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {
+  _fsPath?: string;
+  noConfirm?: boolean;
+};
+
+type CommandOutput = EngineDeletePayload | void;
+export type { CommandOutput as DeleteNodeCommandOutput };
+
+function formatDeletedMsg({
+  fsPath,
+  vault,
+}: {
+  fsPath: string;
+  vault: DVault;
+}) {
+  return `${path.basename(fsPath)} (${VaultUtils.getName(vault)}) deleted`;
+}
+
+export class DeleteCommand extends BasicCommand<CommandOpts, CommandOutput> {
+  key = DENDRON_COMMANDS.DELETE_NODE.key;
+  async gatherInputs(): Promise<any> {
+    return {};
+  }
+
+  private getBacklinkFrontmatterLineOffset(opts: {
+    link: DLink;
+    vaults: DVault[];
+    wsRoot: string;
+  }) {
+    const { link, vaults, wsRoot } = opts;
+    const vault = VaultUtils.getVaultByName({
+      vaults,
+      vname: link.from.vaultName as string,
+    }) as DVault;
+    const noteWithLink = NoteUtils.getNoteByFnameFromEngine({
+      fname: link.from.fname as string,
+      vault,
+      engine: ExtensionProvider.getEngine(),
+    }) as NoteProps;
+    const fsPath = NoteUtils.getFullPath({
+      note: noteWithLink,
+      wsRoot,
+    });
+    const fileContent = fs.readFileSync(fsPath).toString();
+    const nodePosition = RemarkUtils.getNodePositionPastFrontmatter(
+      fileContent
+    ) as Position;
+
+    return nodePosition?.end.line;
+  }
+
+  async showNoteDeletePreview(note: NoteProps, backlinks: DLink[]) {
+    let content = [
+      "# Delete Node Preview",
+      "```",
+      `node type: note`,
+      "",
+      `# of backlinks to this note: ${backlinks.length}`,
+      "```",
+      "## Broken links after deletion",
+      `These links will be broken after deleting **${note.fname}**`,
+      "",
+      `Make sure to convert the broken links listed below accordingly.`,
+      "",
+    ];
+
+    const { wsRoot, engine } = ExtensionProvider.getDWorkspace();
+    const { vaults } = engine;
+
+    _.forEach(_.sortBy(backlinks, ["from.vaultName"]), (backlink) => {
+      const fmLineOffset = this.getBacklinkFrontmatterLineOffset({
+        link: backlink,
+        vaults,
+        wsRoot,
+      });
+      const entry = [
+        `- in **${backlink.from.vaultName}/${backlink.from.fname}**`,
+        `  - line *${backlink.position!.start.line + fmLineOffset}* column *${
+          backlink.position?.start.column
+        }*`,
+        `  - alias: \`${backlink.alias ? backlink.alias : "None"}\``,
+      ].join("\n");
+      content = content.concat(entry);
+    });
+
+    const panel = window.createWebviewPanel(
+      "deleteNodeNoteDeletePreview",
+      "Note Delete Preview",
+      ViewColumn.One,
+      {}
+    );
+    panel.webview.html = _md().render(content.join("\n"));
+    return content.join("\n");
+  }
+
+  async promptConfirmation(title: string, noConfirm?: boolean) {
+    if (noConfirm) return true;
+    const options = ["Proceed", "Cancel"];
+    const resp = await VSCodeUtils.showQuickPick(options, {
+      title,
+      placeHolder: "Proceed",
+      ignoreFocusOut: true,
+    });
+    return resp === "Proceed";
+  }
+
+  async execute(opts?: CommandOpts): Promise<CommandOutput> {
+    const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
+    const ctx = "DeleteNoteCommand";
+    if ((opts && opts._fsPath) || editor) {
+      const fsPath =
+        opts && opts._fsPath
+          ? opts._fsPath
+          : VSCodeUtils.getFsPathFromTextEditor(editor);
+      const mode = fsPath.endsWith(".md") ? "note" : "schema";
+      const trimEnd = mode === "note" ? ".md" : ".schema.yml";
+      const fname = path.basename(fsPath, trimEnd);
+      const engine = ExtensionProvider.getEngine();
+      if (mode === "note") {
+        const vault = PickerUtilsV2.getVaultForOpenEditor();
+        const note = NoteUtils.getNoteByFnameFromEngine({
+          fname,
+          vault,
+          engine,
+        }) as NoteProps;
+
+        const backlinks = note.links.filter((link) => link.type === "backlink");
+        let title;
+        if (backlinks.length === 0) {
+          // no need to show preview a simple
+          title = `Delete note ${note.fname}?`;
+        } else {
+          await this.showNoteDeletePreview(note, backlinks);
+          title = `${note.fname} has backlinks. Delete note?`;
+        }
+
+        const shouldProceed = await this.promptConfirmation(
+          title,
+          opts?.noConfirm
+        );
+        if (!shouldProceed) {
+          window.showInformationMessage("Cancelled");
+          return;
+        }
+
+        const out = (await engine.deleteNote(note.id)) as EngineDeletePayload;
+        if (out.error) {
+          Logger.error({ ctx, msg: "error deleting node", error: out.error });
+          return;
+        }
+        window.showInformationMessage(
+          formatDeletedMsg({ fsPath, vault: note.vault })
+        );
+        return out;
+      } else {
+        const smod = await DendronClientUtilsV2.getSchemaModByFname({
+          fname,
+          client: engine,
+        });
+        await engine.deleteSchema(SchemaUtils.getModuleRoot(smod).id);
+        window.showInformationMessage(
+          formatDeletedMsg({ fsPath, vault: smod.vault })
+        );
+        return;
+      }
+    } else {
+      window.showErrorMessage("no active text editor");
+      return;
+    }
+  }
+}

--- a/packages/plugin-core/src/commands/DeleteCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteCommand.ts
@@ -41,7 +41,7 @@ function formatDeletedMsg({
 }
 
 export class DeleteCommand extends BasicCommand<CommandOpts, CommandOutput> {
-  key = DENDRON_COMMANDS.DELETE_NODE.key;
+  key = DENDRON_COMMANDS.DELETE.key;
   async gatherInputs(): Promise<any> {
     return {};
   }

--- a/packages/plugin-core/src/commands/DeleteCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteCommand.ts
@@ -167,6 +167,11 @@ export class DeleteCommand extends BasicCommand<CommandOpts, CommandOutput> {
           return;
         }
 
+        // If Delete note preview is open, close it first
+        if (backlinks.length !== 0) {
+          await VSCodeUtils.closeCurrentFileEditor();
+        }
+
         const out = (await engine.deleteNote(note.id)) as EngineDeletePayload;
         if (out.error) {
           Logger.error({ ctx, msg: "error deleting node", error: out.error });
@@ -175,6 +180,7 @@ export class DeleteCommand extends BasicCommand<CommandOpts, CommandOutput> {
         window.showInformationMessage(
           formatDeletedMsg({ fsPath, vault: note.vault })
         );
+        await VSCodeUtils.closeCurrentFileEditor();
         return out;
       } else {
         const smod = await DendronClientUtilsV2.getSchemaModByFname({
@@ -185,6 +191,7 @@ export class DeleteCommand extends BasicCommand<CommandOpts, CommandOutput> {
         window.showInformationMessage(
           formatDeletedMsg({ fsPath, vault: smod.vault })
         );
+        await VSCodeUtils.closeCurrentFileEditor();
         return;
       }
     } else {

--- a/packages/plugin-core/src/commands/DeleteNodeCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteNodeCommand.ts
@@ -183,6 +183,11 @@ export class DeleteNodeCommand extends BasicCommand<
           return;
         }
 
+        // If Delete note preview is open, close it first
+        if (backlinks.length !== 0) {
+          await VSCodeUtils.closeCurrentFileEditor();
+        }
+
         const out = (await engine.deleteNote(note.id)) as EngineDeletePayload;
         if (out.error) {
           Logger.error({ ctx, msg: "error deleting node", error: out.error });
@@ -191,6 +196,7 @@ export class DeleteNodeCommand extends BasicCommand<
         window.showInformationMessage(
           formatDeletedMsg({ fsPath, vault: note.vault })
         );
+        await VSCodeUtils.closeCurrentFileEditor();
         return out;
       } else {
         const smod = await DendronClientUtilsV2.getSchemaModByFname({
@@ -201,6 +207,7 @@ export class DeleteNodeCommand extends BasicCommand<
         window.showInformationMessage(
           formatDeletedMsg({ fsPath, vault: smod.vault })
         );
+        await VSCodeUtils.closeCurrentFileEditor();
         return;
       }
     } else {

--- a/packages/plugin-core/src/commands/DeleteNodeCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteNodeCommand.ts
@@ -2,6 +2,7 @@ import {
   DLink,
   DVault,
   EngineDeletePayload,
+  ExtensionEvents,
   NoteProps,
   NoteUtils,
   Position,
@@ -19,7 +20,8 @@ import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
-import { VSCodeUtils } from "../vsCodeUtils";
+import { AnalyticsUtils } from "../utils/analytics";
+import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {
@@ -134,6 +136,17 @@ export class DeleteNodeCommand extends BasicCommand<
   async execute(opts?: CommandOpts): Promise<CommandOutput> {
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
     const ctx = "DeleteNoteCommand";
+
+    AnalyticsUtils.track(ExtensionEvents.DeprecationNoticeShow, {
+      source: DENDRON_COMMANDS.DELETE_NODE.key,
+    });
+
+    VSCodeUtils.showMessage(
+      MessageSeverity.WARN,
+      "Heads up that DeleteNode is being deprecated and will be replaced with the 'Delete' command",
+      {}
+    );
+
     if ((opts && opts._fsPath) || editor) {
       const fsPath =
         opts && opts._fsPath

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -26,6 +26,7 @@ import { CreateSchemaFromHierarchyCommand } from "./CreateSchemaFromHierarchyCom
 import { CreateScratchNoteCommand } from "./CreateScratchNoteCommand";
 import { CreateTaskCommand } from "./CreateTask";
 import { DeleteHookCommand } from "./DeleteHookCommand";
+import { DeleteCommand } from "./DeleteCommand";
 import { DeleteNodeCommand } from "./DeleteNodeCommand";
 import { DevTriggerCommand } from "./DevTriggerCommand";
 import { DiagnosticsReportCommand } from "./DiagnosticsReport";
@@ -109,6 +110,7 @@ const ALL_COMMANDS = [
   MigrateSelfContainedVaultCommand,
   CreateSchemaFromHierarchyCommand,
   DeleteHookCommand,
+  DeleteCommand,
   DeleteNodeCommand,
   DiagnosticsReportCommand,
   DisableTelemetryCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -275,6 +275,12 @@ export const DENDRON_MENUS = {
       group: "2_workspace",
     },
     {
+      // [[Command Enablement / When Clause Gotchas|dendron://dendron.docs/pkg.plugin-core.t.commands.ops#command-enablement--when-clause-gotchas]]
+      when: "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive",
+      command: "dendron.delete",
+      group: "2_workspace",
+    },
+    {
       when: "resourceExtname == .md && dendron:pluginActive",
       command: "dendron.moveNote",
       group: "2_workspace",
@@ -434,6 +440,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   DELETE_NODE: {
     key: "dendron.deleteNode",
     title: `${CMD_PREFIX} Delete Node`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
+  DELETE: {
+    key: "dendron.delete",
+    title: `${CMD_PREFIX} Delete`,
     keybindings: {
       key: "ctrl+shift+d",
       mac: "cmd+shift+d",


### PR DESCRIPTION
## Add `Dendron: Delete` that closes tab when deleting a note. Deprecate `Dendron: Delete Node`

task: `[[Delete Should Also Close Note|task.2022.07.06.delete-should-also-close-note]]`
doc pr: [585](https://github.com/dendronhq/dendron-site/pull/585)