### PR TITLE
fix(workspace): correctly decorate begin and end anchors

### DIFF
--- a/packages/engine-server/src/markdown/decorations/wikilinks.ts
+++ b/packages/engine-server/src/markdown/decorations/wikilinks.ts
@@ -17,6 +17,7 @@ import _ from "lodash";
 import { WikiLinkNoteV4 } from "../types";
 import { decorateTaskNote, DecorationTaskNote } from "./taskNotes";
 import { findNonNoteFile } from "@dendronhq/common-server";
+import { isBeginBlockAnchorId, isEndBlockAnchorId } from "../remark/noteRefsV2";
 
 export type DecorationWikilink = Decoration & {
   type: DECORATION_TYPES.wikiLink | DECORATION_TYPES.brokenWikilink;
@@ -102,6 +103,9 @@ function checkIfAnchorIsValid({
 }): boolean {
   // if there's no anchor, there's nothing that could be invalid
   if (!anchor) return true;
+  // if it's a ^begin or ^end, it's valid;
+  if (anchor && isBeginBlockAnchorId(anchor.slice(1))) return true;
+  if (anchor && isEndBlockAnchorId(anchor.slice(1))) return true;
   // wildcard header anchor or line anchor. These are hard to check, so let's just say they exist.
   if (anchor && /^[*L]/.test(anchor)) return true;
   // otherwise, check that the anchor actually exists inside the note

--- a/packages/engine-server/src/markdown/remark/noteRefsV2.ts
+++ b/packages/engine-server/src/markdown/remark/noteRefsV2.ts
@@ -100,11 +100,11 @@ function gatherNoteRefs({
   return noteRefs;
 }
 
-function isBeginBlockAnchorId(anchorId: string) {
+export function isBeginBlockAnchorId(anchorId: string) {
   return anchorId === "begin";
 }
 
-function isEndBlockAnchorId(anchorId: string) {
+export function isEndBlockAnchorId(anchorId: string) {
   return anchorId === "end";
 }
 

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -378,6 +378,13 @@ suite("GIVEN a text document with decorations", function () {
               "![[#^anchor-not-exists]]",
               "![[#^anchor-1:#*]]",
               "![[#^anchor-not-exists]]",
+              "[[#^begin]]",
+              "[[#^end]]",
+              "![[#^begin]]",
+              "![[#^end]]",
+              "![[#^begin:#^end]]",
+              "![[#^anchor-1:#^end]]",
+              "![[#^begin:#^anchor-1]]",
             ].join("\n"),
             vault: vaults[0],
             wsRoot,
@@ -393,20 +400,24 @@ suite("GIVEN a text document with decorations", function () {
           const wikilinkDecorations = allDecorations!.get(
             EDITOR_DECORATION_TYPES.wikiLink
           );
-          expect(wikilinkDecorations!.length).toEqual(3);
-          expect(
-            isTextDecorated("[[#^anchor-1]]", wikilinkDecorations!, document)
-          ).toBeTruthy();
-          expect(
-            isTextDecorated("![[#^anchor-1]]", wikilinkDecorations!, document)
-          ).toBeTruthy();
-          expect(
-            isTextDecorated(
-              "![[#^anchor-1:#*]]",
-              wikilinkDecorations!,
-              document
-            )
-          ).toBeTruthy();
+          expect(wikilinkDecorations!.length).toEqual(10);
+          const shouldBeDecorated = [
+            "[[#^anchor-1]]",
+            "![[#^anchor-1]]",
+            "![[#^anchor-1:#*]]",
+            "[[#^begin]]",
+            "[[#^end]]",
+            "![[#^begin]]",
+            "![[#^end]]",
+            "![[#^begin:#^end]]",
+            "![[#^anchor-1:#^end]]",
+            "![[#^begin:#^anchor-1]]",
+          ];
+          shouldBeDecorated.forEach((text) => {
+            expect(
+              isTextDecorated(text, wikilinkDecorations!, document)
+            ).toBeTruthy();
+          });
 
           const brokenWikilinkDecorations = allDecorations!.get(
             EDITOR_DECORATION_TYPES.brokenWikilink

--- a/test-workspace/vault/dendron.ref.links.begin-end.md
+++ b/test-workspace/vault/dendron.ref.links.begin-end.md
@@ -1,0 +1,18 @@
+---
+id: j1hpsp16ydd7054yntb0z07
+title: Begin End
+desc: ""
+updated: 1659527759092
+created: 1659527572910
+---
+
+## Decorations for "^begin" and "^end"
+
+[[dendron.ref.links.block-anchors#^begin]]
+[[dendron.ref.links.block-anchors#^end]]
+[[dendron.ref.links.block-anchors#^end]]
+![[dendron.ref.links.block-anchors#^begin]]
+![[dendron.ref.links.block-anchors#^end]]
+![[dendron.ref.links.block-anchors#^begin:#^end]]
+![[dendron.ref.links.block-anchors#^fifth-item:#^end]]
+![[dendron.ref.links.block-anchors#^begin:#^fifth-item]]


### PR DESCRIPTION
# fix(workspace): correctly decorate begin and end anchors
This PR:
- fixes window decoration for wikilink / note references that contain the anchors `^begin` and `^end`

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [x] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)