### PR TITLE
fix(workspace): case insensitive tree view sorting

### DIFF
--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -170,10 +170,10 @@ export class TreeUtils {
       (noteId) => {
         if (labelType) {
           return labelType === TreeViewItemLabelTypeEnum.filename
-            ? _.last(noteDict[noteId]?.fname.split("."))
-            : noteDict[noteId]?.title;
+            ? _.last(noteDict[noteId]?.fname.split("."))?.toLowerCase()
+            : noteDict[noteId]?.title.toLowerCase();
         } else {
-          return noteDict[noteId]?.title;
+          return noteDict[noteId]?.title.toLowerCase();
         }
       },
       // If titles are identical, sort by last updated date

--- a/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/EngineNoteProvider.test.ts
@@ -215,8 +215,8 @@ suite("EngineNoteProvider Tests", function testSuite() {
             const children = await provider.getChildren(vault1RootProps);
             expect(children?.map((child) => child.title)).toEqual([
               "Zebra", // nav_order: 1
-              "Aardvark", // uppercase alphabets comes before underscore alphabets
-              "_underscore", // underscore comes before lowercase alphabets
+              "_underscore", // underscore comes first
+              "Aardvark",
               "aaron",
             ]);
           });
@@ -248,8 +248,8 @@ suite("EngineNoteProvider Tests", function testSuite() {
             const children = await provider.getChildren(vault1RootProps);
             expect(children?.map((child) => child.title)).toEqual([
               "Zebra", // nav_order: 1
-              "Aardvark", // uppercase alphabets comes before underscore alphabets
-              "_underscore", // underscore comes before lowercase alphabets
+              "_underscore", // underscore comes before alphabets
+              "Aardvark",
               "aaron",
             ]);
           });
@@ -378,8 +378,8 @@ suite("EngineNoteProvider Tests", function testSuite() {
             const children = await provider.getChildren(vault1RootProps);
             expect(children?.map((child) => child.title)).toEqual([
               "Zebra", // nav_order: 1
-              "Aardvark", // uppercase alphabets comes before underscore alphabets
-              "_underscore", // underscore comes before lowercase alphabets
+              "_underscore", // underscore comes before alphabets
+              "Aardvark",
               "aaron",
               "Tags", // tags come last.
             ]);
@@ -422,8 +422,8 @@ suite("EngineNoteProvider Tests", function testSuite() {
             expect(children?.map((child) => child.title)).toEqual([
               "Zebra", // nav_order: 1
               "Tags", // nav_order respected
-              "Aardvark", // uppercase alphabets comes before underscore alphabets
-              "_underscore", // underscore comes before lowercase alphabets
+              "_underscore", // underscore comes before alphabets
+              "Aardvark",
               "aaron",
             ]);
           });

--- a/packages/plugin-core/src/web/views/treeView/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/web/views/treeView/EngineNoteProvider.ts
@@ -289,10 +289,10 @@ export class EngineNoteProvider
       (noteProps) => {
         if (labelType) {
           return labelType === TreeViewItemLabelTypeEnum.filename
-            ? _.last(noteProps.fname.split("."))
-            : noteProps.title;
+            ? _.last(noteProps.fname.split("."))?.toLowerCase()
+            : noteProps.title.toLowerCase();
         } else {
-          return noteProps.title;
+          return noteProps.title.toLowerCase();
         }
       },
       // If titles are identical, sort by last updated date


### PR DESCRIPTION
## fix(workspace): case insensitive tree view sorting

Make the sort order in tree view case insensitive. This addresses the issue both in current tree view and the upcoming web ext tree view.

related to: https://github.com/dendronhq/dendron/issues/3418