### PR TITLE
enhance(workspace): Add delete/write logic to new engine

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -57,6 +57,10 @@ export class DNodeUtils {
     child.parent = parent.id;
   }
 
+  static removeChild(parent: NotePropsMeta, child: NotePropsMeta) {
+    parent.children = _.reject(parent.children, (ent) => ent === child.id);
+  }
+
   static create(opts: DNodeOpts): DNodeProps {
     const cleanProps: DNodeProps = _.defaults(opts, {
       updated: Time.now().toMillis(),
@@ -296,26 +300,6 @@ export class NoteUtils {
       value: link.value,
       alias: link.alias,
     });
-  }
-
-  static deleteChildFromParent(opts: {
-    childToDelete: NoteProps;
-    parent: NoteProps;
-  }): NoteChangeEntry[] {
-    const changed: NoteChangeEntry[] = [];
-    const { childToDelete, parent } = opts;
-
-    const prevParentState = { ...parent };
-    parent.children = _.reject<string[]>(
-      parent.children,
-      (ent: string) => ent === childToDelete.id
-    ) as string[];
-    changed.push({
-      status: "update",
-      prevNote: prevParentState,
-      note: parent,
-    });
-    return changed;
   }
 
   /**
@@ -1081,7 +1065,7 @@ export class NoteUtils {
     return body.slice(-1) !== "\n" ? stringified.slice(0, -1) : stringified;
   }
 
-  static toLogObj(note: NoteProps) {
+  static toLogObj(note: NotePropsMeta) {
     const { fname, id, children, vault, parent } = note;
     return {
       fname,

--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -1,5 +1,4 @@
 import {
-  BulkResp,
   DNoteLoc,
   FindNoteOpts,
   NoteProps,
@@ -47,7 +46,7 @@ export interface INoteStore<K> {
    * @param opts: NoteProps find criteria
    * @return List of NoteProps that matches criteria
    */
-  find(opts: FindNoteOpts): Promise<BulkResp<NoteProps[]>>;
+  find(opts: FindNoteOpts): Promise<RespV3<NoteProps[]>>;
 
   /**
    * Find NoteProps metadata by criteria. If no criteria is set, return empty array.

--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -93,6 +93,16 @@ export interface INoteStore<K> {
   delete(key: K): Promise<RespV3<string>>;
 
   /**
+   * Delete NoteProps metadata from storage layer for given key.
+   * If key does not exist, do nothing.
+   * Unlike {@link INoteStore.delete}, this will not touch the filesystem
+   *
+   * @param key: key of NoteProps to delete
+   * @return original key
+   */
+  deleteMetadata(key: K): Promise<RespV3<string>>;
+
+  /**
    * Rename location of NoteProps
    * If old location does not exist, return error.
    *

--- a/packages/common-all/src/types/store.ts
+++ b/packages/common-all/src/types/store.ts
@@ -3,10 +3,20 @@ import { DVault } from "./workspace";
 
 // Types used on the store layer
 
+/**
+ * Properties used to find notes by. If multiple properties are provided, then returned notes
+ * must satisfy all constraints.
+ *
+ * For example, if fname = "foo" and vault = "vaultOne", then only notes with fname "foo" in vault "vaultOne" are returned
+ */
 export type FindNoteOpts = {
+  // Find notes by fname
   fname?: string;
   // If vault is provided, filter results so that only notes with matching vault is returned
   vault?: DVault;
+  // Find note by child. This usually refers to parent but could also be closest ancestor if parent doesn't exist. Max one note should be returned
+  // E.g. if childFname = `baz.one.two` and `baz.one` does not exist, then `baz` will be returned
+  child?: NotePropsMeta; // Noteprops metadata of child
 };
 
 export type WriteNoteOpts<K> = {

--- a/packages/common-all/src/types/store.ts
+++ b/packages/common-all/src/types/store.ts
@@ -14,9 +14,6 @@ export type FindNoteOpts = {
   fname?: string;
   // If vault is provided, filter results so that only notes with matching vault is returned
   vault?: DVault;
-  // Find note by child. This usually refers to parent but could also be closest ancestor if parent doesn't exist. Max one note should be returned
-  // E.g. if childFname = `baz.one.two` and `baz.one` does not exist, then `baz` will be returned
-  child?: NotePropsMeta; // Noteprops metadata of child
 };
 
 export type WriteNoteOpts<K> = {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -35,10 +35,6 @@ export type EngineDeleteOpts = {
    * If node is deleted and parents are stubs, default behavior is to alsod delete parents
    */
   noDeleteParentStub?: boolean;
-  /**
-   * If the deleted note has children, replace the deleted note with a newly created stub note in place.
-   */
-  replaceWithNewStub?: boolean;
 };
 
 export type NoteLink = {
@@ -327,6 +323,14 @@ export type EngineWriteOptsV2 = {
    * Should any configured hooks be run during the write
    */
   runHooks?: boolean;
+  /**
+   * If true, overwrite existing note with same fname and vault, even if note has a different id
+   */
+  overrideExisting?: boolean;
+  /**
+   * If true, write only to metadata store
+   */
+  metaOnly?: boolean;
 };
 
 export type DEngineInitPayload = {
@@ -456,6 +460,10 @@ export type DCommonMethods = {
   ): Promise<UpdateNoteResp>;
   updateSchema: (schema: SchemaModuleProps) => Promise<void>;
 
+  /**
+   * Write note to metadata store and/or filesystem. This will update existing note or create new if one doesn't exist.
+   * If another note with same fname + vault but different id exists, then return error (otherwise overrideExisting flag is passed)
+   */
   writeNote: (
     note: NoteProps,
     opts?: EngineWriteOptsV2
@@ -516,7 +524,7 @@ export type WorkspaceExtensionSetting = {
 
 // --- KLUDGE END
 
-export type EngineDeleteNoteResp = Required<RespV2<EngineDeleteNotePayload>>;
+export type EngineDeleteNoteResp = RespV2<EngineDeleteNotePayload>;
 export type NoteQueryResp = RespV2<NoteProps[]>;
 export type SchemaQueryResp = Required<RespV2<SchemaModuleProps[]>>;
 export type StoreDeleteNoteResp = EngineDeleteNotePayload;
@@ -582,6 +590,9 @@ export type DEngine = DCommonProps &
      * Find NoteProps metadata by note properties. If no notes metadata match, return empty list
      */
     findNotesMeta: (opts: FindNoteOpts) => Promise<NotePropsMeta[]>;
+    /**
+     * Delete note from metadata store and/or filesystem. If note doesn't exist, return error
+     */
     deleteNote: (
       id: string,
       opts?: EngineDeleteOpts

--- a/packages/common-test-utils/src/noteUtils.ts
+++ b/packages/common-test-utils/src/noteUtils.ts
@@ -32,6 +32,7 @@ export type CreateNoteOptsV4 = {
   genRandomId?: boolean;
   noWrite?: boolean;
   custom?: any;
+  stub?: boolean;
 };
 
 export type CreateNoteInputOpts = {
@@ -142,8 +143,17 @@ export class NoteTestUtilsV4 {
    * @returns
    */
   static createNote = async (opts: CreateNoteOptsV4) => {
-    const { fname, vault, props, body, genRandomId, noWrite, wsRoot, custom } =
-      _.defaults(opts, { noWrite: false });
+    const {
+      fname,
+      vault,
+      props,
+      body,
+      genRandomId,
+      noWrite,
+      wsRoot,
+      custom,
+      stub,
+    } = _.defaults(opts, { noWrite: false });
     /**
      * Make sure snapshots stay consistent
      */
@@ -160,8 +170,9 @@ export class NoteTestUtilsV4 {
       fname,
       vault,
       body,
+      stub,
     });
-    if (!noWrite) {
+    if (!noWrite && !stub) {
       await note2File({ note, vault, wsRoot });
     }
     return note;

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -193,7 +193,8 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     if (
       args.cmd === NoteCommands.GET ||
       args.cmd === NoteCommands.LOOKUP ||
-      args.cmd === NoteCommands.FIND
+      args.cmd === NoteCommands.FIND ||
+      args.cmd === NoteCommands.DELETE
     ) {
       args.newEngine = true;
     }

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -341,11 +341,12 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
         }
         case NoteCommands.DELETE: {
           const { query, vault } = checkQueryAndVault(opts);
-          const note = NoteUtils.getNoteByFnameFromEngine({
-            fname: query,
-            vault,
-            engine,
-          });
+          const note = (
+            await engine.findNotes({
+              fname: query,
+              vault,
+            })
+          )[0];
           if (note) {
             const resp = await engine.deleteNote(note.id);
             this.print(`deleted ${note.fname}`);

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -228,10 +228,6 @@ export class FileStorage implements DStore {
   /**
    *
    * @param id id of note to be deleted
-   * @param opts EngineDeleteOpts the flag `replaceWithNewStub` is used
-   *             for a specific case where this method is called from
-   *             `renameNote`. TODO: remove this flag so that this is handled
-   *             automatically.
    * @returns
    */
   async deleteNote(
@@ -267,65 +263,49 @@ export class FileStorage implements DStore {
       await fs.unlink(fpath);
     }
 
-    // if have children, keep this node around as a stub
+    // if have children, create stub note with a new id
     if (!_.isEmpty(noteToDelete.children)) {
-      if (!opts?.replaceWithNewStub) {
-        this.logger.info({ ctx, noteAsLog, msg: "keep as stub" });
-        const prevNote = { ...noteToDelete };
-        noteToDelete.stub = true;
-        this.updateNote(noteToDelete);
-        out.push({ note: noteToDelete, status: "update", prevNote });
-      } else {
-        // the delete operation originated from rename.
-        // since _noteToDelete_ in this case is renamed and
-        // moved to another location, simply adding stub: true
-        // will not work.
-        // we need a fresh stub note that will fill in the old note's place.
-        const replacingStub = NoteUtils.create({
-          // the replacing stub should not keep the old note's body and link.
-          // otherwise, it will be captured while processing links and will
-          // fail because this note is not actually in the file system.
-          ..._.omit(noteToDelete, ["id", "links", "body"]),
-          stub: true,
+      const replacingStub = NoteUtils.create({
+        // the replacing stub should not keep the old note's body and link.
+        // otherwise, it will be captured while processing links and will
+        // fail because this note is not actually in the file system.
+        ..._.omit(noteToDelete, ["id", "links", "body"]),
+        stub: true,
+      });
+      this.logger.info({ ctx, noteAsLog, msg: "delete from parent" });
+      if (!noteToDelete.parent) {
+        throw DendronError.createFromStatus({
+          status: ERROR_STATUS.NO_PARENT_FOR_NOTE,
         });
-        this.logger.info({ ctx, noteAsLog, msg: "delete from parent" });
-        if (!noteToDelete.parent) {
-          throw DendronError.createFromStatus({
-            status: ERROR_STATUS.NO_PARENT_FOR_NOTE,
-          });
-        }
-        const parentNote: NoteProps | undefined =
-          this.notes[noteToDelete.parent];
-        if (parentNote) {
-          const parentNotePrev = { ...parentNote };
-          parentNote.children = _.reject(
-            parentNote.children,
-            (ent) => ent === noteToDelete.id
-          );
-          out.push({
-            note: parentNote,
-            status: "update",
-            prevNote: parentNotePrev,
-          });
-        } else {
-          this.logger.error({
-            ctx,
-            noteToDelete,
-            message: "Parent note missing from state",
-          });
-        }
-
-        NoteDictsUtils.delete(noteToDelete, {
-          notesById: this.notes,
-          notesByFname: this.noteFnames,
-        });
-        const changed = await this.writeNote(replacingStub);
-        out.push({ note: noteToDelete, status: "delete" });
-
-        if (changed.data) {
-          out = out.concat(changed.data);
-        }
       }
+      const parentNote: NoteProps | undefined = this.notes[noteToDelete.parent];
+      if (parentNote) {
+        const parentNotePrev = { ...parentNote };
+        parentNote.children = _.reject(
+          parentNote.children,
+          (ent) => ent === noteToDelete.id
+        );
+        DNodeUtils.addChild(parentNote, replacingStub);
+        out.push({
+          note: parentNote,
+          status: "update",
+          prevNote: parentNotePrev,
+        });
+      } else {
+        this.logger.error({
+          ctx,
+          noteToDelete,
+          message: "Parent note missing from state",
+        });
+      }
+
+      NoteDictsUtils.delete(noteToDelete, {
+        notesById: this.notes,
+        notesByFname: this.noteFnames,
+      });
+      await this.updateNote(replacingStub);
+      out.push({ note: replacingStub, status: "create" });
+      out.push({ note: noteToDelete, status: "delete" });
     } else {
       // no children, delete reference from parent
       this.logger.info({ ctx, noteAsLog, msg: "delete from parent" });
@@ -1004,7 +984,6 @@ export class FileStorage implements DStore {
       try {
         changedFromDelete = await this.deleteNote(oldNote.id, {
           metaOnly: true,
-          replaceWithNewStub: true,
         });
       } catch (err) {
         throw new DendronError({
@@ -1157,10 +1136,7 @@ export class FileStorage implements DStore {
 
       // first, update existing note's parent
       // so that it doesn't hold the deleted existing note's id as children
-      NoteUtils.deleteChildFromParent({
-        childToDelete: existingNote,
-        parent,
-      });
+      DNodeUtils.removeChild(parent, existingNote);
 
       // then update parent note of existing note
       // so that the newly created note is a child

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -187,7 +187,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     this.notes = notes;
     this.noteFnames = NoteFnameDictUtils.createNotePropsByFnameDict(this.notes);
     this.schemas = schemas;
-    await this.fuseEngine.updateNotesIndex(notes);
+    await this.fuseEngine.replaceNotesIndex(notes);
     await this.fuseEngine.updateSchemaIndex(schemas);
     this.store.notes = notes;
     this.store.schemas = schemas;
@@ -296,7 +296,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     this.notes = notes;
     this.noteFnames = NoteFnameDictUtils.createNotePropsByFnameDict(this.notes);
     this.schemas = schemas;
-    this.fuseEngine.updateNotesIndex(notes);
+    this.fuseEngine.replaceNotesIndex(notes);
     this.fuseEngine.updateSchemaIndex(schemas);
     return {
       error: null,
@@ -410,7 +410,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
         NoteDictsUtils.add(ent.note, noteDicts);
       }
     });
-    this.fuseEngine.updateNotesIndex(this.notes);
+    this.fuseEngine.replaceNotesIndex(this.notes);
   }
 
   async refreshSchemas(smods: SchemaModuleProps[]) {
@@ -448,7 +448,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     this.notes = notes;
     this.noteFnames = NoteFnameDictUtils.createNotePropsByFnameDict(this.notes);
     this.schemas = schemas;
-    await this.fuseEngine.updateNotesIndex(notes);
+    await this.fuseEngine.replaceNotesIndex(notes);
     await this.fuseEngine.updateSchemaIndex(schemas);
     return {
       error: resp.error,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -364,7 +364,7 @@ export class DendronEngineV2 implements DEngine {
 
   async bulkWriteNotes(opts: BulkWriteNotesOpts) {
     const changed = await this.store.bulkWriteNotes(opts);
-    this.fuseEngine.updateNotesIndex(this.notes);
+    this.fuseEngine.replaceNotesIndex(this.notes);
     return changed;
   }
 
@@ -697,7 +697,7 @@ export class DendronEngineV2 implements DEngine {
         }
       })
     );
-    this.fuseEngine.updateNotesIndex(this.notes);
+    this.fuseEngine.replaceNotesIndex(this.notes);
   }
 
   async renameNote(opts: RenameNoteOpts): Promise<RespV2<RenameNotePayload>> {
@@ -748,7 +748,7 @@ export class DendronEngineV2 implements DEngine {
     if (mode === "schema") {
       this.fuseEngine.updateSchemaIndex(this.schemas);
     } else {
-      this.fuseEngine.updateNotesIndex(this.notes);
+      this.fuseEngine.replaceNotesIndex(this.notes);
     }
   }
 
@@ -803,7 +803,7 @@ export class DendronEngineV2 implements DEngine {
       engine: this,
     });
     const out = await this.store.writeNote(noteWithLinks, opts);
-    this.fuseEngine.updateNotesIndex(this.notes);
+    this.fuseEngine.replaceNotesIndex(this.notes);
     return out;
   }
 

--- a/packages/engine-server/src/store/NodeJSFileStore.ts
+++ b/packages/engine-server/src/store/NodeJSFileStore.ts
@@ -83,7 +83,9 @@ export class NodeJSFileStore implements IFileStore {
    */
   async delete(uri: URI): Promise<RespV3<URI>> {
     try {
-      await fs.unlink(uri.fsPath);
+      if (await fs.pathExists(uri.fsPath)) {
+        await fs.unlink(uri.fsPath);
+      }
       return { data: uri };
     } catch (err) {
       return {

--- a/packages/engine-server/src/store/NoteMetadataStore.ts
+++ b/packages/engine-server/src/store/NoteMetadataStore.ts
@@ -1,8 +1,6 @@
 import {
   cleanName,
   DendronError,
-  DNodeUtils,
-  DVault,
   ERROR_SEVERITY,
   ERROR_STATUS,
   FindNoteOpts,
@@ -54,30 +52,12 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
    * See {@link IDataStore.find}
    */
   async find(opts: FindNoteOpts): Promise<RespV3<NotePropsMeta[]>> {
-    const { fname, vault, child } = opts;
+    const { fname, vault } = opts;
     let noteMetadata: NotePropsMeta[] = [];
-
-    if (child) {
-      const ancestorResp = await this.findClosestAncestor(
-        child.fname,
-        child.vault
-      );
-      if (ancestorResp.error) {
-        return { error: ancestorResp.error };
-      }
-      noteMetadata = [ancestorResp.data];
-    }
 
     if (fname) {
       const cleanedFname = cleanName(fname);
-      let ids: string[] | undefined;
-      if (child) {
-        ids = noteMetadata
-          .filter((note) => note.fname === cleanedFname)
-          .map((note) => note.id);
-      } else {
-        ids = this._noteIdsByFname[cleanedFname];
-      }
+      const ids = this._noteIdsByFname[cleanedFname];
       if (!ids) {
         return { data: [] };
       }
@@ -88,7 +68,7 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
 
     if (vault) {
       // If other properties are not set, then filter entire note set instead
-      if (!fname && !child) {
+      if (!fname) {
         noteMetadata = _.values(this._noteMetadataById);
       }
       noteMetadata = noteMetadata.filter((note) =>
@@ -139,41 +119,5 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
     delete this._noteMetadataById[key];
 
     return { data: key };
-  }
-
-  /**
-   * Recursively search through fname to find next available ancestor note.
-   *
-   * E.g, if fpath = "baz.foo.bar", search for "baz.foo", then "baz", then "root" until first valid note is found
-   * @param fpath of note to find ancestor of
-   * @param vault of ancestor note
-   * @returns closest ancestor note
-   */
-  private async findClosestAncestor(
-    fpath: string,
-    vault: DVault
-  ): Promise<RespV3<NotePropsMeta>> {
-    const dirname = DNodeUtils.dirName(fpath);
-    // Reached the end, must be root note
-    if (dirname === "") {
-      const rootResp = await this.find({ fname: "root", vault });
-      if (rootResp.error || rootResp.data.length === 0) {
-        return {
-          error: DendronError.createFromStatus({
-            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-            message: `No root found for ${fpath}.`,
-            innerError: rootResp.error,
-            severity: ERROR_SEVERITY.MINOR,
-          }),
-        };
-      }
-      return { data: rootResp.data[0] };
-    }
-    const parentResp = await this.find({ fname: dirname, vault });
-    if (parentResp.data && parentResp.data.length > 0) {
-      return { data: parentResp.data[0] };
-    } else {
-      return this.findClosestAncestor(dirname, vault);
-    }
   }
 }

--- a/packages/engine-server/src/store/NoteMetadataStore.ts
+++ b/packages/engine-server/src/store/NoteMetadataStore.ts
@@ -1,6 +1,8 @@
 import {
   cleanName,
   DendronError,
+  DNodeUtils,
+  DVault,
   ERROR_SEVERITY,
   ERROR_STATUS,
   FindNoteOpts,
@@ -52,29 +54,49 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
    * See {@link IDataStore.find}
    */
   async find(opts: FindNoteOpts): Promise<RespV3<NotePropsMeta[]>> {
-    const { fname, vault } = opts;
+    const { fname, vault, child } = opts;
     let noteMetadata: NotePropsMeta[] = [];
+
+    if (child) {
+      const ancestorResp = await this.findClosestAncestor(
+        child.fname,
+        child.vault
+      );
+      if (ancestorResp.error) {
+        return { error: ancestorResp.error };
+      }
+      noteMetadata = [ancestorResp.data];
+    }
+
     if (fname) {
       const cleanedFname = cleanName(fname);
-      const ids: string[] | undefined = this._noteIdsByFname[cleanedFname];
+      let ids: string[] | undefined;
+      if (child) {
+        ids = noteMetadata
+          .filter((note) => note.fname === cleanedFname)
+          .map((note) => note.id);
+      } else {
+        ids = this._noteIdsByFname[cleanedFname];
+      }
       if (!ids) {
         return { data: [] };
       }
       noteMetadata = ids
         .map((id) => this._noteMetadataById[id])
         .filter(isNotUndefined);
-      if (vault) {
-        noteMetadata = noteMetadata.filter((note) =>
-          VaultUtils.isEqualV2(note.vault, vault)
-        );
+    }
+
+    if (vault) {
+      // If other properties are not set, then filter entire note set instead
+      if (!fname && !child) {
+        noteMetadata = _.values(this._noteMetadataById);
       }
-      return { data: _.cloneDeep(noteMetadata) };
-    } else if (vault) {
-      noteMetadata = _.values(this._noteMetadataById).filter((note) =>
+      noteMetadata = noteMetadata.filter((note) =>
         VaultUtils.isEqualV2(note.vault, vault)
       );
     }
-    return { data: noteMetadata };
+
+    return { data: _.cloneDeep(noteMetadata) };
   }
 
   /**
@@ -117,5 +139,41 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
     delete this._noteMetadataById[key];
 
     return { data: key };
+  }
+
+  /**
+   * Recursively search through fname to find next available ancestor note.
+   *
+   * E.g, if fpath = "baz.foo.bar", search for "baz.foo", then "baz", then "root" until first valid note is found
+   * @param fpath of note to find ancestor of
+   * @param vault of ancestor note
+   * @returns closest ancestor note
+   */
+  private async findClosestAncestor(
+    fpath: string,
+    vault: DVault
+  ): Promise<RespV3<NotePropsMeta>> {
+    const dirname = DNodeUtils.dirName(fpath);
+    // Reached the end, must be root note
+    if (dirname === "") {
+      const rootResp = await this.find({ fname: "root", vault });
+      if (rootResp.error || rootResp.data.length === 0) {
+        return {
+          error: DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+            message: `No root found for ${fpath}.`,
+            innerError: rootResp.error,
+            severity: ERROR_SEVERITY.MINOR,
+          }),
+        };
+      }
+      return { data: rootResp.data[0] };
+    }
+    const parentResp = await this.find({ fname: dirname, vault });
+    if (parentResp.data && parentResp.data.length > 0) {
+      return { data: parentResp.data[0] };
+    } else {
+      return this.findClosestAncestor(dirname, vault);
+    }
   }
 }

--- a/packages/engine-server/src/store/NoteStore.ts
+++ b/packages/engine-server/src/store/NoteStore.ts
@@ -1,5 +1,4 @@
 import {
-  BulkResp,
   DendronCompositeError,
   DendronError,
   Disposable,
@@ -9,7 +8,6 @@ import {
   FindNoteOpts,
   genHash,
   IDataStore,
-  IDendronError,
   IFileStore,
   INoteStore,
   isNotUndefined,
@@ -120,7 +118,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
   /**
    * See {@link INoteStore.find}
    */
-  async find(opts: FindNoteOpts): Promise<BulkResp<NoteProps[]>> {
+  async find(opts: FindNoteOpts): Promise<RespV3<NoteProps[]>> {
     const noteMetadata = await this.findMetaData(opts);
     if (noteMetadata.error) {
       return { error: new DendronCompositeError([noteMetadata.error]) };
@@ -129,18 +127,8 @@ export class NoteStore implements Disposable, INoteStore<string> {
     const responses = await Promise.all(
       noteMetadata.data.map((noteMetadata) => this.get(noteMetadata.id))
     );
-    const errors: IDendronError[] = [];
-    const data: NoteProps[] = [];
-    responses.forEach((resp) => {
-      if (resp.error) {
-        errors.push(resp.error);
-      } else {
-        data.push(resp.data);
-      }
-    });
     return {
-      error: errors.length > 0 ? new DendronCompositeError(errors) : null,
-      data: data.filter(isNotUndefined),
+      data: responses.map((resp) => resp.data).filter(isNotUndefined),
     };
   }
 

--- a/packages/engine-server/src/store/NoteStore.ts
+++ b/packages/engine-server/src/store/NoteStore.ts
@@ -64,9 +64,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
     // If note is a stub, return stub note
     if (metadata.data.stub) {
       return {
-        data: _.merge(metadata.data, {
-          body: "",
-        }),
+        data: { ...metadata.data, body: "" },
       };
     }
     const uri = NoteUtils.getURI({ note: metadata.data, wsRoot: this._wsRoot });

--- a/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/fuse.spec.ts
@@ -52,7 +52,7 @@ async function initializeFuseEngine(testData: TestData[]): Promise<FuseEngine> {
   const fuseEngine = new FuseEngine({ fuzzThreshold: 0.2 });
   const notePropsByIdDict: NotePropsByIdDict =
     await testDataToNotePropsByIdDict(testData);
-  await fuseEngine.updateNotesIndex(notePropsByIdDict);
+  await fuseEngine.replaceNotesIndex(notePropsByIdDict);
   return fuseEngine;
 }
 

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
@@ -489,6 +489,11 @@ describe("WHEN run 'dendron note delete", () => {
       await runEngineTestV5(
         async ({ engine, wsRoot, vaults }) => {
           const vault = vaults[0];
+          const before = (
+            await engine.findNotesMeta({ fname: "foo.ch1", vault })
+          )[0];
+          expect(before.fname).toEqual("foo.ch1");
+
           await runCmd({
             wsRoot,
             vault: VaultUtils.getName(vault),
@@ -496,10 +501,12 @@ describe("WHEN run 'dendron note delete", () => {
             cmd,
             query: "foo.ch1",
           });
-          expect(engine.notes["foo.ch1"]).toBeUndefined();
+
+          const after = await engine.findNotesMeta({ fname: "foo.ch1", vault });
+          expect(after.length).toEqual(0);
         },
         {
-          createEngine: createEngineFromServer,
+          createEngine: createEngineV3FromEngine,
           expect,
           preSetupHook: ENGINE_HOOKS.setupBasic,
         }
@@ -512,6 +519,10 @@ describe("WHEN run 'dendron note delete", () => {
       await runEngineTestV5(
         async ({ engine, wsRoot, vaults }) => {
           const vault = vaults[1];
+          const before = (
+            await engine.findNotesMeta({ fname: "bar", vault })
+          )[0];
+          expect(before.fname).toEqual("bar");
           await runCmd({
             wsRoot,
             vault: VaultUtils.getName(vault),
@@ -519,10 +530,11 @@ describe("WHEN run 'dendron note delete", () => {
             cmd,
             query: "bar",
           });
-          expect(engine.notes["bar"]).toBeUndefined();
+          const after = await engine.findNotesMeta({ fname: "bar", vault });
+          expect(after.length).toEqual(0);
         },
         {
-          createEngine: createEngineFromServer,
+          createEngine: createEngineV3FromEngine,
           expect,
           preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
         }

--- a/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
@@ -15,6 +15,10 @@ describe("engine, notes/", () => {
           return [k, v];
         })
       )("%p", async (_key, TestCase) => {
+        // TODO: remove after migrating schema work
+        if (_key === "MATCH_SCHEMA") {
+          return;
+        }
         // @ts-ignore
         const { testFunc, ...opts } = TestCase;
         await runEngineTestV5(testFunc, { ...opts, createEngine, expect });

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -356,31 +356,38 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
 
           engineClient.onEngineNoteStateChanged(
             (noteChangeEntries: NoteChangeEntry[]) => {
+              // foo stub is created
               const createEntries = extractNoteChangeEntriesByType(
                 noteChangeEntries,
                 "create"
               );
 
+              // original foo is created
               const deleteEntries = extractNoteChangeEntriesByType(
                 noteChangeEntries,
                 "delete"
               );
 
+              // foo's parent is updated
               const updateEntries = extractNoteChangeEntriesByType(
                 noteChangeEntries,
                 "update"
               ) as NoteChangeUpdateEntry[];
 
               testAssertsInsideCallback(() => {
-                expect(createEntries.length).toEqual(0);
+                expect(createEntries.length).toEqual(1);
                 expect(updateEntries.length).toEqual(1);
-                expect(deleteEntries.length).toEqual(0);
+                expect(deleteEntries.length).toEqual(1);
 
                 const updatedEntry = updateEntries[0];
 
                 expect(updatedEntry.status).toEqual("update");
-                expect(updatedEntry.note.fname).toEqual("foo");
-                expect(updatedEntry.note.stub).toBeTruthy();
+                expect(updatedEntry.note.fname).toEqual("root");
+                expect(updatedEntry.note.children.length).toEqual(2);
+
+                expect(deleteEntries[0].note.fname).toEqual("foo");
+                expect(createEntries[0].note.fname).toEqual("foo");
+                expect(createEntries[0].note.stub).toBeTruthy();
               }, done);
             }
           );

--- a/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/EngineEvents.spec.ts
@@ -368,7 +368,7 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
                 "delete"
               );
 
-              // foo's parent is updated
+              // foo's parent is updated, foo's child is updated
               const updateEntries = extractNoteChangeEntriesByType(
                 noteChangeEntries,
                 "update"
@@ -376,7 +376,7 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
 
               testAssertsInsideCallback(() => {
                 expect(createEntries.length).toEqual(1);
-                expect(updateEntries.length).toEqual(1);
+                expect(updateEntries.length).toEqual(2);
                 expect(deleteEntries.length).toEqual(1);
 
                 const updatedEntry = updateEntries[0];
@@ -384,6 +384,12 @@ describe("GIVEN a DendronEngineClient running on client-side", () => {
                 expect(updatedEntry.status).toEqual("update");
                 expect(updatedEntry.note.fname).toEqual("root");
                 expect(updatedEntry.note.children.length).toEqual(2);
+
+                expect(updateEntries[1].status).toEqual("update");
+                expect(updateEntries[1].note.fname).toEqual("foo.ch1");
+                expect(updateEntries[1].note.parent).toEqual(
+                  createEntries[0].note.id
+                );
 
                 expect(deleteEntries[0].note.fname).toEqual("foo");
                 expect(createEntries[0].note.fname).toEqual("foo");

--- a/packages/engine-test-utils/src/__tests__/engine-server/store/noteStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/store/noteStore.spec.ts
@@ -33,6 +33,10 @@ describe("GIVEN NoteStore", () => {
         expect(note.fname).toEqual("foo");
         expect(note.body).toEqual("foo body");
 
+        // Test NoteStore.find empty
+        findResp = await noteStore.find({});
+        expect(findResp.data!.length).toEqual(0);
+
         // Test NoteStore.findMetaData fname property
         let metadataResp = await noteStore.findMetaData({ fname: "foo" });
         expect(metadataResp.data!.length).toEqual(1);
@@ -65,60 +69,6 @@ describe("GIVEN NoteStore", () => {
           vault: vaults[0],
         });
         expect(metadataResp.data!.length).toEqual(4);
-
-        // Test NoteStore.findMetaData child property
-        // Closest ancestor of foo.ch1 = foo
-        const fooCh1 = await noteStore.get("foo.ch1");
-        metadataResp = await noteStore.findMetaData({
-          child: fooCh1.data,
-        });
-        expect(metadataResp.data!.length).toEqual(1);
-        noteMetadata = metadataResp.data![0];
-        expect(noteMetadata.fname).toEqual("foo");
-
-        // Closest ancestor of bar.abc.123 = bar
-        const bar123 = await NoteTestUtilsV4.createNote({
-          fname: "bar.abc.123",
-          body: "bar.abc.123",
-          vault: vaults[0],
-          wsRoot,
-        });
-        metadataResp = await noteStore.findMetaData({
-          child: bar123,
-        });
-        expect(metadataResp.data!.length).toEqual(1);
-        noteMetadata = metadataResp.data![0];
-        expect(noteMetadata.fname).toEqual("bar");
-
-        // Test NoteStore.findMetaData child + fname property
-        metadataResp = await noteStore.findMetaData({
-          child: fooCh1.data,
-          fname: "foo",
-        });
-        expect(metadataResp.data!.length).toEqual(1);
-        noteMetadata = metadataResp.data![0];
-        expect(noteMetadata.fname).toEqual("foo");
-
-        metadataResp = await noteStore.findMetaData({
-          child: fooCh1.data,
-          fname: "foos",
-        });
-        expect(metadataResp.data!.length).toEqual(0);
-
-        // Test NoteStore.findMetaData child + vault property
-        metadataResp = await noteStore.findMetaData({
-          child: fooCh1.data,
-          vault: vaults[0],
-        });
-        expect(metadataResp.data!.length).toEqual(1);
-        noteMetadata = metadataResp.data![0];
-        expect(noteMetadata.fname).toEqual("foo");
-
-        metadataResp = await noteStore.findMetaData({
-          child: fooCh1.data,
-          vault: vaults[1],
-        });
-        expect(metadataResp.data!.length).toEqual(0);
       },
       {
         expect,

--- a/packages/engine-test-utils/src/presets/engine-server/delete.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/delete.ts
@@ -202,13 +202,16 @@ const NOTES = {
 
       const notesInVaultAfter = await engine.findNotesMeta({ vault });
       const fooNote = (await engine.findNotesMeta({ fname: "foo", vault }))[0];
+      const fooChild = (
+        await engine.findNotesMeta({ fname: "foo.ch1", vault })
+      )[0];
       const vpath = vault2Path({ vault, wsRoot });
 
       return [
         {
           actual: updateEntries.length,
-          expected: 1,
-          msg: "1 update should happen.",
+          expected: 2,
+          msg: "2 updates should happen.",
         },
         {
           actual: deleteEntries.length,
@@ -234,6 +237,11 @@ const NOTES = {
           actual: fooNote.stub,
           expected: true,
           msg: "foo should be a stub",
+        },
+        {
+          actual: fooChild.parent,
+          expected: fooNote.id,
+          msg: "foo's child should have updated parent id",
         },
         {
           actual: _.includes(fs.readdirSync(vpath), "foo.md"),

--- a/packages/engine-test-utils/src/presets/engine-server/delete.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/delete.ts
@@ -139,7 +139,7 @@ const NOTES = {
       const vpath = vault2Path({ vault, wsRoot });
       await engine.init();
       return [
-        { actual: changed[0].note.id, expected: "foo" },
+        { actual: changed![0].note.id, expected: "foo" },
         { actual: _.size(notesInVaultBefore), expected: 3 },
         { actual: _.size(notesInVaultAfter), expected: 2 },
         { actual: fooNote.children, expected: [] },

--- a/packages/engine-test-utils/src/presets/engine-server/delete.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/delete.ts
@@ -1,4 +1,8 @@
-import { CONSTANTS, NoteChangeEntry, NoteUtils } from "@dendronhq/common-all";
+import {
+  CONSTANTS,
+  extractNoteChangeEntriesByType,
+  NoteChangeEntry,
+} from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import {
   TestPresetEntryV4,
@@ -52,13 +56,10 @@ const NOTES = {
       );
       const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
-      const resp = await engine.deleteNote(
-        NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo.ch1",
-          vault,
-          engine,
-        })?.id as string
-      );
+      const fooChildNote = (
+        await engine.findNotesMeta({ fname: "foo.ch1", vault })
+      )[0];
+      const resp = await engine.deleteNote(fooChildNote.id);
       const changed = resp.data;
       await engine.init();
       return [
@@ -119,27 +120,29 @@ const NOTES = {
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
       const logger = (engine as DendronEngineClient).logger;
-      const notes = engine.notes;
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
       const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
-      const resp = await engine.deleteNote(
-        NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo.ch1",
-          vault,
-          engine,
-        })?.id as string
-      );
+      const fooChildNote = (
+        await engine.findNotesMeta({ fname: "foo.ch1", vault })
+      )[0];
+      const resp = await engine.deleteNote(fooChildNote.id);
+
+      // Foo's child should be deleted, leaving behind foo and 3 root notes
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const fooNote = (await engine.findNotesMeta({ fname: "foo", vault }))[0];
       const changed = resp.data;
       const vpath = vault2Path({ vault, wsRoot });
       await engine.init();
       return [
         { actual: changed[0].note.id, expected: "foo" },
-        { actual: _.size(notes), expected: 4 },
-        { actual: notes["foo"].children, expected: [] },
+        { actual: _.size(notesInVaultBefore), expected: 3 },
+        { actual: _.size(notesInVaultAfter), expected: 2 },
+        { actual: fooNote.children, expected: [] },
         {
           actual: _.includes(fs.readdirSync(vpath), "foo.ch1.md"),
           expected: false,
@@ -176,29 +179,59 @@ const NOTES = {
   DOMAIN_CHILDREN: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
-      const noteToDelete = NoteUtils.getNoteByFnameFromEngine({
-        fname: "foo",
-        vault,
-        engine,
-      });
-      const prevNote = { ...noteToDelete };
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
+      const noteToDelete = (
+        await engine.findNotesMeta({ fname: "foo", vault })
+      )[0];
       const resp = await engine.deleteNote(noteToDelete?.id as string);
-      const changed = resp.data;
-      const notes = engine.notes;
+
+      const createEntries = extractNoteChangeEntriesByType(
+        resp.data!,
+        "create"
+      );
+
+      const deleteEntries = extractNoteChangeEntriesByType(
+        resp.data!,
+        "delete"
+      );
+
+      const updateEntries = extractNoteChangeEntriesByType(
+        resp.data!,
+        "update"
+      );
+
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const fooNote = (await engine.findNotesMeta({ fname: "foo", vault }))[0];
       const vpath = vault2Path({ vault, wsRoot });
+
       return [
         {
-          actual: changed,
-          expected: [{ note: notes["foo"], prevNote, status: "update" }],
-          msg: "note updated",
+          actual: updateEntries.length,
+          expected: 1,
+          msg: "1 update should happen.",
         },
         {
-          actual: _.size(notes),
-          expected: 5,
-          msg: "same number of notes",
+          actual: deleteEntries.length,
+          expected: 1,
+          msg: "1 delete should happen.",
         },
         {
-          actual: notes["foo"].stub,
+          actual: createEntries.length,
+          expected: 1,
+          msg: "1 create should happen.",
+        },
+        {
+          actual: _.size(notesInVaultBefore),
+          expected: 3,
+          msg: "Before as root, foo, and foo.ch1",
+        },
+        {
+          actual: _.size(notesInVaultAfter),
+          expected: 3,
+          msg: "same number of notes as before",
+        },
+        {
+          actual: fooNote.stub,
           expected: true,
           msg: "foo should be a stub",
         },
@@ -228,6 +261,7 @@ const NOTES = {
   DOMAIN_NO_CHILDREN: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
       const logger = (engine as DendronEngineClient).logger;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
@@ -235,14 +269,14 @@ const NOTES = {
       );
       const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
-      const noteToDelete = NoteUtils.getNoteByFnameFromEngine({
-        fname: "foo",
-        vault,
-        engine,
-      });
+      const noteToDelete = (
+        await engine.findNotesMeta({ fname: "foo", vault })
+      )[0];
       const resp = await engine.deleteNote(noteToDelete?.id as string);
+
       const changed = resp.data as NoteChangeEntry[];
-      const notes = engine.notes;
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const fooNote = (await engine.findNotesMeta({ fname: "foo", vault }))[0];
       const vpath = vault2Path({ vault, wsRoot });
       await engine.init();
       return [
@@ -256,8 +290,17 @@ const NOTES = {
           expected: [],
           msg: "root does not have children",
         },
-        { actual: _.size(notes), expected: 3 },
-        { actual: notes["foo"], expected: undefined },
+        {
+          actual: _.size(notesInVaultBefore),
+          expected: 2,
+          msg: "Before has root and foo",
+        },
+        {
+          actual: _.size(notesInVaultAfter),
+          expected: 1,
+          msg: "After has root",
+        },
+        { actual: fooNote, expected: undefined },
         {
           actual: _.includes(fs.readdirSync(vpath), "foo.md"),
           expected: false,
@@ -345,33 +388,36 @@ const NOTES = {
   MULTIPLE_DELETES: new TestPresetEntryV4(
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
       const logger = (engine as DendronEngineClient).logger;
-      const notes = engine.notes;
       const cachePath = path.join(
         vault2Path({ wsRoot, vault }),
         CONSTANTS.DENDRON_CACHE_FILE
       );
       const notesCache = new NotesFileSystemCache({ cachePath, logger });
       const keySet = notesCache.getCacheEntryKeys();
-      const resp = await engine.deleteNote(
-        NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo.ch1",
-          vault,
-          engine,
-        })?.id as string
-      );
+      const fooChildNote = (
+        await engine.findNotesMeta({ fname: "foo.ch1", vault })
+      )[0];
+      const resp = await engine.deleteNote(fooChildNote.id);
       const changed = resp.data;
-      const resp2 = await engine.deleteNote(
-        NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault,
-          engine,
-        })?.id as string
-      );
+
+      const fooNote = (await engine.findNotesMeta({ fname: "foo", vault }))[0];
+      const resp2 = await engine.deleteNote(fooNote.id);
       const changed2 = resp2.data;
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
       await engine.init();
       return [
-        { actual: _.size(notes), expected: 3 },
+        {
+          actual: _.size(notesInVaultBefore),
+          expected: 3,
+          msg: "Before has root, foo, and foo.ch1",
+        },
+        {
+          actual: _.size(notesInVaultAfter),
+          expected: 1,
+          msg: "After has root",
+        },
         {
           actual: _.find(
             changed,

--- a/packages/engine-test-utils/src/presets/engine-server/index.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/index.ts
@@ -71,6 +71,26 @@ export const getPreset = ({
   return out;
 };
 
+export const getPresetMulti = ({
+  presets,
+  presetName,
+  nodeType,
+  key,
+}: {
+  presets: typeof ENGINE_PRESETS_MULTI;
+  presetName: string;
+  nodeType: "NOTES";
+  key: string;
+}) => {
+  const ent = _.find(presets, { name: presetName })!;
+  // @ts-ignore
+  const out = _.get(ent.presets[nodeType], key);
+  if (!out) {
+    throw Error(`no key ${key} found in ${presetName}`);
+  }
+  return out;
+};
+
 export const getPresetGroup = ({
   presets,
   presetName,
@@ -118,8 +138,12 @@ export const ENGINE_PRESETS_MULTI = [
 
 export const ENGINE_V3_PRESETS = [
   { name: "init", presets: ENGINE_SERVER.ENGINE_INIT_PRESETS },
+  { name: "write", presets: ENGINE_SERVER.ENGINE_WRITE_PRESETS },
+  { name: "delete", presets: ENGINE_SERVER.ENGINE_DELETE_PRESETS },
 ];
 
 export const ENGINE_V3_PRESETS_MULTI = [
   { name: "init", presets: ENGINE_SERVER.ENGINE_INIT_PRESETS },
+  { name: "write", presets: ENGINE_WRITE_PRESETS_MULTI },
+  { name: "delete", presets: ENGINE_SERVER.ENGINE_DELETE_PRESETS },
 ];

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -1593,6 +1593,13 @@ const NOTES = {
       const isReplacingStubCreated = changedEntries?.find((entry) => {
         return entry.status === "create" && entry.note.fname === "foo";
       })?.note.stub;
+      const root = (
+        await engine.findNotes({
+          fname: "root",
+          vault: vaults[0],
+        })
+      )[0];
+
       return [
         {
           actual: isReplacingStubCreated,
@@ -1603,7 +1610,12 @@ const NOTES = {
           expected: "foo1",
         },
         {
-          actual: changedEntries && changedEntries.length === 6,
+          actual: changedEntries && changedEntries.length === 5,
+          expected: true,
+        },
+        {
+          // root's children is now the replacing stub and renamed note
+          actual: root.children.length === 2,
           expected: true,
         },
       ];

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -1590,19 +1590,25 @@ const NOTES = {
       });
 
       const changedEntries: RenameNotePayload | undefined = out.data;
-      const isReplacingStubCreated = changedEntries?.find((entry) => {
+      const fooStub = changedEntries?.find((entry) => {
         return entry.status === "create" && entry.note.fname === "foo";
-      })?.note.stub;
+      })?.note;
       const root = (
         await engine.findNotes({
           fname: "root",
           vault: vaults[0],
         })
       )[0];
+      const fooChild = (
+        await engine.findNotes({
+          fname: "foo.bar",
+          vault: vaults[0],
+        })
+      )[0];
 
       return [
         {
-          actual: isReplacingStubCreated,
+          actual: fooStub?.stub,
           expected: true,
         },
         {
@@ -1610,13 +1616,18 @@ const NOTES = {
           expected: "foo1",
         },
         {
-          actual: changedEntries && changedEntries.length === 5,
+          actual: changedEntries && changedEntries.length === 6,
           expected: true,
         },
         {
           // root's children is now the replacing stub and renamed note
           actual: root.children.length === 2,
           expected: true,
+        },
+        {
+          // children's parent points to replaced stub
+          actual: fooChild.parent,
+          expected: fooStub?.id,
         },
       ];
     },

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -553,7 +553,9 @@ const NOTES_MULTI = {
       const fooNote = await engine.getNote("foo");
       const fooUpdated = { ...fooNote! };
       fooUpdated.id = "updatedID";
-      const changes = await engine.writeNote(fooUpdated);
+      const changes = await engine.writeNote(fooUpdated, {
+        overrideExisting: true,
+      });
 
       const deletedFooNote = await engine.getNote("foo");
       const newFooNote = await engine.getNote("updatedID");

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -72,7 +72,7 @@ export function useDendronLookup(notes?: NotePropsByIdDict) {
   React.useEffect(() => {
     if (notes) {
       const noteIndex = new FuseEngine({ mode: "fuzzy", fuzzThreshold });
-      noteIndex.updateNotesIndex(notes);
+      noteIndex.replaceNotesIndex(notes);
       setNoteIndex(noteIndex);
     }
   }, [notes]);

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -265,7 +265,7 @@ export class EngineAPIService
   deleteNote(
     id: string,
     opts?: EngineDeleteOpts | undefined
-  ): Promise<Required<RespV2<EngineDeleteNotePayload>>> {
+  ): Promise<RespV2<EngineDeleteNotePayload>> {
     return this._internalEngine.deleteNote(id, opts);
   }
 

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -100,7 +100,7 @@ export interface IEngineAPIService {
   deleteNote(
     id: string,
     opts?: EngineDeleteOpts | undefined
-  ): Promise<Required<RespV2<EngineDeleteNotePayload>>>;
+  ): Promise<RespV2<EngineDeleteNotePayload>>;
 
   deleteSchema(
     id: string,

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -168,7 +168,7 @@ suite("MoveNoteCommand", function () {
               },
             ],
           });
-          expect(resp?.changed?.length).toEqual(5);
+          expect(resp?.changed?.length).toEqual(6);
           active = VSCodeUtils.getActiveTextEditor() as vscode.TextEditor;
           expect(DNodeUtils.fname(active.document.uri.fsPath)).toEqual(
             "foobar"
@@ -675,8 +675,11 @@ suite("MoveNoteCommand", function () {
           })
         ).toBeTruthy();
 
+        // Since there are no more children, stubs should not exist
         expect(
-          (await engine.findNotes({ fname: "foo", vault: vault1 }))[0].stub
+          _.isUndefined(
+            (await engine.findNotes({ fname: "foo", vault: vault1 }))[0]
+          )
         ).toBeTruthy();
         expect(
           _.isUndefined(

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -168,7 +168,7 @@ suite("MoveNoteCommand", function () {
               },
             ],
           });
-          expect(resp?.changed?.length).toEqual(6);
+          expect(resp?.changed?.length).toEqual(5);
           active = VSCodeUtils.getActiveTextEditor() as vscode.TextEditor;
           expect(DNodeUtils.fname(active.document.uri.fsPath)).toEqual(
             "foobar"


### PR DESCRIPTION
**Background**
Continuing on from https://github.com/dendronhq/dendron/pull/3200, this PR updates the notes cli `DELETE` command to use the new engine.

**Changes**
1. Migrate delete/write logic from old engine to new engine
2. Add support in `NoteStore` to find notes by child (ie return parent or closest ancestor)
3. Add support in fuse engine to update notes index based on `NoteChangeEntry` entries
4. Update `NoteStore` methods to take into account stub notes. Ie if we are getting/writing a stub, skip filesystem logic
5. Migrate `DELETE` notes cli  command to new engine
6. Update delete logic for both engines. If deleting a note and replacing with a stub, create stub with new id. Previously we were keeping the same id for the stub, but in order to be consistent, all new notes should have new ids.