### PR TITLE
feat(workspace): Create Note Command

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -297,6 +297,10 @@
         "title": "Dendron: Create Scratch Note"
       },
       {
+        "command": "dendron.createNote",
+        "title": "Dendron: Create Note"
+      },
+      {
         "command": "dendron.createMeetingNote",
         "title": "Dendron: Create Meeting Note"
       },
@@ -698,6 +702,10 @@
         },
         {
           "command": "dendron.createScratchNote",
+          "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.createNote",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/src/commands/CreateNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteCommand.ts
@@ -1,0 +1,28 @@
+import { DENDRON_COMMANDS } from "../constants";
+import { Logger } from "../logger";
+import { BasicCommand } from "./base";
+import { CommandOutput as NoteLookupOutput } from "./NoteLookupCommand";
+import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
+
+type CommandOpts = {};
+
+type CommandOutput = {
+  lookup: Promise<NoteLookupOutput | undefined>;
+};
+
+export class CreateNoteCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CREATE_NOTE.key;
+
+  async execute(opts: CommandOpts) {
+    const ctx = "CreateNoteCommand";
+
+    Logger.info({ ctx, msg: "enter", opts });
+
+    return {
+      lookup: AutoCompletableRegistrar.getNoteLookupCmd().run(),
+    };
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -83,6 +83,7 @@ import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
 import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
+import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
 
 /**
@@ -175,6 +176,7 @@ const ALL_COMMANDS = [
   InstrumentedWrapperCommand,
   ValidateEngineCommand,
   MergeNoteCommand,
+  CreateNoteCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -610,6 +610,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     },
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
+  CREATE_NOTE: {
+    key: "dendron.createNote",
+    title: `${CMD_PREFIX} Create Note`,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+  },
   CREATE_MEETING_NOTE: {
     key: "dendron.createMeetingNote",
     title: `${CMD_PREFIX} Create Meeting Note`,


### PR DESCRIPTION
This PR aims to add a create note command. This a wrapper around `Ctrl/Cmd + L` for visibility


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
NA
## Instrumentation

### Basics
NA

### Extended
NA

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

