### PR TITLE
fix(workspace): workspace sync will maintain proper engine state

### DIFF
--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -5,13 +5,13 @@ import {
   EngineInfoResp,
   EngineRenameNotePayload,
   EngineRenameNoteRequest,
-  EngineUpdateNotePayload,
   EngineUpdateNoteRequest,
   NoteQueryRequest,
   NoteQueryResp,
   RenderNoteOpts,
   RenderNotePayload,
   RespV2,
+  UpdateNoteResp,
 } from "@dendronhq/common-all";
 import { NodeJSUtils } from "@dendronhq/common-server";
 import { getLogger } from "../../core";
@@ -126,11 +126,10 @@ export class NoteController {
     ws,
     note,
     opts,
-  }: EngineUpdateNoteRequest): Promise<EngineUpdateNotePayload> {
+  }: EngineUpdateNoteRequest): Promise<UpdateNoteResp> {
     const engine = await getWSEngine({ ws });
     try {
-      const data = await engine.updateNote(note, opts);
-      return { error: null, data };
+      return engine.updateNote(note, opts);
     } catch (err) {
       return {
         error: new DendronError({ message: JSON.stringify(err) }),

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -33,6 +33,7 @@ import {
   NoteQueryResp,
   RenderNoteOpts,
   RenderNotePayload,
+  UpdateNoteResp,
   VSRange,
 } from "./types";
 
@@ -200,7 +201,6 @@ export type WorkspaceListPayload = APIPayload<{ workspaces: string[] }>;
 
 export type EngineQueryPayload = APIPayload<DNodeProps[]>;
 export type EngineRenameNotePayload = APIPayload<RenameNotePayload>;
-export type EngineUpdateNotePayload = APIPayload<NoteProps>;
 export type EngineDeletePayload = APIPayload<EngineDeleteNotePayload>;
 
 export type SchemaDeletePayload = APIPayload<DEngineDeleteSchemaPayload>;
@@ -439,9 +439,7 @@ export class DendronAPI extends API {
     });
   }
 
-  engineUpdateNote(
-    req: EngineUpdateNoteRequest
-  ): Promise<EngineUpdateNotePayload> {
+  engineUpdateNote(req: EngineUpdateNoteRequest): Promise<UpdateNoteResp> {
     return this._makeRequest({
       path: "note/update",
       method: "post",

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -438,6 +438,7 @@ export type NoteBlock = {
  */
 export type WriteNoteResp = RespV2<NoteChangeEntry[]>;
 export type BulkWriteNoteResp = BulkResp<NoteChangeEntry[]>;
+export type UpdateNoteResp = RespV2<NoteChangeEntry[]>;
 
 // --- Common
 export type ConfigGetPayload = IntermediateDendronConfig;
@@ -457,7 +458,7 @@ export type DCommonMethods = {
   updateNote(
     note: NoteProps,
     opts?: EngineUpdateNodesOptsV2
-  ): Promise<NoteProps>;
+  ): Promise<UpdateNoteResp>;
   updateSchema: (schema: SchemaModuleProps) => Promise<void>;
 
   writeNote: (

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -47,6 +47,7 @@ import {
   SchemaModuleProps,
   SchemaQueryResp,
   stringifyError,
+  UpdateNoteResp,
   VaultUtils,
   WorkspaceOpts,
   WriteNoteResp,
@@ -361,7 +362,7 @@ export class DendronEngineV3 implements DEngine {
     throw Error("renameNote not implemented");
   }
 
-  async updateNote(): Promise<NoteProps> {
+  async updateNote(): Promise<UpdateNoteResp> {
     throw new Error("updateNote not implemented");
   }
 

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -1060,24 +1060,32 @@ export class FileStorage implements DStore {
     const ctx = "updateNote";
     this.logger.debug({ ctx, note: NoteUtils.toLogObj(note), msg: "enter" });
 
+    const changes: NoteChangeEntry[] = [];
+
     const noteDicts = {
       notesById: this.notes,
       notesByFname: this.noteFnames,
     };
     if (opts?.newNode) {
-      const changed = NoteUtils.addOrUpdateParents({
+      const changesToParents = NoteUtils.addOrUpdateParents({
         note,
         noteDicts,
         createStubs: true,
         wsRoot: this.wsRoot,
       });
-      changed.forEach((changedEntry) =>
-        NoteDictsUtils.add(changedEntry.note, noteDicts)
-      );
+      changesToParents.forEach((changedEntry) => {
+        NoteDictsUtils.add(changedEntry.note, noteDicts);
+        changes.push(changedEntry);
+      });
+
+      changes.push({
+        note,
+        status: "create",
+      });
     }
     this.logger.debug({ ctx, note: NoteUtils.toLogObj(note) });
     NoteDictsUtils.add(note, noteDicts);
-    return note;
+    return { data: changes, error: null };
   }
 
   async updateSchema(schemaModule: SchemaModuleProps) {

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -42,6 +42,7 @@ import {
   RespV2,
   SchemaModuleDict,
   SchemaModuleProps,
+  UpdateNoteResp,
 } from "@dendronhq/common-all";
 import {
   DendronEngineClient,
@@ -230,7 +231,7 @@ export class EngineAPIService
   updateNote(
     note: NoteProps,
     opts?: EngineUpdateNodesOptsV2
-  ): Promise<NoteProps> {
+  ): Promise<UpdateNoteResp> {
     return this._internalEngine.updateNote(note, opts);
   }
 

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -37,6 +37,7 @@ import {
   RespV2,
   SchemaModuleDict,
   SchemaModuleProps,
+  UpdateNoteResp,
 } from "@dendronhq/common-all";
 import { EngineEventEmitter } from "@dendronhq/engine-server";
 
@@ -83,7 +84,7 @@ export interface IEngineAPIService {
   updateNote(
     note: NoteProps,
     opts?: EngineUpdateNodesOptsV2
-  ): Promise<NoteProps>;
+  ): Promise<UpdateNoteResp>;
 
   updateSchema(schema: SchemaModuleProps): Promise<void>;
 

--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -1,5 +1,6 @@
 import {
   DVault,
+  extractNoteChangeEntriesByType,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -126,7 +127,9 @@ export class TextDocumentService implements ITextDocumentService {
    * @param document
    * @returns
    */
-  private async onDidSave(document: TextDocument) {
+  private async onDidSave(
+    document: TextDocument
+  ): Promise<NoteProps | undefined> {
     const ctx = "TextDocumentService:onDidSave";
     const uri = document.uri;
     const fname = path.basename(uri.fsPath, ".md");
@@ -172,7 +175,16 @@ export class TextDocumentService implements ITextDocumentService {
       fname,
       vault,
     });
-    return engine.updateNote(props);
+
+    const resp = await engine.updateNote(props);
+
+    // This altering of response type is only for maintaining test compatibility
+    if (resp.data) {
+      const entries = extractNoteChangeEntriesByType(resp.data, "create");
+      return entries.length > 0 ? entries[0].note : undefined;
+    }
+
+    return;
   }
 
   /**

--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -179,9 +179,8 @@ export class TextDocumentService implements ITextDocumentService {
     const resp = await engine.updateNote(props);
 
     // This altering of response type is only for maintaining test compatibility
-    if (resp.data) {
-      const entries = extractNoteChangeEntriesByType(resp.data, "create");
-      return entries.length > 0 ? entries[0].note : undefined;
+    if (resp.data && resp.data.length > 0) {
+      return resp.data[0].note;
     }
 
     return;

--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -1,6 +1,5 @@
 import {
   DVault,
-  extractNoteChangeEntriesByType,
   NoteProps,
   NoteUtils,
   VaultUtils,


### PR DESCRIPTION
## fix(workspace): workspace sync will maintain proper engine state

This change fixes an issue where notes added by workspace sync were causing engine state drift.  The root cause is that the `updateNote` API doesn't return `NoteChangedEvents[]`, and we were using `updateNote` instead of `writeNote` in the file watcher `onCreate` callback.

This change adds a full `NoteChangedEvents[]` in the updateNote response.  I've intentionally not added tests for this, since we will likely modify this API surface as part of @tma66's refactoring work.

---

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)