### PR TITLE
enhance/improve write note old engine

### DIFF
--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -10,7 +10,7 @@ import {
   DNodeProps,
   DVault,
   EngineDeleteNotePayload,
-  EngineDeleteOptsV2,
+  EngineDeleteOpts,
   EngineInfoResp,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
@@ -138,7 +138,7 @@ export type EngineWriteRequest = {
 } & { ws: string };
 export type EngineDeleteRequest = {
   id: string;
-  opts?: EngineDeleteOptsV2;
+  opts?: EngineDeleteOpts;
 } & { ws: string };
 export type EngineBulkAddRequest = {
   opts: BulkWriteNotesOpts;
@@ -172,7 +172,7 @@ export type GetLinksRequest = {
 
 export type SchemaDeleteRequest = {
   id: string;
-  opts?: EngineDeleteOptsV2;
+  opts?: EngineDeleteOpts;
 } & Partial<WorkspaceRequest>;
 export type SchemaReadRequest = {
   id: string;

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -339,6 +339,12 @@ export class NoteUtils {
     wsRoot: string;
   }): NoteChangeEntry[] {
     const { note, noteDicts, createStubs, wsRoot } = opts;
+    const changed: NoteChangeEntry[] = [];
+
+    // Ignore if root note
+    if (DNodeUtils.isRoot(note)) {
+      return changed;
+    }
     const parentPath = DNodeUtils.dirName(note.fname).toLowerCase();
     const parent = NoteDictsUtils.findByFname(
       parentPath,
@@ -346,7 +352,6 @@ export class NoteUtils {
       note.vault
     )[0];
 
-    const changed: NoteChangeEntry[] = [];
     if (parent) {
       const prevParentState = { ...parent };
       DNodeUtils.addChild(parent, note);

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -324,14 +324,10 @@ export type EngineWriteOptsV2 = {
    */
   noAddParent?: boolean;
   /**
-   * Should update existing note instead of overwriting
-   */
-  updateExisting?: boolean;
-  /**
    * Should any configured hooks be run during the write
    */
   runHooks?: boolean;
-} & Partial<EngineUpdateNodesOptsV2>;
+};
 
 export type DEngineInitPayload = {
   notes: NotePropsByIdDict;

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -312,7 +312,6 @@ export type EngineUpdateNodesOptsV2 = {
    */
   newNode: boolean;
 };
-export type EngineDeleteOptsV2 = EngineDeleteOpts;
 export type EngineWriteOptsV2 = {
   /**
    * Write all children?
@@ -589,11 +588,11 @@ export type DEngine = DCommonProps &
     findNotesMeta: (opts: FindNoteOpts) => Promise<NotePropsMeta[]>;
     deleteNote: (
       id: string,
-      opts?: EngineDeleteOptsV2
+      opts?: EngineDeleteOpts
     ) => Promise<EngineDeleteNoteResp>;
     deleteSchema: (
       id: string,
-      opts?: EngineDeleteOptsV2
+      opts?: EngineDeleteOpts
     ) => Promise<DEngineDeleteSchemaResp>;
     info: () => Promise<RespV2<EngineInfoResp>>;
     sync: (opts?: DEngineSyncOpts) => Promise<DEngineInitResp>;
@@ -656,11 +655,11 @@ export type DStore = DCommonProps &
     findNotes: (opts: FindNoteOpts) => Promise<NoteProps[]>;
     deleteNote: (
       id: string,
-      opts?: EngineDeleteOptsV2
+      opts?: EngineDeleteOpts
     ) => Promise<StoreDeleteNoteResp>;
     deleteSchema: (
       id: string,
-      opts?: EngineDeleteOptsV2
+      opts?: EngineDeleteOpts
     ) => Promise<DEngineDeleteSchemaResp>;
     renameNote: (opts: RenameNoteOpts) => Promise<RenameNotePayload>;
   };
@@ -679,11 +678,11 @@ export type DEngineV4Methods = {
   init: () => Promise<DEngineInitResp>;
   deleteNote: (
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ) => Promise<EngineDeleteNoteResp>;
   deleteSchema: (
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ) => Promise<DEngineDeleteSchemaResp>;
   sync: (opts?: DEngineSyncOpts) => Promise<DEngineInitResp>;
 

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -315,9 +315,7 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             // If note exists and its a stub note, delete stub and create new note
             if (note.stub) {
               delete note.stub;
-              const resp = await engine.writeNote(note, {
-                updateExisting: true,
-              });
+              const resp = await engine.writeNote(note);
               if (resp.error) {
                 return {
                   error: ErrorFactory.createInvalidStateError({

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -325,7 +325,7 @@ export class DoctorService implements Disposable {
             .process(note.body);
           note.body = newBody.toString();
           if (!_.isEmpty(changes)) {
-            await engineWrite(note, { updateExisting: true });
+            await engineWrite(note);
             this.L.info({ msg: `changes ${note.fname}`, changes });
             numChanges += 1;
             return;
@@ -355,7 +355,7 @@ export class DoctorService implements Disposable {
             .process(note.body);
           note.body = newBody.toString();
           if (!_.isEmpty(changes)) {
-            await engineWrite(note, { updateExisting: true });
+            await engineWrite(note);
             this.L.info({ msg: `changes ${note.fname}`, changes });
             numChanges += 1;
             return;
@@ -402,8 +402,6 @@ export class DoctorService implements Disposable {
           note.id = genUUID();
           await engine.writeNote(note, {
             runHooks: false,
-            // Old note needs to be removed
-            updateExisting: false,
           });
           numChanges += 1;
         };
@@ -584,7 +582,7 @@ export class DoctorService implements Disposable {
             custom: { ...note.custom, pods },
           };
           // update note
-          await engine.writeNote(updatedNote, { updateExisting: true });
+          await engine.writeNote(updatedNote);
         };
         break;
       }

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -319,7 +319,7 @@ export class FileStorage implements DStore {
           notesById: this.notes,
           notesByFname: this.noteFnames,
         });
-        const changed = await this.writeNote(replacingStub, { newNode: true });
+        const changed = await this.writeNote(replacingStub);
         out.push({ note: noteToDelete, status: "delete" });
 
         if (changed.data) {
@@ -959,7 +959,6 @@ export class FileStorage implements DStore {
       return (
         await this.bulkWriteNotes({
           notes: notesChangedEntries.map((ent) => ent.note),
-          opts: { updateExisting: true },
         })
       ).data;
     }
@@ -997,7 +996,7 @@ export class FileStorage implements DStore {
       // but we don't want that in this case. we need to add the old note's children back in
       newNote.children = oldNote.children;
 
-      const out = await this.writeNote(newNote, { updateExisting: true });
+      const out = await this.writeNote(newNote);
       changeFromWrite = out.data;
     } else {
       // The file is being renamed to a new file.
@@ -1024,14 +1023,13 @@ export class FileStorage implements DStore {
         msg: "writeNewNote:pre",
         note: NoteUtils.toLogObj(newNote),
       });
-      const out = await this.writeNote(newNote, { newNode: true });
+      const out = await this.writeNote(newNote);
       changeFromWrite = out.data;
     }
     this.logger.info({ ctx, msg: "updateAllNotes:pre" });
     // update all new notes
     await this.bulkWriteNotes({
       notes: notesChangedEntries.map((ent) => ent.note),
-      opts: { updateExisting: true },
     });
     if (deleteOldFile) fs.removeSync(oldLocPath);
 

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -15,7 +15,7 @@ import {
   DStore,
   DVault,
   EngineDeleteNotePayload,
-  EngineDeleteOptsV2,
+  EngineDeleteOpts,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
   error2PlainObject,
@@ -228,7 +228,7 @@ export class FileStorage implements DStore {
   /**
    *
    * @param id id of note to be deleted
-   * @param opts EngineDeleteOptsV2 the flag `replaceWithNewStub` is used
+   * @param opts EngineDeleteOpts the flag `replaceWithNewStub` is used
    *             for a specific case where this method is called from
    *             `renameNote`. TODO: remove this flag so that this is handled
    *             automatically.
@@ -236,7 +236,7 @@ export class FileStorage implements DStore {
    */
   async deleteNote(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): Promise<StoreDeleteNoteResp> {
     const ctx = "deleteNote";
     if (id === "root") {
@@ -389,7 +389,7 @@ export class FileStorage implements DStore {
 
   async deleteSchema(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): Promise<DEngineDeleteSchemaResp> {
     const ctx = "deleteSchema";
     this.logger.info({ ctx, msg: "enter", id });
@@ -1108,7 +1108,9 @@ export class FileStorage implements DStore {
   }
 
   /**
-   * Write a new note. Also take care of updating logic of parents and children if new note replaces an existing note
+   * Write a new note. Also take care of updating logic of parents and children if new note replaces an existing note that has a different id.
+   * If the existing and new note have the same id, then do nothing.
+   *
    * @param param0
    * @returns - Changed Entries
    */
@@ -1133,10 +1135,12 @@ export class FileStorage implements DStore {
       notesById: this.notes,
       notesByFname: this.noteFnames,
     };
+    const isSameNote = existingNote ? existingNote.id === note.id : false;
+
     // in this case, we are deleting the old note and writing a new note in its place with the same hierarchy
     // the parent of this note needs to have the old note removed (because the id is now different)
     // the new note needs to have the old note's children
-    if (existingNote) {
+    if (existingNote && !isSameNote) {
       // make sure existing note actually has a parent.
       if (!existingNote.parent) {
         // TODO: We should be able to handle rewriting of root. This happens
@@ -1184,6 +1188,8 @@ export class FileStorage implements DStore {
           status: "update",
         });
       });
+
+      changed.push({ note: existingNote, status: "delete" });
     }
     // check if we need to add parents
     // eg. if user created `baz.one.two` and neither `baz` or `baz.one` exist, then they need to be created
@@ -1232,22 +1238,12 @@ export class FileStorage implements DStore {
       maybeNoteId: _.pick(maybeNote || {}, ["id", "stub"]),
     });
 
-    // don't count as delete if we're updating existing note
-    // we need to preserve the ids, otherwise can result in data conflict
-    let noDelete = false;
-    if (maybeNote?.stub || opts?.updateExisting) {
-      note = { ...maybeNote, ...note };
-      note = _.omit(note, "stub");
-      if (opts?.updateExisting) noDelete = true;
-    }
-
-    if (!opts?.updateExisting) {
-      changedEntries = await this._writeNewNote({
-        note,
-        existingNote: maybeNote,
-        opts,
-      });
-    }
+    // Override existing note if ids are different
+    changedEntries = await this._writeNewNote({
+      note,
+      existingNote: maybeNote,
+      opts,
+    });
 
     // add schema if applicable
     const schemaMatch = SchemaUtils.matchPath({
@@ -1336,9 +1332,6 @@ export class FileStorage implements DStore {
         .map((ent) => this.updateNote(ent))
     );
 
-    if (maybeNote && !noDelete) {
-      changedEntries.push({ note: maybeNote, status: "delete" });
-    }
     changedEntries.push({ note, status: "create" });
     this.logger.info({
       ctx,

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -487,13 +487,9 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
       opts,
       ws: this.ws,
     });
-    let changed = resp.data;
+    const changed = resp.data;
     if (resp.error) {
       return resp;
-    }
-    // we are updating in place, remove deletes
-    if (opts?.updateExisting) {
-      changed = _.reject(changed, (ent) => ent.status === "delete");
     }
 
     if (changed) {

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -14,7 +14,7 @@ import {
   DLink,
   DVault,
   EngineDeleteNoteResp,
-  EngineDeleteOptsV2,
+  EngineDeleteOpts,
   EngineInfoResp,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
@@ -260,7 +260,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
 
   async deleteNote(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): Promise<EngineDeleteNoteResp> {
     const ws = this.ws;
     const resp = await this.api.engineDelete({ id, opts, ws });
@@ -284,7 +284,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
 
   async deleteSchema(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): Promise<DEngineDeleteSchemaResp> {
     const ws = this.ws;
     const resp = await this.api.schemaDelete({ id, opts, ws });

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -17,7 +17,7 @@ import {
   DNodeType,
   DStore,
   DVault,
-  EngineDeleteOptsV2,
+  EngineDeleteOpts,
   EngineInfoResp,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
@@ -370,7 +370,7 @@ export class DendronEngineV2 implements DEngine {
 
   async deleteNote(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): ReturnType<DEngineClient["deleteNote"]> {
     try {
       const note = this.notes[id];
@@ -396,7 +396,7 @@ export class DendronEngineV2 implements DEngine {
 
   async deleteSchema(
     id: string,
-    opts?: EngineDeleteOptsV2
+    opts?: EngineDeleteOpts
   ): Promise<DEngineDeleteSchemaResp> {
     try {
       const data = (await this.store.deleteSchema(

--- a/packages/engine-test-utils/src/__tests__/engine-server/topics/hooks.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/topics/hooks.spec.ts
@@ -50,7 +50,7 @@ const writeNote = async ({
   engine: DEngineClient;
 }) => {
   const note = NoteUtils.create(noteOpts);
-  await engine.writeNote(note, { newNode: true });
+  await engine.writeNote(note);
   const out = engine.notes[note.id];
   return { note: out };
 };
@@ -86,7 +86,7 @@ describe("engine", () => {
         body: "hooked body",
         vault,
       });
-      await engine.writeNote(note, { newNode: true });
+      await engine.writeNote(note);
       const ent = engine.notes["hooked"];
       expect(
         await AssertUtils.assertInString({
@@ -129,7 +129,7 @@ describe("engine", () => {
         body: "hooked body",
         vault,
       });
-      await engine.writeNote(note, { newNode: true });
+      await engine.writeNote(note);
       const ent = engine.notes["hooked"];
       expect(
         await AssertUtils.assertInString({
@@ -178,7 +178,7 @@ describe("engine", () => {
         body: "hooked body",
         vault,
       });
-      await engine.writeNote(note, { newNode: true });
+      await engine.writeNote(note);
       const ent = engine.notes["hooked"];
       expect(
         await AssertUtils.assertInString({
@@ -224,7 +224,7 @@ describe("engine", () => {
         body: "hooked body",
         vault,
       });
-      await engine.writeNote(note, { newNode: true });
+      await engine.writeNote(note);
       const ent = engine.notes["hooked"];
       expect(
         await AssertUtils.assertInString({
@@ -326,7 +326,7 @@ describe("engine", () => {
           body: "hooked body",
           vault,
         });
-        await engine.writeNote(note, { newNode: true, runHooks: false });
+        await engine.writeNote(note, { runHooks: false });
         const ent = engine.notes["hooked"];
         expect(
           await AssertUtils.assertInString({
@@ -407,7 +407,7 @@ describe("remote engine", () => {
           body: "hooked body",
           vault,
         });
-        const resp = await engine.writeNote(note, { newNode: true });
+        const resp = await engine.writeNote(note);
         expect(
           resp.error!.message.startsWith("NoteProps is undefined")
         ).toBeTruthy();

--- a/packages/engine-test-utils/src/__tests__/pods-core/GDocPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GDocPod.spec.ts
@@ -205,7 +205,7 @@ describe("GDoc import pod", () => {
         const mockedAxios = axios as jest.Mocked<typeof axios>;
         result = response;
         pod.getAllDocuments = jest.fn().mockReturnValue({ docIdsHashMap });
-        await engine.writeNote(existingNote, { newNode: true });
+        await engine.writeNote(existingNote);
         mockedAxios.get.mockResolvedValue(result);
         await pod.execute({
           engine,
@@ -243,7 +243,7 @@ describe("GDoc import pod", () => {
         result = response;
         existingNote.custom.revisionId = "jslkdhsal";
         pod.getAllDocuments = jest.fn().mockReturnValue({ docIdsHashMap });
-        await engine.writeNote(existingNote, { newNode: true });
+        await engine.writeNote(existingNote);
         mockedAxios.get.mockResolvedValue(result);
         stubWindow(undefined);
         const { importedNotes } = await pod.execute({
@@ -278,7 +278,7 @@ describe("GDoc import pod", () => {
         result = response;
         existingNote.custom.revisionId = "jslkdhsa";
         pod.getAllDocuments = jest.fn().mockReturnValue({ docIdsHashMap });
-        await engine.writeNote(existingNote, { newNode: true });
+        await engine.writeNote(existingNote);
         mockedAxios.get.mockResolvedValue(result);
         const resp = {
           title: "Yes",

--- a/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
@@ -220,7 +220,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             throw new Error("No root note found.");
           }
           issue.parent = rootNote.id;
-          await engine.writeNote(issue, { newNode: true });
+          await engine.writeNote(issue);
           const resp = await pod.execute({
             engine,
             vaults,
@@ -259,7 +259,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             throw new Error("No root note found.");
           }
           scratchIssue.parent = rootNote.id;
-          await engine.writeNote(scratchIssue, { newNode: true });
+          await engine.writeNote(scratchIssue);
           const resp = await pod.execute({
             engine,
             vaults,
@@ -304,7 +304,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
           }
           scratchIssue.parent = rootNote.id;
           scratchIssue.custom = {};
-          await engine.writeNote(scratchIssue, { newNode: true });
+          await engine.writeNote(scratchIssue);
           const resp = await pod.execute({
             engine,
             vaults,
@@ -347,7 +347,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             throw new Error("No root note found.");
           }
           issue.parent = rootNote.id;
-          await engine.writeNote(issue, { newNode: true });
+          await engine.writeNote(issue);
           const resp = await pod.execute({
             engine,
             vaults,
@@ -389,7 +389,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             throw new Error("No root note found.");
           }
           issue.parent = rootNote.id;
-          await engine.writeNote(issue, { newNode: true });
+          await engine.writeNote(issue);
           const resp = await pod.execute({
             engine,
             vaults,
@@ -432,7 +432,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             throw new Error("No root note found.");
           }
           issue.parent = rootNote.id;
-          await engine.writeNote(issue, { newNode: true });
+          await engine.writeNote(issue);
           const resp = await pod.execute({
             engine,
             vaults,

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -164,7 +164,7 @@ const NOTES = {
         })
       )[0];
       note.custom = { bond: 43 };
-      await engine.writeNote(note, { updateExisting: true });
+      await engine.writeNote(note);
       const newNote = (
         await engine.findNotes({
           fname: "foo",

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -632,7 +632,6 @@ const NOTES_MULTI = {
       const fooNote = await engine.getNote("foo");
       const fooUpdated = { ...fooNote! };
       fooUpdated.body = "updatedBody";
-      debugger;
       const changes = await engine.writeNote(fooUpdated);
       const createEntries = extractNoteChangeEntriesByType(
         changes.data!,

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -627,6 +627,60 @@ const NOTES_MULTI = {
       preSetupHook: setupBasic,
     }
   ),
+  BODY_UPDATED: new TestPresetEntryV4(
+    async ({ engine }) => {
+      const fooNote = await engine.getNote("foo");
+      const fooUpdated = { ...fooNote! };
+      fooUpdated.body = "updatedBody";
+      debugger;
+      const changes = await engine.writeNote(fooUpdated);
+      const createEntries = extractNoteChangeEntriesByType(
+        changes.data!,
+        "create"
+      );
+
+      const deleteEntries = extractNoteChangeEntriesByType(
+        changes.data!,
+        "delete"
+      );
+
+      const updateEntries = extractNoteChangeEntriesByType(
+        changes.data!,
+        "update"
+      ) as NoteChangeUpdateEntry[];
+
+      return [
+        {
+          actual: updateEntries.length,
+          expected: 0,
+          msg: "0 updates should happen.",
+        },
+        {
+          actual: deleteEntries.length,
+          expected: 0,
+          msg: "0 delete should happen.",
+        },
+        {
+          actual: createEntries.length,
+          expected: 1,
+          msg: "1 create should happen.",
+        },
+        {
+          actual: createEntries[0].note.fname,
+          expected: "foo",
+          msg: "foo note is created.",
+        },
+        {
+          actual: createEntries[0].note.body,
+          expected: "updatedBody",
+          msg: "created foo note's body is updatedBody",
+        },
+      ];
+    },
+    {
+      preSetupHook: setupBasic,
+    }
+  ),
 };
 
 export const ENGINE_WRITE_PRESETS = {

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -461,7 +461,7 @@ export class WorkspaceWatcher {
         noteHydrated: engine.notes[noteRaw.id],
       });
       newNote.title = NoteUtils.genTitle(fname);
-      await engine.writeNote(newNote, { updateExisting: true });
+      await engine.writeNote(newNote);
     } catch (error: any) {
       Sentry.captureException(error);
       throw error;

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -316,7 +316,7 @@ export class GotoNoteCommand extends BasicCommand<
           if (note.stub) {
             delete note.stub;
             note = _.merge(note, overrides || {});
-            await client.writeNote(note, { updateExisting: true });
+            await client.writeNote(note);
           }
         }
 

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -313,9 +313,7 @@ export class MoveHeaderCommand extends BasicCommand<
 
     // add the stringified blocks to destination note body
     dest.body = `${dest.body}\n\n${destContentToAppend}`;
-    await engine.writeNote(dest, {
-      updateExisting: true,
-    });
+    await engine.writeNote(dest);
   }
 
   /**
@@ -548,9 +546,7 @@ export class MoveHeaderCommand extends BasicCommand<
           dest,
         });
         note!.body = modifiedNote.body;
-        const writeResp = await engine.writeNote(note!, {
-          updateExisting: true,
-        });
+        const writeResp = await engine.writeNote(note!);
         if (writeResp.data) {
           noteChangeEntries = noteChangeEntries.concat(writeResp.data);
         }
@@ -590,9 +586,7 @@ export class MoveHeaderCommand extends BasicCommand<
 
     origin.body = modifiedOriginContent;
 
-    await engine.writeNote(origin, {
-      updateExisting: true,
-    });
+    await engine.writeNote(origin);
 
     return modifiedOriginContent;
   }

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -552,9 +552,7 @@ export class NoteLookupCommand
       const nodeModified = await picker.onCreate(nodeNew);
       if (nodeModified) nodeNew = nodeModified;
     }
-    const resp = await engine.writeNote(nodeNew, {
-      newNode: true,
-    });
+    const resp = await engine.writeNote(nodeNew);
     if (resp.error) {
       Logger.error({ ctx, error: resp.error });
       return;

--- a/packages/plugin-core/src/commands/TaskStatus.ts
+++ b/packages/plugin-core/src/commands/TaskStatus.ts
@@ -155,7 +155,7 @@ export class TaskStatusCommand extends BasicCommand<
       status: opts.setStatus,
     };
 
-    await this._ext.getEngine().writeNote(opts.note, { updateExisting: true });
+    await this._ext.getEngine().writeNote(opts.note);
 
     delayedUpdateDecorations();
 

--- a/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
@@ -82,7 +82,7 @@ suite("AirtableExportCommand", function () {
               },
             },
           };
-          await engine.writeNote(note, { updateExisting: true });
+          await engine.writeNote(note);
           const payload = await cmd.enrichInputs(config);
           const airtableId = "airtable-proj.beta";
           const DendronId = note.id;

--- a/packages/pods-core/src/builtin/AirtablePod.ts
+++ b/packages/pods-core/src/builtin/AirtablePod.ts
@@ -462,9 +462,7 @@ export class AirtableUtils {
           ...note,
           custom: { ...note.custom, pods },
         };
-        const out = await engine.writeNote(updatedNote, {
-          updateExisting: true,
-        });
+        const out = await engine.writeNote(updatedNote);
         return out;
       })
     );

--- a/packages/pods-core/src/builtin/GDocPod.ts
+++ b/packages/pods-core/src/builtin/GDocPod.ts
@@ -361,18 +361,18 @@ export class GDocImportPod extends ImportPod<GDocImportPodConfig> {
           const resp = await onPrompt(PROMPT.USERPROMPT);
 
           if (resp?.title.toLowerCase() === "yes") {
-            await engine.writeNote(existingNote, { newNode: true });
+            await engine.writeNote(existingNote);
             return existingNote;
           }
         } else {
-          await engine.writeNote(existingNote, { newNode: true });
+          await engine.writeNote(existingNote);
           return existingNote;
         }
       } else if (onPrompt) {
         onPrompt();
       }
     } else {
-      await engine.writeNote(note, { newNode: true });
+      await engine.writeNote(note);
       return note;
     }
     return undefined;

--- a/packages/pods-core/src/builtin/GithubIssuePod.ts
+++ b/packages/pods-core/src/builtin/GithubIssuePod.ts
@@ -289,7 +289,7 @@ export class GithubIssueImportPod extends ImportPod<GithubIssueImportPodConfig> 
         n.custom.status = note.custom.status;
         n.custom.issueID = note.custom.issueID;
         updatedNotes = [...updatedNotes, n];
-        await engine.writeNote(n, { newNode: true });
+        await engine.writeNote(n);
       }
     });
     return updatedNotes;
@@ -707,7 +707,7 @@ export class GithubIssuePublishPod extends PublishPod<GithubIssuePublishPodConfi
         note.custom.issueID = issue.id;
         note.custom.url = issue.url;
         note.custom.status = issue.state;
-        await engine.writeNote(note, { updateExisting: true });
+        await engine.writeNote(note);
         showMessage.info(GITHUBMESSAGE.ISSUE_CREATED);
         resp = issue.url;
       }
@@ -775,7 +775,7 @@ export class GithubIssuePublishPod extends PublishPod<GithubIssuePublishPodConfi
         note.custom.discussionID = discussion.id;
         note.custom.url = discussion.url;
         note.custom.author = discussion.author.url;
-        await engine.writeNote(note, { updateExisting: true });
+        await engine.writeNote(note);
         showMessage.info(GITHUBMESSAGE.DISCUSSION_CREATED);
         resp = discussion.url;
       }

--- a/packages/pods-core/src/builtin/JSONPod.ts
+++ b/packages/pods-core/src/builtin/JSONPod.ts
@@ -43,9 +43,7 @@ export class JSONImportPod extends ImportPod {
       destName,
       concatenate,
     });
-    await Promise.all(
-      _.map(notes, (n) => engine.writeNote(n, { newNode: true }))
-    );
+    await Promise.all(_.map(notes, (n) => engine.writeNote(n)));
     return { importedNotes: notes };
   }
 

--- a/packages/pods-core/src/builtin/OrbitPod.ts
+++ b/packages/pods-core/src/builtin/OrbitPod.ts
@@ -253,7 +253,7 @@ export class OrbitImportPod extends ImportPod<OrbitImportPodConfig> {
       }
     });
     if (shouldUpdate) {
-      await engine.writeNote(note, { updateExisting: true });
+      await engine.writeNote(note);
     }
   };
 
@@ -281,9 +281,7 @@ export class OrbitImportPod extends ImportPod<OrbitImportPodConfig> {
     switch (resp) {
       case MergeConflictOptions.OVERWRITE_LOCAL: {
         conflict.conflictEntry.fname = conflict.conflictNote.fname;
-        await engine.writeNote(conflict.conflictEntry, {
-          updateExisting: true,
-        });
+        await engine.writeNote(conflict.conflictEntry);
         break;
       }
       case MergeConflictOptions.SKIP:

--- a/packages/pods-core/src/v2/pods/export/GoogleDocsExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/GoogleDocsExportPodV2.ts
@@ -349,7 +349,7 @@ export class GoogleDocsUtils {
           revisionId,
           uri: `https://docs.google.com/document/d/${documentId}/edit`,
         };
-        await engine.writeNote(note, { updateExisting: true });
+        await engine.writeNote(note);
       })
     );
   }

--- a/packages/pods-core/src/v2/pods/export/NotionExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/NotionExportPodV2.ts
@@ -161,7 +161,7 @@ export class NotionUtils {
           ...note.custom,
           notionId,
         };
-        await engine.writeNote(note, { updateExisting: true });
+        await engine.writeNote(note);
       })
     );
   };


### PR DESCRIPTION
**Changes**
- Updated logic in writeNote so that parent/children rewriting only happens if the new note and existing note have different ids. Currently, writing a note with any other update causes extra updates that are not necessary
- Will no longer depend on clients passing `updateExisting` and `newNode` 
- Minor cleanup of codebase

TODO:
- We currently return a `create` entry for every write note call. This should be changed to update for certain situations. Leaving as is for test compatibility. Will change on my engine refactor