### PR TITLE
fix(views): hide sidebar when clicking a non-submenu note on mobile

### DIFF
--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -34,7 +34,6 @@ export default function DendronTreeMenu(
   const tree = ide.tree;
   const logger = createLogger("DendronTreeMenu");
   const dendronRouter = useDendronRouter();
-  const { changeActiveNote } = dendronRouter;
   const [activeNoteIds, setActiveNoteIds] = useState<string[]>([]);
   const noteActiveId = _.isUndefined(dendronRouter.query.id)
     ? props.noteIndex?.id
@@ -73,13 +72,14 @@ export default function DendronTreeMenu(
   });
 
   // --- Methods
-  const onSelect = (noteId: string) => {
-    if (!props.noteIndex) {
-      return;
-    }
+  const onSubMenuSelect = (noteId: string) => {
+    logger.info({ ctx: "onSubMenuSelect", id: noteId });
     setCollapsed(true);
-    logger.info({ ctx: "onSelect", id: noteId });
-    changeActiveNote(noteId, { noteIndex: props.noteIndex });
+  };
+
+  const onMenuItemClick = (noteId: string) => {
+    logger.info({ ctx: "onMenuItemClick", id: noteId });
+    setCollapsed(true);
   };
 
   const onExpand = (noteId: string) => {
@@ -103,7 +103,8 @@ export default function DendronTreeMenu(
       {...props}
       roots={roots}
       expandKeys={expandKeys}
-      onSelect={onSelect}
+      onSubMenuSelect={onSubMenuSelect}
+      onMenuItemClick={onMenuItemClick}
       onExpand={onExpand}
       collapsed={collapsed}
       activeNote={noteActiveId}
@@ -114,7 +115,8 @@ export default function DendronTreeMenu(
 function MenuView({
   roots,
   expandKeys,
-  onSelect,
+  onSubMenuSelect,
+  onMenuItemClick,
   onExpand,
   collapsed,
   activeNote,
@@ -122,7 +124,8 @@ function MenuView({
 }: {
   roots: DataNode[];
   expandKeys: string[];
-  onSelect: (noteId: string) => void;
+  onSubMenuSelect: (noteId: string) => void;
+  onMenuItemClick: (noteId: string) => void;
   onExpand: (noteId: string) => void;
   collapsed: boolean;
   activeNote: string | undefined;
@@ -159,7 +162,7 @@ function MenuView({
             const target = event.domEvent.target as HTMLElement;
             const isArrow = target.dataset.expandedicon;
             if (!isArrow) {
-              onSelect(event.key);
+              onSubMenuSelect(event.key);
             } else {
               onExpand(event.key);
             }
@@ -196,6 +199,9 @@ function MenuView({
       inlineCollapsed={collapsed}
       // results in gray box otherwise when nav bar is too short for display
       style={{ height: "100%" }}
+      onClick={({ key }) => {
+        onMenuItemClick(key);
+      }}
     >
       {roots.map((menu) => {
         return createMenu(menu);


### PR DESCRIPTION
# About

The SubMenus were closing the sidebar when clicked, but the MenuItems were not.  AntD Menu Items don't have an `onClick` handler built in to them, but their parent `Menu` component does.  So I used that to handle closing the sidebar.

I've decided to create two separate events, even though they do the same thing, but I think that verbosity is good in the long term.

I was very confused by the `changeActiveNote(noteId, { noteIndex: props.noteIndex });` call on line 82.  It made me think that there was some handler somewhere doing something like that for the `MenuItem` click, but it turns out that AFAIK line 82 was extraneous.  Both sub menus and menu items handle their navigation via the `MenuItemTitle` component's `Link` at the bottom of the file.  So I deleted that confusing line.

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [x] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [x] display is correct for following browsers (across the various dimensions)
    - [x] safari
    - [x] firefox
    - [x] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)