### PR TITLE
fix: validate file name on note lookup

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1121,6 +1121,15 @@ export class NoteUtils {
     return true;
   }
 
+  static validateFname(fname: string) {
+    // Each hierarchy string
+    // 1. should not be empty
+    // 2. should not have leading trailing whitespace
+    return fname.split(".").every((value) => {
+      return value !== "" && !value.startsWith(" ") && !value.endsWith(" ");
+    });
+  }
+
   /** Generate a random color for `note`, but allow the user to override that color selection.
    *
    * @param note The fname of note that you want to get the color of.

--- a/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
@@ -130,6 +130,18 @@ export class NoteLookupProvider implements ILookupProviderV3 {
           picker,
         });
       }
+
+      // validates fname.
+      if (selectedItems.length === 1) {
+        const item = selectedItems[0];
+        if (!NoteUtils.validateFname(item.fname)) {
+          window.showErrorMessage(
+            "Hierarchies cannot have leading / trailing whitespace or be empty."
+          );
+          return;
+        }
+      }
+
       // when doing lookup, opening existing notes don't require vault picker
       if (
         PickerUtilsV2.hasNextPicker(picker, {

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -1,5 +1,4 @@
 import {
-  asyncLoop,
   asyncLoopOneAtATime,
   DVault,
   NoteProps,
@@ -20,13 +19,6 @@ import {
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
-
-const stubVaultPick = (vaults: DVault[]) => {
-  const vault = _.find(vaults, { fsPath: "vault1" });
-  return sinon
-    .stub(PickerUtilsV2, "getOrPromptVaultForNewNote")
-    .returns(Promise.resolve(vault));
-};
 
 suite("LookupProviderV3 utility methods:", () => {
   describe(`shouldBubbleUpCreateNew`, () => {

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -1,17 +1,32 @@
-import { NoteProps } from "@dendronhq/common-all";
+import {
+  asyncLoop,
+  asyncLoopOneAtATime,
+  DVault,
+  NoteProps,
+  NoteUtils,
+} from "@dendronhq/common-all";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestEngineUtils } from "@dendronhq/engine-test-utils";
-import _ from "lodash";
+import _, { last } from "lodash";
 import { beforeEach, describe, it, suite } from "mocha";
+import sinon from "sinon";
 import { ExtensionContext, Selection } from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import {
+  PickerUtilsV2,
   shouldBubbleUpCreateNew,
   sortBySimilarity,
 } from "../../components/lookup/utils";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+
+const stubVaultPick = (vaults: DVault[]) => {
+  const vault = _.find(vaults, { fsPath: "vault1" });
+  return sinon
+    .stub(PickerUtilsV2, "getOrPromptVaultForNewNote")
+    .returns(Promise.resolve(vault));
+};
 
 suite("LookupProviderV3 utility methods:", () => {
   describe(`shouldBubbleUpCreateNew`, () => {
@@ -280,6 +295,54 @@ suite("selection2Items", () => {
         expect(expectedItemLabels).toEqual(actualItemLabels);
 
         cmd.cleanUp();
+      });
+    }
+  );
+});
+
+suite("onAccept", () => {
+  describeMultiWS(
+    "GIVEN invalid fname",
+    {
+      preSetupHook: ENGINE_HOOKS.setupBasic,
+    },
+    () => {
+      test("THEN rejected", async () => {
+        const validateFnameSpy = sinon.spy(NoteUtils, "validateFname");
+        const cmd = new NoteLookupCommand();
+        const { controller, provider, quickpick } = await cmd.gatherInputs();
+        const invalidFnames = [
+          "foo.", // trailing dot
+          "foo..", // multiple trailing dots
+          ".foo", // leading dot
+          "..foo", // multiple leading dots
+          " foo", // leading whitespace
+          "  foo", // multiple leading whitespace
+          "foo ", // trailing whitespace
+          "foo  ", // multiple trailing whitespace
+          " foo ", // leading and trailing whitespace
+          "  foo  ", // multiple leading and trailing whitespace
+          "foo..bar", // empty hierarchy
+          "foo...bar", // multiple empty hierarchy
+          "foo. .bar", // whitespace hierarchy
+          "foo.bar .baz", // hierarchy with trailing whitespace
+          "foo. bar.baz", // hierarchy with leading whitespace
+          "foo. bar .baz", // hierarchy with leading and trailing whitespace
+          " foo . . bar . . baz ", // everything
+        ];
+
+        await asyncLoopOneAtATime(invalidFnames, async (fname) => {
+          quickpick.value = fname;
+          await provider.onDidAccept({
+            quickpick,
+            cancellationToken: controller.cancelToken,
+          })();
+          const lastCall = validateFnameSpy.lastCall;
+          expect(lastCall.args[0]).toEqual(fname);
+          expect(lastCall.returnValue).toBeFalsy();
+        });
+        cmd.cleanUp();
+        validateFnameSpy.restore();
       });
     }
   );

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -1,18 +1,16 @@
 import {
   asyncLoopOneAtATime,
-  DVault,
   NoteProps,
   NoteUtils,
 } from "@dendronhq/common-all";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestEngineUtils } from "@dendronhq/engine-test-utils";
-import _, { last } from "lodash";
+import _ from "lodash";
 import { beforeEach, describe, it, suite } from "mocha";
 import sinon from "sinon";
 import { ExtensionContext, Selection } from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import {
-  PickerUtilsV2,
   shouldBubbleUpCreateNew,
   sortBySimilarity,
 } from "../../components/lookup/utils";

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -29,7 +29,7 @@ import {
 import assert from "assert";
 import fs from "fs-extra";
 import _ from "lodash";
-import { afterEach, beforeEach, describe, Done } from "mocha";
+import { afterEach, beforeEach, describe } from "mocha";
 import path from "path";
 import sinon, { SinonStub } from "sinon";
 import * as vscode from "vscode";


### PR DESCRIPTION
# Pull Request Checklist

This PR:
- Validates the value of the quickpick of note lookup
- disallows 
  - leading / trailing whitespaces in individual hierarchy string
  - leading / trailing dots
  - empty hierarchy string
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)