### PR TITLE
chore(internal): Fix bug where note is not properly deleted via writeNote

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -52,7 +52,7 @@ import { NoteDictsUtils } from "./noteDictsUtils";
  * Utilities for dealing with nodes
  */
 export class DNodeUtils {
-  static addChild(parent: DNodeProps, child: DNodeProps) {
+  static addChild(parent: NotePropsMeta, child: NotePropsMeta) {
     parent.children = Array.from(new Set(parent.children).add(child.id));
     child.parent = parent.id;
   }
@@ -300,18 +300,10 @@ export class NoteUtils {
 
   static deleteChildFromParent(opts: {
     childToDelete: NoteProps;
-    notes: NotePropsByIdDict;
+    parent: NoteProps;
   }): NoteChangeEntry[] {
     const changed: NoteChangeEntry[] = [];
-    const { childToDelete, notes } = opts;
-    let parent;
-    if (childToDelete.parent) {
-      parent = notes[childToDelete.parent];
-    } else {
-      throw new DendronError({
-        message: `No parent found for ${childToDelete.fname}`,
-      });
-    }
+    const { childToDelete, parent } = opts;
 
     const prevParentState = { ...parent };
     parent.children = _.reject<string[]>(

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -2,7 +2,6 @@ import {
   CONSTANTS,
   DNodeUtils,
   NoteChangeUpdateEntry,
-  NoteProps,
   NoteUtils,
   SchemaUtils,
   extractNoteChangeEntriesByType,
@@ -127,11 +126,12 @@ const NOTES = {
       noWrite: true,
     });
     await engine.writeNote(note);
-    const noteRoot = NoteUtils.getNoteByFnameFromEngine({
-      fname: note.fname,
-      engine,
-      vault,
-    }) as NoteProps;
+    const noteRoot = (
+      await engine.findNotes({
+        fname: note.fname,
+        vault,
+      })
+    )[0];
     await engine.init();
     return [
       {
@@ -280,7 +280,7 @@ const NOTES = {
       })
     )[0];
     const bar = (
-      await engine.findNotes({
+      await engine.findNotesMeta({
         fname: "bar",
         vault,
       })
@@ -554,6 +554,9 @@ const NOTES_MULTI = {
       const fooUpdated = { ...fooNote! };
       fooUpdated.id = "updatedID";
       const changes = await engine.writeNote(fooUpdated);
+
+      const deletedFooNote = await engine.getNote("foo");
+      const newFooNote = await engine.getNote("updatedID");
       const createEntries = extractNoteChangeEntriesByType(
         changes.data!,
         "create"
@@ -621,6 +624,16 @@ const NOTES_MULTI = {
           expected: "updatedID",
           msg: "updated child's parent should be updatedID.",
         },
+        {
+          actual: deletedFooNote,
+          expected: undefined,
+          msg: "Foo should be deleted",
+        },
+        {
+          actual: newFooNote?.id,
+          expected: "updatedID",
+          msg: "New Foo should be created",
+        },
       ];
     },
     {
@@ -651,8 +664,8 @@ const NOTES_MULTI = {
       return [
         {
           actual: updateEntries.length,
-          expected: 0,
-          msg: "0 updates should happen.",
+          expected: 1,
+          msg: "1 update should happen.",
         },
         {
           actual: deleteEntries.length,
@@ -661,18 +674,18 @@ const NOTES_MULTI = {
         },
         {
           actual: createEntries.length,
-          expected: 1,
-          msg: "1 create should happen.",
+          expected: 0,
+          msg: "0 creates should happen.",
         },
         {
-          actual: createEntries[0].note.fname,
+          actual: updateEntries[0].note.fname,
           expected: "foo",
-          msg: "foo note is created.",
+          msg: "foo note is updated.",
         },
         {
-          actual: createEntries[0].note.body,
+          actual: updateEntries[0].note.body,
           expected: "updatedBody",
-          msg: "created foo note's body is updatedBody",
+          msg: "updated foo note's body is updatedBody",
         },
       ];
     },

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -91,7 +91,9 @@ suite("RenameNote", function () {
         const updateResps = out!.data?.filter((resp) => {
           return resp.status === "update";
         });
-        expect(updateResps?.length).toEqual(0);
+        // Only target note should be updated
+        expect(updateResps?.length).toEqual(1);
+        expect(updateResps![0].note.fname).toEqual("target");
       });
     }
   );


### PR DESCRIPTION
**Bug**
When `engine.writeNote` is called and the id is different, the intended behavior is to delete the old note with the old id and create a new note with the new id. Currently there is a out-of-sync issue where the engine retains the old note b/c we forgot to filter out the `delete` entries from changeEntries.