### PR TITLE
fix(lookup): allow lookup accept for existing invalid hierarchy

### DIFF
--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -241,6 +241,7 @@ export class WorkspaceWatcher {
         document,
         "onDidOpenTextDocument"
       );
+      DoctorUtils.validateFilenameFromDocumentAndPromptIfNecessary(document);
     } catch (error) {
       Sentry.captureException(error);
       throw error;

--- a/packages/plugin-core/src/commands/RenameNoteCommand.ts
+++ b/packages/plugin-core/src/commands/RenameNoteCommand.ts
@@ -1,6 +1,7 @@
 import { extractNoteChangeEntryCounts } from "@dendronhq/common-all";
 import _ from "lodash";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { ProxyMetricUtils } from "../utils/ProxyMetricUtils";
 import { BasicCommand } from "./base";
 import {
@@ -26,7 +27,14 @@ export class RenameNoteCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.RENAME_NOTE.key;
-  private _moveNoteCommand = new MoveNoteCommand();
+  private extension: IDendronExtension;
+  private _moveNoteCommand;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+    this._moveNoteCommand = new MoveNoteCommand(this.extension);
+  }
 
   async sanityCheck() {
     return this._moveNoteCommand.sanityCheck();

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -128,7 +128,8 @@ export class DoctorUtils {
   static async validateFilenameFromDocumentAndPromptIfNecessary(
     document: vscode.TextDocument
   ) {
-    const wsUtils = ExtensionProvider.getExtension().wsUtils;
+    const extension = ExtensionProvider.getExtension();
+    const wsUtils = extension.wsUtils;
     const filename = path.basename(document.fileName, ".md");
     const note = wsUtils.getNoteFromDocument(document);
 
@@ -149,7 +150,7 @@ export class DoctorUtils {
     ).then(async (resp) => {
       if (resp && resp.title === "Rename note") {
         await wsUtils.openNote(note);
-        const cmd = new RenameNoteCommand();
+        const cmd = new RenameNoteCommand(extension);
         await cmd.run();
       }
     });

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -1,13 +1,17 @@
 import {
+  DendronError,
   DuplicateNoteError,
   ErrorUtils,
+  NoteUtils,
   VaultUtils,
   WorkspaceEvents,
 } from "@dendronhq/common-all";
 import { file2Note } from "@dendronhq/common-server";
 import { DoctorActionsEnum } from "@dendronhq/engine-server";
+import path from "path";
 import * as vscode from "vscode";
 import { DoctorCommand } from "../../commands/Doctor";
+import { RenameNoteCommand } from "../../commands/RenameNoteCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
@@ -119,5 +123,37 @@ export class DoctorUtils {
         });
       }
     }
+  }
+
+  static async validateFilenameFromDocumentAndPromptIfNecessary(
+    document: vscode.TextDocument
+  ) {
+    const wsUtils = ExtensionProvider.getExtension().wsUtils;
+    const filename = path.basename(document.fileName, ".md");
+    const note = wsUtils.getNoteFromDocument(document);
+
+    if (!note) return true;
+
+    const isValid = NoteUtils.validateFname(filename);
+
+    if (isValid) return true;
+
+    const error = new DendronError({
+      message: `"${filename}" is not a valid hierarchy. Please rename the note so that every hierarchy is non-empty and doesn't contain leading or trailing whitespaces`,
+    });
+    VSCodeUtils.showMessage(
+      MessageSeverity.WARN,
+      error.message,
+      {},
+      { title: "Rename note" }
+    ).then(async (resp) => {
+      if (resp && resp.title === "Rename note") {
+        await wsUtils.openNote(note);
+        const cmd = new RenameNoteCommand();
+        await cmd.run();
+      }
+    });
+
+    return false;
   }
 }

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -16,6 +16,7 @@ export type ILookupProviderV3 = {
     quickpick: DendronQuickPickerV2;
     cancellationToken: CancellationTokenSource;
   }): any;
+  shouldRejectItem?: (opts: { item: NoteQuickInput }) => boolean;
 };
 
 export interface INoteLookupProviderFactory {

--- a/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
@@ -97,6 +97,14 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     return;
   }
 
