### PR TITLE
fix(sync): nextjs export pod to fetch latest dendron config

### DIFF
--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -464,12 +464,16 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
   async plant(opts: NextjsExportPlantOpts) {
     const ctx = `${ID}:plant`;
     const { dest, engine, wsRoot, config: podConfig } = opts;
-
+    const resp = await engine.getConfig();
+    if (resp.error) {
+      throw resp.error;
+    }
+    const config = resp.data!;
     const podDstDir = path.join(dest.fsPath, "data");
     fs.ensureDirSync(podDstDir);
 
     const siteConfig = getSiteConfig({
-      config: engine.config,
+      config,
       overrides: podConfig.overrides,
     });
 
@@ -478,11 +482,11 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
       throw error;
     }
 
-    await this.copyAssets({ wsRoot, config: engine.config, dest: dest.fsPath });
+    await this.copyAssets({ wsRoot, config, dest: dest.fsPath });
 
     this.L.info({ ctx, msg: "filtering notes..." });
     const engineConfig: IntermediateDendronConfig =
-      ConfigUtils.overridePublishingConfig(engine.config, siteConfig);
+      ConfigUtils.overridePublishingConfig(config, siteConfig);
 
     const { notes: publishedNotes, domains } = await SiteUtils.filterByConfig({
       engine,


### PR DESCRIPTION
Related issue: https://github.com/dendronhq/dendron/issues/3426 and https://github.com/dendronhq/dendron/issues/3425

In nextjsexportpod `engine.config` has stale value and is only updated when workspace is reloaded. Updated references of engine.config with engine.getConfig which returns the latest config values