### PR TITLE
fix(publish): deprecate Dendron: Publish Dev command

### DIFF
--- a/packages/plugin-core/src/commands/PublishDevCommand.ts
+++ b/packages/plugin-core/src/commands/PublishDevCommand.ts
@@ -1,14 +1,9 @@
-import { DENDRON_EMOJIS } from "@dendronhq/common-all";
-import fs from "fs-extra";
-import _ from "lodash";
+import * as vscode from "vscode";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { getSiteRootDirPath, NextJSPublishUtils } from "../utils/site";
 import { BasicCommand } from "./base";
 
-type CommandOutput = {
-  pid: number;
-};
+type CommandOutput = {};
 
 export class PublishDevCommand extends BasicCommand<CommandOutput> {
   key = DENDRON_COMMANDS.PUBLISH_DEV.key;
@@ -17,54 +12,20 @@ export class PublishDevCommand extends BasicCommand<CommandOutput> {
     return {};
   }
 
-  async sanityCheck() {
-    const sitePath = getSiteRootDirPath();
-    if (!fs.existsSync(sitePath)) {
-      fs.ensureDirSync(sitePath);
-    }
-    return undefined;
-  }
-
   async execute() {
     const ctx = "PublishDevCommand";
     this.L.info({ ctx, msg: "enter" });
-
-    const prepareOut = await NextJSPublishUtils.prepareNextJSExportPod();
-    const { enrichedOpts, wsRoot, cmd, nextPath } = prepareOut;
-    this.L.info({ ctx, msg: "prepare", enrichedOpts, nextPath });
-
-    if (_.isUndefined(enrichedOpts)) {
-      return {};
-    }
-
-    const isInitialized = await NextJSPublishUtils.isInitialized(wsRoot);
-    if (!isInitialized) {
-      await NextJSPublishUtils.initialize(nextPath);
-    }
-
-    const skipBuild = await NextJSPublishUtils.promptSkipBuild();
-    this.L.info({ ctx, msg: "skipBuild?", skipBuild });
-    if (!skipBuild) {
-      const { podChoice, config } = enrichedOpts;
-      await NextJSPublishUtils.build(cmd, podChoice, config);
-    }
-
-    this.L.info({ ctx, msg: "starting dev" });
-    const pid = await NextJSPublishUtils.dev(nextPath);
-
-    return { pid };
-  }
-
-  async showResponse(opts: CommandOutput) {
     window
-      .showInformationMessage(
-        `Server is running on localhost:3000 ${DENDRON_EMOJIS.SEEDLING}`,
-        ...["Stop serving"]
+      .showWarningMessage(
+        "The Dendron: Publish Dev command is now deprecated. Please use Dendron CLI to publish your notes.",
+        ...["Open docs"]
       )
-      .then(async (resp) => {
-        if (resp === "Stop serving") {
-          const { pid } = opts;
-          process.kill(pid, "SIGTERM");
+      .then((resp) => {
+        if (resp === "Open docs") {
+          vscode.commands.executeCommand(
+            "vscode.open",
+            "https://wiki.dendron.so/notes/2340KhiZJWUy31Nrn37Fd/"
+          );
         }
       });
   }


### PR DESCRIPTION
This PR aims to deprecate `Dendron: Publish Dev` command. The user gets a warning toaster to use Dendron CLI instead with a button to publish cook docs.
added it as a `fix` to include this in changelog