### PR TITLE
chore: fix type error in tutorial initializer

### DIFF
--- a/packages/plugin-core/src/workspace/tutorialInitializer.ts
+++ b/packages/plugin-core/src/workspace/tutorialInitializer.ts
@@ -192,8 +192,8 @@ export class TutorialInitializer
       skipTreeView: boolean;
     }>;
   }) {
-    const { skipOpts } = opts;
-    if (!skipOpts.skipTreeView) {
+    const skipOpts = opts.skipOpts;
+    if (!skipOpts?.skipTreeView) {
       // for tutorial workspaces,
       // we want the tree view to be focused
       // so that new users can discover the tree view feature.


### PR DESCRIPTION
# chore: fix type error in tutorial initializer
- This PR:
  - Fixes a type error introduced in https://github.com/dendronhq/dendron/pull/3380
