### PR TITLE
enhance(workspace): 'Fix It' button in warning toaster for duplicate note id

### DIFF
--- a/packages/engine-server/src/markdown/decorations/diagnostics.ts
+++ b/packages/engine-server/src/markdown/decorations/diagnostics.ts
@@ -32,8 +32,9 @@ function badFrontmatter(props: Omit<Diagnostic, "source">) {
 export function warnMissingFrontmatter() {
   const diagnostic: Diagnostic = badFrontmatter({
     message: `The frontmatter is missing. All notes in Dendron must have a frontmatter. ${RESOLVE_MESSAGE_AUTO_ONLY}`,
-    range: newRange(0, 0, 0, 0),
+    range: newRange(0, 0, 0, 10),
     severity: DiagnosticSeverity.Error,
+    code: BAD_FRONTMATTER_CODE,
   });
   return diagnostic;
 }

--- a/packages/engine-server/src/markdown/decorations/diagnostics.ts
+++ b/packages/engine-server/src/markdown/decorations/diagnostics.ts
@@ -32,7 +32,7 @@ function badFrontmatter(props: Omit<Diagnostic, "source">) {
 export function warnMissingFrontmatter() {
   const diagnostic: Diagnostic = badFrontmatter({
     message: `The frontmatter is missing. All notes in Dendron must have a frontmatter. ${RESOLVE_MESSAGE_AUTO_ONLY}`,
-    range: newRange(0, 0, 0, 10),
+    range: newRange(0, 0, 8, 15),
     severity: DiagnosticSeverity.Error,
     code: BAD_FRONTMATTER_CODE,
   });

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -5,7 +5,9 @@ import {
   WorkspaceEvents,
 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
+import { DoctorActionsEnum } from "@dendronhq/engine-server";
 import * as vscode from "vscode";
+import { DoctorCommand } from "../../commands/Doctor";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
@@ -88,7 +90,24 @@ export class DoctorUtils {
           noteA: duplicate,
           noteB: note,
         });
-        VSCodeUtils.showMessage(MessageSeverity.WARN, error.message, {});
+        VSCodeUtils.showMessage(
+          MessageSeverity.WARN,
+          error.message,
+          {},
+          { title: "Fix It" }
+        ).then((resp) => {
+          if (resp && resp.title === "Fix It") {
+            const cmd: vscode.Command = {
+              command: new DoctorCommand(ExtensionProvider.getExtension()).key,
+              title: "Fix the frontmatter",
+              arguments: [
+                { scope: "file", action: DoctorActionsEnum.REGENERATE_NOTE_ID },
+              ],
+            };
+
+            vscode.commands.executeCommand(cmd.command, ...cmd.arguments);
+          }
+        });
         AnalyticsUtils.track(WorkspaceEvents.DuplicateNoteFound, {
           source,
         });

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -101,10 +101,16 @@ export class DoctorUtils {
               command: new DoctorCommand(ExtensionProvider.getExtension()).key,
               title: "Fix the frontmatter",
               arguments: [
-                { scope: "file", action: DoctorActionsEnum.REGENERATE_NOTE_ID },
+                {
+                  scope: "file",
+                  action: DoctorActionsEnum.REGENERATE_NOTE_ID,
+                  data: { note: duplicate },
+                },
               ],
             };
-
+            AnalyticsUtils.track(WorkspaceEvents.DuplicateNoteFound, {
+              state: "resolved",
+            });
             vscode.commands.executeCommand(cmd.command, ...cmd.arguments!);
           }
         });

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -105,7 +105,7 @@ export class DoctorUtils {
               ],
             };
 
