### PR TITLE
fix(workspace): don't throw during activation

### DIFF
--- a/packages/plugin-core/src/web/extension.ts
+++ b/packages/plugin-core/src/web/extension.ts
@@ -11,11 +11,16 @@ import { setupWebExtContainer } from "./injection-providers/setupWebExtContainer
  */
 export async function activate(context: vscode.ExtensionContext) {
   // Use the web extension injection container:
-  await setupWebExtContainer();
+  try {
+    await setupWebExtContainer();
+    await setupCommands(context);
+    vscode.commands.executeCommand("setContext", "dendron:pluginActive", true);
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `Something went wrong during initialization.`
+    );
+  }
 
-  setupCommands(context);
-
-  vscode.commands.executeCommand("setContext", "dendron:pluginActive", true);
   vscode.window.showInformationMessage("Dendron is active");
 }
 


### PR DESCRIPTION
## fix(workspace): don't throw during activation

Don't throw during activation of web ext - seeing if this will bypass Marketplace validation checks.