### PR TITLE
enhance(cli): New write notes CLI command

### DIFF
--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -2,7 +2,6 @@ import {
   assertUnreachable,
   DendronError,
   DEngineClient,
-  DVault,
   ErrorFactory,
   NoteLookupUtils,
   NoteProps,

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -369,14 +369,17 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
           const vault = checkVault(opts);
           const notes = await engine.findNotes({ fname, vault });
           let note: NoteProps;
+          let status: string;
 
           // If note doesn't exist, create new note
           if (notes.length === 0) {
             note = NoteUtils.create({ fname, vault, body });
+            status = "CREATE";
           } else {
             // If note exists, update note body
             const newBody = body || "";
             note = { ...notes[0], body: newBody };
+            status = "UPDATE";
           }
           const resp = await engine.writeNote(note);
           if (resp.error) {
@@ -388,7 +391,9 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             };
           } else {
             this.print(`wrote ${note.fname}`);
-            return { data: { payload: note.fname, rawData: resp } };
+            return {
+              data: { payload: note.fname, rawData: resp, status },
+            };
           }
         }
         case NoteCommands.DELETE: {

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
@@ -242,7 +242,7 @@ describe("WHEN run 'dendron note find'", () => {
             wsRoot,
             engine,
             cmd,
-            fName: "gamma",
+            fname: "gamma",
             output: NoteCLIOutput.JSON,
           })) as { data: NoteCommandData };
           expect(data.notesOutput).toEqual([]);
@@ -266,7 +266,7 @@ describe("WHEN run 'dendron note find'", () => {
             wsRoot,
             engine,
             cmd,
-            fName: "foo.ch1",
+            fname: "foo.ch1",
             output: NoteCLIOutput.JSON,
           })) as { data: NoteCommandData };
           expect(_.map(data.notesOutput, (n) => n.fname)).toEqual(["foo.ch1"]);
@@ -288,7 +288,7 @@ describe("WHEN run 'dendron note find'", () => {
             wsRoot,
             engine,
             cmd,
-            fName: "root",
+            fname: "root",
             output: NoteCLIOutput.JSON,
           })) as { data: NoteCommandData };
           expect(_.map(data.notesOutput, (n) => n.fname)).toEqual([
@@ -314,7 +314,7 @@ describe("WHEN run 'dendron note find'", () => {
             wsRoot,
             engine,
             cmd,
-            fName: "root",
+            fname: "root",
             vault: vaults[1].fsPath,
             output: NoteCLIOutput.JSON,
           })) as { data: NoteCommandData };
@@ -551,7 +551,7 @@ describe("WHEN run 'dendron note write", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "newbar",
+            fname: "newbar",
             body: "this is body of newbar",
           });
           const after = await engine.findNotes({ fname: "newbar", vault });
@@ -578,13 +578,38 @@ describe("WHEN run 'dendron note write", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "bar",
+            fname: "bar",
             body: "updateBody",
           });
           const after = (await engine.findNotes({ fname: "bar", vault }))[0];
           expect(after.body).toEqual("updateBody");
           expect(before.fname).toEqual(after.fname);
           expect(before.vault).toEqual(after.vault);
+        },
+        {
+          createEngine: createEngineV3FromEngine,
+          expect,
+          preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
+        }
+      );
+    });
+  });
+
+  describe("WHEN fname is not provided", () => {
+    test("THEN error is returned", async () => {
+      await runEngineTestV5(
+        async ({ engine, wsRoot, vaults }) => {
+          const vault = vaults[1];
+          const resp = await runCmd({
+            wsRoot,
+            vault: VaultUtils.getName(vault),
+            engine,
+            cmd,
+            body: "updateBody",
+          });
+          expect(resp.error?.message).toEqual(
+            "Please specify an fname to write to"
+          );
         },
         {
           createEngine: createEngineV3FromEngine,

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/noteCli.spec.ts
@@ -500,7 +500,7 @@ describe("WHEN run 'dendron note delete", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "bar",
+            fname: "bar",
           });
           const after = await engine.findNotesMeta({ fname: "bar", vault });
           expect(after.length).toEqual(0);
@@ -524,7 +524,7 @@ describe("WHEN run 'dendron note delete", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "blahblah",
+            fname: "blahblah",
           });
           expect(resp.error?.message).toEqual("note blahblah not found");
         },
@@ -594,31 +594,6 @@ describe("WHEN run 'dendron note write", () => {
       );
     });
   });
-
-  describe("WHEN fname is not provided", () => {
-    test("THEN error is returned", async () => {
-      await runEngineTestV5(
-        async ({ engine, wsRoot, vaults }) => {
-          const vault = vaults[1];
-          const resp = await runCmd({
-            wsRoot,
-            vault: VaultUtils.getName(vault),
-            engine,
-            cmd,
-            body: "updateBody",
-          });
-          expect(resp.error?.message).toEqual(
-            "Please specify an fname to write to"
-          );
-        },
-        {
-          createEngine: createEngineV3FromEngine,
-          expect,
-          preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti,
-        }
-      );
-    });
-  });
 });
 
 describe("WHEN run 'dendron note move'", () => {
@@ -634,7 +609,7 @@ describe("WHEN run 'dendron note move'", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "foo",
+            fname: "foo",
             destFname: "moved-note",
           });
           expect(
@@ -665,7 +640,7 @@ describe("WHEN run 'dendron note move'", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "bar",
+            fname: "bar",
             destFname: "moved-note",
           });
           expect(
@@ -697,7 +672,7 @@ describe("WHEN run 'dendron note move'", () => {
             vault: VaultUtils.getName(vault),
             engine,
             cmd,
-            query: "bar",
+            fname: "bar",
             destFname: "car",
             destVaultName: VaultUtils.getName(otherVault),
           });


### PR DESCRIPTION
**Background**
Moving forward, we would like the notes CLI to closely mirror engine notes methods. For this pr, we will introduce a `WRITE` cli command that will create a note if fname/vault doesn't exist or update body of existing note.

Options:
`fname`: Required
`vault`: Required if more than one vault exists
`body`: Not required. Defaults to ""

**How to use**
```
dendron note write --useLocalEngine --fname "mytest" --vault vault --body "this is a body"
```

**Other Changes**
1. Renamed options for `DELETE` and `MOVE` to use `fname` instead of `query`