### PR TITLE
enhance(plugin-core): fill in current hierarchy for Move Header

### DIFF
--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -42,6 +42,7 @@ import {
 } from "../components/lookup/LookupControllerV3Interface";
 import { NoteLookupProviderSuccessResp } from "../components/lookup/LookupProviderV3Interface";
 import { NoteLookupProviderUtils } from "../components/lookup/NoteLookupProviderUtils";
+import { NotePickerUtils } from "../components/lookup/NotePickerUtils";
 import { DendronQuickPickerV2 } from "../components/lookup/types";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
@@ -192,7 +193,7 @@ export class MoveHeaderCommand extends BasicCommand<
       title: "Select note to move header to",
       placeholder: "note",
       provider: lookupProvider,
-      initialValue: opts?.initialValue,
+      initialValue: NotePickerUtils.getInitialValueFromOpenEditor(),
       nonInteractive: opts?.nonInteractive,
     });
     return lookupController;

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -56,7 +56,6 @@ import { BasicCommand } from "./base";
 
 type CommandInput =
   | {
-      initialValue?: string;
       nonInteractive?: boolean;
       useSameVault?: boolean;
     }

--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -10,13 +10,15 @@ import {
 } from "@dendronhq/common-test-utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
-import { describe, beforeEach } from "mocha";
+import { describe, beforeEach, afterEach } from "mocha";
 import vscode from "vscode";
 import { expect } from "../testUtilsv2";
 import { MoveHeaderCommand } from "../../commands/MoveHeader";
 import _ from "lodash";
 import { WSUtils } from "../../WSUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
