### PR TITLE
enhance(view): context menu for tree view

### DIFF
--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -19,6 +19,7 @@ export type TreeMenuNode = {
   vaultName: string;
   navExclude: boolean;
   children?: TreeMenuNode[];
+  contextValue?: string;
 };
 
 export type TreeMenu = {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1114,6 +1114,10 @@
         {
           "command": "dendron.delete",
           "when": "view == dendron.treeView && viewItem == note"
+        },
+        {
+          "command": "dendron.createNote",
+          "when": "view == dendron.treeView"
         }
       ]
     },

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1109,6 +1109,12 @@
           "when": "resourceLangId == markdown && dendron:pluginActive && shellExecutionSupported",
           "group": "1_open"
         }
+      ],
+      "view/item/context": [
+        {
+          "command": "dendron.delete",
+          "when": "view == dendron.treeView && viewItem == note"
+        }
       ]
     },
     "configuration": {

--- a/packages/plugin-core/src/commands/CreateNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteCommand.ts
@@ -8,8 +8,10 @@ import {
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 import _ from "lodash";
 import { window } from "vscode";
+import { NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { AnalyticsUtils } from "../utils/analytics";
 
-type CommandOpts = any;
+type CommandOpts = NoteProps & {};
 
 type CommandOutput = {
   lookup: Promise<NoteLookupOutput | undefined>;
@@ -20,10 +22,6 @@ export class CreateNoteCommand extends InputArgCommand<
 > {
   key = DENDRON_COMMANDS.CREATE_NOTE.key;
 
-  private isNotePropsArgs(opts: CommandOpts) {
-    return !_.isEmpty(opts) && opts.id;
-  }
-
   async execute(opts: CommandOpts) {
     const ctx = "CreateNoteCommand";
 
@@ -33,12 +31,13 @@ export class CreateNoteCommand extends InputArgCommand<
      * If the command is ran from Tree View, update the initial value in lookup to
      * selected tree item's fname
      */
-    if (this.isNotePropsArgs(opts)) {
+    if (NoteUtils.isNoteProps(opts)) {
       args.initialValue = opts.fname;
-      window.showInformationMessage(
-        "💡 Tip: Enter `Ctrl+L` / `Cmd+L` to open the lookup bar!"
-      );
+      AnalyticsUtils.track(this.key, { source: "TreeView" });
     }
+    window.showInformationMessage(
+      "💡 Tip: Enter `Ctrl+L` / `Cmd+L` to open the lookup bar!"
+    );
     return {
       lookup: AutoCompletableRegistrar.getNoteLookupCmd().run(args),
     };

--- a/packages/plugin-core/src/commands/CreateNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteCommand.ts
@@ -7,6 +7,7 @@ import {
 } from "./NoteLookupCommand";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
 import _ from "lodash";
+import { window } from "vscode";
 
 type CommandOpts = any;
 
@@ -28,8 +29,15 @@ export class CreateNoteCommand extends InputArgCommand<
 
     Logger.info({ ctx, msg: "enter", opts });
     const args: NoteLookupRunOpts = {};
+    /**
+     * If the command is ran from Tree View, update the initial value in lookup to
+     * selected tree item's fname
+     */
     if (this.isNotePropsArgs(opts)) {
       args.initialValue = opts.fname;
+      window.showInformationMessage(
+        "💡 Tip: Enter `Ctrl+L` / `Cmd+L` to open the lookup bar!"
+      );
     }
     return {
       lookup: AutoCompletableRegistrar.getNoteLookupCmd().run(args),

--- a/packages/plugin-core/src/commands/CreateNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNoteCommand.ts
@@ -1,28 +1,38 @@
 import { DENDRON_COMMANDS } from "../constants";
 import { Logger } from "../logger";
-import { BasicCommand } from "./base";
-import { CommandOutput as NoteLookupOutput } from "./NoteLookupCommand";
+import { InputArgCommand } from "./base";
+import {
+  CommandOutput as NoteLookupOutput,
+  CommandRunOpts as NoteLookupRunOpts,
+} from "./NoteLookupCommand";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
+import _ from "lodash";
 
-type CommandOpts = {};
+type CommandOpts = any;
 
 type CommandOutput = {
   lookup: Promise<NoteLookupOutput | undefined>;
 };
-
-export class CreateNoteCommand extends BasicCommand<
+export class CreateNoteCommand extends InputArgCommand<
   CommandOpts,
   CommandOutput
 > {
   key = DENDRON_COMMANDS.CREATE_NOTE.key;
 
+  private isNotePropsArgs(opts: CommandOpts) {
+    return !_.isEmpty(opts) && opts.id;
+  }
+
   async execute(opts: CommandOpts) {
     const ctx = "CreateNoteCommand";
 
     Logger.info({ ctx, msg: "enter", opts });
-
+    const args: NoteLookupRunOpts = {};
+    if (this.isNotePropsArgs(opts)) {
+      args.initialValue = opts.fname;
+    }
     return {
-      lookup: AutoCompletableRegistrar.getNoteLookupCmd().run(),
+      lookup: AutoCompletableRegistrar.getNoteLookupCmd().run(args),
     };
   }
 }

--- a/packages/plugin-core/src/commands/DeleteCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteCommand.ts
@@ -68,10 +68,16 @@ export class DeleteCommand extends InputArgCommand<CommandOpts, CommandOutput> {
     return nodePosition?.end.line;
   }
 
+  /**
+   * When Delete Command is ran from Tree view, it gets Noteprops as args
+   */
   private isNotePropsArgs(opts: CommandOpts) {
     return !_.isEmpty(opts) && opts.id;
   }
 
+  /**
+   * When Delete Command is ran from explorer menu, it gets Uri as args
+   */
   private isUriArgs(opts: CommandOpts) {
     return !_.isEmpty(opts) && opts.fsPath;
   }

--- a/packages/plugin-core/src/commands/DeleteCommand.ts
+++ b/packages/plugin-core/src/commands/DeleteCommand.ts
@@ -20,6 +20,7 @@ import { DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { IEngineAPIService } from "../services/EngineAPIServiceInterface";
+import { AnalyticsUtils } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { InputArgCommand } from "./base";
 
@@ -67,14 +68,6 @@ export class DeleteCommand extends InputArgCommand<CommandOpts, CommandOutput> {
 
     return nodePosition?.end.line;
   }
-
-  /**
-   * When Delete Command is ran from Tree view, it gets Noteprops as args
-   */
-  private isNotePropsArgs(opts: CommandOpts) {
-    return !_.isEmpty(opts) && opts.id;
-  }
-
   /**
    * When Delete Command is ran from explorer menu, it gets Uri as args
    */
@@ -188,7 +181,8 @@ export class DeleteCommand extends InputArgCommand<CommandOpts, CommandOutput> {
     const engine = ExtensionProvider.getEngine();
     const ctx = "DeleteNoteCommand";
 
-    if (this.isNotePropsArgs(opts)) {
+    if (NoteUtils.isNoteProps(opts)) {
+      AnalyticsUtils.track(this.key, { source: "TreeView" });
       const out = this.deleteNote({ note: opts, opts, engine, ctx });
       return out;
     } else {

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -339,25 +339,26 @@ export class PickerUtilsV2 {
    * Defaults to first vault if current note is not part of a vault
    * @returns
    */
-  static getVaultForOpenEditor(): DVault {
+  static getVaultForOpenEditor(fsPath?: string): DVault {
     const ctx = "getVaultForOpenEditor";
     const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
 
     let vault: DVault;
     const activeDocument = VSCodeUtils.getActiveTextEditor()?.document;
+    const fpath = fsPath || activeDocument?.uri.fsPath;
     if (
-      activeDocument &&
+      fpath &&
       WorkspaceUtils.isPathInWorkspace({
         wsRoot,
         vaults,
-        fpath: activeDocument.uri.fsPath,
+        fpath,
       })
     ) {
-      Logger.info({ ctx, activeDocument: activeDocument.fileName });
+      Logger.info({ ctx, activeDocument: fpath });
       vault = VaultUtils.getVaultByFilePath({
         vaults,
         wsRoot,
-        fsPath: activeDocument.uri.fsPath,
+        fsPath: fpath,
       });
     } else {
       Logger.info({ ctx, msg: "no active doc" });

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -336,6 +336,12 @@ export const DENDRON_MENUS = {
       group: "1_open",
     },
   ],
+  "view/item/context": [
+    {
+      command: "dendron.delete",
+      when: "view == dendron.treeView && viewItem == note",
+    },
+  ],
 };
 
 export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -341,6 +341,10 @@ export const DENDRON_MENUS = {
       command: "dendron.delete",
       when: "view == dendron.treeView && viewItem == note",
     },
+    {
+      command: "dendron.createNote",
+      when: "view == dendron.treeView",
+    },
   ],
 };
 

--- a/packages/plugin-core/src/test/suite-integ/DeleteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DeleteCommand.test.ts
@@ -1,0 +1,88 @@
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { describeSingleWS } from "../testUtilsV3";
+import { WSUtilsV2 } from "../../WSUtilsV2";
+import { DeleteCommand } from "../../commands/DeleteCommand";
+import sinon from "sinon";
+import { expect } from "../testUtilsv2";
+import { VaultUtils } from "@dendronhq/common-all";
+import * as vscode from "vscode";
+import { Utils } from "vscode-uri";
+
+suite("Delete Command", function () {
+  describeSingleWS(
+    "GIVEN a note open in text editor and Delete Command is run",
+    {
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout: 1e6,
+    },
+    () => {
+      test("WHEN selected proceed to delete THEN delete the note", async () => {
+        const engine = ExtensionProvider.getEngine();
+        const deleteCmd = new DeleteCommand();
+        sinon.stub(deleteCmd, "promptConfirmation").resolves(true);
+        const note = (await engine.findNotes({ fname: "bar" }))[0];
+        await WSUtilsV2.instance().openNote(note);
+        const resp = await deleteCmd.execute();
+        expect(resp?.error).toEqual(null);
+        const noteAfterDelete = await engine.findNotes({ fname: "bar" });
+        expect(noteAfterDelete).toEqual([]);
+      });
+      test("WHEN noConfirm: true is sent via keyvinding args THEN delete the note", async () => {
+        const engine = ExtensionProvider.getEngine();
+        const deleteCmd = new DeleteCommand();
+        const note = (await engine.findNotes({ fname: "foo.ch1" }))[0];
+        await WSUtilsV2.instance().openNote(note);
+        const resp = await deleteCmd.execute({ noConfirm: true });
+        expect(resp?.error).toEqual(null);
+        const noteAfterDelete = await engine.findNotes({ fname: "foo.ch1" });
+        expect(noteAfterDelete).toEqual([]);
+      });
+    }
+  );
+  describeSingleWS(
+    "GIVEN Delete Command is run from Explorer Menu for a note",
+    {
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout: 1e6,
+    },
+    () => {
+      test("THEN delete the note", async () => {
+        const engine = ExtensionProvider.getEngine();
+        const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+        const vaultPath = VaultUtils.getRelPath(vaults[0]);
+        const barUri = Utils.joinPath(
+          vscode.Uri.file(wsRoot),
+          vaultPath,
+          "bar.md"
+        );
+        const deleteCmd = new DeleteCommand();
+        sinon.stub(deleteCmd, "promptConfirmation").resolves(true);
+        await engine.findNotes({ fname: "bar" });
+        const resp = await deleteCmd.execute(barUri);
+        expect(resp?.error).toEqual(null);
+        const noteAfterDelete = await engine.findNotes({ fname: "bar" });
+        expect(noteAfterDelete).toEqual([]);
+      });
+    }
+  );
+  describeSingleWS(
+    "GIVEN Delete Command is run from Tree View Context Menu for a note",
+    {
+      postSetupHook: ENGINE_HOOKS.setupBasic,
+      timeout: 1e6,
+    },
+    () => {
+      test("THEN delete the note", async () => {
+        const engine = ExtensionProvider.getEngine();
+        const deleteCmd = new DeleteCommand();
+        sinon.stub(deleteCmd, "promptConfirmation").resolves(true);
+        const note = (await engine.findNotes({ fname: "bar" }))[0];
+        const resp = await deleteCmd.execute(note);
+        expect(resp?.error).toEqual(null);
+        const noteAfterDelete = await engine.findNotes({ fname: "bar" });
+        expect(noteAfterDelete).toEqual([]);
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -58,10 +58,10 @@ async function runDeleteNote(opts: { noteId: string }) {
   const { wsRoot } = engine;
   const { noteId } = opts;
   const noteToDelete = engine.notes[noteId];
-  const _fsPath = getNoteUri({ note: noteToDelete, wsRoot }).fsPath;
+  const fsPath = getNoteUri({ note: noteToDelete, wsRoot }).fsPath;
   const deleteCmd = new DeleteCommand();
   const deleteOpts = {
-    _fsPath,
+    fsPath,
     noConfirm: true,
   };
   await deleteCmd.execute(deleteOpts);
@@ -102,7 +102,7 @@ async function getFullTree(opts: {
 }
 
 suite("NativeTreeView tests", function () {
-  this.timeout(2000);
+  this.timeout(4000);
 
   describe("Rename Note Command interactions", function () {
     describeMultiWS(
@@ -117,6 +117,7 @@ suite("NativeTreeView tests", function () {
             genRandomId: true,
           });
         },
+        timeout: 1e6,
       },
       () => {
         test("THEN tree view correctly displays renamed note", async () => {

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -117,7 +117,6 @@ suite("NativeTreeView tests", function () {
             genRandomId: true,
           });
         },
-        timeout: 1e6,
       },
       () => {
         test("THEN tree view correctly displays renamed note", async () => {

--- a/packages/plugin-core/src/views/TreeNote.ts
+++ b/packages/plugin-core/src/views/TreeNote.ts
@@ -37,6 +37,7 @@ export class TreeNote extends vscode.TreeItem {
     this.note = note;
     this.id = this.note.id;
     this.tooltip = this.note.title;
+    this.contextValue = this.note.stub ? "stub" : "note";
     const { wsRoot } = ExtensionProvider.getDWorkspace();
     const vpath = vault2Path({
       vault: this.note.vault,


### PR DESCRIPTION
- This PR aims to add a context menu for tree view. Added Delete Command in tree view context menu.
- It also fixes an issue with Delete Command: If the note is not open in the text editor. it is not deleted when the command is run from the explorer menu.
- It adds a Create Note command in context menu of Tree view, the lookup bar has the initial value of tree item responsible for action.
- adds source: Tree view property for Create Note and Delete Command

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)