### PR TITLE
feat(refactor): merge note command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-21
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-22
           restore-keys: |
             ${{ runner.os }}-yarn-9
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-22
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-21
           restore-keys: |
             ${{ runner.os }}-yarn-9
 

--- a/packages/engine-server/src/markdown/remark/utils.ts
+++ b/packages/engine-server/src/markdown/remark/utils.ts
@@ -719,6 +719,19 @@ export class LinkUtils {
     }
   }
 
+  /**
+   * Given a note, updates old link to new link.
+   * If you are calling this on a note multiple times,
+   * You need to start from the last link in the body
+   * Because each updateLink call will shift the location of
+   * every element in the note body that comes after
+   * the link you update
+   *
+   * @param note the note that contains link to update
+   * @param oldLink the old link that needs to be updated
+   * @param newLink new link
+   * @returns
+   */
   static updateLink({
     note,
     oldLink,

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -249,6 +249,10 @@
         "title": "Dendron: Move Note"
       },
       {
+        "command": "dendron.mergeNote",
+        "title": "Dendron: Merge Note"
+      },
+      {
         "command": "dendron.randomNote",
         "title": "Dendron: Random Note"
       },
@@ -647,6 +651,10 @@
         {
           "command": "dendron.moveNote",
           "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.mergeNote",
+          "when": "dendron:pluginActive"
         },
         {
           "command": "dendron.randomNote",

--- a/packages/plugin-core/src/commands/MergeNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MergeNoteCommand.ts
@@ -86,6 +86,177 @@ export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
     });
   }
 