+import { NotePickerUtils } from "../../components/lookup/NotePickerUtils";
+import sinon from "sinon";
 
 suite("MoveHeader", function () {
   const ctx = setupBeforeAfter(this);
@@ -60,6 +62,10 @@ suite("MoveHeader", function () {
       };
     });
 
+    afterEach(() => {
+      sinon.restore();
+    });
+
     describe("WHEN header is selected", () => {
       let onInitFunc: Function;
       beforeEach(() => {
@@ -78,9 +84,11 @@ suite("MoveHeader", function () {
             ctx,
             preSetupHook,
             onInit: onInitFunc(async () => {
+              sinon
+                .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+                .returns("dest");
               const cmd = new MoveHeaderCommand();
               const gatherOut = await cmd.gatherInputs({
-                initialValue: "dest",
                 nonInteractive: true,
               });
 
@@ -97,10 +105,12 @@ suite("MoveHeader", function () {
             ctx,
             preSetupHook,
             onInit: onInitFunc(async () => {
+              sinon
+                .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+                .returns("new-note");
               const cmd = new MoveHeaderCommand();
               const out = await cmd.run({
                 useSameVault: true,
-                initialValue: "new-note",
                 nonInteractive: true,
               });
               const { engine, vaults } = ExtensionProvider.getDWorkspace();
@@ -152,9 +162,11 @@ suite("MoveHeader", function () {
               });
             },
             onInit: onInitFunc(async () => {
+              sinon
+                .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+                .returns("dest");
               const cmd = new MoveHeaderCommand();
               const out = await cmd.run({
-                initialValue: "dest",
                 useSameVault: true,
                 nonInteractive: true,
               });
@@ -171,9 +183,12 @@ suite("MoveHeader", function () {
           ctx,
           preSetupHook,
           onInit: onInitFunc(async () => {
+            sinon
+              .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+              .returns("dest");
             const cmd = new MoveHeaderCommand();
+
             const out = await cmd.run({
-              initialValue: "dest",
               useSameVault: true,
               nonInteractive: true,
             });
@@ -189,9 +204,11 @@ suite("MoveHeader", function () {
           ctx,
           preSetupHook,
           onInit: onInitFunc(async () => {
+            sinon
+              .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+              .returns("dest");
             const cmd = new MoveHeaderCommand();
             const out = await cmd.run({
-              initialValue: "dest",
               useSameVault: true,
               nonInteractive: true,
             });
@@ -232,9 +249,11 @@ suite("MoveHeader", function () {
             });
           },
           onInit: onInitFunc(async () => {
+            sinon
+              .stub(NotePickerUtils, "getInitialValueFromOpenEditor")
+              .returns("dest");
             const cmd = new MoveHeaderCommand();
             const out = await cmd.run({
-              initialValue: "dest",
               useSameVault: true,
               nonInteractive: true,
             });
@@ -277,7 +296,6 @@ suite("MoveHeader", function () {
             let wasThrown = false;
             try {
               out = await cmd.gatherInputs({
-                initialValue: "dest",
                 useSameVault: true,
                 nonInteractive: true,
               });

--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -78,6 +78,22 @@ suite("MoveHeader", function () {
         };
       });
 
+      test("THEN the initial value is filled in with the current hierarchy", (done) => {
+        runLegacyMultiWorkspaceTest({
+          ctx,
+          preSetupHook,
+          onInit: onInitFunc(async () => {
+            const cmd = new MoveHeaderCommand();
+            const gatherOut = await cmd.gatherInputs({
+              nonInteractive: true,
+            });
+
+            expect(gatherOut?.dest?.fname).toEqual(originNote.fname);
+            done();
+          }),
+        });
+      });
+
       describe("AND WHEN existing item is selected for destination", () => {
         test("THEN selected item is used for destination", (done) => {
           runLegacyMultiWorkspaceTest({

--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -15,10 +15,10 @@ import vscode from "vscode";
 import { expect } from "../testUtilsv2";
 import { MoveHeaderCommand } from "../../commands/MoveHeader";
 import _ from "lodash";
-import { WSUtils } from "../../WSUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { NotePickerUtils } from "../../components/lookup/NotePickerUtils";
 import sinon from "sinon";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 
 suite("MoveHeader", function () {
   const ctx = setupBeforeAfter(this);
@@ -71,7 +71,8 @@ suite("MoveHeader", function () {
       beforeEach(() => {
         onInitFunc = (nextFunc: Function) => {
           return async () => {
-            const editor = await WSUtils.openNote(originNote);
+            const ext = ExtensionProvider.getExtension();
+            const editor = await new WSUtilsV2(ext).openNote(originNote);
             editor.selection = new vscode.Selection(7, 0, 7, 0);
             nextFunc();
           };
@@ -297,7 +298,8 @@ suite("MoveHeader", function () {
     describe("WHEN header is not select", () => {
       const onInitFunc = (nextFunc: Function) => {
         return async () => {
-          const editor = await WSUtils.openNote(originNote);
+          const ext = ExtensionProvider.getExtension();
+          const editor = await new WSUtilsV2(ext).openNote(originNote);
           editor.selection = new vscode.Selection(8, 0, 8, 0);
           nextFunc();
         };


### PR DESCRIPTION
Related to #2238

I wasn't sure about the tests - I couldn't get the integration tests for the `MoveHeader.test.ts` to progress - it seems like it fails at an assertion that seems to take time and is repeated on the CI until it passes? Is this related to using the old testing utils?

EDIT: I noticed that the tests are failing for the plugin on the CI, I'll have to take a look at that too.

If there are any pointers on how to get this to work, I can have a go at writing a test for this. 

https://user-images.githubusercontent.com/9913851/186452753-232d5a03-a904-4f4e-b438-da1c5ed40526.mp4

## Commit

- [x] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)
- [x] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/QN46JTSWpEkDkr94TJ85w)
- [x] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
  - NOTE: make sure to read [Addressing open issues](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)

## Code

- [x] code should follow [Code Conventions](https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e)
- [x] sticking to existing conventions instead of creating new ones 

## Tests

- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing [snapshot](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
  - [ ] [Update the Snapshot](https://docs.dendron.so/notes/u7utw5w8gyacuh3ok9ehi8j)

## Docs

- ~~[ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR (NOTE: submit the PR against the `dev` branch of the dendron-site repo)~~
- ~~[ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/ce9b9b29-d85b-492b-b76d-5e0c5dc52b03) or [Packages](https://wiki.dendron.so/notes/ok9ifke0zsfxnnh7xog79z5)~~