### PR TITLE
enhance(views): option to filter hierarchical edges from graph panel

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -810,7 +810,7 @@ export enum GraphViewMessageEnum {
   "configureCustomStyling" = "configureCustomStyling",
   "toggleGraphView" = "toggleGraphView",
   "onGraphDepthChange" = "onGraphDepthChange",
-  "toggleLinkedEdges" = "toggleLinkedEdges",
+  "toggleGraphEdges" = "toggleGraphEdges",
 }
 
 export enum CalendarViewMessageType {

--- a/packages/common-frontend/src/features/ide/slice.ts
+++ b/packages/common-frontend/src/features/ide/slice.ts
@@ -30,6 +30,7 @@ type InitialState = {
   graphDepth?: number;
   showBacklinks?: boolean;
   showOutwardLinks?: boolean;
+  showHierarchy?: boolean;
 };
 
 const INITIAL_STATE: InitialState = {
@@ -45,6 +46,7 @@ const INITIAL_STATE: InitialState = {
   graphDepth: 1,
   showBacklinks: true,
   showOutwardLinks: true,
+  showHierarchy: true,
 };
 
 export { InitialState as IDEState };
@@ -93,6 +95,9 @@ export const ideSlice = createSlice({
     },
     setShowOutwardLinks: (state, action: PayloadAction<boolean>) => {
       state.showOutwardLinks = action.payload;
+    },
+    setShowHierarchy: (state, action: PayloadAction<boolean>) => {
+      state.showHierarchy = action.payload;
     },
   },
 });

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -107,6 +107,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
           graphDepth,
           showBacklinks,
           showOutwardLinks,
+          showHierarchy,
         } = cmsg.data;
         logger.info({ ctx, styles, msg: "styles" });
         if (styles) {
@@ -125,6 +126,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         }
         ideDispatch(ideSlice.actions.setShowBacklinks(showBacklinks));
         ideDispatch(ideSlice.actions.setShowOutwardLinks(showOutwardLinks));
+        ideDispatch(ideSlice.actions.setShowHierarchy(showHierarchy));
         break;
       }
       case SeedBrowserMessageType.onSeedStateChange: {
@@ -141,9 +143,9 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ideDispatch(ideSlice.actions.setGraphDepth(graphDepth));
         break;
       }
