### PR TITLE
fix(schema): correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1744,11 +1744,15 @@ export class SchemaUtils {
     const match = _.find(schemas, (sc) => {
       const pattern = SchemaUtils.getPatternRecursive(sc, schemaModule.schemas);
       if (sc?.data?.namespace && matchNamespace) {
-        // if we are matching a namespace node,
-        // match on the level of the node itself and its immediate children.
         namespace = true;
+        // current note is at the level of the namespace node.
+        // the glob pattern accounts for its immediate children (/*/*),
+        // so in order to match the current note, we should slice off
+        // the last bit of the glob pattern (/*)
         return minimatch(notePathClean, pattern.slice(0, -2));
       } else {
+        // we are either trying to match the immediate child of a namespace node,
+        // or match a non-namespace regular schema. use the pattern as-is
         return minimatch(notePathClean, pattern);
       }
     });

--- a/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/dnode.spec.ts
@@ -267,6 +267,38 @@ schemas:
         })
       );
     });
+
+    describe("GIVEN a schema with namespace node", () => {
+      runAllTests(
+        makeSchemaTests({
+          schema: `version: 1
+imports: []
+schemas:
+  - id: test
+    children: 
+      - testing
+    title: test
+    parent: root
+  - id: testing
+    pattern: "*"
+    title: "testing"
+    namespace: true
+    template:
+      id: template.test
+      type: note`,
+          checks: {
+            test: true,
+            "test.test1": true,
+            "test.foo": true,
+            "test.test1.test2": true,
+            "test.test1.foo": true,
+            "test.test1.test2.test3": false,
+            "test.foo.bar.baz": false,
+          },
+          expect,
+        })
+      );
+    });
   });
 });
 

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -2608,7 +2608,7 @@ suite("NoteLookupCommand", function () {
           expect(createdNote.schema).toBeTruthy();
 
           // created note has template that was specified by the schema applied
-          const templateNote = await engine.getNote("template.test");
+          const templateNote = (await engine.getNote("template.test")).data;
           expect(createdNote.body).toEqual(templateNote?.body);
         });
       }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -10,6 +10,7 @@ import {
   NoteQuickInput,
   NoteUtils,
   SchemaTemplate,
+  SchemaUtils,
   Time,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -2534,6 +2535,84 @@ suite("NoteLookupCommand", function () {
         });
       });
     });
+  });
+
+  describe("GIVEN a stub note that should match some schema", () => {
+    describeMultiWS(
+      "WHEN it is accepted as a new item",
+      {
+        preSetupHook: async ({ wsRoot, vaults }) => {
+          await NoteTestUtilsV4.createSchema({
+            fname: "test",
+            wsRoot,
+            vault: vaults[0],
+            modifier: (schema) => {
+              const schemas = [
+                SchemaUtils.createFromSchemaOpts({
+                  fname: "test",
+                  id: "test",
+                  children: ["testing"],
+                  title: "test",
+                  parent: "root",
+                  vault: vaults[0],
+                }),
+                SchemaUtils.createFromSchemaRaw({
+                  id: "testing",
+                  pattern: "*",
+                  title: "testing",
+                  namespace: true,
+                  template: {
+                    id: "template.test",
+                    type: "note",
+                  },
+                  vault: vaults[0],
+                }),
+              ];
+              schemas.map((s) => {
+                schema.schemas[s.id] = s;
+              });
+              return schema;
+            },
+          });
+          await NoteTestUtilsV4.createNote({
+            fname: "template.test",
+            wsRoot,
+            vault: vaults[0],
+            body: "template body",
+          });
+          await NoteTestUtilsV4.createNote({
+            fname: "test.one.two.three",
+            wsRoot,
+            vault: vaults[0],
+          });
+        },
+      },
+      () => {
+        test("stub note that was accepted is created with the schema applied", async () => {
+          VSCodeUtils.closeAllEditors();
+          const cmd = new NoteLookupCommand();
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          stubVaultPick(vaults);
+          const engine = ExtensionProvider.getEngine();
+          await cmd.run({
+            noConfirm: true,
+            initialValue: "test.one.two",
+          });
+          const findResp = await engine.findNotes({
+            fname: "test.one.two",
+          });
+          expect(findResp.length).toEqual(1);
+          const createdNote = findResp[0];
+
+          // created note has schema applied
+          expect(createdNote.schema).toBeTruthy();
+
+          // created note has template that was specified by the schema applied
+          const templateNote = await engine.getNote("template.test");
+          expect(createdNote.body).toEqual(templateNote?.body);
+        });
+      }
+    );
   });
 });
 


### PR DESCRIPTION
# fix(schema): correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub

This PR:
- Correctly matches notes with namespace schema nodes
  - namespace node match pattern was trimmed excessively and was not matching the node on the same depth as well as its immediate children
- Correctly apply schema when a note that existed as a stub is accepted as a new item through note lookup
  - When a note is created as a stub (because of a leaf note), it bypasses any schema application.
  - When this note is later accepted as a new note through lookup, this note that can potentially have a schema match does not get created with a schema applied.

## Manual testing
### correctly matches namespace
1. create the following schema:
```
    version: 1
    imports: []
    schemas:
      - id: test
        children: 
          - testing
        title: test
        parent: root
      - id: testing
        pattern: "*"
        title: "testing"
        namespace: true
        template:
          id: template.test
          type: note
```
2. Create `template.test` with any note body
3. Create notes `test.test1` and `test.test1.test2` and see that `template.test` was applied to both of them
### correctly applies schema to newly accepted stub notes
1. Create the same schema describe above
2. Create note `test.one.two.three`
    - Note that this has no schema match, but it's parent that is a stub should match the schema above
3. Using lookup, create the note `test.one.two`.
    - This should already be in the quickpick as a stub
5. Since it has a matching schema, it should have the template applied to it.


# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)