### PR TITLE
chore(workspace): Fix engine sync issue from manual rename

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -37,7 +37,6 @@ import {
   NotePropsMeta,
 } from "./types";
 import {
-  ConfigUtils,
   DefaultMap,
   getSlugger,
   isNotUndefined,
@@ -895,78 +894,6 @@ export class NoteUtils {
     }
 
     return { ...noteRaw, ...hydrateProps };
-  }
-
-  /**
-   * Update note metadata (eg. links and anchors)
-   * Calculate note metadata based on contents of the notes
-   */
-  static async updateNoteMetadata({
-    note,
-    fmChangeOnly,
-    engine,
-    enableLinkCandidates,
-  }: {
-    note: NoteProps;
-    fmChangeOnly: boolean;
-    engine: DEngineClient;
-    enableLinkCandidates?: boolean;
-  }) {
-    // Avoid calculating links/anchors if the note is too long
-    if (
-      note.body.length > ConfigUtils.getWorkspace(engine.config).maxNoteLength
-    ) {
-      return note;
-    }
-    // Links have to be updated even with frontmatter only changes
-    // because `tags` in frontmatter adds new links
-    const links = await engine.getLinks({ note, type: "regular" });
-    if (!links.data) {
-      throw new DendronError({
-        message: "Unable to calculate the links in note",
-        payload: {
-          note: NoteUtils.toLogObj(note),
-          error: links.error,
-        },
-      });
-    }
-    note.links = links.data;
-
-    // if only frontmatter changed, don't bother with heavy updates
-    if (!fmChangeOnly) {
-      const anchors = await engine.getAnchors({
-        note,
-      });
-      if (!anchors.data) {
-        throw new DendronError({
-          message: "Unable to calculate anchors in note",
-          payload: {
-            note: NoteUtils.toLogObj(note),
-            error: anchors.error,
-          },
-        });
-      }
-      note.anchors = anchors.data;
-
-      if (enableLinkCandidates) {
-        const linkCandidates = await engine.getLinks({
-          note,
-          type: "candidate",
-        });
-        if (!linkCandidates.data) {
-          throw new DendronError({
-            message: "Unable to calculate the backlink candidates in note",
-            payload: {
-              note: NoteUtils.toLogObj(note),
-              error: linkCandidates.error,
-            },
-          });
-        }
-        note.links = note.links.concat(linkCandidates.data);
-      }
-    }
-
-    return note;
   }
 
   static match({ notePath, pattern }: { notePath: string; pattern: string }) {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -344,9 +344,11 @@ export type RenameNoteOpts = {
   oldLoc: DNoteLoc;
   newLoc: DNoteLoc;
   /**
-   * added for dendron to recognise vscode `rename` menu option
+   * Flag to determine whether we should touch metadata only
+   * For example, if the code comes from vscode `rename` menu option,
+   * we do not want to touch the filesystem
    */
-  isEventSourceEngine?: boolean;
+  metaOnly?: boolean;
 };
 
 export type RenderNoteOpts = {
@@ -618,6 +620,9 @@ export type DEngine = DCommonProps &
       originalQS: string;
       vault?: DVault;
     }): NoteQueryResp;
+    /**
+     * Rename note from old DNoteLoc to new DNoteLoc. New note keeps original id
+     */
     renameNote: (opts: RenameNoteOpts) => Promise<RespV2<RenameNotePayload>>;
     renderNote: (opts: RenderNoteOpts) => Promise<RespV2<RenderNotePayload>>;
     /**
@@ -637,9 +642,15 @@ export type DEngine = DCommonProps &
     getDecorations: (
       opts: GetDecorationsOpts
     ) => Promise<GetDecorationsPayload>;
+    /**
+     * @deprecated: Use {@link LinkUtils.findLinks}
+     */
     getLinks: (
       opts: Optional<GetLinksRequest, "ws">
     ) => Promise<GetNoteLinksPayload>;
