### PR TITLE
enhance(structure): support xvault template in note traits

### DIFF
--- a/packages/plugin-core/src/test/suite-integ/components/traits/TestTrait.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/traits/TestTrait.ts
@@ -10,6 +10,10 @@ import {
 export class TestTrait implements NoteTrait {
   TEST_NAME_MODIFIER = "Test Name Modifier";
   TEST_TITLE_MODIFIER = "Test Title Modifier";
+  public template: string;
+  constructor(template: string) {
+    this.template = template;
+  }
 
   id: string = "test-trait";
   OnWillCreate: onWillCreateProps = {
@@ -25,7 +29,7 @@ export class TestTrait implements NoteTrait {
       return this.TEST_TITLE_MODIFIER;
     },
     setTemplate: () => {
-      return "foo";
+      return this.template;
     },
   };
 }


### PR DESCRIPTION
This PR aims to support cross vault template in note traits.

## Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
NA

### Extended
NA
## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
NA