### PR TITLE
enhance(publish): use note's `desc`field for SEO description

### DIFF
--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -244,6 +244,7 @@ export type SEOProps = {
   updated: number;
   created: number;
   excerpt?: string;
+  description?: string;
   image?: DNodeImage;
   /**
    * Use as root canonical url for all published notes

--- a/packages/common-all/src/utils/publishUtils.ts
+++ b/packages/common-all/src/utils/publishUtils.ts
@@ -22,31 +22,25 @@ export class PublishUtils {
     config: IntermediateDendronConfig
   ): Partial<SEOProps> {
     if (configIsV4(config)) {
-      const {
-        title,
-        twitter,
-        description: excerpt,
-        image,
-      } = ConfigUtils.getSite(config) as DendronSiteConfig;
-      return { title, twitter, excerpt, image };
+      const { title, twitter, description, image } = ConfigUtils.getSite(
+        config
+      ) as DendronSiteConfig;
+      return { title, twitter, description, image };
     } else {
-      const {
-        title,
-        twitter,
-        description: excerpt,
-        image,
-      } = ConfigUtils.getPublishing(config).seo;
-      return { title, twitter, excerpt, image };
+      const { title, twitter, description, image } =
+        ConfigUtils.getPublishing(config).seo;
+      return { title, twitter, description, image };
     }
   }
 
   static getSEOPropsFromNote(note: NoteProps): SEOProps {
-    const { title, created, updated, image } = note;
+    const { title, created, updated, image, desc } = note;
     const { excerpt, canonicalUrl, noindex, canonicalBaseUrl, twitter } =
       note.custom ? note.custom : ({} as any);
     return {
       title,
       excerpt,
+      description: desc || undefined,
       updated,
       created,
       canonicalBaseUrl,

--- a/packages/common-all/src/utils/publishUtils.ts
+++ b/packages/common-all/src/utils/publishUtils.ts
@@ -40,7 +40,7 @@ export class PublishUtils {
     return {
       title,
       excerpt,
-      description: desc || excerpt || undefined,
+      description: excerpt || desc || undefined,
       updated,
       created,
       canonicalBaseUrl,

--- a/packages/common-all/src/utils/publishUtils.ts
+++ b/packages/common-all/src/utils/publishUtils.ts
@@ -40,7 +40,7 @@ export class PublishUtils {
     return {
       title,
       excerpt,
-      description: desc || undefined,
+      description: desc || excerpt || undefined,
       updated,
       created,
       canonicalBaseUrl,

--- a/packages/nextjs-template/components/DendronSEO.tsx
+++ b/packages/nextjs-template/components/DendronSEO.tsx
@@ -69,7 +69,7 @@ export default function DendronSEO({
   const cleanSeoProps: SEOProps = _.defaults(noteSeoProps, siteSeoProps);
 
   const title = cleanSeoProps.title;
-  const description = cleanSeoProps.description || cleanSeoProps.excerpt;
+  const description = cleanSeoProps.description;
   const images = cleanSeoProps?.image ? [cleanSeoProps.image] : [];
   const publishingConfig = ConfigUtils.getPublishingConfig(config);
   const canonical = getCanonicalUrl({

--- a/packages/nextjs-template/components/DendronSEO.tsx
+++ b/packages/nextjs-template/components/DendronSEO.tsx
@@ -69,7 +69,7 @@ export default function DendronSEO({
   const cleanSeoProps: SEOProps = _.defaults(noteSeoProps, siteSeoProps);
 
   const title = cleanSeoProps.title;
-  const description = cleanSeoProps.excerpt;
+  const description = cleanSeoProps.description || cleanSeoProps.excerpt;
   const images = cleanSeoProps?.image ? [cleanSeoProps.image] : [];
   const publishingConfig = ConfigUtils.getPublishingConfig(config);
   const canonical = getCanonicalUrl({


### PR DESCRIPTION
docs: 
- [[seo description should be generated from `desc` field of note if available|task.2022.07.17.seo-description-should-be-generated-from-desc-field-of-note-if-available]]
- https://github.com/dendronhq/dendron/issues/1596

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.