### PR TITLE
fix(views): show whitespace for links in headers

### DIFF
--- a/packages/common-assets/styles/scss/content.scss
+++ b/packages/common-assets/styles/scss/content.scss
@@ -169,6 +169,7 @@
     // Align the anchor to the middle of the heading
     display: flex;
     align-items: center;
+    white-space: pre-wrap;
 
     .anchor-heading {
       // headings can fit a slightly bigger icon


### PR DESCRIPTION
fixes: https://github.com/dendronhq/dendron/issues/3396

[[Preview Headers Link No Whitespace|dendron://private/task.2022.08.16.preview-headers-link-no-whitespace]]