-      case GraphViewMessageEnum.toggleLinkedEdges: {
+      case GraphViewMessageEnum.toggleGraphEdges: {
         const cmsg = msg;
-        const { showBacklinks, showOutwardLinks } = cmsg.data;
+        const { showBacklinks, showOutwardLinks, showHierarchy } = cmsg.data;
         if (!_.isUndefined(showBacklinks)) {
           logger.info({ ctx, showBacklinks, msg: "showBacklinks" });
           ideDispatch(ideSlice.actions.setShowBacklinks(showBacklinks));
@@ -151,6 +153,11 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         if (!_.isUndefined(showOutwardLinks)) {
           logger.info({ ctx, showOutwardLinks, msg: "showOutwardLinks" });
           ideDispatch(ideSlice.actions.setShowOutwardLinks(showOutwardLinks));
+        }
+
+        if (!_.isUndefined(showHierarchy)) {
+          logger.info({ ctx, showHierarchy, msg: "showHierarchy" });
+          ideDispatch(ideSlice.actions.setShowHierarchy(showHierarchy));
         }
         break;
       }

--- a/packages/dendron-plugin-views/src/components/DendronGraphPanel.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronGraphPanel.tsx
@@ -38,6 +38,7 @@ const DendronGraphPanel: DendronComponent = (props) => {
     wsRoot: workspace.ws,
     showBacklinks: ide.showBacklinks || !isSidePanel,
     showOutwardLinks: ide.showOutwardLinks || !isSidePanel,
+    showHierarchy: ide.showHierarchy || !isSidePanel,
   });
   useEffect(() => {
     if (!_.isUndefined(elements)) {

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -53,10 +53,12 @@ function computeHierarchicalGraphElements({
   notes,
   noteActive,
   maxDistance,
+  showHierarchy,
 }: {
   notes: NotePropsByIdDict;
   noteActive: NoteProps;
   maxDistance: number;
+  showHierarchy?: boolean;
 }): GraphElements {
   // Initialize edges
   const edges: GraphEdges = {
@@ -64,6 +66,13 @@ function computeHierarchicalGraphElements({
     links: [],
   };
   const nodes: GraphNodes = [];
+
+  if (!showHierarchy) {
+    return {
+      nodes,
+      edges,
+    };
+  }
   const activeNote = notes[noteActive.id];
 
   // Add descendents (children, grandchildren, etc) depending on the specified
@@ -300,6 +309,7 @@ const getLocalNoteGraphElements = ({
   maxDistance,
   showBacklinks,
   showOutwardLinks,
+  showHierarchy,
 }: {
   notes: NotePropsByIdDict;
   fNameDict: NotePropsByFnameDict;
@@ -309,6 +319,7 @@ const getLocalNoteGraphElements = ({
   maxDistance: number;
   showBacklinks?: boolean;
   showOutwardLinks?: boolean;
+  showHierarchy?: boolean;
 }): GraphElements => {
   if (_.isUndefined(noteActive)) {
     return {
@@ -329,6 +340,7 @@ const getLocalNoteGraphElements = ({
     notes,
     noteActive,
     maxDistance,
+    showHierarchy,
   });
 
   const linkedElements = computeLinkedElements({
@@ -745,6 +757,7 @@ const useGraphElements = ({
   wsRoot,
   showBacklinks,
   showOutwardLinks,
+  showHierarchy,
 }: {
   type: "note" | "schema";
   engine: engineSlice.EngineState;
@@ -753,6 +766,7 @@ const useGraphElements = ({
   wsRoot: string;
   showBacklinks?: boolean | undefined;
   showOutwardLinks?: boolean | undefined;
+  showHierarchy?: boolean | undefined;
 }) => {
   const [elements, setElements] = useState<GraphElements>({
     nodes: [],
@@ -809,6 +823,7 @@ const useGraphElements = ({
           maxDistance: config["filter.depth"].value || 1,
           showBacklinks,
           showOutwardLinks,
+          showHierarchy,
         })
       );
     }
@@ -818,6 +833,7 @@ const useGraphElements = ({
     isLocalGraph,
     showBacklinks,
     showOutwardLinks,
+    showHierarchy,
     config["filter.depth"].value,
   ]);
 

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -154,6 +154,10 @@ type Metadata = Partial<{
    * graph panel show outward links
    */
   graphPanelShowOutwardLinks: boolean;
+  /**
+   * graph panel show hierarchical edges
+   */
+  graphPanelShowHierarchy: boolean;
 }>;
 
 export enum InactvieUserMsgStatusEnum {
@@ -270,6 +274,10 @@ export class MetadataService {
 
   get graphPanelShowOutwardLinks(): boolean | undefined {
     return this.getMeta().graphPanelShowOutwardLinks;
+  }
+
+  get graphPanelShowHierarchy(): boolean | undefined {
+    return this.getMeta().graphPanelShowHierarchy;
   }
 
   setMeta(key: keyof Metadata, value: any) {
@@ -391,6 +399,10 @@ export class MetadataService {
 
   set graphPanelShowOutwardLinks(showOutwardLinks: boolean | undefined) {
     this.setMeta("graphPanelShowOutwardLinks", showOutwardLinks);
+  }
+
+  set graphPanelShowHierarchy(showHierarchy: boolean | undefined) {
+    this.setMeta("graphPanelShowHierarchy", showHierarchy);
   }
   // Add a single path to recent workspaces. Recent workspaces acts like a FIFO
   // queue

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -178,12 +178,20 @@
         "title": "Show Outward Links"
       },
       {
+        "command": "dendron.graph-panel.showHierarchy",
+        "title": "Show Hierarchy"
+      },
+      {
         "command": "dendron.graph-panel.showBacklinksChecked",
         "title": "✓ Show Backlinks"
       },
       {
         "command": "dendron.graph-panel.showOutwardLinksChecked",
         "title": "✓ Show Outward Links"
+      },
+      {
+        "command": "dendron.graph-panel.showHierarchyChecked",
+        "title": "✓ Show Hierarchy"
       },
       {
         "command": "dendron.browseNote",
@@ -976,12 +984,20 @@
           "when": "view == dendron.graph-panel && dendron.graph-panel.showOutwardLinks"
         },
         {
+          "command": "dendron.graph-panel.showHierarchyChecked",
+          "when": "view == dendron.graph-panel && dendron.graph-panel.showHierarchy"
+        },
+        {
           "command": "dendron.graph-panel.showBacklinks",
           "when": "view == dendron.graph-panel && !dendron.graph-panel.showBacklinks"
         },
         {
           "command": "dendron.graph-panel.showOutwardLinks",
           "when": "view == dendron.graph-panel && !dendron.graph-panel.showOutwardLinks"
+        },
+        {
+          "command": "dendron.graph-panel.showHierarchy",
+          "when": "view == dendron.graph-panel && !dendron.graph-panel.showHierarchy"
         }
       ],
       "explorer/context": [

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -24,6 +24,7 @@ export enum DendronContext {
   TREEVIEW_TREE_ITEM_LABEL_TYPE = "dendron:treeviewItemLabelType",
   GRAPH_PANEL_SHOW_BACKLINKS = "dendron.graph-panel.showBacklinks",
   GRAPH_PANEL_SHOW_OUTWARD_LINKS = "dendron.graph-panel.showOutwardLinks",
+  GRAPH_PANEL_SHOW_HIERARCHY = "dendron.graph-panel.showHierarchy",
 }
 
 const treeViewConfig2VSCodeEntry = (id: DendronTreeViewKey) => {
@@ -267,12 +268,20 @@ export const DENDRON_MENUS = {
       when: `view == dendron.graph-panel && ${DendronContext.GRAPH_PANEL_SHOW_OUTWARD_LINKS}`,
     },
     {
+      command: "dendron.graph-panel.showHierarchyChecked",
+      when: `view == dendron.graph-panel && ${DendronContext.GRAPH_PANEL_SHOW_HIERARCHY}`,
+    },
+    {
       command: "dendron.graph-panel.showBacklinks",
       when: `view == dendron.graph-panel && !${DendronContext.GRAPH_PANEL_SHOW_BACKLINKS}`,
     },
     {
       command: "dendron.graph-panel.showOutwardLinks",
       when: `view == dendron.graph-panel && !${DendronContext.GRAPH_PANEL_SHOW_OUTWARD_LINKS}`,
+    },
+    {
+      command: "dendron.graph-panel.showHierarchy",
+      when: `view == dendron.graph-panel && !${DendronContext.GRAPH_PANEL_SHOW_HIERARCHY}`,
     },
   ],
   "explorer/context": [
@@ -393,6 +402,10 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.graph-panel.showOutwardLinks",
     title: "Show Outward Links",
   },
+  GRAPH_PANEL_SHOW_HIERARCHY: {
+    key: "dendron.graph-panel.showHierarchy",
+    title: "Show Hierarchy",
+  },
   GRAPH_PANEL_SHOW_BACKLINKS_CHECKED: {
     key: "dendron.graph-panel.showBacklinksChecked",
     title: "✓ Show Backlinks",
@@ -400,6 +413,10 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   GRAPH_PANEL_SHOW_OUTWARD_LINKS_CHECKED: {
     key: "dendron.graph-panel.showOutwardLinksChecked",
     title: "✓ Show Outward Links",
+  },
+  GRAPH_PANEL_SHOW_HIERARCHY_CHECKED: {
+    key: "dendron.graph-panel.showHierarchyChecked",
+    title: "✓ Show Hierarchy",
   },
   // --- Notes
   BROWSE_NOTE: {

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -30,6 +30,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
   private _graphDepth: number | undefined;
   private _showBacklinks: boolean | undefined;
   private _showOutwardLinks: boolean | undefined;
+  private _showHierarchy: boolean | undefined;
 
   constructor(extension: IDendronExtension) {
     this._ext = extension;
@@ -42,6 +43,9 @@ export class GraphPanel implements vscode.WebviewViewProvider {
 
     this.showOutwardLinks =
       MetadataService.instance().graphPanelShowOutwardLinks ?? true;
+
+    this.showHierarchy =
+      MetadataService.instance().graphPanelShowHierarchy ?? true;
   }
 
   private get graphDepth(): number | undefined {
@@ -76,7 +80,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
         displayBacklinks
       );
       this.postMessage({
-        type: GraphViewMessageEnum.toggleLinkedEdges,
+        type: GraphViewMessageEnum.toggleGraphEdges,
         data: {
           showBacklinks: this._showBacklinks,
         },
@@ -102,7 +106,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
         displayOutwardLinks
       );
       this.postMessage({
-        type: GraphViewMessageEnum.toggleLinkedEdges,
+        type: GraphViewMessageEnum.toggleGraphEdges,
         data: {
           showOutwardLinks: this._showOutwardLinks,
         },
@@ -111,6 +115,32 @@ export class GraphPanel implements vscode.WebviewViewProvider {
       // Save the setting update into persistance storage:
       MetadataService.instance().graphPanelShowOutwardLinks =
         displayOutwardLinks;
+    }
+  }
+
+  public get showHierarchy(): boolean | undefined {
+    return this._showHierarchy;
+  }
+
+  public set showHierarchy(displayHierarchy: boolean | undefined) {
+    if (
+      !_.isUndefined(displayHierarchy) &&
+      this._showHierarchy !== displayHierarchy
+    ) {
+      this._showHierarchy = displayHierarchy;
+      VSCodeUtils.setContext(
+        DendronContext.GRAPH_PANEL_SHOW_HIERARCHY,
+        displayHierarchy
+      );
+      this.postMessage({
+        type: GraphViewMessageEnum.toggleGraphEdges,
+        data: {
+          showHierarchy: this._showHierarchy,
+        },
+        source: DMessageSource.vscode,
+      });
+      // Save the setting update into persistance storage:
+      MetadataService.instance().graphPanelShowHierarchy = displayHierarchy;
     }
   }
 
@@ -217,7 +247,8 @@ export class GraphPanel implements vscode.WebviewViewProvider {
             graphTheme ||
             this.graphDepth ||
             this.showBacklinks ||
-            this.showOutwardLinks)
+            this.showOutwardLinks ||
+            this.showHierarchy)
         ) {
           this._view.webview.postMessage({
             type: GraphViewMessageEnum.onGraphLoad,
@@ -227,6 +258,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
               graphDepth: this.graphDepth,
               showBacklinks: this.showBacklinks,
               showOutwardLinks: this.showOutwardLinks,
+              showHierarchy: this.showHierarchy,
             },
             source: "vscode",
           });

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -48,11 +48,11 @@ export class GraphPanel implements vscode.WebviewViewProvider {
       MetadataService.instance().graphPanelShowHierarchy ?? true;
   }
 
-  private get graphDepth(): number | undefined {
+  public get graphDepth(): number | undefined {
     return this._graphDepth;
   }
 
-  private set graphDepth(depth: number | undefined) {
+  public set graphDepth(depth: number | undefined) {
     if (depth) {
       this._graphDepth = depth;
       this.postMessage({

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -713,6 +713,18 @@ export class DendronExtension implements IDendronExtension {
         graphPanel.showOutwardLinks = true;
       })
     );
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.GRAPH_PANEL_SHOW_HIERARCHY_CHECKED.key,
+      sentryReportingCallback(() => {
+        graphPanel.showHierarchy = false;
+      })
+    );
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.GRAPH_PANEL_SHOW_HIERARCHY.key,
+      sentryReportingCallback(() => {
+        graphPanel.showHierarchy = true;
+      })
+    );
     return vscode.window.registerWebviewViewProvider(
       GraphPanel.viewType,
       graphPanel


### PR DESCRIPTION
This PR aims to add an option to toggle hierarchical edges in the Graph Panel.
loom: https://www.loom.com/share/88c169c981244c289dde63eac2419bd1

# Dendron Extended PR Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)


## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)



