### PR TITLE
chore: update init tutorial

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -75,7 +75,7 @@ const _2022_06_QUICKSTART_TUTORIAL_TEST = new ABTest(
     },
     {
       name: QuickstartTutorialTestGroups["quickstart-skip-welcome"],
-      weight: 1,
+      weight: 0,
     },
   ]
 );

--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
@@ -2,7 +2,7 @@
 id: c1bs7wsjfbhb0zipaywqv1
 title: Tutorial
 desc: ""
-updated: 1658447800901
+updated: 1658931733078
 created: 1654223767390
 currentStep: 0
 totalSteps: 0
@@ -67,7 +67,7 @@ You just navigated the link!
 
 ## Refactor a Note
 
-1. Open [[tutorial.one]], bring up the command prompt and type `Dendron: Rename Note`
+1. Open [[tutorial.one]], bring up the command prompt (`CTRL+SHIFT+P`/`CMD+SHIFT+P`) and type `Dendron: Rename Note`
 1. Replace `tutorial` with `my-note` and then press `<ENTER>`
 1. You just refactored the note!
 

--- a/packages/plugin-core/src/commands/LaunchTutorialWorkspaceCommand.ts
+++ b/packages/plugin-core/src/commands/LaunchTutorialWorkspaceCommand.ts
@@ -45,7 +45,7 @@ export class LaunchTutorialWorkspaceCommand extends BasicCommand<
       rootDirRaw: filePath,
       workspaceInitializer: new TutorialInitializer(),
       workspaceType: WorkspaceType.NATIVE,
-      EXPERIMENTAL_openNativeWorkspaceNoReload: true,
+      EXPERIMENTAL_openNativeWorkspaceNoReload: false,
     });
   }
 }

--- a/packages/plugin-core/src/commands/LaunchTutorialWorkspaceCommand.ts
+++ b/packages/plugin-core/src/commands/LaunchTutorialWorkspaceCommand.ts
@@ -44,7 +44,7 @@ export class LaunchTutorialWorkspaceCommand extends BasicCommand<
     await new SetupWorkspaceCommand().execute({
       rootDirRaw: filePath,
       workspaceInitializer: new TutorialInitializer(),
-      workspaceType: WorkspaceType.NATIVE,
+      workspaceType: WorkspaceType.CODE,
       EXPERIMENTAL_openNativeWorkspaceNoReload: false,
     });
   }


### PR DESCRIPTION
chore: update init tutorial

- disable instant load of tutorial (we rely on workspace settings that are not being activated)
- explicitly call out how to open command prompt