+    /**
+     * @deprecated: Use {@link AnchorUtils.findAnchors}
+     */
     getAnchors: (opts: GetAnchorsRequest) => Promise<GetNoteAnchorsPayload>;
   };
 

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -786,7 +786,7 @@ export class DendronEngineV3 implements DEngine {
     let links;
     switch (type) {
       case "regular":
-        links = LinkUtils.findLinks({
+        links = LinkUtils.findLinksFromBody({
           note,
           engine: this,
         });
@@ -860,7 +860,6 @@ export class DendronEngineV3 implements DEngine {
           cache: notesCache,
           engine: this,
           logger: this.logger,
-          maxNoteLength: ConfigUtils.getWorkspace(this.config).maxNoteLength,
         }).parseFiles(maybeFiles.data, vault);
         if (error) {
           errors = errors.concat(error?.errors);

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -393,6 +393,43 @@ export class LinkUtils {
       position: link.position,
     };
   }
+
+  /**
+   * Get links from note body while maintaining existing backlinks
+   */
+  static findLinks({
+    note,
+    engine,
+    type,
+    filter,
+  }: {
+    note: NoteProps;
+    engine: DEngineClient;
+    filter?: LinkFilter;
+    type: "regular" | "candidate";
+  }): DLink[] {
+    let links = [];
+    switch (type) {
+      case "regular":
+        links = LinkUtils.findLinksFromBody({
+          note,
+          engine,
+          filter,
+        });
+        break;
+      case "candidate":
+        links = LinkUtils.findLinkCandidates({
+          note,
+          engine,
+        });
+        break;
+      default:
+        assertUnreachable(type);
+    }
+    const backlinks = note.links.filter((link) => link.type === "backlink");
+    return links.concat(backlinks);
+  }
+
   /**
    * Get all links from the note body
    * Currently, just look for wiki links
@@ -402,7 +439,7 @@ export class LinkUtils {
    * - type: filter by {@link DendronASTTypes}
    * - loc: filter by {@link DLoc}
    */
-  static findLinks({
+  static findLinksFromBody({
     note,
     engine,
     filter,

--- a/packages/engine-server/src/store/NoteStore.ts
+++ b/packages/engine-server/src/store/NoteStore.ts
@@ -1,5 +1,4 @@
 import {
-  DendronCompositeError,
   DendronError,
   Disposable,
   DNoteLoc,
@@ -108,11 +107,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
    * See {@link INoteStore.getMetadata}
    */
   async getMetadata(key: string): Promise<RespV3<NotePropsMeta>> {
-    const resp = await this._metadataStore.get(key);
-    if (resp.error) {
-      return { error: resp.error };
-    }
-    return { data: resp.data };
+    return this._metadataStore.get(key);
   }
 
   /**
@@ -121,7 +116,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
   async find(opts: FindNoteOpts): Promise<RespV3<NoteProps[]>> {
     const noteMetadata = await this.findMetaData(opts);
     if (noteMetadata.error) {
-      return { error: new DendronCompositeError([noteMetadata.error]) };
+      return { error: noteMetadata.error };
     }
 
     const responses = await Promise.all(
@@ -136,11 +131,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
    * See {@link INoteStore.findMetaData}
    */
   async findMetaData(opts: FindNoteOpts): Promise<RespV3<NotePropsMeta[]>> {
-    const resp = await this._metadataStore.find(opts);
-    if (resp.error) {
-      return { error: resp.error };
-    }
-    return { data: resp.data };
+    return this._metadataStore.find(opts);
   }
 
   /**
@@ -185,12 +176,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
         }),
       };
     }
-    const metaResp = await this._metadataStore.write(key, noteMeta);
-    if (metaResp.error) {
-      return { error: metaResp.error };
-    }
-
-    return { data: key };
+    return this._metadataStore.write(key, noteMeta);
   }
 
   /**s
@@ -251,12 +237,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
       };
     }
 
-    const metaResp = await this._metadataStore.delete(key);
-    if (metaResp.error) {
-      return { error: metaResp.error };
-    }
-
-    return { data: key };
+    return this._metadataStore.delete(key);
   }
 
   async rename(oldLoc: DNoteLoc, newLoc: DNoteLoc): Promise<RespV3<string>> {

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/remarkUtils.spec.ts.snap
@@ -70,9 +70,9 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findLinks empty link 1`] = `Array []`;
+exports[`RemarkUtils and LinkUtils findLinksFromBody empty link 1`] = `Array []`;
 
-exports[`RemarkUtils and LinkUtils findLinks filter loc match 1`] = `
+exports[`RemarkUtils and LinkUtils findLinksFromBody filter loc match 1`] = `
 Array [
   Object {
     "alias": "foo",
@@ -107,9 +107,9 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findLinks filter loc no match 1`] = `Array []`;
+exports[`RemarkUtils and LinkUtils findLinksFromBody filter loc no match 1`] = `Array []`;
 
-exports[`RemarkUtils and LinkUtils findLinks hashtag link 1`] = `
+exports[`RemarkUtils and LinkUtils findLinksFromBody hashtag link 1`] = `
 Array [
   Object {
     "alias": "#bar",
@@ -144,7 +144,7 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findLinks note ref 1`] = `
+exports[`RemarkUtils and LinkUtils findLinksFromBody note ref 1`] = `
 Array [
   Object {
     "alias": "foo.two",
@@ -207,7 +207,7 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findLinks one link 1`] = `
+exports[`RemarkUtils and LinkUtils findLinksFromBody one link 1`] = `
 Array [
   Object {
     "alias": "bar",
@@ -242,7 +242,7 @@ Array [
 ]
 `;
 
-exports[`RemarkUtils and LinkUtils findLinks xvault link 1`] = `
+exports[`RemarkUtils and LinkUtils findLinksFromBody xvault link 1`] = `
 Array [
   Object {
     "alias": "bar",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/remarkUtils.spec.ts
@@ -179,12 +179,12 @@ describe("RemarkUtils and LinkUtils", () => {
     );
   });
 
-  describe("findLinks", () => {
+  describe("findLinksFromBody", () => {
     testWithEngine(
       "one link",
       async ({ engine }) => {
         const note = engine.notes["foo"];
-        const links = LinkUtils.findLinks({ note, engine });
+        const links = LinkUtils.findLinksFromBody({ note, engine });
         expect(links).toMatchSnapshot();
         expect(links[0].to?.fname).toEqual("bar");
       },
@@ -204,7 +204,7 @@ describe("RemarkUtils and LinkUtils", () => {
       "empty link",
       async ({ engine }) => {
         const note = engine.notes["foo"];
-        const links = LinkUtils.findLinks({ note, engine });
+        const links = LinkUtils.findLinksFromBody({ note, engine });
         expect(links).toMatchSnapshot();
         expect(_.isEmpty(links)).toBeTruthy();
       },
@@ -224,7 +224,7 @@ describe("RemarkUtils and LinkUtils", () => {
       "xvault link",
       async ({ engine }) => {
         const note = engine.notes["foo"];
-        const links = LinkUtils.findLinks({ note, engine });
+        const links = LinkUtils.findLinksFromBody({ note, engine });
         expect(links).toMatchSnapshot();
         expect(links[0].from).toEqual({
           fname: "foo",
@@ -252,7 +252,7 @@ describe("RemarkUtils and LinkUtils", () => {
       "hashtag link",
       async ({ engine }) => {
         const note = engine.notes["foo"];
-        const links = LinkUtils.findLinks({ note, engine });
+        const links = LinkUtils.findLinksFromBody({ note, engine });
         expect(links).toMatchSnapshot();
         expect(links[0].to?.fname).toEqual("tags.bar");
       },
@@ -272,7 +272,7 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const note = engine.notes["foo.one-id"];
-          const links = LinkUtils.findLinks({ note, engine });
+          const links = LinkUtils.findLinksFromBody({ note, engine });
           expect(links).toMatchSnapshot();
           checkLink({
             src: {
@@ -318,7 +318,7 @@ describe("RemarkUtils and LinkUtils", () => {
 
       const getLinks = (engine: DEngineClient, filter: LinkFilter) => {
         const note = engine.notes["foo"];
-        const links = LinkUtils.findLinks({
+        const links = LinkUtils.findLinksFromBody({
           note,
           engine,
           filter,
@@ -373,7 +373,7 @@ describe("RemarkUtils and LinkUtils", () => {
       await runEngineTestV5(
         async ({ engine }) => {
           const note = engine.notes["foo.one-id"];
-          const links = LinkUtils.findLinks({ note, engine });
+          const links = LinkUtils.findLinksFromBody({ note, engine });
           const link = LinkUtils.dlink2DNoteLink(links[0]);
           const newBody = LinkUtils.updateLink({
             note,
@@ -412,7 +412,7 @@ describe("RemarkUtils and LinkUtils", () => {
         await runEngineTestV5(
           async ({ engine }) => {
             const note = engine.notes["foo"];
-            const links = LinkUtils.findLinks({ note, engine });
+            const links = LinkUtils.findLinksFromBody({ note, engine });
             const link = LinkUtils.dlink2DNoteLink(links[0]);
             const newLink = {
               ...link,
@@ -441,7 +441,7 @@ describe("RemarkUtils and LinkUtils", () => {
             const idx = 1;
             const newLine = "nospace[[bar]]";
             const note = engine.notes["foo"];
-            const links = LinkUtils.findLinks({ note, engine });
+            const links = LinkUtils.findLinksFromBody({ note, engine });
             const link = LinkUtils.dlink2DNoteLink(links[idx]);
             const newLink = {
               ...link,
@@ -470,7 +470,7 @@ describe("RemarkUtils and LinkUtils", () => {
             const idx = 2;
             const newLine = "onespace [[bar]]";
             const note = engine.notes["foo"];
-            const links = LinkUtils.findLinks({ note, engine });
+            const links = LinkUtils.findLinksFromBody({ note, engine });
             const link = LinkUtils.dlink2DNoteLink(links[idx]);
             const newLink = {
               ...link,

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -2,18 +2,21 @@ import {
   ConfigUtils,
   ContextualUIEvents,
   DNodeUtils,
+  ErrorUtils,
   NoteUtils,
   SchemaUtils,
   Time,
   VaultUtils,
   Wrap,
 } from "@dendronhq/common-all";
+import { file2Note, vault2Path } from "@dendronhq/common-server";
 import { RemarkUtils, WorkspaceUtils } from "@dendronhq/engine-server";
 import * as Sentry from "@sentry/node";
 import _ from "lodash";
 import path from "path";
 import {
   ExtensionContext,
+  FileRenameEvent,
   FileWillRenameEvent,
   Range,
   Selection,
@@ -148,6 +151,14 @@ export class WorkspaceWatcher {
     this._extension.addDisposable(
       workspace.onWillRenameFiles(
         this.onWillRenameFiles,
+        this,
+        context.subscriptions
+      )
+    );
+
+    this._extension.addDisposable(
+      workspace.onDidRenameFiles(
+        this.onDidRenameFiles,
         this,
         context.subscriptions
       )
@@ -418,6 +429,51 @@ export class WorkspaceWatcher {
       const engine = this._extension.getEngine();
       const updateNoteReferences = engine.renameNote(opts);
       args.waitUntil(updateNoteReferences);
+    } catch (error: any) {
+      Sentry.captureException(error);
+      throw error;
+    }
+  }
+
+  /**
+   * method to make modifications to the workspace after the file is renamed.
+   * It updates the title of the note wrt the new fname and refreshes tree view
+   */
+  async onDidRenameFiles(args: FileRenameEvent) {
+    // No-op if we're not in a Dendron Workspace
+    if (!this._extension.isActive()) {
+      return;
+    }
+    try {
+      const files = args.files[0];
+      const { newUri } = files;
+      const fname = DNodeUtils.fname(newUri.fsPath);
+      const engine = this._extension.getEngine();
+      const { vaults, wsRoot } = this._extension.getDWorkspace();
+
+      // No-op if we are not dealing with a Dendron note.
+      if (!NoteUtils.isNote(newUri)) {
+        return;
+      }
+
+      const newVault = VaultUtils.getVaultByFilePath({
+        vaults,
+        wsRoot,
+        fsPath: newUri.fsPath,
+      });
+      const vpath = vault2Path({ wsRoot, vault: newVault });
+      const newLocPath = path.join(vpath, fname + ".md");
+      const resp = file2Note(newLocPath, newVault);
+      if (ErrorUtils.isErrorResp(resp)) {
+        throw resp.error;
+      }
+      const noteRaw = resp.data;
+      const newNote = NoteUtils.hydrate({
+        noteRaw,
+        noteHydrated: engine.notes[noteRaw.id],
+      });
+      newNote.title = NoteUtils.genTitle(fname);
+      await engine.writeNote(newNote);
     } catch (error: any) {
       Sentry.captureException(error);
       throw error;

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -415,7 +415,7 @@ export class MoveHeaderCommand extends BasicCommand<
     origin: NoteProps,
     anchorNamesToUpdate: string[]
   ) {
-    const links = LinkUtils.findLinks({
+    const links = LinkUtils.findLinksFromBody({
       note,
       engine,
     }).filter((link) => {

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -11,6 +11,7 @@ import {
 import { file2Note } from "@dendronhq/common-server";
 import {
   EngineFileWatcher,
+  EngineUtils,
   FileWatcherAdapter,
   HistoryService,
 } from "@dendronhq/engine-server";
@@ -134,7 +135,7 @@ export class FileWatcher {
         //TODO recognise vscode's create new file menu option to create a note.
       }
 
-      note = await NoteUtils.updateNoteMetadata({
+      EngineUtils.refreshNoteLinksAndAnchors({
         note,
         fmChangeOnly: false,
         engine,

--- a/packages/plugin-core/src/services/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/TextDocumentService.ts
@@ -7,6 +7,7 @@ import {
 import { DLogger, string2Note } from "@dendronhq/common-server";
 import {
   DendronASTDest,
+  EngineUtils,
   MDUtilsV5,
   WorkspaceUtils,
 } from "@dendronhq/engine-server";
@@ -82,7 +83,7 @@ export class TextDocumentService implements ITextDocumentService {
     this._textDocumentEventHandle.dispose();
   }
 
-  private async updateNoteContents(opts: {
+  private updateNoteContents(opts: {
     oldNote: NoteProps;
     content: string;
     fmChangeOnly: boolean;
@@ -108,12 +109,10 @@ export class TextDocumentService implements ITextDocumentService {
         keepBackLinks: true,
       },
     });
-    note = await NoteUtils.updateNoteMetadata({
+    EngineUtils.refreshNoteLinksAndAnchors({
       note,
       fmChangeOnly,
       engine: this._extension.getEngine(),
-      enableLinkCandidates:
-        this._extension.workspaceService?.config.dev?.enableLinkCandidates,
     });
 
     this.L.debug({ ctx, fname: note.fname, msg: "exit" });
@@ -167,7 +166,7 @@ export class TextDocumentService implements ITextDocumentService {
       return noteHydrated;
     }
 
-    const props = await this.updateNoteContents({
+    const props = this.updateNoteContents({
       oldNote: noteHydrated,
       content,
       fmChangeOnly: false,


### PR DESCRIPTION
**Background**
While working on the engine `rename` refactoring, I've realized that manually renaming a file outside of dendron can easily cause the engine state to drift. This is due to not properly cleaning up the note metadata of the old file

**Changes**
1. Update `renameNote` param to use `metaOnly` instead of `isEventSourceEngine`. Therefore if the change is from vscode, we will delete/write to only the note metadata store
2. Consolidate link/anchor refresh logic into one method under `EngineUtils`
3. Deprecate `getLinks` and `getAnchors` on engine. In the future, we will not need the engine to perform these actions
4. Remove `onDidRenameFiles` from watcher. Since `renameNote` handles writing the note metadata, there is no need to write the same thing again.