### PR TITLE
fix(views): properly focus tree view to active note when it is first shown

### DIFF
--- a/packages/plugin-core/src/views/NativeTreeView.ts
+++ b/packages/plugin-core/src/views/NativeTreeView.ts
@@ -12,6 +12,7 @@ import _ from "lodash";
 import path from "path";
 import { Disposable, TextEditor, TreeView, window } from "vscode";
 import { ExtensionProvider } from "../ExtensionProvider";
+import { VSCodeUtils } from "../vsCodeUtils";
 import { EngineNoteProvider } from "./EngineNoteProvider";
 import { TreeNote } from "./TreeNote";
 
@@ -76,6 +77,8 @@ export class NativeTreeView implements Disposable {
         this.onOpenTextDocument,
         this
       );
+
+      this.forceReveal({ treeView: this.treeView });
     });
   }
 
@@ -96,6 +99,18 @@ export class NativeTreeView implements Disposable {
             select: false,
           });
         });
+      }
+    }
+  }
+
+  private forceReveal({ treeView }: { treeView: TreeView<NoteProps> }) {
+    const maybeActiveEditor = VSCodeUtils.getActiveTextEditor();
+    if (maybeActiveEditor !== undefined) {
+      const activeNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+        maybeActiveEditor.document
+      );
+      if (activeNote !== undefined) {
+        treeView.reveal(activeNote);
       }
     }
   }

--- a/packages/plugin-core/src/workspace/workspaceActivator.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivator.ts
@@ -184,7 +184,7 @@ async function checkNoDuplicateVaultNames(vaults: DVault[]): Promise<boolean> {
   // check for vaults with same name
   const uniqueVaults = new Set<string>();
   const duplicates = new Set<string>();
-  vaults.forEach(vault => {
+  vaults.forEach((vault) => {
     const vaultName = VaultUtils.getName(vault);
     if (uniqueVaults.has(vaultName)) duplicates.add(vaultName);
     uniqueVaults.add(vaultName);
@@ -539,14 +539,6 @@ export class WorkspaceActivator {
     // setup services
     context.subscriptions.push(TextDocumentServiceFactory.create(ext));
 
-    // Setup tree viiew
-    const providerConstructor = function () {
-      return new EngineNoteProvider(engine);
-    };
-    if (!opts?.skipTreeView) {
-      await initTreeView({ context, providerConstructor });
-    }
-
     // Reload
     WSUtils.showActivateProgress();
     const start = process.hrtime();
@@ -581,6 +573,15 @@ export class WorkspaceActivator {
     if (stage !== "test") {
       ext.activateWatchers();
       togglePluginActiveContext(true);
+    }
+
+    // Setup tree view
+    // This needs to happen after activation because we need the engine.
+    const providerConstructor = function () {
+      return new EngineNoteProvider(engine);
+    };
+    if (!opts?.skipTreeView) {
+      await initTreeView({ context, providerConstructor, ext });
     }
 
     // Add the current workspace to the recent workspace list. The current

--- a/packages/plugin-core/src/workspace/workspaceActivator.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivator.ts
@@ -581,7 +581,8 @@ export class WorkspaceActivator {
       return new EngineNoteProvider(engine);
     };
     if (!opts?.skipTreeView) {
-      await initTreeView({ context, providerConstructor, ext });
+      await initTreeView({ context, providerConstructor });
+      vscode.commands.executeCommand("dendron.treeView.focus");
     }
 
     // Add the current workspace to the recent workspace list. The current

--- a/yarn.lock
+++ b/yarn.lock
@@ -16934,10 +16934,10 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@^9.1.1:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.1.2.tgz#98cdc55603464240987fe1a15f68dd06304c07f1"
-  integrity sha512-RVf3hBKqiMfyORHboCaEjOAK1TomLO50hYRPvlTrZCXlCniM5pRpe8UlkHBjjpaLtioZnbdYv/vEVj7iKnwkJQ==
+mermaid@^9.1.2:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.1.3.tgz#15d08662c66250124ce31106a4620285061ac59c"
+  integrity sha512-jTIYiqKwsUXVCoxHUVkK8t0QN3zSKIdJlb9thT0J5jCnzXyc+gqTbZE2QmjRfavFTPPn5eRy5zaFp7V+6RhxYg==
   dependencies:
     "@braintree/sanitize-url" "^6.0.0"
     d3 "^7.0.0"


### PR DESCRIPTION
# fix(views): properly focus tree view to active note when it is first shown 

This PR:
- Forces a focus to the tree view panel once when the workspace is activated
- Fixes an issue where if the a note was already open, the tree view was not being focused to the active note that was open when the tree view was first turned visible

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)