### PR TITLE
fix typos and enhance tutorial

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-skip-welcome/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-skip-welcome/tutorial.md
@@ -1,69 +1,73 @@
 ---
 id: c1bs7wsjfbhb0zipaywqins
-title: Quickstart
+title: Tutorial
 desc: ""
-updated: 1658180875356
+updated: 1658342369402
 created: 1654223767390
 currentStep: 0
 totalSteps: 0
 ---
 
-Welcome to Dendron! Dendron is a developer-focused knowledge base that helps you manage information using flexible hierarchies!
+Welcome to Dendron! Dendron is a developer-focused knowledge base that helps you manage information using **flexible hierarchies**!
 
 You are currently in the tutorial vault (a vault is the folder where your notes are stored). Feel free to edit this note and create new files as you go through the quickstart!
 
 ## Create a Note
 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt
-1. Type 'dendron' and press `<ENTER>`
-1. Congrats, you just created your first note!
+1. Type `dendron` and select `Create New`
+
+- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<ALT>-<TAB>/<WINDOW>-<TAB>` to come back to this note
+
+You just created your first note!
 
 - > NOTE: Notes in Dendron are just plain text markdown with some [frontmatter](https://wiki.dendron.so/notes/ffec2853-c0e0-4165-a368-339db12c8e4b) on the top. You can edit them in Dendron or using ~~vim~~ your favourite text editor.
 
 ## Find a Note
 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt again
-1. Backspace over the current result and type `tutorial` and press `<ENTER>`
+1. Type `dendron` and press `<ENTER>`
 
 - > TIP: you don't have to type out the entire query, press `<TAB>` to autocomplete
 
-1. You just `looked up` a note!
+You just `looked up` a note!
 
 - > NOTE: in Dendron, you can find or create notes using the lookup prompt
 
 ## Organize your Notes
 
 1. Bring up the lookup prompt again
-1. Use the `<RIGHT-ARROW>` key to navigate to the end of the current text cursor and type `.one`. Then press `<ENTER>`
-1. You just created your first hierarchy!
+1. Type `tutorial.one`
+
+You just created your first hierarchy!
 
 - > NOTE: hierarchies in Dendron are just `.` delimited files. This makes each note both a file and a folder and makes it easy to keep your notes organized
 
-- > TIP: You can use the [Dendron Tree View](https://wiki.dendron.so/notes/hur7r6gr3kqa56s2vme986j) to view your hierarchy. If it's not currently in focus, you can use `CTRL+P`/`CMD+P` to open the command prompt and type in `dendron: focus on tree view` to make it appear
+- > TIP: You can use the [Dendron Tree View](https://wiki.dendron.so/notes/hur7r6gr3kqa56s2vme986j) to view your hierarchy. If it's not currently in focus, you can use `CTRL+SHIFT+P`/`CMD+SHIFT+P` to open the command prompt and type in `Dendron: focus on tree view` to make it appear
 
 ## Create a link
 
-1. Switch back to your previous note. You can use lookup or click on it in the tree view.
-
-- > TIP: You can also use the `<ALT>-<TAB>` shortcut to switch to your previous note
-
 1. In the current note, type `[[` - this should trigger the autocomplete. You can type `one` to narrow it down to the note you just created and hit enter
-1. You just created your first link!
+<!-- Enter '[[' below-->
+
+<!-- End space-->
+
+You just created your first link!
 
 - > NOTE: the links with the `[[` are called wikilinks (because they were first popularized by Wikipedia)
 - > TIP: If you hover your mouse over the link, you can get a preview of the contents inside the note!
 
 ## Navigate a link
 
-1. Move your text cursor over the note and use `<CTRL>+<ENTER>`/`<CMD>+<ENTER>`
+1. Move your text cursor over the link you just created. Hold down `<CTRL>+<ENTER>`/`<CMD>+<ENTER>`
 
 - > TIP: You can also use `CTRL+CLICK` or `CMD+CLICK` to navigate links via mouse
 
-1. You just navigated the link!
+You just navigated the link!
 
 ## Refactor a Note
 
-1. In the current note, use `CTRL+P`/`CMD+P` to bring up the command prompt and type `Dendron: Rename Note`
+1. Open [[tutorial.one]], bring up the command prompt and type `Dendron: Rename Note`
 1. Replace `tutorial` with `my-note` and then press `<ENTER>`
 1. You just refactored the note!
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-skip-welcome/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-skip-welcome/tutorial.md
@@ -2,7 +2,7 @@
 id: c1bs7wsjfbhb0zipaywqins
 title: Tutorial
 desc: ""
-updated: 1658342369402
+updated: 1658447808735
 created: 1654223767390
 currentStep: 0
 totalSteps: 0
@@ -17,7 +17,7 @@ You are currently in the tutorial vault (a vault is the folder where your notes 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt
 1. Type `dendron` and select `Create New`
 
-- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<ALT>-<TAB>/<WINDOW>-<TAB>` to come back to this note
+- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<CTRL>-<TAB>` to come back to this note
 
 You just created your first note!
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
@@ -2,7 +2,7 @@
 id: c1bs7wsjfbhb0zipaywqv1
 title: Tutorial
 desc: ""
-updated: 1658342257809
+updated: 1658447800901
 created: 1654223767390
 currentStep: 0
 totalSteps: 0
@@ -17,7 +17,7 @@ You are currently in the tutorial vault (a vault is the folder where your notes 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt
 1. Type `dendron` and select `Create New`
 
-- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<ALT>-<TAB>/<WINDOW>-<TAB>` to come back to this note
+- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<CTRL>-<TAB>` to come back to this note
 
 You just created your first note!
 

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
@@ -1,69 +1,73 @@
 ---
 id: c1bs7wsjfbhb0zipaywqv1
-title: Quickstart
+title: Tutorial
 desc: ""
-updated: 1658180902177
+updated: 1658342257809
 created: 1654223767390
 currentStep: 0
 totalSteps: 0
 ---
 
-Welcome to Dendron! Dendron is a developer-focused knowledge base that helps you manage information using flexible hierarchies!
+Welcome to Dendron! Dendron is a developer-focused knowledge base that helps you manage information using **flexible hierarchies**!
 
 You are currently in the tutorial vault (a vault is the folder where your notes are stored). Feel free to edit this note and create new files as you go through the quickstart!
 
 ## Create a Note
 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt
-1. Type 'dendron' and press `<ENTER>`
-1. Congrats, you just created your first note!
+1. Type `dendron` and select `Create New`
+
+- > NOTE: After you press enter, Dendron will create and open the `dendron` note. Use `<ALT>-<TAB>/<WINDOW>-<TAB>` to come back to this note
+
+You just created your first note!
 
 - > NOTE: Notes in Dendron are just plain text markdown with some [frontmatter](https://wiki.dendron.so/notes/ffec2853-c0e0-4165-a368-339db12c8e4b) on the top. You can edit them in Dendron or using ~~vim~~ your favourite text editor.
 
 ## Find a Note
 
 1. Use `Ctrl+L` / `Cmd+L` to bring up the lookup prompt again
-1. Backspace over the current result and type `tutorial` and press `<ENTER>`
+1. Type `dendron` and press `<ENTER>`
 
 - > TIP: you don't have to type out the entire query, press `<TAB>` to autocomplete
 
-1. You just `looked up` a note!
+You just `looked up` a note!
 
 - > NOTE: in Dendron, you can find or create notes using the lookup prompt
 
 ## Organize your Notes
 
 1. Bring up the lookup prompt again
-1. Use the `<RIGHT-ARROW>` key to navigate to the end of the current text cursor and type `.one`. Then press `<ENTER>`
-1. You just created your first hierarchy!
+1. Type `tutorial.one`
+
+You just created your first hierarchy!
 
 - > NOTE: hierarchies in Dendron are just `.` delimited files. This makes each note both a file and a folder and makes it easy to keep your notes organized
 
-- > TIP: You can use the [Dendron Tree View](https://wiki.dendron.so/notes/hur7r6gr3kqa56s2vme986j) to view your hierarchy. If it's not currently in focus, you can use `CTRL+P`/`CMD+P` to open the command prompt and type in `dendron: focus on tree view` to make it appear
+- > TIP: You can use the [Dendron Tree View](https://wiki.dendron.so/notes/hur7r6gr3kqa56s2vme986j) to view your hierarchy. If it's not currently in focus, you can use `CTRL+SHIFT+P`/`CMD+SHIFT+P` to open the command prompt and type in `Dendron: focus on tree view` to make it appear
 
 ## Create a link
 
-1. Switch back to your previous note. You can use lookup or click on it in the tree view.
-
-- > TIP: You can also use the `<ALT>-<TAB>` shortcut to switch to your previous note
-
 1. In the current note, type `[[` - this should trigger the autocomplete. You can type `one` to narrow it down to the note you just created and hit enter
-1. You just created your first link!
+<!-- Enter '[[' below-->
+
+<!-- End space-->
+
+You just created your first link!
 
 - > NOTE: the links with the `[[` are called wikilinks (because they were first popularized by Wikipedia)
 - > TIP: If you hover your mouse over the link, you can get a preview of the contents inside the note!
 
 ## Navigate a link
 
-1. Move your text cursor over the note and use `<CTRL>+<ENTER>`/`<CMD>+<ENTER>`
+1. Move your text cursor over the link you just created. Hold down `<CTRL>+<ENTER>`/`<CMD>+<ENTER>`
 
 - > TIP: You can also use `CTRL+CLICK` or `CMD+CLICK` to navigate links via mouse
 
-1. You just navigated the link!
+You just navigated the link!
 
 ## Refactor a Note
 
-1. In the current note, use `CTRL+P`/`CMD+P` to bring up the command prompt and type `Dendron: Rename Note`
+1. Open [[tutorial.one]], bring up the command prompt and type `Dendron: Rename Note`
 1. Replace `tutorial` with `my-note` and then press `<ENTER>`
 1. You just refactored the note!
 


### PR DESCRIPTION
fix(workspace): fix typos in getting started tutorial

- correct shortcut for triggering `command prompt`
- better emphasis on note names
- clarify directions
- correct shortcut for switching back to previous note