### PR TITLE
enhance(view): added settings UI tip

### DIFF
--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -24,6 +24,7 @@ export enum ShowcaseEntry {
   GraphPanel = "GraphPanel",
   BacklinksPanelHover = "BacklinksPanelHover",
   ObsidianImport = "ObsidianImport",
+  SettingsUI = "SettingsUI",
 }
 
 /**

--- a/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
+++ b/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
@@ -5,6 +5,7 @@ import { GraphThemeTip } from "./GraphThemeTip";
 import { IFeatureShowcaseMessage } from "./IFeatureShowcaseMessage";
 import { MeetingNotesTip } from "./MeetingNotesTip";
 import { ObsidianImportTip } from "./ObsidianImportTip";
+import { SettingsUITip } from "./SettingsUITip";
 import {
   createSimpleTipOfDayMsg,
   createTipOfDayMsgWithDocsLink,
@@ -88,4 +89,5 @@ export const ALL_FEATURE_SHOWCASES: IFeatureShowcaseMessage[] = [
   PREVIEW_THEME_LINK,
   new BacklinksPanelHoverTip(),
   new ObsidianImportTip(),
+  new SettingsUITip(),
 ];

--- a/packages/plugin-core/src/showcase/SettingsUITip.ts
+++ b/packages/plugin-core/src/showcase/SettingsUITip.ts
@@ -22,7 +22,7 @@ export class SettingsUITip implements IFeatureShowcaseMessage {
   }
 
   getDisplayMessage(_displayLocation: DisplayLocation): string {
-    return `Modify Dendron Config using Dendron: Configure(UI) command`;
+    return "You can configure Dendron by using the `Dendron: Configure(UI) command`. You can also optionally edit the config file directly it with the `Dendron: Configure(yaml) command`";
   }
 
   onConfirm() {

--- a/packages/plugin-core/src/showcase/SettingsUITip.ts
+++ b/packages/plugin-core/src/showcase/SettingsUITip.ts
@@ -1,0 +1,45 @@
+import { assertUnreachable } from "@dendronhq/common-all";
+import { ShowcaseEntry } from "@dendronhq/engine-server";
+import * as vscode from "vscode";
+import { showMeHowView } from "../views/ShowMeHowView";
+import {
+  DisplayLocation,
+  IFeatureShowcaseMessage,
+} from "./IFeatureShowcaseMessage";
+
+export class SettingsUITip implements IFeatureShowcaseMessage {
+  shouldShow(displayLocation: DisplayLocation): boolean {
+    switch (displayLocation) {
+      case DisplayLocation.InformationMessage:
+      case DisplayLocation.TipOfTheDayView:
+        return true;
+      default:
+        assertUnreachable(displayLocation);
+    }
+  }
+  get showcaseEntry(): ShowcaseEntry {
+    return ShowcaseEntry.SettingsUI;
+  }
+
+  getDisplayMessage(_displayLocation: DisplayLocation): string {
+    return `Modify Dendron Config using Dendron: Configure(UI) command`;
+  }
+
+  onConfirm() {
+    vscode.commands.executeCommand("dendron.configureUI");
+    showMeHowView({
+      name: "Dendron Configure (UI)",
+      src: "https://org-dendron-public-assets.s3.amazonaws.com/images/settingsUI.gif",
+      href: "https://www.loom.com/share/3eba0f8523ac4d1ab150e8d3af9f1b0b",
+      alt: "Run Ctrl+shift+P > Dendron: Configure (UI)",
+    });
+  }
+
+  get confirmText(): string {
+    return "Show me how";
+  }
+
+  get deferText(): string {
+    return "Later";
+  }
+}


### PR DESCRIPTION
Added Settings UI tip to tip of the day

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA
## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)