### PR TITLE
enhance(views): toggle preview lock from inside preview

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -925,8 +925,7 @@ export type CalendarViewMessage = DMessage<
 
 export type NoteViewMessage = DMessage<
   NoteViewMessageType,
-  // TODO use id instead of fName and use engine.findNotes({ vault, fname }) to find note from fileName
-  { id?: string; href?: string; fName?: string }
+  { id?: string; href?: string }
 >;
 
 /** @deprecated: Tree view v2 is deprecated */

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -925,7 +925,8 @@ export type CalendarViewMessage = DMessage<
 
 export type NoteViewMessage = DMessage<
   NoteViewMessageType,
-  { id?: string; href?: string }
+  // TODO use id instead of fName and use engine.findNotes({ vault, fname }) to find note from fileName
+  { id?: string; href?: string; fName?: string }
 >;
 
 /** @deprecated: Tree view v2 is deprecated */

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -194,7 +194,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
         ? NoteViewMessageEnum.onUnlock
         : NoteViewMessageEnum.onLock,
       data: {
-        fName: props.ide.noteActive?.fname,
+        id: props.ide.noteActive?.id,
       },
       source: DMessageSource.webClient,
     });

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -22,12 +22,15 @@ import {
 } from "@dendronhq/common-frontend";
 import { Layout, Button } from "antd";
 import LockFilled from "@ant-design/icons/lib/icons/LockFilled";
+import UnlockOutlined from "@ant-design/icons/lib/icons/UnlockOutlined";
 import _ from "lodash";
 import React from "react";
 import { useWorkspaceProps } from "../hooks";
 import "../styles/scss/main.scss";
 import { DendronComponent } from "../types";
 import { postVSCodeMessage, useVSCodeMessage } from "../utils/vscode";
+import type { SyntheticEvent } from "react";
+
 const { Content } = Layout;
 
 const { useEngineAppSelector } = engineHooks;
@@ -179,27 +182,39 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
     }
   });
 
-  const isLocked = props.ide.isLocked;
+  const handleLock = (event: SyntheticEvent<HTMLElement>) => {
+    if (!(event.target instanceof HTMLElement)) {
+      return;
+    }
 
-  const handleLock = () => {
+    const _islocked = event.target.dataset.islocked === "true";
+
     postVSCodeMessage({
-      type: NoteViewMessageEnum.onUnlock,
+      type: _islocked
+        ? NoteViewMessageEnum.onUnlock
+        : NoteViewMessageEnum.onLock,
       data: {},
       source: DMessageSource.webClient,
     });
   };
 
+  const isLocked = props.ide.isLocked;
+
   return (
     <>
       <Component {...props} />
-      {isLocked && (
-        <Button
-          shape="circle"
-          icon={<LockFilled />}
-          onClick={handleLock}
-          style={{ position: "absolute", top: 33, right: 33 }}
-        />
-      )}
+      <Button
+        data-islocked={isLocked}
+        shape="circle"
+        icon={isLocked ? <LockFilled /> : <UnlockOutlined />}
+        onClick={handleLock}
+        style={{
+          position: "absolute",
+          top: 33,
+          right: 33,
+          opacity: isLocked ? 1 : 0.5,
+        }}
+      />
     </>
   );
 }

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -211,7 +211,7 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
           position: "absolute",
           top: 33,
           right: 33,
-          opacity: isLocked ? 1 : 0.5,
+          opacity: isLocked ? 1 : 0.3,
         }}
       />
     </>

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -182,29 +182,28 @@ function DendronVSCodeApp({ Component }: { Component: DendronComponent }) {
     }
   });
 
