### PR TITLE
chore: update templates for special notes

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -15,11 +15,6 @@ export const isABTest = (value: any): value is ABTest<any> => {
  * See [[A/B Testing|dendron://dendron.docs/ref.ab-testing]] for more details.
  */
 
-export enum MeetingNoteTestGroups {
-  show = "show",
-  noShow = "noShow",
-}
-
 export enum GraphThemeTestGroups {
   /**
    * New user will get Monokai graph theme by default
@@ -50,11 +45,6 @@ export const GRAPH_THEME_TEST = new ABTest("GraphThemeTest", [
   },
 ]);
 
-export enum DailyJournalTestGroups {
-  withTemplate = "withTemplate",
-  withoutTemplate = "withoutTemplate",
-}
-
 export enum QuickstartTutorialTestGroups {
   "quickstart-v1" = "quickstart-v1",
   "quickstart-skip-welcome" = "quickstart-skip-welcome",
@@ -76,26 +66,6 @@ const _2022_06_QUICKSTART_TUTORIAL_TEST = new ABTest(
     {
       name: QuickstartTutorialTestGroups["quickstart-skip-welcome"],
       weight: 0,
-    },
-  ]
-);
-
-/**
- * Experiment to test whether users running `Daily Journal` for the first time should get an auto-generated template/schema or not.
- *
- * withTemplate = auto-generate a template and a schema for them that will apply the template to the journal note
- * withoutTemplate = no template/schema gets generated
- */
-export const _2022_05_DAILY_JOURNAL_TEMPLATE_TEST = new ABTest(
-  "2022-05-DailyJournalTemplateTest",
-  [
-    {
-      name: DailyJournalTestGroups.withTemplate,
-      weight: 1,
-    },
-    {
-      name: DailyJournalTestGroups.withoutTemplate,
-      weight: 1,
     },
   ]
 );
@@ -124,6 +94,5 @@ export const CURRENT_TUTORIAL_TEST: ABTest<any> | undefined =
  */
 export const CURRENT_AB_TESTS = [
   GRAPH_THEME_TEST,
-  _2022_05_DAILY_JOURNAL_TEMPLATE_TEST,
   CURRENT_TUTORIAL_TEST,
 ].filter((entry): entry is ABTest<any> => !!entry);

--- a/packages/plugin-core/assets/dendron-ws/templates/templates.daily.md
+++ b/packages/plugin-core/assets/dendron-ws/templates/templates.daily.md
@@ -1,4 +1,4 @@
-This template was applied using the daily journal schema. Edit the [[dendron.templates.daily]] note to change this template.
+This template was applied using the daily journal schema. Edit the [[templates.daily]] note to change this template.
 To create your own schemas to auto-apply templates when they match a hierarchy, follow the [schema tutorial](https://blog.dendron.so/notes/P1DL2uXHpKUCa7hLiFbFA/) to get started.
 
 <!--

--- a/packages/plugin-core/assets/dendron-ws/templates/templates.meet.md
+++ b/packages/plugin-core/assets/dendron-ws/templates/templates.meet.md
@@ -1,20 +1,25 @@
-_Edit the [[dendron.templates.meet]] note to change this template generated for Dendron Meeting Notes._
+_Edit the [[templates.meet]] note to change this template generated for Dendron Meeting Notes._
 
 ## Attendees
+
 <!-- Meeting attendees. If you prefix users with an '@', you can then optionally click Ctrl+Enter to create a note for that user. -->
 
-- @JohnDoe
+- @johndoe
 
 ## Goals
+
 <!-- Main objectives of the meeting -->
 
 ## Agenda
+
 <!-- Agenda to be covered in the meeting -->
 
 ## Minutes
+
 <!-- Notes of discussion occurring during the meeting -->
 
 ## Action Items
+
 <!-- You can add any follow up items here. If they require more detail, you can use `Create Task Note` to create each follow up item as a separate note. -->
 
 - Follow Up Task 1

--- a/packages/plugin-core/assets/dendron-ws/templates/templates.meet.md
+++ b/packages/plugin-core/assets/dendron-ws/templates/templates.meet.md
@@ -4,7 +4,7 @@ _Edit the [[templates.meet]] note to change this template generated for Dendron 
 
 <!-- Meeting attendees. If you prefix users with an '@', you can then optionally click Ctrl+Enter to create a note for that user. -->
 
-- @johndoe
+- @john-doe
 
 ## Goals
 

--- a/packages/plugin-core/src/commands/CreateDailyJournal.ts
+++ b/packages/plugin-core/src/commands/CreateDailyJournal.ts
@@ -1,6 +1,5 @@
 import {
   ConfigUtils,
-  DailyJournalTestGroups,
   genUUID,
   JournalConfig,
   NoteUtils,
@@ -9,9 +8,8 @@ import {
   SchemaUtils,
   Time,
   VaultUtils,
-  _2022_05_DAILY_JOURNAL_TEMPLATE_TEST,
 } from "@dendronhq/common-all";
-import { SegmentClient, vault2Path } from "@dendronhq/common-server";
+import { vault2Path } from "@dendronhq/common-server";
 import { MetadataService } from "@dendronhq/engine-server";
 import * as fs from "fs-extra";
 import _ from "lodash";
@@ -36,7 +34,7 @@ export type CreateDailyJournalData = {
 
 export class CreateDailyJournalCommand extends CreateNoteWithTraitCommand {
   static requireActiveWorkspace: boolean = true;
-  public static DENDRON_TEMPLATES_FNAME: string = "dendron.templates";
+  public static DENDRON_TEMPLATES_FNAME: string = "templates";
 
   constructor(ext: IDendronExtension) {
     const initTrait = () => {
@@ -71,19 +69,12 @@ export class CreateDailyJournalCommand extends CreateNoteWithTraitCommand {
         !_.isUndefined(metaData.firstInstall) &&
         metaData.firstInstall > Time.DateTime.fromISO("2022-06-06").toSeconds()
       ) {
-        const ABUserGroup = _2022_05_DAILY_JOURNAL_TEMPLATE_TEST.getUserGroup(
-          SegmentClient.instance().anonymousId
+        // Check if a schema file exists, and if it doesn't, then create it first.
+        isSchemaCreated = await this.makeSchemaFileIfNotExisting(journalConfig);
+        // same with template file:
+        isTemplateCreated = await this.createTemplateFileIfNotExisting(
+          journalConfig
         );
-        if (ABUserGroup === DailyJournalTestGroups.withTemplate) {
-          // Check if a schema file exists, and if it doesn't, then create it first.
-          isSchemaCreated = await this.makeSchemaFileIfNotExisting(
-            journalConfig
-          );
-          // same with template file:
-          isTemplateCreated = await this.createTemplateFileIfNotExisting(
-            journalConfig
-          );
-        }
       }
     }
 

--- a/packages/plugin-core/src/commands/CreateMeetingNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateMeetingNoteCommand.ts
@@ -29,7 +29,7 @@ type ExecuteData = {
 export class CreateMeetingNoteCommand extends CreateNoteWithTraitCommand {
   private _ext: IDendronExtension;
   public static requireActiveWorkspace: boolean = true;
-  public static MEETING_TEMPLATE_FNAME: string = "dendron.templates.meet";
+  public static MEETING_TEMPLATE_FNAME: string = "templates.meet";
 
   /**
    *

--- a/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
@@ -1,10 +1,4 @@
-import {
-  ConfigUtils,
-  DailyJournalTestGroups,
-  DVault,
-  Time,
-  _2022_05_DAILY_JOURNAL_TEMPLATE_TEST,
-} from "@dendronhq/common-all";
+import { ConfigUtils, DVault, Time } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { MetadataService } from "@dendronhq/engine-server";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
@@ -41,9 +35,6 @@ suite("Create Daily Journal Suite", function () {
     MetadataService.instance().setInitialInstall(
       Time.DateTime.fromISO("2022-06-30").toSeconds()
     );
-    sinon
-      .stub(_2022_05_DAILY_JOURNAL_TEMPLATE_TEST, "getUserGroup")
-      .returns(DailyJournalTestGroups.withTemplate!);
   });
 
   describeMultiWS(


### PR DESCRIPTION
# chore: update templates for special notes

This PR:
- ends `_2022_05_DAILY_JOURNAL_TEMPLATE_TEST`
- change occurence of `dendron.templates.*` to `templates.*` to match the default configuration
- clean up template contents for meeting note and daily journal note

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)