### PR TITLE
enhance(views): improve vscode theme integration

### DIFF
--- a/packages/common-assets/styles/scss/main.scss
+++ b/packages/common-assets/styles/scss/main.scss
@@ -20,6 +20,10 @@ $text-color: #111 !default;
 // Portal end
 @import "portal.scss";
 
+.ant-picker-calendar, .ant-picker-calendar .ant-picker-panel {
+  background-color: var(--vscode-editor-background) !important,
+}
+
 // TODO_START: hardcoded
 .vscode-light {
   .calendar {

--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -70,7 +70,7 @@ export class WebViewCommonUtils {
       <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
       <link rel="stylesheet" href="${cssSrc}" />
       <title>Dendron </title>
-      
+
       <style id="${builtinStyle}">
       body, h1, h2, h3, h4 {
         color: var(--vscode-editor-foreground);
@@ -81,7 +81,7 @@ export class WebViewCommonUtils {
         list-style-type: disc;
       }
 
-      body, .ant-layout {
+      body {
         background-color: var(--vscode-editor-background);
       }
 
@@ -169,7 +169,7 @@ export class WebViewCommonUtils {
         if (overrideTheme === "light" || overrideTheme === "dark") {
             // If user picked light or dark as the override, only apply the override
             console.log("Theme override is overriding the default theme", overrideTheme);
-          
+
             defaultTheme = overrideTheme;
             addThemeCSS(defaultTheme, "${defaultStyle}");
         } else if (overrideTheme === "custom") {

--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -70,26 +70,25 @@ export class WebViewCommonUtils {
       <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
       <link rel="stylesheet" href="${cssSrc}" />
       <title>Dendron </title>
-
       <style id="${builtinStyle}">
-      body, h1, h2, h3, h4 {
-        color: var(--vscode-editor-foreground);
-      }
+        body, h1, h2, h3, h4 {
+          color: var(--vscode-editor-foreground);
+        }
 
-      .main-content ul {
-        list-style: unset;
-        list-style-type: disc;
-      }
+        .main-content ul {
+          list-style: unset;
+          list-style-type: disc;
+        }
 
-      body {
-        background-color: var(--vscode-editor-background);
-      }
+        body {
+          background-color: var(--vscode-editor-background);
+        }
 
-      a,
-      a:hover,
-      a:active {
-        color: var(--vscode-textLink-foreground);
-      }
+        a,
+        a:hover,
+        a:active {
+          color: var(--vscode-textLink-foreground);
+        }
       </style>
     </head>
 

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -224,9 +224,13 @@ export type DendronAppProps = {
 };
 
 function DendronApp(props: DendronAppProps) {
+  const style = {
+    padding: props.opts.padding,
+    backgroundColor: "var(--vscode-editor-background)",
+  } as React.CSSProperties;
   return (
     <Provider store={combinedStore}>
-      <Layout style={{ padding: props.opts.padding }}>
+      <Layout style={style}>
         <Content>
           <DendronVSCodeApp {...props} />
         </Content>

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -224,13 +224,14 @@ export type DendronAppProps = {
 };
 
 function DendronApp(props: DendronAppProps) {
-  const style = {
-    padding: props.opts.padding,
-    backgroundColor: "var(--vscode-editor-background)",
-  } as React.CSSProperties;
   return (
     <Provider store={combinedStore}>
-      <Layout style={style}>
+      <Layout
+        style={{
+          padding: props.opts.padding,
+          backgroundColor: "var(--vscode-editor-background)",
+        }}
+      >
         <Content>
           <DendronVSCodeApp {...props} />
         </Content>


### PR DESCRIPTION
This PR aims to improve the calendar view by integrating with vscode theme.
Here we make use of vscode theme editor background token and set calendar-view's background to it.

task: [[Better Compatibility with Vscode Theme|dendron://private/task.2022.07.28.better-compatibility-with-vscode-theme]]