+  shouldRejectItem(opts: { item: NoteQuickInput }) {
+    const { item } = opts;
+    return (
+      !NoteUtils.validateFname(item.fname) &&
+      PickerUtilsV2.isCreateNewNotePick(item)
+    );
+  }
+
   /**
    * Takes selection and runs accept, followed by hooks.
    * @param opts
@@ -141,7 +149,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       // validates fname.
       if (selectedItems.length === 1) {
         const item = selectedItems[0];
-        if (!NoteUtils.validateFname(item.fname)) {
+        if (this.shouldRejectItem({ item })) {
           window.showErrorMessage(
             "Hierarchies cannot have leading / trailing whitespace or be empty."
           );

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -378,7 +378,6 @@ suite("onAccept", () => {
     "GIVEN a new item with invalid name",
     {
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      timeout: 5e3,
     },
     () => {
       test("THEN reject lookup", async () => {

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -37,7 +37,8 @@ const createEngine = createEngineFactory({
       oldLoc,
       newLoc,
     }) => {
-      const cmd = new MoveNoteCommand();
+      const extension = ExtensionProvider.getExtension();
+      const cmd = new MoveNoteCommand(extension);
       const vpathOld = vault2Path({
         vault: VaultUtils.getVaultByName({
           vaults: opts.vaults,
@@ -153,7 +154,8 @@ suite("MoveNoteCommand", function () {
           });
           await active.document.save();
 
-          const cmd = new MoveNoteCommand();
+          const extension = ExtensionProvider.getExtension();
+          const cmd = new MoveNoteCommand(extension);
           const resp = await cmd.execute({
             moves: [
               {
@@ -200,9 +202,9 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN update hashtags correctly", async () => {
         const { vaults, engine } = ExtensionProvider.getDWorkspace();
-        await WSUtils.openNote(tagNote);
-
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(tagNote);
+        const cmd = new MoveNoteCommand(extension);
         await cmd.execute({
           moves: [
             {
@@ -250,9 +252,9 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN  turns links to hashtags", async () => {
         const { vaults, engine } = ExtensionProvider.getDWorkspace();
-        await WSUtils.openNote(tagNote);
-
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(tagNote);
+        const cmd = new MoveNoteCommand(extension);
         await cmd.execute({
           moves: [
             {
@@ -300,9 +302,9 @@ suite("MoveNoteCommand", function () {
     () => {
       test("THEN turns hashtags into regular links", async () => {
         const { vaults, engine } = ExtensionProvider.getDWorkspace();
-        await WSUtils.openNote(tagNote);
-
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(tagNote);
+        const cmd = new MoveNoteCommand(extension);
         await cmd.execute({
           moves: [
             {
@@ -347,8 +349,9 @@ suite("MoveNoteCommand", function () {
           vault: vaultFrom,
           engine,
         }) as NoteProps;
-        await WSUtils.openNote(fooNote);
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(fooNote);
+        const cmd = new MoveNoteCommand(extension);
         await cmd.execute({
           moves: [
             {
@@ -420,7 +423,7 @@ suite("MoveNoteCommand", function () {
         });
 
         await ext.wsUtils.openNote(scratchNote);
-        const cmd = new MoveNoteCommand();
+        const cmd = new MoveNoteCommand(ext);
         await cmd.execute({
           moves: [
             {
@@ -465,8 +468,9 @@ suite("MoveNoteCommand", function () {
         const fooNote = (
           await engine.findNotes({ fname: "foo", vault: vault1 })
         )[0];
-        await WSUtils.openNote(fooNote);
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(fooNote);
+        const cmd = new MoveNoteCommand(extension);
         await cmd.execute({
           moves: [
             {
@@ -540,8 +544,9 @@ suite("MoveNoteCommand", function () {
           await engine.findNotes({ fname: "foo", vault: vault1 })
         )[0];
 
-        await WSUtils.openNote(fooNote);
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(fooNote);
+        const cmd = new MoveNoteCommand(extension);
 
         sinon
           .stub(VSCodeUtils, "showQuickPick")
@@ -630,8 +635,9 @@ suite("MoveNoteCommand", function () {
           await engine.findNotes({ fname: "foo", vault: vault1 })
         )[0];
 
-        await WSUtils.openNote(fooNote);
-        const cmd = new MoveNoteCommand();
+        const extension = ExtensionProvider.getExtension();
+        await extension.wsUtils.openNote(fooNote);
+        const cmd = new MoveNoteCommand(extension);
 
         sinon
           .stub(VSCodeUtils, "showQuickPick")

--- a/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
@@ -1,0 +1,69 @@
+import { VaultUtils } from "@dendronhq/common-all";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
+import { RenameNoteCommand } from "../../commands/RenameNoteCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { describeMultiWS } from "../testUtilsV3";
+import { expect } from "../testUtilsv2";
+
+suite("RenameNoteCommand", function () {
+  describeMultiWS("GIVEN note with invalid hierarchy", {}, () => {
+    test("WHEN renamed to valid hierarchy THEN renamed properly", async () => {
+      const extension = ExtensionProvider.getExtension();
+      const { vaults, wsRoot } = extension.getDWorkspace();
+      const engine = extension.getEngine();
+
+      const invalidNote = await NoteTestUtilsV4.createNoteWithEngine({
+        fname: ".foo",
+        body: "invalid note body",
+        vault: vaults[0],
+        engine,
+        wsRoot,
+      });
+
+      await NoteTestUtilsV4.createNoteWithEngine({
+        fname: "some-note",
+        body: "[[.foo]]",
+        vault: vaults[0],
+        wsRoot,
+        engine,
+      });
+      await extension.wsUtils.openNote(invalidNote);
+      const cmd = new RenameNoteCommand(extension);
+      const vaultName = VaultUtils.getName(vaults[0]);
+      const out = await cmd.execute({
+        moves: [
+          {
+            oldLoc: {
+              fname: invalidNote.fname,
+              vaultName,
+            },
+            newLoc: {
+              fname: "foo",
+              vaultName,
+            },
+          },
+        ],
+        nonInteractive: true,
+        initialValue: "foo",
+      });
+
+      // note `.foo` is renamed to `foo`, `some-note`'s reference to `.foo` is updated to `foo`
+      expect(out.changed.length).toEqual(5);
+      const foo = (
+        await engine.findNotes({
+          vault: vaults[0],
+          fname: "foo",
+        })
+      )[0];
+      expect(foo).toBeTruthy();
+
+      const updatedSomeNote = (
+        await engine.findNotes({
+          vault: vaults[0],
+          fname: "some-note",
+        })
+      )[0];
+      expect(updatedSomeNote.body).toEqual("[[foo]]");
+    });
+  });
+});


### PR DESCRIPTION
# fix(lookup): allow lookup accept for existing invalid hierarchy

This PR:
- fixes an issue with lookup validation that blocked lookup of already existing notes with invalid names
  - allows lookup of invalid name if it already exists
  - prompts for a rename of that note when it opens

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)