+  const isLocked = props.ide.isLocked;
+
   const handleLock = (event: SyntheticEvent<HTMLElement>) => {
-    if (!(event.target instanceof HTMLElement)) {
+    if (!(event.currentTarget instanceof HTMLElement)) {
       return;
     }
 
-    const _islocked = event.target.dataset.islocked === "true";
-
     postVSCodeMessage({
-      type: _islocked
+      type: isLocked
         ? NoteViewMessageEnum.onUnlock
         : NoteViewMessageEnum.onLock,
-      data: {},
+      data: {
+        fName: props.ide.noteActive?.fname,
+      },
       source: DMessageSource.webClient,
     });
   };
-
-  const isLocked = props.ide.isLocked;
 
   return (
     <>
       <Component {...props} />
       <Button
-        data-islocked={isLocked}
         shape="circle"
         icon={isLocked ? <LockFilled /> : <UnlockOutlined />}
         onClick={handleLock}

--- a/packages/plugin-core/src/commands/TogglePreviewLock.ts
+++ b/packages/plugin-core/src/commands/TogglePreviewLock.ts
@@ -16,7 +16,7 @@ export class TogglePreviewLock extends BasicCommand<
   key = DENDRON_COMMANDS.TOGGLE_PREVIEW_LOCK.key;
   _panel: PreviewProxy | undefined;
 
-  constructor(previewPanel: PreviewProxy | undefined) {
+  constructor(previewPanel: PreviewProxy) {
     super();
     this._panel = previewPanel;
   }
@@ -30,14 +30,14 @@ export class TogglePreviewLock extends BasicCommand<
 
   async execute(_opts?: CommandOpts) {
     if (this._panel) {
+      const note = ExtensionProvider.getWSUtils().getActiveNote();
       if (this._panel.isLocked()) {
         this._panel.unlock();
-        const note = ExtensionProvider.getWSUtils().getActiveNote();
         if (note) {
           this._panel.show(note);
         }
       } else {
-        this._panel.lock();
+        this._panel.lock(note?.id);
       }
     }
 

--- a/packages/plugin-core/src/components/views/PreviewPanel.ts
+++ b/packages/plugin-core/src/components/views/PreviewPanel.ts
@@ -152,13 +152,20 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
   hide(): void {
     this.dispose();
   }
-  lock() {
+  lock(fileName?: string) {
     const activeTextEditor = VSCodeUtils.getActiveTextEditor();
-    if (activeTextEditor) {
-      this._lockedEditorFileName = activeTextEditor?.document.fileName;
+    const lockedEditorFileName =
+      fileName ?? activeTextEditor?.document.fileName;
+    if (lockedEditorFileName) {
+      this._lockedEditorFileName = lockedEditorFileName;
       this.sendLockMessage(this._panel, this.isLocked());
     } else {
-      Logger.error({ ctx: "lock preview", msg: "No active texteditor found" });
+      Logger.error({
+        ctx: "lock preview",
+        msg: activeTextEditor
+          ? "Did not find note to lock."
+          : "No active texteditor found.",
+      });
     }
   }
   unlock() {
@@ -252,8 +259,10 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
           break;
         }
         case NoteViewMessageEnum.onLock: {
+          const { data } = msg;
           Logger.debug({ ctx, "msg.type": "onLock" });
-          this.lock();
+          // TODO data.fName points only to the fileName but not the whole filePath. use note id instead.
+          this.lock(data.fName);
           break;
         }
         case NoteViewMessageEnum.onUnlock: {

--- a/packages/plugin-core/src/components/views/PreviewProxy.ts
+++ b/packages/plugin-core/src/components/views/PreviewProxy.ts
@@ -24,7 +24,7 @@ export interface PreviewProxy {
   /**
    * lock the preview webview
    */
-  lock(): void;
+  lock(noteId?: string): void;
 
   /**
    * unlock the preview webview

--- a/packages/plugin-core/src/test/MockPreviewProxy.ts
+++ b/packages/plugin-core/src/test/MockPreviewProxy.ts
@@ -23,7 +23,7 @@ export class MockPreviewProxy implements PreviewProxy {
   isOpen(): boolean {
     return this._isOpen;
   }
-  lock(): void {
+  lock(_noteId?: string): void {
     this._isLocked = true;
   }
   unlock(): void {


### PR DESCRIPTION
This PR aims to allow the user to toggle preview's lock-state from inside the preview instead from the command "Toggle Preview Lock" only.

- [[Allow Preview Lock Toggle from inside Preview|dendron://private/task.2022.07.29.allow-preview-lock-toggle-from-inside-preview]]
- https://github.com/dendronhq/dendron-site/pull/604

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)