### PR TITLE
chore: fix init error on windows

### DIFF
--- a/packages/common-server/src/StateValidator.ts
+++ b/packages/common-server/src/StateValidator.ts
@@ -29,7 +29,7 @@ export class StateValidator {
 
             const vpath = vault2Path({ vault, wsRoot: engine.wsRoot });
             const out = await getAllFiles({
-              root: URI.parse(vpath),
+              root: URI.file(vpath),
               include: ["*.md"],
             });
 

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -157,7 +157,7 @@ export class DendronEngineV3 implements DEngine {
       noteStore: new NoteStore(
         fileStore,
         new NoteMetadataStore(),
-        URI.parse(wsRoot)
+        URI.file(wsRoot)
       ),
       fileStore,
       mode: "fuzzy",
@@ -1028,7 +1028,7 @@ export class DendronEngineV3 implements DEngine {
         const vpath = vault2Path({ vault, wsRoot: this.wsRoot });
         // Get list of files from filesystem
         const maybeFiles = await this._fileStore.readDir({
-          root: URI.parse(vpath),
+          root: URI.file(vpath),
           include: ["*.md"],
         });
         if (maybeFiles.error) {

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -434,7 +434,7 @@ export class FileStorage implements DStore {
     this.logger.info({ ctx, msg: "enter" });
     const vpath = vault2Path({ vault, wsRoot: this.wsRoot });
     const out = await getAllFiles({
-      root: URI.parse(vpath),
+      root: URI.file(vpath),
       include: ["*.schema.yml"],
     });
     if (out.error || !out.data) {
@@ -605,7 +605,7 @@ export class FileStorage implements DStore {
     const wsRoot = this.wsRoot;
     const vpath = vault2Path({ vault, wsRoot });
     const out = await getAllFiles({
-      root: URI.parse(vpath),
+      root: URI.file(vpath),
       include: ["*.md"],
     });
     if (out.error) {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -523,7 +523,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     await fs.ensureDir(newFolder);
     // Move all note files
     const noteFiles = await getAllFiles({
-      root: URI.parse(oldFolder),
+      root: URI.file(oldFolder),
       include: ["*.md"],
     });
     if (!noteFiles.data) {

--- a/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/drivers/file/schemaParser.spec.ts
@@ -32,7 +32,7 @@ async function parseSchemas(
       const vault = vaults[0];
       const vpath = vault2Path({ vault, wsRoot });
       const schemaFiles = await getAllFiles({
-        root: URI.parse(vpath),
+        root: URI.file(vpath),
         include: ["*.schema.yml"],
       });
       expect(schemaFiles.data).toBeTruthy();

--- a/packages/engine-test-utils/src/__tests__/engine-server/store/noteStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/store/noteStore.spec.ts
@@ -20,7 +20,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
 
         _.values(engine.notes).forEach(async (note) => {
@@ -86,7 +86,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
 
         const newNote = await NoteTestUtilsV4.createNote({
@@ -128,7 +128,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -170,7 +170,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -205,7 +205,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -255,7 +255,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -302,7 +302,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -328,7 +328,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -389,7 +389,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar123",
@@ -449,7 +449,7 @@ describe("GIVEN NoteStore", () => {
         const noteStore = new NoteStore(
           new NodeJSFileStore(),
           new NoteMetadataStore(),
-          URI.parse(wsRoot)
+          URI.file(wsRoot)
         );
 
         _.values(engine.notes).forEach(async (note) => {

--- a/packages/plugin-core/src/commands/Refactor.ts
+++ b/packages/plugin-core/src/commands/Refactor.ts
@@ -69,7 +69,7 @@ export abstract class RefactorBaseCommand<
     const out = await getAllFilesWithTypes({
       include: opts.include,
       exclude: opts.exclude,
-      root: Uri.parse(opts.root),
+      root: Uri.file(opts.root),
     });
     if (out.data === undefined) throw out.error;
     return out.data;

--- a/packages/plugin-core/src/web/test/helpers/WorkspaceHelpers.ts
+++ b/packages/plugin-core/src/web/test/helpers/WorkspaceHelpers.ts
@@ -15,7 +15,7 @@ export class WorkspaceHelpers {
 
     const randomUUID = require("crypto-randomuuid");
 
-    const tmpDirectory = Utils.joinPath(URI.parse(tmp), randomUUID());
+    const tmpDirectory = Utils.joinPath(URI.file(tmp), randomUUID());
     await vscode.workspace.fs.createDirectory(tmpDirectory);
 
     return tmpDirectory;

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -15,7 +15,7 @@ require("mocha/mocha");
 
 suite("GIVEN a NoteLookupCmd", () => {
   test("WHEN the user selects nothing THEN nothing is written to the engine", async () => {
-    const wsRoot = vscode.Uri.parse("tmp");
+    const wsRoot = vscode.Uri.file("tmp");
 
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
@@ -50,7 +50,7 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN the user selects a note THEN that note is opened", async () => {
-    const wsRoot = vscode.Uri.parse("tmp");
+    const wsRoot = vscode.Uri.file("tmp");
 
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
@@ -97,7 +97,7 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN Create New is selected THEN a new note is written", async () => {
-    const wsRoot = vscode.Uri.parse("tmp");
+    const wsRoot = vscode.Uri.file("tmp");
 
     const mockNoteProvider = stubInterface<ILookupProvider>();
 


### PR DESCRIPTION
This PR aims to fix an error on master and nightly `107.4` which throws error on windows.
```DendronError: Schema 'undefined' is malformed. Reason: undefined\\n    at g.createMalformedSchemaError``` : https://github.com/dendronhq/dendron/runs/7788087046?check_suite_focus=true#step:15:9

