### PR TITLE
fix(workspace): insertNote and templateHierarchy yaml config validators

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -490,6 +490,9 @@
         "randomNote": {
           "$ref": "#/definitions/RandomNoteConfig"
         },
+        "insertNote": {
+          "$ref": "#/definitions/InsertNoteConfig"
+        },
         "insertNoteLink": {
           "$ref": "#/definitions/InsertNoteLinkConfig"
         },
@@ -498,15 +501,12 @@
         },
         "copyNoteLink": {
           "$ref": "#/definitions/CopyNoteLinkConfig"
-        },
-        "templateHierarchy": {
-          "type": "string",
-          "description": "Default template hiearchy used when running commands like `Apply template`"
         }
       },
       "required": [
         "lookup",
         "randomNote",
+        "insertNote",
         "insertNoteLink",
         "insertNoteIndex",
         "copyNoteLink"
@@ -594,6 +594,19 @@
       },
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  RandomNoteCommand }"
+    },
+    "InsertNoteConfig": {
+      "type": "object",
+      "properties": {
+        "initialValue": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "initialValue"
+      ],
+      "additionalProperties": false,
+      "description": ""
     },
     "InsertNoteLinkConfig": {
       "type": "object",
@@ -743,6 +756,10 @@
         },
         "enableFullHierarchyNoteTitle": {
           "type": "boolean"
+        },
+        "templateHierarchy": {
+          "type": "string",
+          "description": "Default template hierarchy used when running commands like `Apply template`"
         },
         "maxPreviewsCached": {
           "type": "number"


### PR DESCRIPTION
## What is this change?

`insertNote` doesn't have an entry in the `dendron-yaml.validator.json` config, and `templateHierarchy` was moved under `workspace`.

### Questions

This PR is in draft state because:
- I'm not sure what I need to do when it comes to tests
- What should `InsertNoteConfig` have for the `description`? I noticed it doesn't have an entry in the Dendron wiki here, even though it is listed in the config example on the page: https://wiki.dendron.so/notes/F9LWJEjscrGkxnYi2JNby/
- Are both `insertNote` and `templateHierarchy` required? So should they be in the required lists?
- Should `templateHierarchy` be added to the Dendron wiki:
  - Should the definition be the same as in the validator:
    > Default template hierarchy used when running commands like `Apply template`

---

## Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.

---

## Commit

- [x] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/QN46JTSWpEkDkr94TJ85w)
- [x] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
  - NOTE: make sure to read [Addressing open issues](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)

## Code

- [x] code should follow [Code Conventions](https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e)
- [x] sticking to existing conventions instead of creating new ones 

## Tests

- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing [snapshot](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
  - [ ] [Update the Snapshot](https://docs.dendron.so/notes/u7utw5w8gyacuh3ok9ehi8j)



## Docs

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR (NOTE: submit the PR against the `dev` branch of the dendron-site repo)

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/ce9b9b29-d85b-492b-b76d-5e0c5dc52b03) or [Packages](https://wiki.dendron.so/notes/ok9ifke0zsfxnnh7xog79z5)