### PR TITLE
chore(internal): fix timeout on some tests

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -336,6 +336,7 @@ export async function _activate(
         wsRoot: maybeWsRoot,
         engine: resp.data.engine,
         wsService,
+        opts,
       });
       if (respActivate.error) {
         return false;

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -95,6 +95,7 @@ suite("CopyNoteRef", function () {
               });
             },
             preActivateHook: postSetupHook,
+            timeout: 5e3,
           },
           () => {
             test("THEN generate note ref", async () => {
@@ -172,6 +173,7 @@ suite("CopyNoteRef", function () {
               });
             },
             preActivateHook: postSetupHook,
+            timeout: 5e3,
           },
           () => {
             test("THEN generate note ref", async () => {

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -257,6 +257,7 @@ suite("CopyNoteRef", function () {
       "AND WHEN reference entire note",
       {
         preSetupHook: ENGINE_HOOKS.setupBasic,
+        timeout: 5e3,
       },
       () => {
         test("THEN generate note to note", async () => {

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -148,6 +148,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
     "AND when cancelled",
     {
       postSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout: 5e3,
     },
     () => {
       test("THEN create no notes", async () => {
@@ -195,6 +196,7 @@ suite("CREATE_MISSING_LINKED_NOTES", function () {
     "GIVEN broken link with alias",
     {
       postSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout: 5e3,
     },
     () => {
       test("THEN fix link", async () => {


### PR DESCRIPTION
# chore(internal): fix timeout on some tests

This PR:
- Fix timeout issue on some long running tests that commonly fail during the pipeline.
- This should resolve the recent issue with the plugin test that fails for mac in CI.
