### PR TITLE
fix: windows keybindings for toggle preview

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -230,10 +230,6 @@
         "title": "Dendron: Copy To Clipboard"
       },
       {
-        "command": "dendron.deleteNode",
-        "title": "Dendron: Delete Node"
-      },
-      {
         "command": "dendron.delete",
         "title": "Dendron: Delete"
       },
@@ -619,10 +615,6 @@
         {
           "command": "dendron.copyToClipboard",
           "when": "false"
-        },
-        {
-          "command": "dendron.deleteNode",
-          "when": "dendron:pluginActive"
         },
         {
           "command": "dendron.delete",
@@ -1292,7 +1284,7 @@
       },
       {
         "command": "dendron.togglePreview",
-        "windows": "ctrl+k v",
+        "key": "ctrl+k v",
         "mac": "cmd+ctrl+p",
         "when": "dendron:pluginActive"
       }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -896,7 +896,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Toggle Preview`,
     icon: `$(open-preview)`,
     keybindings: {
-      windows: "ctrl+k v",
+      key: "ctrl+k v",
       mac: "cmd+ctrl+p",
       when: "dendron:pluginActive",
     },


### PR DESCRIPTION
fix: windows keybindings for toggle preview

turns out the `key` settings needs to be set for the keybinding to take into effect