### PR TITLE
fix: tree view init problem on web

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -53,6 +53,10 @@
       {
         "view": "dendron.recent-workspaces",
         "contents": "No recent workspaces detected. If this is your first time using Dendron, [try out our tutorial workspace](command:dendron.launchTutorialWorkspace?%7B%22invocationPoint%22%3A%22RecentWorkspacesPanel%22%7D)."
+      },
+      {
+        "view": "dendron.treeView",
+        "contents": "Open a Dendron note to see the tree view."
       }
     ],
     "viewsContainers": {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -66,6 +66,10 @@ export const DENDRON_VIEWS_WELCOME = [
     view: DendronTreeViewKey.RECENT_WORKSPACES,
     contents: `No recent workspaces detected. If this is your first time using Dendron, [try out our tutorial workspace](${commandUri}).`,
   },
+  {
+    view: DendronTreeViewKey.TREE_VIEW,
+    contents: "First open a Dendron note to see the tree view.",
+  },
 ];
 
 export const DENDRON_VIEWS_CONTAINERS = {

--- a/packages/plugin-core/src/web/views/treeView/NativeTreeView.ts
+++ b/packages/plugin-core/src/web/views/treeView/NativeTreeView.ts
@@ -1,7 +1,6 @@
 import {
   asyncLoopOneAtATime,
   DendronTreeViewKey,
-  NoteProps,
   TreeViewItemLabelTypeEnum,
 } from "@dendronhq/common-all";
 import _ from "lodash";

--- a/packages/plugin-core/src/web/views/treeView/NativeTreeView.ts
+++ b/packages/plugin-core/src/web/views/treeView/NativeTreeView.ts
@@ -10,7 +10,7 @@ import { Disposable, TextEditor, TreeView, window } from "vscode";
 import { WSUtilsWeb } from "../../utils/WSUtils";
 import { EngineNoteProvider } from "./EngineNoteProvider";
 import { TreeNote } from "./TreeNote";
-
+import * as vscode from "vscode";
 /**
  * Class managing the vscode native version of the Dendron tree view - this is
  * the side panel UI that gives a tree view of the Dendron note hierarchy
@@ -53,23 +53,21 @@ export class NativeTreeView implements Disposable {
       this._provider
     );
 
-    const result = this._provider.getChildren() as Promise<
-      NoteProps | undefined | null
-    >;
-
-    result.then(() => {
-      const treeView = window.createTreeView(DendronTreeViewKey.TREE_VIEW, {
-        treeDataProvider: this._provider,
-        showCollapseAll: true,
-      });
-
-      this.treeView = treeView;
-
-      this._handler = window.onDidChangeActiveTextEditor(
-        this.onOpenTextDocument,
-        this
-      );
+    this.treeView = window.createTreeView(DendronTreeViewKey.TREE_VIEW, {
+      treeDataProvider: this._provider,
+      showCollapseAll: true,
     });
+
+    this.treeView.onDidChangeVisibility((e) => {
+      if (e.visible) {
+        this.onOpenTextDocument(vscode.window.activeTextEditor);
+      }
+    });
+
+    this._handler = window.onDidChangeActiveTextEditor(
+      this.onOpenTextDocument,
+      this
+    );
   }
 
   public updateLabelType(opts: { labelType: TreeViewItemLabelTypeEnum }) {


### PR DESCRIPTION
## fix: tree view init problem on web

There's an issue where the tree view on the web ext won't show any contents when you open up a repository for the first time. It'll show up if you focus on a note, and it seems that it'll remain in a good state on all subsequent times you open that repository.

I'm not sure what's the exact cause of the issue, but this change adds a mitigation: it leaves a message whenever the tree view is empty that tells the user to open a Dendron note.  

This also fixes a tangentially related issue where the tree view will focus on the active note when you toggle its visibility.

Credit to @hkievet for identifying the issue.