### PR TITLE
fix(views): removes semicolon in preview

### DIFF
--- a/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
@@ -145,7 +145,7 @@ const DendronNotePreview: DendronComponent = (props) => {
 
   return (
     <>
-      <DendronNote noteContent={noteRenderedBody} config={config} />;
+      <DendronNote noteContent={noteRenderedBody} config={config} />
       <Button
         shape="circle"
         icon={isLocked ? <LockFilled /> : <UnlockOutlined />}


### PR DESCRIPTION
This PR aims to remove an accidentially added semicolon into the render function of the preview view.
