### PR TITLE
chore: update graph commands key

### DIFF
--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -89,11 +89,13 @@ jobs:
         run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}
 
       - name: Tag Release on Github
+        if: success() || failure()
         run: |
           git tag $DENDRON_RELEASE_VERSION
           git push origin $DENDRON_RELEASE_VERSION
 
       - name: Raise Pull Request back to master
+        if: success() || failure()
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "master"

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -230,10 +230,6 @@
         "title": "Dendron: Copy To Clipboard"
       },
       {
-        "command": "dendron.deleteNode",
-        "title": "Dendron: Delete Node"
-      },
-      {
         "command": "dendron.delete",
         "title": "Dendron: Delete"
       },
@@ -485,11 +481,11 @@
         "title": "Dendron: Show Help"
       },
       {
-        "command": "dendron.showNoteGraph",
+        "command": "dendron.showNoteGraphView",
         "title": "Dendron: Show Note Graph"
       },
       {
-        "command": "dendron.showSchemaGraph",
+        "command": "dendron.showSchemaGraphView",
         "title": "Dendron: Show Schema Graph"
       },
       {
@@ -619,10 +615,6 @@
         {
           "command": "dendron.copyToClipboard",
           "when": "false"
-        },
-        {
-          "command": "dendron.deleteNode",
-          "when": "dendron:pluginActive"
         },
         {
           "command": "dendron.delete",
@@ -833,11 +825,11 @@
           "when": "dendron:pluginActive"
         },
         {
-          "command": "dendron.showNoteGraph",
+          "command": "dendron.showNoteGraphView",
           "when": "dendron:pluginActive"
         },
         {
-          "command": "dendron.showSchemaGraph",
+          "command": "dendron.showSchemaGraphView",
           "when": "dendron:pluginActive"
         },
         {
@@ -1004,7 +996,7 @@
         },
         {
           "when": "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive",
-          "command": "dendron.deleteNode",
+          "command": "dendron.delete",
           "group": "2_workspace"
         },
         {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -298,7 +298,7 @@ export const DENDRON_MENUS = {
     {
       // [[Command Enablement / When Clause Gotchas|dendron://dendron.docs/pkg.plugin-core.t.commands.ops#command-enablement--when-clause-gotchas]]
       when: "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive",
-      command: "dendron.deleteNode",
+      command: "dendron.delete",
       group: "2_workspace",
     },
     {
@@ -872,12 +872,12 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Show Help`,
   },
   SHOW_NOTE_GRAPH: {
-    key: "dendron.showNoteGraph",
+    key: "dendron.showNoteGraphView",
     title: `${CMD_PREFIX} Show Note Graph`,
     when: DendronContext.PLUGIN_ACTIVE,
   },
   SHOW_SCHEMA_GRAPH: {
-    key: "dendron.showSchemaGraph",
+    key: "dendron.showSchemaGraphView",
     title: `${CMD_PREFIX} Show Schema Graph`,
     when: DendronContext.PLUGIN_ACTIVE,
   },

--- a/packages/plugin-core/src/showcase/GraphThemeTip.ts
+++ b/packages/plugin-core/src/showcase/GraphThemeTip.ts
@@ -32,7 +32,7 @@ export class GraphThemeTip implements IFeatureShowcaseMessage {
       href: "https://www.loom.com/share/f2c53d2a5aeb48209b5587a3dfbb1015",
       alt: "Click on menu icon in the Graph View to change themes",
     });
-    vscode.commands.executeCommand("dendron.showNoteGraph");
+    vscode.commands.executeCommand("dendron.showNoteGraphView");
   }
 
   get confirmText(): string {


### PR DESCRIPTION
This PR aims to
-  update graph commands key to resolve `dendron.showSchemaGraph already exists` error
- updates patch release pipeline to always raise a PR even if the above step fails