### PR TITLE
enhance(workspace): Add new FIND notes CLI command

### DIFF
--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -23,6 +23,15 @@ export interface INoteStore<K> {
   get(key: K): Promise<RespV3<NoteProps>>;
 
   /**
+   * Bulk get NoteProps by list of key
+   * If no notes are found, return empty list.
+   *
+   * @param key: keys of NoteProps
+   * @return list of NoteProps
+   */
+  bulkGet(keys: K[]): Promise<RespV3<NoteProps>[]>;
+
+  /**
    * Get NoteProps metadata by key
    * If key is not found, return error.
    *

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -599,6 +599,9 @@ export type DEngine = DCommonProps &
 
     getSchema: (qs: string) => Promise<RespV2<SchemaModuleProps>>;
     querySchema: (qs: string) => Promise<SchemaQueryResp>;
+    /**
+     * Query for NoteProps from fuse engine
+     */
     queryNotes: (opts: QueryNotesOpts) => Promise<NoteQueryResp>;
     queryNotesSync({
       qs,

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -39,6 +39,7 @@ import {
   NotePropsByFnameDict,
   NotePropsByIdDict,
   NotePropsMeta,
+  NoteQueryResp,
   NoteUtils,
   Optional,
   QueryNotesOpts,
@@ -346,9 +347,7 @@ export class DendronEngineV3 implements DEngine {
   /**
    * See {@link DEngine.queryNotes}
    */
-  async queryNotes(
-    opts: QueryNotesOpts
-  ): ReturnType<DEngineClient["queryNotes"]> {
+  async queryNotes(opts: QueryNotesOpts): Promise<NoteQueryResp> {
     const ctx = "Engine:queryNotes";
     const { qs, vault, onlyDirectChildren, originalQS } = opts;
 
@@ -368,8 +367,6 @@ export class DendronEngineV3 implements DEngine {
     if (noteIds.length === 0) {
       return { error: null, data: [] };
     }
-
-    // TODO: Support createifNew? Doesn't seem to be actively used
 
     this.logger.info({ ctx, msg: "exit" });
     const responses = await this._noteStore.bulkGet(noteIds);

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -44,6 +44,7 @@ import {
   NoteProps,
   NotePropsByIdDict,
   NotePropsMeta,
+  NoteQueryResp,
   NoteUtils,
   NullCache,
   Optional,
@@ -496,11 +497,9 @@ export class DendronEngineV2 implements DEngine {
     };
   }
 
-  async queryNotes(
-    opts: QueryNotesOpts
-  ): ReturnType<DEngineClient["queryNotes"]> {
+  async queryNotes(opts: QueryNotesOpts): Promise<NoteQueryResp> {
     const ctx = "Engine:queryNotes";
-    const { qs, vault, createIfNew, onlyDirectChildren, originalQS } = opts;
+    const { qs, vault, onlyDirectChildren, originalQS } = opts;
 
     // Need to ignore this because the engine stringifies this property, so the types are incorrect.
     // @ts-ignore
@@ -517,24 +516,6 @@ export class DendronEngineV2 implements DEngine {
       return { error: null, data: [] };
     }
 
-    const item = this.notes[items[0].id];
-    if (createIfNew) {
-      let noteNew: NoteProps;
-      if (item?.fname === qs && item?.stub) {
-        noteNew = item;
-        noteNew.stub = false;
-      } else {
-        if (_.isUndefined(vault)) {
-          return {
-            error: new DendronError({ message: "no vault specified" }),
-            data: null as any,
-          };
-        }
-        noteNew = NoteUtils.create({ fname: qs, vault });
-      }
-      await this.writeNote(noteNew, { newNode: true });
-      this.fuseEngine.updateNotesIndex(this.notes);
-    }
     this.logger.info({ ctx, msg: "exit" });
     let notes = items.map((ent) => this.notes[ent.id]);
     if (!_.isUndefined(vault)) {

--- a/packages/engine-server/src/store/NoteStore.ts
+++ b/packages/engine-server/src/store/NoteStore.ts
@@ -90,6 +90,16 @@ export class NoteStore implements Disposable, INoteStore<string> {
   }
 
   /**
+   * See {@link INoteStore.bulkGet}
+   */
+  async bulkGet(keys: string[]): Promise<RespV3<NoteProps>[]> {
+    const ctx = "NoteStore:bulkGet";
+    this._logger.info({ ctx, msg: `Bulk getting NoteProps for ${keys}` });
+
+    return Promise.all(keys.map((key) => this.get(key)));
+  }
+
+  /**
    * See {@link INoteStore.getMetadata}
    */
   async getMetadata(key: string): Promise<RespV3<NotePropsMeta>> {

--- a/packages/pods-core/src/basev3.ts
+++ b/packages/pods-core/src/basev3.ts
@@ -3,7 +3,6 @@ import {
   DVault,
   minimatch,
   NoteProps,
-  NoteUtils,
   stringifyError,
   VaultUtils,
   WorkspaceOpts,
@@ -82,11 +81,7 @@ export abstract class PublishPod<
       vaults: engine.vaults,
       vname: vaultName,
     });
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      engine,
-      vault: vault!,
-    });
+    const note = (await engine.findNotes({ fname, vault }))[0];
     if (!note) {
       throw Error("no note found");
     }


### PR DESCRIPTION
**Background**
Continuing to test the new dendron store via the notes cli command, we will also introduce a new command `FIND` that will find notes based on note properties (currently only fname and vault).

**Changes**
1. New `FIND` cli command that uses new engine
2. Migrate `LOOKUP` command to use new engine

TODO: update docs after approval