### PR TITLE
refactor(nextjs-template): componetize the parts of DendronLayout.tsx

### DIFF
--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -7,14 +7,11 @@ import { DendronContent } from "./layout/DendronContent";
 import { DendronHeader } from "./layout/DendronHeader";
 import { Layout } from "antd";
 import { useEngineAppSelector } from "../features/engine/hooks";
+import { useRouter } from "next/router";
 
 export default function DendronLayout(
   props: React.PropsWithChildren<DendronCommonProps>
 ) {
-  const engine = useEngineAppSelector((state) => state.engine);
-  const config = engine.config;
-  const enableMermaid = config && ConfigUtils.getEnableMermaid(config, true);
-
   return (
     <Layout
       style={{
@@ -22,26 +19,6 @@ export default function DendronLayout(
         minHeight: "100%",
       }}
     >
-      {enableMermaid && (
-        <Script
-          id="initmermaid"
-          src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"
-          onLoad={() => {
-            const mermaid = (window as any).mermaid;
-            // save for debugging
-            // when trying to access mermaid in DOM, <div id="mermaid"></div> gets returned
-            // we disambiguate by saving a copy of mermaid
-            (window as any)._mermaid = mermaid;
-
-            mermaid.initialize({
-              startOnLoad: false,
-            });
-            // initialize
-            mermaid.init();
-          }}
-          strategy="lazyOnload"
-        />
-      )}
       <DendronHeader {...props} />
       <Layout
         style={{

--- a/packages/nextjs-template/components/DendronLayout.tsx
+++ b/packages/nextjs-template/components/DendronLayout.tsx
@@ -1,81 +1,16 @@
-import { MenuOutlined } from "@ant-design/icons";
-import { ConfigUtils } from "@dendronhq/common-all";
-import { Col, Divider, Layout, Row } from "antd";
-import Script from "next/script";
 import * as React from "react";
-import { useEngineAppSelector } from "../features/engine/hooks";
-import { DENDRON_STYLE_CONSTANTS } from "../styles/constants";
+import DendronSideBar from "./layout/DendronSidebar";
+import Script from "next/script";
+import { ConfigUtils } from "@dendronhq/common-all";
 import { DendronCommonProps } from "../utils/types";
-import { DendronBreadCrumb } from "./DendronBreadCrumb";
-import DendronLogoOrTitle from "./DendronLogoOrTitle";
-import { FooterText } from "./DendronNoteFooter";
-import { DendronSearch } from "./DendronSearch";
-import DendronTreeMenu from "./DendronTreeMenu";
-
-const { Header, Content, Sider, Footer } = Layout;
-const { LAYOUT, HEADER, SIDER } = DENDRON_STYLE_CONSTANTS;
+import { DendronContent } from "./layout/DendronContent";
+import { DendronHeader } from "./layout/DendronHeader";
+import { Layout } from "antd";
+import { useEngineAppSelector } from "../features/engine/hooks";
 
 export default function DendronLayout(
   props: React.PropsWithChildren<DendronCommonProps>
 ) {
-  const [isCollapsed, setCollapsed] = React.useState(false);
-  const [isResponsive, setResponsive] = React.useState(false);
-
-  const sidebar = (
-    <Sider
-      width={isResponsive ? "100%" : SIDER.WIDTH}
-      collapsible
-      collapsed={isCollapsed && isResponsive}
-      collapsedWidth={SIDER.COLLAPSED_WIDTH}
-      onCollapse={(collapsed) => {
-        setCollapsed(collapsed);
-      }}
-      breakpoint="sm"
-      onBreakpoint={(broken) => {
-        setResponsive(broken);
-      }}
-      style={{
-        position: "fixed",
-        overflow: "auto",
-        height: `calc(100vh - ${HEADER.HEIGHT}px)`,
-        backgroundColor: `transparent`,
-      }}
-      trigger={null}
-    >
-      {isResponsive && (
-        <div style={{ padding: 16 }}>
-          <DendronSearch {...props} />
-        </div>
-      )}
-      <DendronTreeMenu
-        {...props}
-        collapsed={isCollapsed && isResponsive}
-        setCollapsed={setCollapsed}
-      />
-    </Sider>
-  );
-
-  const content = (
-    <>
-      <Content
-        className="main-content"
-        role="main"
-        style={{ padding: `0 ${LAYOUT.PADDING}px` }}
-      >
-        <DendronBreadCrumb {...props} />
-        {props.children}
-      </Content>
-      <Divider />
-      <Footer
-        style={{
-          padding: `0 ${LAYOUT.PADDING}px ${LAYOUT.PADDING}px`,
-        }}
-      >
-        <FooterText />
-      </Footer>
-    </>
-  );
-
   const engine = useEngineAppSelector((state) => state.engine);
   const config = engine.config;
   const enableMermaid = config && ConfigUtils.getEnableMermaid(config, true);
@@ -107,85 +42,16 @@ export default function DendronLayout(
           strategy="lazyOnload"
         />
       )}
-      <Header
-        style={{
-          position: "fixed",
-          isolation: "isolate",
-          zIndex: 1,
-          width: "100%",
-          borderBottom: "1px solid #d4dadf",
-          height: HEADER.HEIGHT,
-          padding: isResponsive ? 0 : `0 ${LAYOUT.PADDING}px 0 2px`,
-        }}
-      >
-        <Row
-          justify="center"
-          style={{
-            maxWidth: "992px",
-            justifyContent: "space-between",
-            margin: "0 auto",
-          }}
-        >
-          <Col xs={20} sm={4} style={{ display: "flex" }}>
-            <DendronLogoOrTitle />
-          </Col>
-          <Col xs={0} sm={20} md={20} lg={19} className="gutter-row">
-            <DendronSearch {...props} />
-          </Col>
-          <Col
-            xs={4}
-            sm={4}
-            md={0}
-            lg={0}
-            style={{
-              display: isResponsive ? "flex" : "none",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <MenuOutlined
-              style={{ fontSize: 24 }}
-              onClick={() => setCollapsed(!isCollapsed)}
-            />
-          </Col>
-        </Row>
-      </Header>
+      <DendronHeader {...props} />
       <Layout
-        className="site-layout"
         style={{
           marginTop: 64,
+          display: "flex",
+          flexDirection: "row",
         }}
       >
-        <Layout className="site-layout">
-          <div
-            className="site-layout-sidebar"
-            style={{
-              flex: "0 0 auto",
-              width: `calc(max((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2, 0px) + ${
-                // eslint-disable-next-line no-nested-ternary
-                isResponsive
-                  ? isCollapsed
-                    ? SIDER.COLLAPSED_WIDTH
-                    : "100%"
-                  : SIDER.WIDTH
-              }px)`,
-              minWidth: isResponsive || isCollapsed ? 0 : SIDER.WIDTH,
-              paddingLeft: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2)`,
-              // eslint-disable-next-line no-nested-ternary
-            }}
-          >
-            {sidebar}
-          </div>
-          <Layout
-            className="side-layout-main"
-            style={{
-              maxWidth: "1200px",
-              display: !isCollapsed && isResponsive ? "none" : "initial",
-            }}
-          >
-            {content}
-          </Layout>
-        </Layout>
+        <DendronSideBar {...props} />
+        <DendronContent {...props} />
       </Layout>
     </Layout>
   );

--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -12,7 +12,6 @@ import {
 } from "@dendronhq/common-frontend";
 import { Col, Row } from "antd";
 import _ from "lodash";
-import dynamic from "next/dynamic";
 import React from "react";
 import { DendronCollectionItem } from "../components/DendronCollection";
 import DendronCustomHead from "../components/DendronCustomHead";
@@ -23,6 +22,7 @@ import { useCombinedDispatch } from "../features";
 import { browserEngineSlice } from "../features/engine";
 import { DENDRON_STYLE_CONSTANTS } from "../styles/constants";
 import { useDendronRouter } from "../utils/hooks";
+import { MermaidScript } from "./MermaidScript";
 
 const { HEADER } = DENDRON_STYLE_CONSTANTS;
 
@@ -110,6 +110,7 @@ export default function Note({
 
   return (
     <>
+      <MermaidScript noteBody={noteBody} />
       <DendronSEO note={note} config={config} />
       {customHeadContent && <DendronCustomHead content={customHeadContent} />}
       <Row>

--- a/packages/nextjs-template/components/MermaidScript.tsx
+++ b/packages/nextjs-template/components/MermaidScript.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from "react";
+import Script from "next/script";
+import { useEngineAppSelector } from "../features/engine/hooks";
+import { ConfigUtils } from "@dendronhq/common-all";
+import { createLogger } from "@dendronhq/common-frontend";
+
+interface MermaidScriptProps {
+  noteBody: string;
+}
+
+export const MermaidScript: React.FC<MermaidScriptProps> = (props) => {
+  const [loadMermaid, setLoadMermaid] = React.useState(false);
+  const engine = useEngineAppSelector((state) => state.engine);
+  const config = engine.config;
+  const enableMermaid = config && ConfigUtils.getEnableMermaid(config, true);
+  const { noteBody } = props;
+
+  useEffect(() => {
+    const isMermaidOnWindow = window.mermaid !== undefined;
+    if (isMermaidOnWindow || !enableMermaid) {
+      return;
+    }
+    // semi expensive?
+    const noteHasMermaid = noteBody.includes('class="mermaid"');
+    if (noteHasMermaid) {
+      setLoadMermaid(true);
+    }
+  }, [noteBody, enableMermaid]);
+
+  if (loadMermaid) {
+    const logger = createLogger("MermaidScript");
+    logger.info({ ctx: "loading mermaid" });
+    return (
+      <Script
+        id="initmermaid"
+        src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"
+        onLoad={() => {
+          const mermaid = (window as any).mermaid;
+          // save for debugging
+          // when trying to access mermaid in DOM, <div id="mermaid"></div> gets returned
+          // we disambiguate by saving a copy of mermaid
+          (window as any)._mermaid = mermaid;
+          mermaid.initialize({
+            startOnLoad: false,
+          });
+          // initialize
+          mermaid.init();
+        }}
+      />
+    );
+  }
+  return <></>;
+};

--- a/packages/nextjs-template/components/layout/DendronContent.tsx
+++ b/packages/nextjs-template/components/layout/DendronContent.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Divider } from "antd";
+import Layout, { Content, Footer } from "antd/lib/layout/layout";
+import { DendronBreadCrumb } from "../DendronBreadCrumb";
+import { FooterText } from "../DendronNoteFooter";
+import { DENDRON_STYLE_CONSTANTS } from "../../styles/constants";
+import { useDendronContext } from "../../context/useDendronContext";
+
+const { LAYOUT, HEADER, SIDER } = DENDRON_STYLE_CONSTANTS;
+
+export const DendronContent: React.FC<any> = (props) => {
+  const { isResponsive, isSidebarCollapsed } = useDendronContext();
+  return (
+    <Layout
+      className="side-layout-main"
+      style={{
+        maxWidth: "1200px",
+        display: !isSidebarCollapsed && isResponsive ? "none" : "initial",
+      }}
+    >
+      <Content
+        className="main-content"
+        role="main"
+        style={{ padding: `0 ${LAYOUT.PADDING}px` }}
+      >
+        <DendronBreadCrumb {...props} />
+        {props.children}
+      </Content>
+      <Divider />
+      <Footer
+        style={{
+          padding: `0 ${LAYOUT.PADDING}px ${LAYOUT.PADDING}px`,
+        }}
+      >
+        <FooterText />
+      </Footer>
+    </Layout>
+  );
+};

--- a/packages/nextjs-template/components/layout/DendronHeader.tsx
+++ b/packages/nextjs-template/components/layout/DendronHeader.tsx
@@ -1,0 +1,60 @@
+import { MenuOutlined } from "@ant-design/icons";
+import { Col, Layout, Row } from "antd";
+import * as React from "react";
+import { useDendronContext } from "../../context/useDendronContext";
+import { DENDRON_STYLE_CONSTANTS } from "../../styles/constants";
+import DendronLogoOrTitle from "../DendronLogoOrTitle";
+import { DendronSearch } from "../DendronSearch";
+
+const { Header } = Layout;
+const { LAYOUT, HEADER } = DENDRON_STYLE_CONSTANTS;
+
+export const DendronHeader: React.FC<any> = (props) => {
+  const { isResponsive, isSidebarCollapsed, setIsSidebarCollapsed } =
+    useDendronContext();
+  return (
+    <Header
+      style={{
+        position: "fixed",
+        isolation: "isolate",
+        zIndex: 1,
+        width: "100%",
+        borderBottom: "1px solid #d4dadf",
+        height: HEADER.HEIGHT,
+        padding: isResponsive ? 0 : `0 ${LAYOUT.PADDING}px 0 2px`,
+      }}
+    >
+      <Row
+        justify="center"
+        style={{
+          maxWidth: "992px",
+          justifyContent: "space-between",
+          margin: "0 auto",
+        }}
+      >
+        <Col xs={20} sm={4} style={{ display: "flex" }}>
+          <DendronLogoOrTitle />
+        </Col>
+        <Col xs={0} sm={20} md={20} lg={19} className="gutter-row">
+          <DendronSearch {...props} />
+        </Col>
+        <Col
+          xs={4}
+          sm={4}
+          md={0}
+          lg={0}
+          style={{
+            display: isResponsive ? "flex" : "none",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <MenuOutlined
+            style={{ fontSize: 24 }}
+            onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+          />
+        </Col>
+      </Row>
+    </Header>
+  );
+};

--- a/packages/nextjs-template/components/layout/DendronSidebar.tsx
+++ b/packages/nextjs-template/components/layout/DendronSidebar.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import Sider from "antd/lib/layout/Sider";
+import { useDendronContext } from "../../context/useDendronContext";
+import { DENDRON_STYLE_CONSTANTS } from "../../styles/constants";
+import { DendronSearch } from "../DendronSearch";
+import DendronTreeMenu from "../DendronTreeMenu";
+
+const { LAYOUT, HEADER, SIDER } = DENDRON_STYLE_CONSTANTS;
+
+export const DendronSideBar: React.FC<any> = (props) => {
+  const {
+    isResponsive,
+    isSidebarCollapsed,
+    setIsSidebarCollapsed,
+    setResponsive,
+  } = useDendronContext();
+  return (
+    <div
+      className="site-layout-sidebar"
+      style={{
+        flex: "0 0 auto",
+        width: `calc(max((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2, 0px) + ${
+          // eslint-disable-next-line no-nested-ternary
+          isResponsive
+            ? isSidebarCollapsed
+              ? SIDER.COLLAPSED_WIDTH
+              : "100%"
+            : SIDER.WIDTH
+        }px)`,
+        minWidth: isResponsive || isSidebarCollapsed ? 0 : SIDER.WIDTH,
+        paddingLeft: `calc((100% - ${LAYOUT.BREAKPOINTS.lg}) / 2)`,
+      }}
+    >
+      <Sider
+        width={isResponsive ? "100%" : SIDER.WIDTH}
+        collapsible
+        collapsed={isSidebarCollapsed && isResponsive}
+        collapsedWidth={SIDER.COLLAPSED_WIDTH}
+        onCollapse={(collapsed) => {
+          setIsSidebarCollapsed(collapsed);
+        }}
+        breakpoint="sm"
+        onBreakpoint={(broken) => {
+          setResponsive(broken);
+        }}
+        style={{
+          position: "fixed",
+          overflow: "auto",
+          height: `calc(100vh - ${HEADER.HEIGHT}px)`,
+          backgroundColor: `transparent`,
+        }}
+        trigger={null}
+      >
+        {isResponsive && (
+          <div style={{ padding: 16 }}>
+            <DendronSearch {...props} />
+          </div>
+        )}
+        <DendronTreeMenu
+          {...props}
+          collapsed={isSidebarCollapsed && isResponsive}
+          setCollapsed={setIsSidebarCollapsed}
+        />
+      </Sider>
+    </div>
+  );
+};
+
+export default DendronSideBar;

--- a/packages/nextjs-template/context/DendronProvider.tsx
+++ b/packages/nextjs-template/context/DendronProvider.tsx
@@ -1,4 +1,3 @@
-import { convertLegacyProps } from "antd/lib/button/button";
 import React from "react";
 
 export interface DendronState {

--- a/packages/nextjs-template/context/DendronProvider.tsx
+++ b/packages/nextjs-template/context/DendronProvider.tsx
@@ -1,0 +1,47 @@
+import { convertLegacyProps } from "antd/lib/button/button";
+import React from "react";
+
+export interface DendronState {
+  isResponsive: boolean;
+  isSidebarCollapsed: boolean;
+}
+
+const defaultDendronState: DendronState = {
+  isResponsive: false,
+  isSidebarCollapsed: false,
+};
+
+export interface DendronContext extends DendronState {
+  setResponsive: (isResponsive: boolean) => void;
+  setIsSidebarCollapsed: (isSidebarCollapsed: boolean) => void;
+}
+
+export const dendronContext = React.createContext<DendronContext>(null as any); // null because it gets set in the jsx
+
+export const DendronProvider: React.FC = (props: any) => {
+  const [state, setState] = React.useState<DendronState>({
+    ...defaultDendronState,
+  });
+
+  function setResponsive(isResponsive: boolean) {
+    setState((state) => {
+      return { ...state, isResponsive };
+    });
+  }
+
+  function setIsSidebarCollapsed(isSidebarCollapsed: boolean) {
+    setState((state) => {
+      return { ...state, isSidebarCollapsed };
+    });
+  }
+
+  return (
+    <dendronContext.Provider
+      value={{ setResponsive, setIsSidebarCollapsed, ...state }}
+    >
+      {props.children}
+    </dendronContext.Provider>
+  );
+};
+
+export default DendronProvider;

--- a/packages/nextjs-template/context/useDendronContext.tsx
+++ b/packages/nextjs-template/context/useDendronContext.tsx
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { dendronContext } from "./DendronProvider";
+
+export function useDendronContext() {
+  const context = useContext(dendronContext);
+
+  return context;
+}

--- a/packages/nextjs-template/pages/_app.tsx
+++ b/packages/nextjs-template/pages/_app.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from "react";
 import { ThemeSwitcherProvider } from "react-css-theme-switcher";
 import { useDendronGATracking } from "../components/DendronGATracking";
 import DendronLayout from "../components/DendronLayout";
+import DendronProvider from "../context/DendronProvider";
 import { combinedStore, useCombinedDispatch } from "../features";
 import { browserEngineSlice } from "../features/engine";
 import "../public/assets-dendron/css/light.css";
@@ -88,20 +89,22 @@ function DendronApp({ Component, pageProps }: AppProps) {
   logger.info({ ctx: "render" });
 
   return (
-    <DendronLayout
-      {...noteData}
-      noteIndex={pageProps.noteIndex}
-      dendronRouter={dendronRouter}
-    >
-      <Head>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-      <Component
-        {...pageProps}
-        notes={noteData}
+    <DendronProvider>
+      <DendronLayout
+        {...noteData}
+        noteIndex={pageProps.noteIndex}
         dendronRouter={dendronRouter}
-      />
-    </DendronLayout>
+      >
+        <Head>
+          <link rel="icon" href="/favicon.ico" />
+        </Head>
+        <Component
+          {...pageProps}
+          notes={noteData}
+          dendronRouter={dendronRouter}
+        />
+      </DendronLayout>
+    </DendronProvider>
   );
 }
 

--- a/packages/nextjs-template/types/window.d.ts
+++ b/packages/nextjs-template/types/window.d.ts
@@ -1,8 +1,11 @@
+import { Mermaid } from "mermaid";
+
 // make it a module
 export {};
 
 declare global {
   interface Window {
     currentTheme: "light" | "dark";
+    mermaid?: Mermaid;
   }
 }


### PR DESCRIPTION
In addition to cleaning up DendronLayout, this also optimizes Mermaid so that it only loads the mermaid library once and only once, when a note page that has a mermaid chart is encountered.

# Cleanup some of the frontend code
- Track if isMobile and whether or not the sidebar is open using a useDendronContext hook.  Can add more to that state in the future.
- Split the DendronLayout component to make it easier to grok in the future.

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [x] display is correct for following dimensions
    - [x] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [x] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [x] firefox
    - [x] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)