### PR TITLE
fix(workspace): noisy warnings in engine startup

### DIFF
--- a/packages/common-all/src/drivers/string2Note.ts
+++ b/packages/common-all/src/drivers/string2Note.ts
@@ -2,7 +2,7 @@ import matter from "gray-matter";
 import YAML from "js-yaml";
 import _ from "lodash";
 import { DNodeUtils } from "../dnode";
-import { DVault } from "../types";
+import { DNodeImplicitPropsEnum, DVault } from "../types";
 import { genHash } from "../utils";
 
 /**
@@ -38,7 +38,7 @@ export function string2Note({
 
   const contentHash = calculateHash ? genHash(content) : undefined;
   const note = DNodeUtils.create({
-    ...data,
+    ..._.omit(data, Object.values(DNodeImplicitPropsEnum)),
     custom,
     fname,
     body,

--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -105,6 +105,7 @@ export enum DNodeImplicitPropsEnum {
   schemaStub = "schemaStub",
   type = "type",
   custom = "custom",
+  links = "links",
 }
 
 /**

--- a/packages/engine-server/src/drivers/file/noteParser.ts
+++ b/packages/engine-server/src/drivers/file/noteParser.ts
@@ -439,7 +439,11 @@ export class NoteParser extends ParserBase {
     note.contentHash = sig;
     // Link/anchor errors should be logged but not interfere with rest of parsing
     try {
-      EngineUtils.refreshNoteLinksAndAnchors({ note, engine: this.engine });
+      EngineUtils.refreshNoteLinksAndAnchors({
+        note,
+        engine: this.engine,
+        silent: true,
+      });
     } catch (_err: any) {
       errors.push(ErrorFactory.wrapIfNeeded(_err));
     }

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -562,6 +562,7 @@ export class FileStorage implements DStore {
     const noteCache = new InMemoryNoteCache(allNotes);
 
     notesWithLinks.forEach((noteFrom) => {
+      let _noteToForErrorLog: NoteProps | undefined;
       try {
         noteFrom.links.forEach((link) => {
           const fname = link.to?.fname;
@@ -570,6 +571,7 @@ export class FileStorage implements DStore {
             const notes = noteCache.getNotesByFileNameIgnoreCase(fname);
 
             notes.forEach((noteTo: NoteProps) => {
+              _noteToForErrorLog = noteTo;
               NoteUtils.addBacklink({
                 from: noteFrom,
                 to: noteTo,
@@ -580,7 +582,14 @@ export class FileStorage implements DStore {
         });
       } catch (err: any) {
         const error = error2PlainObject(err);
-        this.logger.error({ error, noteFrom, message: "issue with backlinks" });
+        this.logger.error({
+          error,
+          noteFrom: NoteUtils.toLogObj(noteFrom),
+          noteTo: _noteToForErrorLog
+            ? NoteUtils.toLogObj(_noteToForErrorLog)
+            : null,
+          message: "issue with backlinks",
+        });
       }
     });
   }

--- a/packages/engine-server/src/utils/engineUtils.ts
+++ b/packages/engine-server/src/utils/engineUtils.ts
@@ -94,16 +94,22 @@ export class EngineUtils {
     note,
     engine,
     fmChangeOnly,
+    silent,
   }: {
     note: NoteProps;
     engine: DEngineClient;
     fmChangeOnly?: boolean;
+    silent?: boolean;
   }): void {
     const maxNoteLength = Math.min(
       ConfigUtils.getWorkspace(engine.config).maxNoteLength,
       CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH
     );
     if (note.body.length > maxNoteLength) {
+      if (silent) {
+        return;
+      }
+      // this should only show up if a user navigates
       throw new DendronError({
         message:
           `Note "${note.fname}" in vault "${VaultUtils.getName(


### PR DESCRIPTION
- `links` frontmatter will override implict note `links` prop, causing notes with `links` property to throw errors during startup
- no warning about notes being too long when initiliazing engine
