### PR TITLE
enhance(workspace): Add new SchemaStore

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1455,6 +1455,38 @@ export class SchemaUtils {
     return path.join(root, fname + ".schema.yml");
   }
 
+  static getFullPath({
+    schema,
+    wsRoot,
+  }: {
+    schema: SchemaModuleProps;
+    wsRoot: string;
+  }): string {
+    try {
+      const fpath = DNodeUtils.getFullPath({
+        wsRoot,
+        vault: schema.vault,
+        basename: schema.fname + ".schema.yml",
+      });
+      return fpath;
+    } catch (err) {
+      throw new DendronError({
+        message: "bad path",
+        payload: { schema, wsRoot },
+      });
+    }
+  }
+
+  static getURI({
+    schema,
+    wsRoot,
+  }: {
+    schema: SchemaModuleProps;
+    wsRoot: string;
+  }): URI {
+    return URI.file(this.getFullPath({ schema, wsRoot }));
+  }
+
   /**
    @deprecated
    */

--- a/packages/common-all/src/store/ISchemaStore.ts
+++ b/packages/common-all/src/store/ISchemaStore.ts
@@ -1,0 +1,52 @@
+import { SchemaModuleProps, RespV3, WriteSchemaOpts } from "../types";
+
+/**
+ * Interface responsible for interacting with SchemaModuleProps storage layer
+ */
+export interface ISchemaStore<K> {
+  /**
+   * Get SchemaModuleProps metadata by key.
+   * Unlike {@link ISchemaStore.get}, this retrieves SchemaModuleProps from the metadata store.
+   * If key is not found, return error.
+   *
+   * @param key: key of SchemaModuleProps
+   * @return SchemaModuleProps metadata
+   */
+  getMetadata(key: K): Promise<RespV3<SchemaModuleProps>>;
+
+  /**
+   * Write SchemaModuleProps to storage layer for given key, overriding existing SchemaModuleProps if it already exists
+   *
+   * @param opts: SchemaModuleProps write criteria
+   * @return original key
+   */
+  write(opts: WriteSchemaOpts<K>): Promise<RespV3<K>>;
+
+  /**
+   * Write SchemaModuleProps metadata to storage layer for given key, overriding existing SchemaModuleProps metadata if it already exists
+   * Unlike {@link ISchemaStore.write}, this will not touch the filesystem
+   *
+   * @param opts: SchemaModuleProps write criteria
+   * @return original key
+   */
+  writeMetadata(opts: WriteSchemaOpts<K>): Promise<RespV3<K>>;
+
+  /**
+   * Delete SchemaModuleProps from storage layer for given key.
+   * If key does not exist, do nothing.
+   *
+   * @param key: key of SchemaModuleProps to delete
+   * @return original key
+   */
+  delete(key: K): Promise<RespV3<string>>;
+
+  /**
+   * Delete SchemaModuleProps metadata from storage layer for given key.
+   * If key does not exist, do nothing.
+   * Unlike {@link ISchemaStore.delete}, this will not touch the filesystem
+   *
+   * @param key: key of SchemaModuleProps to delete
+   * @return original key
+   */
+  deleteMetadata(key: K): Promise<RespV3<string>>;
+}