+  /**
+   * Given a source note and destination note,
+   * append the entire body of source note to the destination note.
+   * @param source Source note
+   * @param dest Dest note
+   */
+  private async appendNote(opts: { source: NoteProps; dest: NoteProps }) {
+    const { source, dest } = opts;
+    // grab body from current active note
+    const appendPayload = source.body;
+
+    // append to end
+    const destBody = dest.body;
+    const newBody = `${destBody}\n\n${appendPayload}`;
+    dest.body = newBody;
+    const writeResp = await this.extension.getEngine().writeNote(dest);
+    if (!writeResp.error) {
+      return writeResp.data || [];
+    } else {
+      this.L.error(writeResp.error);
+      return [];
+    }
+  }
+
+  /**
+   * Helper for {@link updateBacklinks}.
+   * Given a note id, source and dest note,
+   * Find all links in note with id that points to source
+   * and update it to point to dest instead.
+   * @param opts
+   */
+  private async updateLinkInNote(opts: {
+    id: string;
+    source: NoteProps;
+    dest: NoteProps;
+  }) {
+    const ctx = `${this.key}:updateLinkInNote`;
+    const { id, source, dest } = opts;
+    const noteToUpdate = await this.extension.getEngine().getNote(id);
+    if (noteToUpdate !== undefined) {
+      const linksToUpdate = noteToUpdate.links.filter(
+        (link) => link.value === source.fname
+      );
+      const noteToUpdateDeepCopy = _.cloneDeep(noteToUpdate);
+      const modifiedNote = await _.reduce<
+        typeof linksToUpdate[0],
+        Promise<NoteProps>
+      >(
+        // we need to do it in reverse order to not mess up the location we update
+        linksToUpdate.reverse(),
+        async (prev, linkToUpdate) => {
+          const acc = await prev;
+          const oldLink = LinkUtils.dlink2DNoteLink(linkToUpdate);
+          const notesWithSameName = await this.extension.getEngine().findNotes({
+            fname: dest.fname,
+          });
+          const isXVault = oldLink.data.xvault || notesWithSameName.length > 1;
+          const newLink = {
+            ...oldLink,
+            from: {
+              ...oldLink.from,
+              alias:
+                oldLink.from.alias === oldLink.from.fname
+                  ? dest.fname
+                  : oldLink.from.alias,
+              fname: dest.fname,
+              vaultName: VaultUtils.getName(dest.vault),
+            },
+            data: {
+              ...oldLink.data,
+              xvault: isXVault,
+            },
+          };
+          const newBody = LinkUtils.updateLink({
+            note: acc,
+            oldLink,
+            newLink,
+          });
+          acc.body = newBody;
+          return acc;
+        },
+        Promise.resolve(noteToUpdateDeepCopy)
+      );
+
+      noteToUpdate.body = modifiedNote.body;
+      const writeResp = await this.extension
+        .getEngine()
+        .writeNote(noteToUpdate);
+      if (writeResp.data) {
+        return writeResp.data;
+      } else {
+        // We specifically filtered for notes that do have some links to update,
+        // so this is very unlikely to be reached.
+        // Gracefully handle and log error
+        this.L.error({ ctx, message: "No links found to update" });
+        return [];
+      }
+    }
+    // Note to update wasn't found
+    // this will likely never happen given a sound engine state.
+    // Log this as a canary for the engine state, and gracefully return.
+    this.L.error({ ctx, message: "No note found" });
+    return [];
+  }
+
+  /**
+   * Given a source note and dest note,
+   * Look at all the backlinks source note has, and update them
+   * to point to the dest note.
+   * @param source Source note
+   * @param dest Dest note
+   */
+  private async updateBacklinks(opts: { source: NoteProps; dest: NoteProps }) {
+    const ctx = "MergeNoteCommand:updateBacklinks";
+    const { source, dest } = opts;
+
+    // grab all backlinks from source note
+    const sourceBacklinks = source.links.filter((link) => {
+      return link.type === "backlink";
+    });
+
+    // scrub through the backlinks and all notes that need to be updated
+    const noteIDsToUpdate = Array.from(
+      new Set(
+        sourceBacklinks
+          .map((backlink) => backlink.from.id)
+          .filter((ent): ent is string => ent !== undefined)
+      )
+    );
+
+    // for each note that needs to be updated,
+    // find all links that need to be updated from end to front.
+    // then update them.
+    let noteChangeEntries: NoteChangeEntry[] = [];
+    await asyncLoopOneAtATime(noteIDsToUpdate, async (id) => {
+      try {
+        const changed = await this.updateLinkInNote({
+          source,
+          dest,
+          id,
+        });
+        noteChangeEntries = noteChangeEntries.concat(changed);
+      } catch (error) {
+        this.L.error({ ctx, error });
+      }
+    });
+    return noteChangeEntries;
+  }
+
+  /**
+   * Given a source note, delete it
+   * @param source source note
+   */
+  private async deleteSource(opts: { source: NoteProps }) {
+    const ctx = `${this.key}:deleteSource`;
+    const { source } = opts;
+    try {
+      const deleteResp = await this.extension.getEngine().deleteNote(source.id);
+      if (deleteResp.data) {
+        return deleteResp.data;
+      } else {
+        // This is very unlikely given a sound engine state.
+        // log it and gracefully return
+        return [];
+      }
+    } catch (error) {
+      this.L.error({ ctx, error });
+      return [];
+    }
+  }
+
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const ctx = "MergeNoteCommand";
     this.L.info({ ctx, notes: opts.notes.map((n) => NoteUtils.toLogObj(n)) });
@@ -98,116 +269,29 @@ export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
       };
     }
 
