### PR TITLE
fix(workspace): duplicate Dendron Delete command in contextual menu

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1064,11 +1064,6 @@
           "group": "2_workspace"
         },
         {
-          "when": "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive && shellExecutionSupported",
-          "command": "dendron.delete",
-          "group": "2_workspace"
-        },
-        {
           "when": "resourceExtname == .md && dendron:pluginActive && shellExecutionSupported",
           "command": "dendron.moveNote",
           "group": "2_workspace"

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -304,12 +304,6 @@ export const DENDRON_MENUS = {
       group: "2_workspace",
     },
     {
-      // [[Command Enablement / When Clause Gotchas|dendron://dendron.docs/pkg.plugin-core.t.commands.ops#command-enablement--when-clause-gotchas]]
-      when: "resourceExtname == .md && dendron:pluginActive || resourceExtname == .yml && dendron:pluginActive && shellExecutionSupported",
-      command: "dendron.delete",
-      group: "2_workspace",
-    },
-    {
       when: "resourceExtname == .md && dendron:pluginActive && shellExecutionSupported",
       command: "dendron.moveNote",
       group: "2_workspace",


### PR DESCRIPTION
This PR aims to fix a regression with duplicate `Dendron Delete` in contextual Menu. 
Source: https://discordapp.com/channels/717965437182410783/739186036495876126/1009055467982557275

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
NA
## Instrumentation

### Basics
NA

### Extended
NA

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