--- a/packages/common-all/src/store/ISchemaStore.ts
+++ b/packages/common-all/src/store/ISchemaStore.ts
@@ -32,6 +32,14 @@ export interface ISchemaStore<K> {
   writeMetadata(opts: WriteSchemaOpts<K>): Promise<RespV3<K>>;
 
   /**
+   * Bulk write SchemaModuleProps metadata to storage layer for given key, overriding existing SchemaModuleProps metadata if it already exists
+   *
+   * @param opts: SchemaModuleProps write criteria array
+   * @return original key array
+   */
+  bulkWriteMetadata(opts: WriteSchemaOpts<K>[]): Promise<RespV3<K>[]>;
+
+  /**
    * Delete SchemaModuleProps from storage layer for given key.
    * If key does not exist, do nothing.
    *

--- a/packages/common-all/src/store/index.ts
+++ b/packages/common-all/src/store/index.ts
@@ -1,3 +1,4 @@
 export * from "./IFileStore";
 export * from "./IDataStore";
 export * from "./INoteStore";
+export * from "./ISchemaStore";

--- a/packages/common-all/src/types/store.ts
+++ b/packages/common-all/src/types/store.ts
@@ -1,4 +1,5 @@
 import { NoteProps, NotePropsMeta } from "./foundation";
+import { SchemaModuleProps } from "./typesv2";
 import { DVault } from "./workspace";
 
 // Types used on the store layer
@@ -24,4 +25,9 @@ export type WriteNoteOpts<K> = {
 export type WriteNoteMetaOpts<K> = {
   key: K;
   noteMeta: NotePropsMeta;
+};
+
+export type WriteSchemaOpts<K> = {
+  key: K;
+  schema: SchemaModuleProps;
 };

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -372,7 +372,7 @@ export async function note2File({
   return genHash(payload);
 }
 
-function serializeModuleProps(moduleProps: SchemaModuleProps) {
+export function serializeModuleProps(moduleProps: SchemaModuleProps) {
   const { version, imports, schemas } = moduleProps;
   // TODO: filter out imported schemas
   const out: any = {

--- a/packages/common-server/src/parser.ts
+++ b/packages/common-server/src/parser.ts
@@ -131,7 +131,7 @@ export class SchemaParserV2 extends ParserBaseV2 {
   ): Promise<SchemaModuleProps> {
     const version = _.isArray(schemaOpts) ? 0 : 1;
     if (version > 0) {
-      return await SchemaParserV2.parseSchemaModuleOpts(
+      return SchemaParserV2.parseSchemaModuleOpts(
         schemaOpts as SchemaModuleOpts,
         opts
       );

--- a/packages/engine-server/src/drivers/file/schemaParser.ts
+++ b/packages/engine-server/src/drivers/file/schemaParser.ts
@@ -4,11 +4,7 @@ import {
   ERROR_STATUS,
   SchemaModuleProps,
 } from "@dendronhq/common-all";
-import {
-  DLogger,
-  SchemaParserV2 as cSchemaParserV2,
-  vault2Path,
-} from "@dendronhq/common-server";
+import { DLogger, SchemaParserV2, vault2Path } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -34,7 +30,7 @@ export class SchemaParser {
       await fs.readFile(path.join(vpath, fpath), "utf8")
     );
 
-    return cSchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
+    return SchemaParserV2.parseRaw(schemaOpts, { root, fname, wsRoot });
   }
 
   async parse(

--- a/packages/engine-server/src/store/NoteStore.ts
+++ b/packages/engine-server/src/store/NoteStore.ts
@@ -179,7 +179,7 @@ export class NoteStore implements Disposable, INoteStore<string> {
     return this._metadataStore.write(key, noteMeta);
   }
 
-  /**s
+  /**
    * See {@link INoteStore.bulkWriteMetadata}
    */
   async bulkWriteMetadata(

--- a/packages/engine-server/src/store/SchemaMetadataStore.ts
+++ b/packages/engine-server/src/store/SchemaMetadataStore.ts
@@ -1,0 +1,67 @@
+import {
+  DendronError,
+  ERROR_SEVERITY,
+  ERROR_STATUS,
+  IDataStore,
+  RespV3,
+  SchemaModuleProps,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+
+export class SchemaMetadataStore
+  implements IDataStore<string, SchemaModuleProps>
+{
+  /**
+   * Map of schema root id -> SchemaModuleProps
+   */
+  private _schemaMetadataById: Record<string, SchemaModuleProps>;
+
+  constructor() {
+    this._schemaMetadataById = {};
+  }
+
+  /**
+   * See {@link IDataStore.get}
+   */
+  async get(key: string): Promise<RespV3<SchemaModuleProps>> {
+    const maybeSchema = this._schemaMetadataById[key];
+
+    if (maybeSchema) {
+      return { data: _.cloneDeep(maybeSchema) };
+    } else {
+      return {
+        error: DendronError.createFromStatus({
+          status: ERROR_STATUS.CONTENT_NOT_FOUND,
+          message: `SchemaModuleProps not found for key ${key}.`,
+          severity: ERROR_SEVERITY.MINOR,
+        }),
+      };
+    }
+  }
+
+  async find(opts: any): Promise<RespV3<SchemaModuleProps[]>> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * See {@link IDataStore.write}
+   *
+   * Add schema to _schemaMetadataById. If schema root id already exists, override existing schema
+   */
+  async write(key: string, data: SchemaModuleProps): Promise<RespV3<string>> {
+    this._schemaMetadataById[data.root.id] = data;
+
+    return { data: key };
+  }
+
+  /**
+   * See {@link IDataStore.delete}
+   *
+   * Remove schema from both _schemaMetadataById.
+   */
+  async delete(key: string): Promise<RespV3<string>> {
+    delete this._schemaMetadataById[key];
+
+    return { data: key };
+  }
+}

--- a/packages/engine-server/src/store/SchemaMetadataStore.ts
+++ b/packages/engine-server/src/store/SchemaMetadataStore.ts
@@ -39,7 +39,7 @@ export class SchemaMetadataStore
     }
   }
 
-  async find(opts: any): Promise<RespV3<SchemaModuleProps[]>> {
+  async find(_opts: any): Promise<RespV3<SchemaModuleProps[]>> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/engine-server/src/store/SchemaStore.ts
+++ b/packages/engine-server/src/store/SchemaStore.ts
@@ -74,19 +74,6 @@ export class SchemaStore implements Disposable, ISchemaStore<string> {
   }
 
   /**
-   * See {@link ISchemaStore.bulkWriteMetadata}
-   */
-  async bulkWriteMetadata(
-    opts: WriteSchemaOpts<string>[]
-  ): Promise<RespV3<string>[]> {
-    return Promise.all(
-      opts.map((writeMetaOpt) => {
-        return this.writeMetadata(writeMetaOpt);
-      })
-    );
-  }
-
-  /**
    * See {@link ISchemaStore.writeMetadata}
    */
   async writeMetadata(opts: WriteSchemaOpts<string>): Promise<RespV3<string>> {
@@ -103,6 +90,19 @@ export class SchemaStore implements Disposable, ISchemaStore<string> {
       };
     }
     return this._metadataStore.write(key, schema);
+  }
+
+  /**
+   * See {@link ISchemaStore.bulkWriteMetadata}
+   */
+  async bulkWriteMetadata(
+    opts: WriteSchemaOpts<string>[]
+  ): Promise<RespV3<string>[]> {
+    return Promise.all(
+      opts.map((writeMetaOpt) => {
+        return this.writeMetadata(writeMetaOpt);
+      })
+    );
   }
 
   /**

--- a/packages/engine-server/src/store/SchemaStore.ts
+++ b/packages/engine-server/src/store/SchemaStore.ts
@@ -1,0 +1,139 @@
+import {
+  DendronError,
+  Disposable,
+  ERROR_SEVERITY,
+  ERROR_STATUS,
+  IDataStore,
+  IFileStore,
+  ISchemaStore,
+  RespV3,
+  SchemaModuleProps,
+  SchemaUtils,
+  WriteSchemaOpts,
+} from "@dendronhq/common-all";
+import {
+  createDisposableLogger,
+  DLogger,
+  serializeModuleProps,
+} from "@dendronhq/common-server";
+
+export class SchemaStore implements Disposable, ISchemaStore<string> {
+  private _fileStore: IFileStore;
+  private _metadataStore: IDataStore<string, SchemaModuleProps>;
+  private _wsRoot: string;
+  private _logger: DLogger;
+  private _loggerDispose: () => any;
+
+  constructor(opts: {
+    fileStore: IFileStore;
+    dataStore: IDataStore<string, SchemaModuleProps>;
+    wsRoot: string;
+  }) {
+    this._fileStore = opts.fileStore;
+    this._metadataStore = opts.dataStore;
+    this._wsRoot = opts.wsRoot;
+    const { logger, dispose } = createDisposableLogger();
+    this._logger = logger;
+    this._loggerDispose = dispose;
+  }
+
+  dispose() {
+    this._loggerDispose();
+  }
+
+  /**
+   * See {@link ISchemaStore.getMetadata}
+   */
+  async getMetadata(key: string): Promise<RespV3<SchemaModuleProps>> {
+    const ctx = "SchemaStore:getMetadata";
+    this._logger.info({ ctx, msg: `Getting SchemaModuleProps for ${key}` });
+    return this._metadataStore.get(key);
+  }
+
+  /**
+   * See {@link ISchemaStore.write}
+   */
+  async write(opts: WriteSchemaOpts<string>): Promise<RespV3<string>> {
+    const { key, schema } = opts;
+
+    const metaResp = await this.writeMetadata({ key, schema });
+    if (metaResp.error) {
+      return { error: metaResp.error };
+    }
+
+    const uri = SchemaUtils.getURI({ schema, wsRoot: this._wsRoot });
+    const writeResp = await this._fileStore.write(
+      uri,
+      serializeModuleProps(schema)
+    );
+    if (writeResp.error) {
+      return { error: writeResp.error };
+    }
+
+    return { data: key };
+  }
+
+  /**
+   * See {@link ISchemaStore.writeMetadata}
+   */
+  async writeMetadata(opts: WriteSchemaOpts<string>): Promise<RespV3<string>> {
+    const { key, schema } = opts;
+
+    // Ids don't match, return error
+    if (key !== schema.root.id) {
+      return {
+        error: DendronError.createFromStatus({
+          status: ERROR_STATUS.WRITE_FAILED,
+          message: `Ids don't match between key ${key} and schema ${schema}.`,
+          severity: ERROR_SEVERITY.MINOR,
+        }),
+      };
+    }
+    return this._metadataStore.write(key, schema);
+  }
+
+  /**
+   * See {@link ISchemaStore.delete}
+   */
+  async delete(key: string): Promise<RespV3<string>> {
+    const metadata = await this.getMetadata(key);
+    if (metadata.error) {
+      return { error: metadata.error };
+    }
+    const resp = await this.deleteMetadata(key);
+    if (resp.error) {
+      return { error: resp.error };
+    }
+
+    const uri = SchemaUtils.getURI({
+      schema: metadata.data,
+      wsRoot: this._wsRoot,
+    });
+    const deleteResp = await this._fileStore.delete(uri);
+    if (deleteResp.error) {
+      return { error: deleteResp.error };
+    }
+
+    return { data: key };
+  }
+
+  /**
+   * See {@link ISchemaStore.deleteMetadata}
+   */
+  async deleteMetadata(key: string): Promise<RespV3<string>> {
+    const metadata = await this.getMetadata(key);
+    if (metadata.error) {
+      return { error: metadata.error };
+    } else if (metadata.data.fname === "root") {
+      return {
+        error: DendronError.createFromStatus({
+          status: ERROR_STATUS.CANT_DELETE_ROOT,
+          message: `Cannot delete ${key}. Root schemas cannot be deleted.`,
+          severity: ERROR_SEVERITY.MINOR,
+        }),
+      };
+    }
+
+    return this._metadataStore.delete(key);
+  }
+}