-    const destNote = opts.notes[0];
-    const sourceNote = this.extension.wsUtils.getActiveNote();
-    if (!sourceNote) {
+    // opts.notes should always have at most one element since we don't allow multiple destinations.
+    const dest = opts.notes[0];
+    const source = this.extension.wsUtils.getActiveNote();
+    if (!source) {
       return {
         ...opts,
         changed: [],
       };
     }
 
-    // grab body from current active note
-    const appendPayload = sourceNote.body;
+    const appendNoteChanges = await this.appendNote({ source, dest });
+    const updateBacklinksChanges = await this.updateBacklinks({ source, dest });
+    const deleteSourceChanges = await this.deleteSource({ source });
 
-    // append to end
-    const destNoteBody = destNote.body;
-    const newBody = `${destNoteBody}\n\n${appendPayload}`;
-    destNote.body = newBody;
-    await this.extension.getEngine().writeNote(destNote);
-    // update backlinks to old note
-
-    // get all backlinks that should be updated
-    const sourceNoteBacklinks = sourceNote?.links.filter((link) => {
-      return link.type === "backlink";
-    });
-
-    const noteIDsToUpdate = Array.from(
-      new Set(
-        sourceNoteBacklinks
-          .map((backlink) => backlink.from.id)
-          .filter((ent): ent is string => ent !== undefined)
-      )
-    );
-
-    let noteChangeEntries: NoteChangeEntry[] = [];
-    await asyncLoopOneAtATime(noteIDsToUpdate, async (id) => {
-      try {
-        const noteToUpdate = await this.extension.getEngine().getNote(id);
-        if (noteToUpdate !== undefined) {
-          const linksToUpdate = noteToUpdate.links.filter(
-            (link) => link.value === sourceNote.fname
-          );
-          const noteToUpdateDeepCopy = _.cloneDeep(noteToUpdate);
-          const modifiedNote = await _.reduce<
-            typeof linksToUpdate[0],
-            Promise<NoteProps>
-          >(
-            // we need to do it backwards to not mess up the location we update
-            linksToUpdate.reverse(),
-            async (prev, linkToUpdate) => {
-              const acc = await prev;
-              const oldLink = LinkUtils.dlink2DNoteLink(linkToUpdate);
-              const notesWithSameName = await this.extension
-                .getEngine()
-                .findNotes({
-                  fname: destNote.fname,
-                });
-              const isXVault =
-                oldLink.data.xvault || notesWithSameName.length > 1;
-              const newLink = {
-                ...oldLink,
-                from: {
-                  ...oldLink.from,
-                  alias:
-                    oldLink.from.alias === oldLink.from.fname
-                      ? destNote.fname
-                      : oldLink.from.alias,
-                  fname: destNote.fname,
-                  vaultName: VaultUtils.getName(destNote.vault),
-                },
-                data: {
-                  ...oldLink.data,
-                  xvault: isXVault,
-                },
-              };
-              const newBody = LinkUtils.updateLink({
-                note: acc,
-                oldLink,
-                newLink,
-              });
-              acc.body = newBody;
-              return acc;
-            },
-            Promise.resolve(noteToUpdateDeepCopy)
-          );
-
-          noteToUpdate.body = modifiedNote.body;
-          const writeResp = await this.extension
-            .getEngine()
-            .writeNote(noteToUpdate);
-          if (writeResp.data) {
-            noteChangeEntries = noteChangeEntries.concat(writeResp.data);
-          }
-        }
-      } catch (error) {
-        this.L.error({ ctx, error });
-      }
-    });
-    // delete old note
-    try {
-      const deleteResp = await this.extension
-        .getEngine()
-        .deleteNote(sourceNote.id);
-      if (deleteResp.data) {
-        noteChangeEntries = noteChangeEntries.concat(deleteResp.data);
-      }
-    } catch (error) {
-      this.L.error({ ctx, error });
-    }
+    const noteChangeEntries = [
+      ...appendNoteChanges,
+      ...updateBacklinksChanges,
+      ...deleteSourceChanges,
+    ];
 
     // open the destination note
-    await this.extension.wsUtils.openNote(destNote);
+    await this.extension.wsUtils.openNote(dest);
+
     return {
       ...opts,
       changed: noteChangeEntries,

--- a/packages/plugin-core/src/commands/MergeNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MergeNoteCommand.ts
@@ -229,7 +229,11 @@ export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }) {
     const ctx = `${this.key}:updateLinkInNote`;
     const { id, sourceNote, destNote } = opts;
-    const noteToUpdate = await this.extension.getEngine().getNote(id);
+    const getNoteResp = await this.extension.getEngine().getNote(id);
+    if (getNoteResp.error) {
+      throw getNoteResp.error;
+    }
+    const noteToUpdate = getNoteResp.data;
     if (noteToUpdate !== undefined) {
       const linksToUpdate = noteToUpdate.links.filter(
         (link) => link.value === sourceNote.fname

--- a/packages/plugin-core/src/commands/MergeNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MergeNoteCommand.ts
@@ -1,0 +1,165 @@
+import {
+  asyncLoopOneAtATime,
+  NoteProps,
+  NoteUtils,
+} from "@dendronhq/common-all";
+import { HistoryEvent, LinkUtils } from "@dendronhq/engine-server";
+import {
+  ILookupControllerV3,
+  LookupControllerV3CreateOpts,
+} from "../components/lookup/LookupControllerV3Interface";
+import { NoteLookupProviderSuccessResp } from "../components/lookup/LookupProviderV3Interface";
+import { NoteLookupProviderUtils } from "../components/lookup/NoteLookupProviderUtils";
+import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { BasicCommand, SanityCheckResults } from "./base";
+import * as vscode from "vscode";
+import _ from "lodash";
+
+type CommandInput = {};
+
+type CommandOpts = {
+  notes: readonly NoteProps[];
+} & CommandInput;
+
+type CommandOutput = {};
+
+export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
+  key = DENDRON_COMMANDS.MERGE_NOTE.key;
+  private extension: IDendronExtension;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+  }
+
+  createLookupController(): ILookupControllerV3 {
+    const opts: LookupControllerV3CreateOpts = {
+      nodeType: "note",
+      disableVaultSelection: true,
+    };
+    const controller = this.extension.lookupControllerFactory.create(opts);
+    return controller;
+  }
+
+  createLookupProvider() {
+    return this.extension.noteLookupProviderFactory.create(this.key, {
+      allowNewNote: false,
+      noHidePickerOnAccept: false,
+    });
+  }
+
+  async sanityCheck(
+    _opts?: Partial<{ notes: readonly NoteProps[] }> | undefined
+  ): Promise<SanityCheckResults> {
+    const note = this.extension.wsUtils.getActiveNote();
+    if (!note) {
+      return "You need to have a note open to merge.";
+    }
+    return;
+  }
+
+  async gatherInputs(
+    _opts?: CommandOpts | undefined
+  ): Promise<CommandOpts | undefined> {
+    const controller = this.createLookupController();
+    const provider = this.createLookupProvider();
+    return new Promise((resolve) => {
+      NoteLookupProviderUtils.subscribe({
+        id: this.key,
+        controller,
+        logger: this.L,
+        onDone: (event: HistoryEvent) => {
+          const data: NoteLookupProviderSuccessResp = event.data;
+          resolve({ notes: data.selectedItems });
+        },
+      });
+      controller.show({
+        title: "Select merge destination note",
+        placeholder: "note",
+        provider,
+      });
+    });
+  }
+
+  async execute(opts: CommandOpts): Promise<CommandOutput> {
+    const ctx = "MergeNoteCommand";
+    this.L.info({ ctx, notes: opts.notes.map((n) => NoteUtils.toLogObj(n)) });
+
+    if (opts.notes.length === 0) {
+      vscode.window.showWarningMessage("Merge destination not selected");
+      return {};
+    }
+
+    const destNote = opts.notes[0];
+    const sourceNote = this.extension.wsUtils.getActiveNote();
+    if (!sourceNote) {
+      return {};
+    }
+
+    // grab body from current active note
+    const appendPayload = sourceNote.body;
+
+    // append to end
+    const destNoteBody = destNote.body;
+    const newBody = `${destNoteBody}\n\n${appendPayload}`;
+    destNote.body = newBody;
+    await this.extension.getEngine().writeNote(destNote);
+    // update backlinks to old note
+
+    // get all backlinks that should be updated
+    const sourceNoteBacklinks = sourceNote?.links.filter((link) => {
+      return link.type === "backlink";
+    });
+    console.log({ sourceNoteBacklinks });
+
+    const noteIDsToUpdate = Array.from(
+      new Set(
+        sourceNoteBacklinks
+          .map((backlink) => backlink.from.id)
+          .filter((ent): ent is string => ent !== undefined)
+      )
+    );
+
+    await asyncLoopOneAtATime(noteIDsToUpdate, async (id) => {
+      const noteToUpdate = await this.extension.getEngine().getNote(id);
+      if (noteToUpdate !== undefined) {
+        const linksToUpdate = noteToUpdate.links.filter(
+          (link) => link.value === sourceNote.fname
+        );
+        console.log({ linksToUpdate });
+        const noteToUpdateDeepCopy = _.cloneDeep(noteToUpdate);
+        const modifiedNote = _.reduce<typeof linksToUpdate[0], NoteProps>(
+          linksToUpdate,
+          (prev, linkToUpdate) => {
+            const oldLink = LinkUtils.dlink2DNoteLink(linkToUpdate);
+            const newLink = {
+              ...oldLink,
+              to: {
+                ...oldLink.to,
+                fname: destNote.fname,
+              },
+            };
+            const newBody = LinkUtils.updateLink({
+              note: prev,
+              oldLink,
+              newLink,
+            });
+            prev.body = newBody;
+            return prev;
+          },
+          noteToUpdateDeepCopy
+        );
+        console.log({ modifiedNote });
+
+        noteToUpdate.body = modifiedNote.body;
+        const writeResp = await this.extension
+          .getEngine()
+          .writeNote(noteToUpdate);
+        console.log({ writeResp });
+      }
+    });
+    // delete old note
+    return {};
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -83,6 +83,7 @@ import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
+import { MergeNoteCommand } from "./MergeNoteCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -173,6 +174,7 @@ const ALL_COMMANDS = [
   OpenBackupCommand,
   InstrumentedWrapperCommand,
   ValidateEngineCommand,
+  MergeNoteCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -53,6 +53,7 @@ export type ILookupProviderOptsV3 = {
    * when (and only when) nothing is queried.
    */
   extraItems?: DNodePropsQuickInputV2[];
+  preAcceptValidators?: ((selectedItems: NoteQuickInput[]) => boolean)[];
 };
 
 export type NoteLookupProviderSuccessResp<T = never> = {

--- a/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
@@ -119,6 +119,13 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       });
 
       let selectedItems = NotePickerUtils.getSelection(picker);
+      const { preAcceptValidators } = this.opts;
+      if (preAcceptValidators) {
+        const isValid = preAcceptValidators.every((validator) => {
+          return validator(selectedItems);
+        });
+        if (!isValid) return;
+      }
       Logger.debug({
         ctx,
         selectedItems: selectedItems.map((item) => NoteUtils.toLogObj(item)),

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -516,6 +516,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Move Note`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
+  MERGE_NOTE: {
+    key: "dendron.mergeNote",
+    title: `${CMD_PREFIX} Merge Note`,
+    when: DendronContext.PLUGIN_ACTIVE,
+  },
   RANDOM_NOTE: {
     key: "dendron.randomNote",
     title: `${CMD_PREFIX} Random Note`,

--- a/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
@@ -48,7 +48,9 @@ suite("MergeNote", function () {
           const postRunDest = await engine.getNote("dest");
           expect(postRunSource).toBeFalsy();
           expect(postRunDest).toBeTruthy();
-          expect(postRunDest?.body).toEqual("Dest body\n\n\nSource body\n");
+          expect(postRunDest?.body).toEqual(
+            "Dest body\n\n---\n\n# Source\n\nSource body\n"
+          );
 
           expect(runOut?.changed.length).toEqual(3);
           expect(runOut?.changed.map((change) => change.status)).toEqual([
@@ -110,7 +112,9 @@ suite("MergeNote", function () {
           const postRunRef = await engine.getNote("ref");
           expect(postRunSource).toBeFalsy();
           expect(postRunDest).toBeTruthy();
-          expect(postRunDest?.body).toEqual("Dest body\n\n\nSource body\n");
+          expect(postRunDest?.body).toEqual(
+            "Dest body\n\n---\n\n# Source\n\nSource body\n"
+          );
           expect(postRunRef?.body).toEqual(
             "[[dest]]\n[[dendron://vault1/dest]]\n![[dest]]\n![[dendron://vault1/dest]]"
           );

--- a/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
@@ -1,0 +1,129 @@
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import { describe } from "mocha";
+import { MergeNoteCommand } from "../../commands/MergeNoteCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { describeMultiWS } from "../testUtilsV3";
+import { expect } from "../testUtilsv2";
+
+suite("MergeNote", function () {
+  describe("GIVEN a source note with no backlinks", () => {
+    describeMultiWS(
+      "WHEN merged",
+      {
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: "source",
+            wsRoot,
+            vault: vaults[0],
+            body: "Source body\n",
+          });
+          await NoteTestUtilsV4.createNote({
+            fname: "dest",
+            wsRoot,
+            vault: vaults[0],
+            body: "Dest body\n",
+          });
+        },
+        timeout: 5e3,
+      },
+      () => {
+        test("THEN source body is appended to dest, source is deleted, and changes are emitted", async () => {
+          const extension = ExtensionProvider.getExtension();
+          const cmd = new MergeNoteCommand(extension);
+          const engine = extension.getEngine();
+          const preRunSource = await engine.getNote("source");
+          const preRunDest = await engine.getNote("dest");
+          if (preRunSource && preRunDest) {
+            await extension.wsUtils.openNote(preRunSource);
+          } else {
+            throw new Error("source and dest not found.");
+          }
+
+          const runOut = await cmd.run({
+            dest: "dest",
+            noConfirm: true,
+          });
+
+          const postRunSource = await engine.getNote("source");
+          const postRunDest = await engine.getNote("dest");
+          expect(postRunSource).toBeFalsy();
+          expect(postRunDest).toBeTruthy();
+          expect(postRunDest?.body).toEqual("Dest body\n\n\nSource body\n");
+
+          expect(runOut?.changed.length).toEqual(3);
+          expect(runOut?.changed.map((change) => change.status)).toEqual([
+            "update", // dest updated
+            "update", // root updated
+            "delete", // source deleted
+          ]);
+        });
+      }
+    );
+  });
+  describe("GIVEN a source note with backlinks", () => {
+    describeMultiWS(
+      "WHEN merged",
+      {
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createNote({
+            fname: "source",
+            wsRoot,
+            vault: vaults[0],
+            body: "Source body\n",
+          });
+          await NoteTestUtilsV4.createNote({
+            fname: "dest",
+            wsRoot,
+            vault: vaults[0],
+            body: "Dest body\n",
+          });
+          await NoteTestUtilsV4.createNote({
+            fname: "ref",
+            wsRoot,
+            vault: vaults[0],
+            body: "[[source]]\n[[dendron://vault1/source]]\n![[source]]\n![[dendron://vault1/source]]",
+          });
+        },
+        timeout: 5e3,
+      },
+      () => {
+        test("THEN source body is appended to dest, source is deleted, and changes are emitted", async () => {
+          const extension = ExtensionProvider.getExtension();
+          const cmd = new MergeNoteCommand(extension);
+          const engine = extension.getEngine();
+          const preRunSource = await engine.getNote("source");
+          const preRunDest = await engine.getNote("dest");
+          const preRunRef = await engine.getNote("ref");
+          if (preRunSource && preRunDest && preRunRef) {
+            await extension.wsUtils.openNote(preRunSource);
+          } else {
+            throw new Error("Note(s) not found.");
+          }
+
+          const runOut = await cmd.run({
+            dest: "dest",
+            noConfirm: true,
+          });
+
+          const postRunSource = await engine.getNote("source");
+          const postRunDest = await engine.getNote("dest");
+          const postRunRef = await engine.getNote("ref");
+          expect(postRunSource).toBeFalsy();
+          expect(postRunDest).toBeTruthy();
+          expect(postRunDest?.body).toEqual("Dest body\n\n\nSource body\n");
+          expect(postRunRef?.body).toEqual(
+            "[[dest]]\n[[dendron://vault1/dest]]\n![[dest]]\n![[dendron://vault1/dest]]"
+          );
+
+          expect(runOut?.changed.length).toEqual(4);
+          expect(runOut?.changed.map((change) => change.status)).toEqual([
+            "update", // dest updated
+            "update", // ref updated
+            "update", // root updated
+            "delete", // source deleted
+          ]);
+        });
+      }
+    );
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
@@ -31,8 +31,8 @@ suite("MergeNote", function () {
           const extension = ExtensionProvider.getExtension();
           const cmd = new MergeNoteCommand(extension);
           const engine = extension.getEngine();
-          const preRunSource = await engine.getNote("source");
-          const preRunDest = await engine.getNote("dest");
+          const preRunSource = (await engine.getNote("source")).data;
+          const preRunDest = (await engine.getNote("dest")).data;
           if (preRunSource && preRunDest) {
             await extension.wsUtils.openNote(preRunSource);
           } else {
@@ -44,8 +44,8 @@ suite("MergeNote", function () {
             noConfirm: true,
           });
 
-          const postRunSource = await engine.getNote("source");
-          const postRunDest = await engine.getNote("dest");
+          const postRunSource = (await engine.getNote("source")).data;
+          const postRunDest = (await engine.getNote("dest")).data;
           expect(postRunSource).toBeFalsy();
           expect(postRunDest).toBeTruthy();
           expect(postRunDest?.body).toEqual(
@@ -93,9 +93,9 @@ suite("MergeNote", function () {
           const extension = ExtensionProvider.getExtension();
           const cmd = new MergeNoteCommand(extension);
           const engine = extension.getEngine();
-          const preRunSource = await engine.getNote("source");
-          const preRunDest = await engine.getNote("dest");
-          const preRunRef = await engine.getNote("ref");
+          const preRunSource = (await engine.getNote("source")).data;
+          const preRunDest = (await engine.getNote("dest")).data;
+          const preRunRef = (await engine.getNote("ref")).data;
           if (preRunSource && preRunDest && preRunRef) {
             await extension.wsUtils.openNote(preRunSource);
           } else {
@@ -107,9 +107,9 @@ suite("MergeNote", function () {
             noConfirm: true,
           });
 
-          const postRunSource = await engine.getNote("source");
-          const postRunDest = await engine.getNote("dest");
-          const postRunRef = await engine.getNote("ref");
+          const postRunSource = (await engine.getNote("source")).data;
+          const postRunDest = (await engine.getNote("dest")).data;
+          const postRunRef = (await engine.getNote("ref")).data;
           expect(postRunSource).toBeFalsy();
           expect(postRunDest).toBeTruthy();
           expect(postRunDest?.body).toEqual(

--- a/test-workspace/vault/dendron.ref.merge-note.destination.md
+++ b/test-workspace/vault/dendron.ref.merge-note.destination.md
@@ -1,0 +1,9 @@
+---
+id: xrnpdp8etxe63w6ov0dps83
+title: Destination
+desc: ''
+updated: 1659680883489
+created: 1659680875718
+---
+
+This is a merge note destination

--- a/test-workspace/vault/dendron.ref.merge-note.should-update-1.md
+++ b/test-workspace/vault/dendron.ref.merge-note.should-update-1.md
@@ -1,0 +1,27 @@
+---
+id: bn6hbetw4zhjyx1273pl2g2
+title: Should Update 1
+desc: ''
+updated: 1659683289975
+created: 1659680942010
+---
+
+This is a note that has a link that should update when merge happens
+
+- links
+[[dendron.ref.merge-note.source]]
+[[anchor link|dendron.ref.merge-note.source#^55nqtav1wh81]]
+[[Some header|dendron.ref.merge-note.source#some-header]]
+
+- refs
+![[dendron.ref.merge-note.source]]
+![[dendron://vault/dendron.ref.merge-note.source]]
+![[alias|dendron://vault/dendron.ref.merge-note.source#some-header,1]]
+
+- these should not update
+[[dendron.ref.assets]]
+[[Block Anchors|dendron.ref.links.block-anchors#^first-paragraph]]
+[[Mollitia ipsum et velit quia vel|dendron.ref.links.block-anchors#mollitia-ipsum-et-velit-quia-vel]]
+![[Mollitia ipsum et velit quia vel|dendron.ref.links.block-anchors#mollitia-ipsum-et-velit-quia-vel]]
+[[Mollitia ipsum et velit quia vel|dendron://vault/dendron.ref.links.block-anchors#mollitia-ipsum-et-velit-quia-vel]]
+![[Mollitia ipsum et velit quia vel|dendron://vault/dendron.ref.links.block-anchors#mollitia-ipsum-et-velit-quia-vel]]

--- a/test-workspace/vault/dendron.ref.merge-note.source.md
+++ b/test-workspace/vault/dendron.ref.merge-note.source.md
@@ -1,0 +1,16 @@
+---
+id: ptyzihyt6ktyek8l0g23tqd
+title: Source
+desc: ''
+updated: 1659681415647
+created: 1659680898744
+---
+
+This is a merge note source
+This is going to be appended to the destination
+
+some content that has an anchor  ^55nqtav1wh81
+
+## Some header
+This is a header in source
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -18286,6 +18286,11 @@ moment@^2.19.3, moment@^2.24.0, moment@^2.25.3:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
+moment@^2.29.2:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 morgan@^1.10.0, morgan@^1.6.1:
   version "1.10.0"
   resolved "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"


### PR DESCRIPTION
# feat(refactor): merge note command
This PR:
- adds a new command `Dendron: Merge Note`
- enhances Lookup provider so that it can take a list of `preAcceptValidators` when it is created by the lookup provider factory.
  - this will allow lookup-derivative commands (such as this one) to pass in list of a predicate functions that would be executed when the user hits enter in the quickpick.
  - if any of the `preAcceptValidator` fails, lookup will not be accepted until the user selects a valid item from the quickpick
  - In merge note command, this is used to prevent users from merging the active note to itself.

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)