### PR TITLE
fix(workspace): proper visibility on views and commands for web ext

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -60,8 +60,7 @@
         {
           "id": "dendron-view",
           "title": "Dendron",
-          "icon": "media/icons/dendron-activity-bar-icon.svg",
-          "when": "shellExecutionSupported"
+          "icon": "media/icons/dendron-activity-bar-icon.svg"
         }
       ]
     },
@@ -89,7 +88,7 @@
         {
           "id": "dendron.treeView",
           "name": "Tree View",
-          "when": "dendron:pluginActive  && shellExecutionSupported",
+          "when": "dendron:pluginActive",
           "icon": "media/icons/dendron-vscode.svg"
         },
         {
@@ -658,7 +657,7 @@
         },
         {
           "command": "dendron.mergeNote",
-          "when": "dendron:pluginActive"
+          "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
           "command": "dendron.randomNote",
@@ -902,7 +901,7 @@
         },
         {
           "command": "dendron.togglePreviewLock",
-          "when": "dendron:pluginActive"
+          "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
           "command": "dendron.pasteFile",

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -74,7 +74,6 @@ export const DENDRON_VIEWS_CONTAINERS = {
       id: "dendron-view",
       title: "Dendron",
       icon: "media/icons/dendron-activity-bar-icon.svg",
-      when: "shellExecutionSupported",
     },
   ],
 };
@@ -100,7 +99,7 @@ export const DENDRON_VIEWS = [
   },
   {
     ...treeViewConfig2VSCodeEntry(DendronTreeViewKey.TREE_VIEW),
-    when: `${DendronContext.PLUGIN_ACTIVE}  && shellExecutionSupported`,
+    when: `${DendronContext.PLUGIN_ACTIVE}`,
     where: "dendron-view",
     icon: "media/icons/dendron-vscode.svg",
   },
@@ -513,7 +512,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   MERGE_NOTE: {
     key: "dendron.mergeNote",
     title: `${CMD_PREFIX} Merge Note`,
-    when: DendronContext.PLUGIN_ACTIVE,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   RANDOM_NOTE: {
     key: "dendron.randomNote",
@@ -920,7 +919,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.togglePreviewLock",
     title: `${CMD_PREFIX} Toggle Preview Lock`,
     icon: `$(lock)`,
-    when: "dendron:pluginActive",
+    when: "dendron:pluginActive && shellExecutionSupported",
   },
   PASTE_FILE: {
     key: "dendron.pasteFile",


### PR DESCRIPTION
## fix(workspace): proper visibility on views and commands for web ext

Fixing tree view visibility in web ext + hiding some recently added commands.  I'll do an async on properly marking the 'when' clause when adding new cmds.