--- a/packages/engine-server/src/store/SchemaStore.ts
+++ b/packages/engine-server/src/store/SchemaStore.ts
@@ -74,6 +74,19 @@ export class SchemaStore implements Disposable, ISchemaStore<string> {
   }
 
   /**
+   * See {@link ISchemaStore.bulkWriteMetadata}
+   */
+  async bulkWriteMetadata(
+    opts: WriteSchemaOpts<string>[]
+  ): Promise<RespV3<string>[]> {
+    return Promise.all(
+      opts.map((writeMetaOpt) => {
+        return this.writeMetadata(writeMetaOpt);
+      })
+    );
+  }
+
+  /**
    * See {@link ISchemaStore.writeMetadata}
    */
   async writeMetadata(opts: WriteSchemaOpts<string>): Promise<RespV3<string>> {

--- a/packages/engine-server/src/store/index.ts
+++ b/packages/engine-server/src/store/index.ts
@@ -1,3 +1,5 @@
 export * from "./NodeJSFileStore";
 export * from "./NoteStore";
 export * from "./NoteMetadataStore";
+export * from "./SchemaStore";
+export * from "./SchemaMetadataStore";

--- a/packages/engine-test-utils/src/__tests__/engine-server/store/schemaStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/store/schemaStore.spec.ts
@@ -1,0 +1,141 @@
+import { ERROR_STATUS } from "@dendronhq/common-all";
+import { vault2Path } from "@dendronhq/common-server";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import {
+  NodeJSFileStore,
+  SchemaMetadataStore,
+  SchemaStore,
+} from "@dendronhq/engine-server";
+import _ from "lodash";
+import { runEngineTestV5 } from "../../../engine";
+import fs from "fs-extra";
+
+describe("GIVEN SchemaStore", () => {
+  test("WHEN writing a schema, THEN getMetadata should retrieve same schema", async () => {
+    await runEngineTestV5(
+      async ({ vaults, wsRoot }) => {
+        const vault = vaults[0];
+        const schemaStore = new SchemaStore({
+          fileStore: new NodeJSFileStore(),
+          dataStore: new SchemaMetadataStore(),
+          wsRoot,
+        });
+        const newSchema = await NoteTestUtilsV4.createSchema({
+          fname: "fname1",
+          vault,
+          wsRoot,
+          noWrite: true,
+        });
+
+        let schema = await schemaStore.getMetadata(newSchema.root.id);
+        expect(schema.data).toBeFalsy();
+        await schemaStore.write({ key: newSchema.root.id, schema: newSchema });
+
+        // Make sure schema is written to filesystem
+        const vpath = vault2Path({ vault, wsRoot });
+        expect(
+          _.includes(fs.readdirSync(vpath), "fname1.schema.yml")
+        ).toBeTruthy();
+
+        // Test SchemaStore.getMetadata
+        schema = await schemaStore.getMetadata(newSchema.root.id);
+        expect(schema.data!.fname).toEqual(newSchema.fname);
+        expect(schema.data!.root.id).toEqual(newSchema.root.id);
+      },
+      {
+        expect,
+      }
+    );
+  });
+
+  test("WHEN writing and deleting a schema, THEN getMetadata should return CONTENT_NOT_FOUND", async () => {
+    await runEngineTestV5(
+      async ({ vaults, wsRoot }) => {
+        const vault = vaults[0];
+        const schemaStore = new SchemaStore({
+          fileStore: new NodeJSFileStore(),
+          dataStore: new SchemaMetadataStore(),
+          wsRoot,
+        });
+        const newSchema = await NoteTestUtilsV4.createSchema({
+          fname: "fname1",
+          vault,
+          wsRoot,
+          noWrite: true,
+        });
+
+        await schemaStore.write({ key: newSchema.root.id, schema: newSchema });
+
+        // Test SchemaStore.getMetadata
+        const schema = await schemaStore.getMetadata(newSchema.root.id);
+        expect(schema.data!.fname).toEqual(newSchema.fname);
+
+        // Test SchemaStore.delete
+        const deleteResp = await schemaStore.delete(newSchema.root.id);
+        expect(deleteResp.data).toBeTruthy();
+
+        const schema2 = await schemaStore.getMetadata(newSchema.root.id);
+        expect(schema2.error?.status).toEqual(ERROR_STATUS.CONTENT_NOT_FOUND);
+      },
+      {
+        expect,
+      }
+    );
+  });
+
+  test("WHEN writing a schema with a mismatched key, THEN error should be returned", async () => {
+    await runEngineTestV5(
+      async ({ vaults, wsRoot }) => {
+        const vault = vaults[0];
+        const schemaStore = new SchemaStore({
+          fileStore: new NodeJSFileStore(),
+          dataStore: new SchemaMetadataStore(),
+          wsRoot,
+        });
+        const newSchema = await NoteTestUtilsV4.createSchema({
+          fname: "fname1",
+          vault,
+          wsRoot,
+          noWrite: true,
+        });
+
+        const writeResp = await schemaStore.write({
+          key: "bar",
+          schema: newSchema,
+        });
+        expect(writeResp.data).toBeFalsy();
+        expect(writeResp.error?.status).toEqual(ERROR_STATUS.WRITE_FAILED);
+      },
+      {
+        expect,
+      }
+    );
+  });
+
+  test("WHEN deleting a root schema, THEN error should return and be CANT_DELETE_ROOT", async () => {
+    await runEngineTestV5(
+      async ({ wsRoot, engine }) => {
+        const schemaStore = new SchemaStore({
+          fileStore: new NodeJSFileStore(),
+          dataStore: new SchemaMetadataStore(),
+          wsRoot,
+        });
+
+        _.values(engine.schemas).forEach(async (schema) => {
+          await schemaStore.writeMetadata({ key: schema.root.id, schema });
+        });
+
+        // Test SchemaStore.getMetadata
+        const resp = await schemaStore.getMetadata("root");
+
+        // Test SchemaStore.delete
+        const deleteResp = await schemaStore.delete(resp.data!.root.id);
+        expect(deleteResp.data).toBeUndefined();
+        expect(deleteResp.error?.status).toEqual(ERROR_STATUS.CANT_DELETE_ROOT);
+      },
+      {
+        expect,
+      }
+    );
+  });
+});


### PR DESCRIPTION
**Changes**
1. Create `SchemaStore` in charge of working with `SchemaModuleProps` storage layer

**Design Decisions**
1. Since we don't have anything metadata specific, I've chosen to use the same typing for both the metadata store and the non-metadata store
2. Get calls will retrieve from the metadata store. This is to align with current behavior of storing schemas in an in-memory dictionary
3. Delete/write will work with both metadata store and file system (like current behavior)