### PR TITLE
fix (navigate): check if dendron note is active

### DIFF
--- a/packages/plugin-core/src/commands/GoToSiblingCommand.ts
+++ b/packages/plugin-core/src/commands/GoToSiblingCommand.ts
@@ -38,7 +38,7 @@ export class GoToSiblingCommand extends BasicCommand<
 
   async execute(opts: CommandOpts) {
     const ctx = "GoToSiblingCommand";
-    // validate editor and note exists
+    // check if editor exists
     const textEditor = VSCodeUtils.getActiveTextEditor();
     if (!textEditor) {
       window.showErrorMessage("You need to be in a note to use this command");
@@ -51,7 +51,14 @@ export class GoToSiblingCommand extends BasicCommand<
     const ext = ExtensionProvider.getExtension();
     const workspace = ext.getDWorkspace();
     const note = await this.getActiveNote(workspace.engine, fname);
-    if (!note) throw new Error(`${ctx}: ${UNKNOWN_ERROR_MSG}`);
+
+    // check if a Dendron note is active
+    if (!note) {
+      window.showErrorMessage("Please open a Dendron note to use this command");
+      return {
+        msg: "other_error" as const,
+      };
+    }
 
     let siblingNote: NoteProps;
     // If the active note is a journal note, get the sibling note based on the chronological order

--- a/packages/plugin-core/src/test/suite-integ/GoToSibling.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoToSibling.test.ts
@@ -189,8 +189,7 @@ suite("GoToSibling", () => {
       test("Warning message should appear", async () => {
         await VSCodeUtils.closeAllEditors();
         // Create a file that is not a Dendron note and show it on editor
-        const workspaceRootPath =
-          vscode.workspace.workspaceFolders![0].uri.fsPath;
+        const workspaceRootPath = ExtensionProvider.getEngine().wsRoot;
         const filePath = path.join(workspaceRootPath, "test.txt");
         fs.writeFileSync(filePath, "sample file content", "utf8");
         const fileUri = vscode.Uri.file(filePath);


### PR DESCRIPTION
This PR fixes the bug caused when `Dendron: Go Next/Previous Sibling` command is run without an active dendron note on the editor.

issue: #3355 