-            vscode.commands.executeCommand(cmd.command, ...cmd.arguments);
+            vscode.commands.executeCommand(cmd.command, ...cmd.arguments!);
           }
         });
         AnalyticsUtils.track(WorkspaceEvents.DuplicateNoteFound, {

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -18,7 +18,6 @@ import { ExtensionProvider } from "../../ExtensionProvider";
 import { KeybindingUtils } from "../../KeybindingUtils";
 import { launchGoogleOAuthFlow } from "../../utils/pods";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import { MultiSelectBtn, Selection2ItemsBtn } from "../lookup/buttons";
 import { LookupControllerV3CreateOpts } from "../lookup/LookupControllerV3Interface";
 import { NoteLookupProviderSuccessResp } from "../lookup/LookupProviderV3Interface";
@@ -291,7 +290,9 @@ export class PodUIControls {
   public static async promptToCreateNewServiceConfig(
     serviceType: ExternalService
   ) {
-    const mngr = new ExternalConnectionManager(getExtension().podsDir);
+    const mngr = new ExternalConnectionManager(
+      ExtensionProvider.getExtension().podsDir
+    );
 
     const id = await this.promptForGenericId();
 
@@ -396,7 +397,7 @@ export class PodUIControls {
     const items: QuickPickItem[] = [];
 
     const configs = PodV2ConfigManager.getAllPodConfigs(
-      path.join(getExtension().podsDir, "custom")
+      path.join(ExtensionProvider.getExtension().podsDir, "custom")
     );
 
     configs.forEach((config) => {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -132,4 +132,9 @@ export interface IDendronExtension {
    * about registered Note Traits
    */
   get traitRegistrar(): NoteTraitService;
+
+  /**
+   * Directory in which pod configs are located
+   */
+  get podsDir(): string;
 }

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -53,6 +53,10 @@ export class MockDendronExtension implements IDendronExtension {
     this._wsRoot = wsRoot;
     this._vaults = vaults;
   }
+  fileWatcher?: FileWatcher | undefined;
+  get podsDir(): string {
+    throw new Error("Method not implemented.");
+  }
   get traitRegistrar(): NoteTraitService {
     throw new Error("Method not implemented.");
   }

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -53,7 +53,6 @@ export class MockDendronExtension implements IDendronExtension {
     this._wsRoot = wsRoot;
     this._vaults = vaults;
   }
-  fileWatcher?: FileWatcher | undefined;
   get podsDir(): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/plugin-core/src/test/suite-integ/DuplicateNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DuplicateNote.test.ts
@@ -9,7 +9,6 @@ import { tmpDir } from "@dendronhq/common-server";
 import { expect } from "../testUtilsv2";
 import { DoctorUtils } from "../../components/doctor/utils";
 import { VaultUtils } from "@dendronhq/common-all";
-import sinon from "sinon";
 
 suite("Duplicate note detection", function () {
   describeSingleWS(
@@ -41,37 +40,6 @@ suite("Duplicate note detection", function () {
           throw Error;
         }
         expect(note.id).toEqual(duplicate.id);
-      });
-    }
-  );
-
-  describeSingleWS(
-    "GIVEN a duplicate note AND WHEN Fix It button is clicked from the toaster",
-    {
-      postSetupHook: ENGINE_HOOKS.setupBasic,
-    },
-    () => {
-      test("THEN duplicate note should not be detected", async () => {
-        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-        const vaultPath = VaultUtils.getRelPath(vaults[0]);
-        const barPath = path.join(wsRoot, vaultPath, "bar.md");
-        const dupeNotePath = path.join(wsRoot, vaultPath, "bar-dupe.md");
-        const dupeNoteUri = vscode.Uri.file(dupeNotePath);
-        const barContent = fs.readFileSync(barPath, { encoding: "utf-8" });
-        fs.writeFileSync(dupeNotePath, barContent, { encoding: "utf-8" });
-
-        await VSCodeUtils.openFileInEditor(dupeNoteUri);
-        const editor = VSCodeUtils.getActiveTextEditor();
-        const document = editor?.document;
-        const showMessageStub = sinon
-          .stub(VSCodeUtils, "showMessage")
-          .resolves({ title: "Fix It" });
-
-        await DoctorUtils.findDuplicateNoteAndPromptIfNecessary(
-          document!,
-          "dendron"
-        );
-        expect(showMessageStub.calledOnce).toBeTruthy();
       });
     }
   );

--- a/packages/plugin-core/src/utils/pods.ts
+++ b/packages/plugin-core/src/utils/pods.ts
@@ -12,11 +12,11 @@ import path from "path";
 import * as queryString from "query-string";
 import { ProgressLocation, QuickPickItem, Uri, window } from "vscode";
 import { gdocRequiredScopes, GLOBAL_STATE } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { StateService } from "../services/stateService";
 import { GOOGLE_OAUTH_ID } from "../types/global";
 import { clipboard } from "../utils";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 
 export type PodQuickPickItemV4 = QuickPickItem & PodItemV4;
 
@@ -37,7 +37,7 @@ export const showPodQuickPickItemsV4 = (podItem: PodItemV4[]) => {
 
 export const launchGoogleOAuthFlow = async (id?: string) => {
   const port = fs.readFileSync(
-    path.join(getDWorkspace().wsRoot, ".dendron.port"),
+    path.join(ExtensionProvider.getDWorkspace().wsRoot, ".dendron.port"),
     {
       encoding: "utf8",
     }
@@ -113,7 +113,7 @@ export const getGlobalState = async (key: GLOBAL_STATE) => {
 export const openFileInEditor = async (note: NoteProps): Promise<void> => {
   const npath = NoteUtils.getFullPath({
     note,
-    wsRoot: getDWorkspace().wsRoot,
+    wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
   });
   const uri = Uri.file(npath);
   await VSCodeUtils.openFileInEditor(uri);


### PR DESCRIPTION
This PR aims to add a Fix It button in duplicate note id warning toaster. Fix It button runs the doctor regenerate note id command underneath the hood. 
This PR also increases the range of no frontmatter error from 0 to line 8.

*** 
Telemetry:
Adds a property `state: "resolved"` for an existing workspace event: `DuplicateNoteFound`
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
NA

## Close the Loop

### Extended
NA