### PR TITLE
chore: remove enableSmartRefs config

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -8,10 +8,7 @@
       "properties": {
         "version": {
           "type": "number",
-          "enum": [
-            4,
-            5
-          ]
+          "enum": [4, 5]
         },
         "dev": {
           "$ref": "#/definitions/DendronDevConfig",
@@ -58,9 +55,7 @@
           "$ref": "#/definitions/DendronPublishingConfig"
         }
       },
-      "required": [
-        "version"
-      ]
+      "required": ["version"]
     },
     "DendronDevConfig": {
       "type": "object",
@@ -87,10 +82,7 @@
         },
         "forceWatcherType": {
           "type": "string",
-          "enum": [
-            "plugin",
-            "engine"
-          ],
+          "enum": ["plugin", "engine"],
           "description": "Force the use of a specific type of watcher.\n\n- plugin: Uses VSCode's builtin watcher\n- engine: Uses the engine watcher, watching the files directly without VSCode"
         },
         "enableExportPodV2": {
@@ -182,10 +174,7 @@
         },
         "gh_edit_view_mode": {
           "type": "string",
-          "enum": [
-            "tree",
-            "edit"
-          ]
+          "enum": ["tree", "edit"]
         },
         "gh_edit_repository": {
           "type": "string"
@@ -243,10 +232,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "url",
-            "alt"
-          ],
+          "required": ["url", "alt"],
           "additionalProperties": false,
           "description": "Default SEO image for published pages"
         },
@@ -282,10 +268,7 @@
           "description": "Display a `#` symbol in front of frontmatter tags in the tags listing. False by default."
         }
       },
-      "required": [
-        "siteHierarchies",
-        "siteRootDir"
-      ],
+      "required": ["siteHierarchies", "siteRootDir"],
       "additionalProperties": false
     },
     "LegacyHierarchyConfig": {
@@ -324,10 +307,7 @@
         },
         "value": {}
       },
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "additionalProperties": false
     },
     "LegacyDuplicateNoteBehavior": {
@@ -343,10 +323,7 @@
           "$ref": "#/definitions/LegacyUseVaultBehaviorPayload"
         }
       },
-      "required": [
-        "action",
-        "payload"
-      ],
+      "required": ["action", "payload"],
       "additionalProperties": false
     },
     "LegacyDuplicateNoteAction": {
@@ -362,9 +339,7 @@
               "$ref": "#/definitions/DVault"
             }
           },
-          "required": [
-            "vault"
-          ],
+          "required": ["vault"],
           "additionalProperties": false
         },
         {
@@ -424,9 +399,7 @@
           "description": "Index page for the vault"
         }
       },
-      "required": [
-        "fsPath"
-      ],
+      "required": ["fsPath"],
       "additionalProperties": false
     },
     "DVaultVisibility": {
@@ -444,10 +417,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "additionalProperties": false
     },
     "DPermission": {
@@ -466,20 +436,12 @@
           }
         }
       },
-      "required": [
-        "read",
-        "write"
-      ],
+      "required": ["read", "write"],
       "additionalProperties": false
     },
     "DVaultSync": {
       "type": "string",
-      "enum": [
-        "skip",
-        "noPush",
-        "noCommit",
-        "sync"
-      ]
+      "enum": ["skip", "noPush", "noCommit", "sync"]
     },
     "DendronCommandConfig": {
       "type": "object",
@@ -521,9 +483,7 @@
           "$ref": "#/definitions/NoteLookupConfig"
         }
       },
-      "required": [
-        "note"
-      ],
+      "required": ["note"],
       "additionalProperties": false,
       "description": "Namespace for configuring lookup commands"
     },
@@ -562,19 +522,12 @@
     },
     "LookupSelectionMode": {
       "type": "string",
-      "enum": [
-        "extract",
-        "link",
-        "none"
-      ],
+      "enum": ["extract", "link", "none"],
       "description": "String literal type generated from  {@link  NoteLookupSelectionBehaviorEnum }"
     },
     "LookupSelectVaultModeOnCreate": {
       "type": "string",
-      "enum": [
-        "smart",
-        "alwaysPrompt"
-      ]
+      "enum": ["smart", "alwaysPrompt"]
     },
     "RandomNoteConfig": {
       "type": "object",
@@ -605,22 +558,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "aliasMode",
-        "enableMultiSelect"
-      ],
+      "required": ["aliasMode", "enableMultiSelect"],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  InsertNoteLinkCommand }"
     },
     "InsertNoteLinkAliasModeEnum": {
       "type": "string",
-      "enum": [
-        "snippet",
-        "selection",
-        "title",
-        "prompt",
-        "none"
-      ],
+      "enum": ["snippet", "selection", "title", "prompt", "none"],
       "description": "Enum definitions of possible alias mode values"
     },
     "InsertNoteIndexConfig": {
@@ -630,9 +574,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "enableMarker"
-      ],
+      "required": ["enableMarker"],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  InsertNoteIndexCommand }"
     },
@@ -650,25 +592,16 @@
         },
         "aliasMode": {
           "type": "string",
-          "enum": [
-            "none",
-            "title"
-          ]
+          "enum": ["none", "title"]
         }
       },
-      "required": [
-        "aliasMode"
-      ],
+      "required": ["aliasMode"],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  CopyNoteLinkCommand }"
     },
     "NonNoteFileLinkAnchorType": {
       "type": "string",
-      "enum": [
-        "line",
-        "block",
-        "prompt"
-      ],
+      "enum": ["line", "block", "prompt"],
       "description": "\"line\" uses line numbers (`L23`), \"block\" inserts block anchors (`^xf1g...`). \"prompt\" means prompt the user to select one."
     },
     "DendronWorkspaceConfig": {
@@ -760,9 +693,6 @@
         "enableEditorDecorations": {
           "type": "boolean"
         },
-        "enableSmartRefs": {
-          "type": "boolean"
-        },
         "feedback": {
           "type": "boolean"
         },
@@ -771,10 +701,7 @@
         },
         "metadataStore": {
           "type": "string",
-          "enum": [
-            "sqlite",
-            "json"
-          ]
+          "enum": ["sqlite", "json"]
         }
       },
       "required": [
@@ -805,9 +732,7 @@
           "$ref": "#/definitions/RemoteEndpoint"
         }
       },
-      "required": [
-        "remote"
-      ],
+      "required": ["remote"],
       "additionalProperties": false
     },
     "DendronSeedEntry": {
@@ -832,9 +757,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false
     },
     "DHookDict": {
@@ -847,9 +770,7 @@
           }
         }
       },
-      "required": [
-        "onCreate"
-      ],
+      "required": ["onCreate"],
       "additionalProperties": false
     },
     "DHookEntry": {
@@ -866,11 +787,7 @@
           "const": "js"
         }
       },
-      "required": [
-        "id",
-        "pattern",
-        "type"
-      ],
+      "required": ["id", "pattern", "type"],
       "additionalProperties": false
     },
     "JournalConfig": {
@@ -892,12 +809,7 @@
           "$ref": "#/definitions/NoteAddBehaviorEnum"
         }
       },
-      "required": [
-        "dailyDomain",
-        "name",
-        "dateFormat",
-        "addBehavior"
-      ],
+      "required": ["dailyDomain", "name", "dateFormat", "addBehavior"],
       "additionalProperties": false,
       "description": "Namespace for configuring journal note behavior"
     },
@@ -924,11 +836,7 @@
           "$ref": "#/definitions/NoteAddBehaviorEnum"
         }
       },
-      "required": [
-        "name",
-        "dateFormat",
-        "addBehavior"
-      ],
+      "required": ["name", "dateFormat", "addBehavior"],
       "additionalProperties": false,
       "description": "Namespace for configuring scratch note behavior"
     },
@@ -989,11 +897,7 @@
     },
     "LegacyLookupSelectionType": {
       "type": "string",
-      "enum": [
-        "selection2link",
-        "selectionExtract",
-        "none"
-      ]
+      "enum": ["selection2link", "selectionExtract", "none"]
     },
     "DendronGraphConfig": {
       "type": "object",
@@ -1006,21 +910,13 @@
           "description": "If true, create a note if it hasn't been created already when clicked on a graph node"
         }
       },
-      "required": [
-        "zoomSpeed",
-        "createStub"
-      ],
+      "required": ["zoomSpeed", "createStub"],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."
     },
     "VaultSyncMode": {
       "type": "string",
-      "enum": [
-        "skip",
-        "noPush",
-        "noCommit",
-        "sync"
-      ]
+      "enum": ["skip", "noPush", "noCommit", "sync"]
     },
     "DendronPreviewConfig": {
       "type": "object",
@@ -1068,11 +964,7 @@
     },
     "Theme": {
       "type": "string",
-      "enum": [
-        "dark",
-        "light",
-        "custom"
-      ]
+      "enum": ["dark", "light", "custom"]
     },
     "DendronPublishingConfig": {
       "type": "object",
@@ -1246,10 +1138,7 @@
         },
         "value": {}
       },
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "additionalProperties": false
     },
     "DuplicateNoteBehavior": {
@@ -1265,10 +1154,7 @@
           "$ref": "#/definitions/DuplicateNoteActionPayload"
         }
       },
-      "required": [
-        "action",
-        "payload"
-      ],
+      "required": ["action", "payload"],
       "additionalProperties": false
     },
     "DuplicateNoteAction": {
@@ -1287,9 +1173,7 @@
               "$ref": "#/definitions/DVault"
             }
           },
-          "required": [
-            "vault"
-          ],
+          "required": ["vault"],
           "additionalProperties": false
         },
         {
@@ -1332,10 +1216,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "url",
-        "alt"
-      ],
+      "required": ["url", "alt"],
       "additionalProperties": false
     },
     "GithubConfig": {
@@ -1360,18 +1241,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "enableEditLink"
-      ],
+      "required": ["enableEditLink"],
       "additionalProperties": false,
       "description": "Namespace for publishing related github configs"
     },
     "GithubEditViewMode": {
       "type": "string",
-      "enum": [
-        "tree",
-        "edit"
-      ]
+      "enum": ["tree", "edit"]
     }
   }
 }

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -8,7 +8,10 @@
       "properties": {
         "version": {
           "type": "number",
-          "enum": [4, 5]
+          "enum": [
+            4,
+            5
+          ]
         },
         "dev": {
           "$ref": "#/definitions/DendronDevConfig",
@@ -55,7 +58,9 @@
           "$ref": "#/definitions/DendronPublishingConfig"
         }
       },
-      "required": ["version"]
+      "required": [
+        "version"
+      ]
     },
     "DendronDevConfig": {
       "type": "object",
@@ -82,7 +87,10 @@
         },
         "forceWatcherType": {
           "type": "string",
-          "enum": ["plugin", "engine"],
+          "enum": [
+            "plugin",
+            "engine"
+          ],
           "description": "Force the use of a specific type of watcher.\n\n- plugin: Uses VSCode's builtin watcher\n- engine: Uses the engine watcher, watching the files directly without VSCode"
         },
         "enableExportPodV2": {
@@ -174,7 +182,10 @@
         },
         "gh_edit_view_mode": {
           "type": "string",
-          "enum": ["tree", "edit"]
+          "enum": [
+            "tree",
+            "edit"
+          ]
         },
         "gh_edit_repository": {
           "type": "string"
@@ -232,7 +243,10 @@
               "type": "string"
             }
           },
-          "required": ["url", "alt"],
+          "required": [
+            "url",
+            "alt"
+          ],
           "additionalProperties": false,
           "description": "Default SEO image for published pages"
         },
@@ -268,7 +282,10 @@
           "description": "Display a `#` symbol in front of frontmatter tags in the tags listing. False by default."
         }
       },
-      "required": ["siteHierarchies", "siteRootDir"],
+      "required": [
+        "siteHierarchies",
+        "siteRootDir"
+      ],
       "additionalProperties": false
     },
     "LegacyHierarchyConfig": {
@@ -307,7 +324,10 @@
         },
         "value": {}
       },
-      "required": ["key", "value"],
+      "required": [
+        "key",
+        "value"
+      ],
       "additionalProperties": false
     },
     "LegacyDuplicateNoteBehavior": {
@@ -323,7 +343,10 @@
           "$ref": "#/definitions/LegacyUseVaultBehaviorPayload"
         }
       },
-      "required": ["action", "payload"],
+      "required": [
+        "action",
+        "payload"
+      ],
       "additionalProperties": false
     },
     "LegacyDuplicateNoteAction": {
@@ -339,7 +362,9 @@
               "$ref": "#/definitions/DVault"
             }
           },
-          "required": ["vault"],
+          "required": [
+            "vault"
+          ],
           "additionalProperties": false
         },
         {
@@ -399,7 +424,9 @@
           "description": "Index page for the vault"
         }
       },
-      "required": ["fsPath"],
+      "required": [
+        "fsPath"
+      ],
       "additionalProperties": false
     },
     "DVaultVisibility": {
@@ -417,7 +444,10 @@
           "type": "string"
         }
       },
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "additionalProperties": false
     },
     "DPermission": {
@@ -436,12 +466,20 @@
           }
         }
       },
-      "required": ["read", "write"],
+      "required": [
+        "read",
+        "write"
+      ],
       "additionalProperties": false
     },
     "DVaultSync": {
       "type": "string",
-      "enum": ["skip", "noPush", "noCommit", "sync"]
+      "enum": [
+        "skip",
+        "noPush",
+        "noCommit",
+        "sync"
+      ]
     },
     "DendronCommandConfig": {
       "type": "object",
@@ -483,7 +521,9 @@
           "$ref": "#/definitions/NoteLookupConfig"
         }
       },
-      "required": ["note"],
+      "required": [
+        "note"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring lookup commands"
     },
@@ -522,12 +562,19 @@
     },
     "LookupSelectionMode": {
       "type": "string",
-      "enum": ["extract", "link", "none"],
+      "enum": [
+        "extract",
+        "link",
+        "none"
+      ],
       "description": "String literal type generated from  {@link  NoteLookupSelectionBehaviorEnum }"
     },
     "LookupSelectVaultModeOnCreate": {
       "type": "string",
-      "enum": ["smart", "alwaysPrompt"]
+      "enum": [
+        "smart",
+        "alwaysPrompt"
+      ]
     },
     "RandomNoteConfig": {
       "type": "object",
@@ -558,13 +605,22 @@
           "type": "boolean"
         }
       },
-      "required": ["aliasMode", "enableMultiSelect"],
+      "required": [
+        "aliasMode",
+        "enableMultiSelect"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  InsertNoteLinkCommand }"
     },
     "InsertNoteLinkAliasModeEnum": {
       "type": "string",
-      "enum": ["snippet", "selection", "title", "prompt", "none"],
+      "enum": [
+        "snippet",
+        "selection",
+        "title",
+        "prompt",
+        "none"
+      ],
       "description": "Enum definitions of possible alias mode values"
     },
     "InsertNoteIndexConfig": {
@@ -574,7 +630,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enableMarker"],
+      "required": [
+        "enableMarker"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  InsertNoteIndexCommand }"
     },
@@ -592,16 +650,25 @@
         },
         "aliasMode": {
           "type": "string",
-          "enum": ["none", "title"]
+          "enum": [
+            "none",
+            "title"
+          ]
         }
       },
-      "required": ["aliasMode"],
+      "required": [
+        "aliasMode"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring  {@link  CopyNoteLinkCommand }"
     },
     "NonNoteFileLinkAnchorType": {
       "type": "string",
-      "enum": ["line", "block", "prompt"],
+      "enum": [
+        "line",
+        "block",
+        "prompt"
+      ],
       "description": "\"line\" uses line numbers (`L23`), \"block\" inserts block anchors (`^xf1g...`). \"prompt\" means prompt the user to select one."
     },
     "DendronWorkspaceConfig": {
@@ -701,7 +768,10 @@
         },
         "metadataStore": {
           "type": "string",
-          "enum": ["sqlite", "json"]
+          "enum": [
+            "sqlite",
+            "json"
+          ]
         }
       },
       "required": [
@@ -732,7 +802,9 @@
           "$ref": "#/definitions/RemoteEndpoint"
         }
       },
-      "required": ["remote"],
+      "required": [
+        "remote"
+      ],
       "additionalProperties": false
     },
     "DendronSeedEntry": {
@@ -757,7 +829,9 @@
           "type": "string"
         }
       },
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false
     },
     "DHookDict": {
@@ -770,7 +844,9 @@
           }
         }
       },
-      "required": ["onCreate"],
+      "required": [
+        "onCreate"
+      ],
       "additionalProperties": false
     },
     "DHookEntry": {
@@ -787,7 +863,11 @@
           "const": "js"
         }
       },
-      "required": ["id", "pattern", "type"],
+      "required": [
+        "id",
+        "pattern",
+        "type"
+      ],
       "additionalProperties": false
     },
     "JournalConfig": {
@@ -809,7 +889,12 @@
           "$ref": "#/definitions/NoteAddBehaviorEnum"
         }
       },
-      "required": ["dailyDomain", "name", "dateFormat", "addBehavior"],
+      "required": [
+        "dailyDomain",
+        "name",
+        "dateFormat",
+        "addBehavior"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring journal note behavior"
     },
@@ -836,7 +921,11 @@
           "$ref": "#/definitions/NoteAddBehaviorEnum"
         }
       },
-      "required": ["name", "dateFormat", "addBehavior"],
+      "required": [
+        "name",
+        "dateFormat",
+        "addBehavior"
+      ],
       "additionalProperties": false,
       "description": "Namespace for configuring scratch note behavior"
     },
@@ -897,7 +986,11 @@
     },
     "LegacyLookupSelectionType": {
       "type": "string",
-      "enum": ["selection2link", "selectionExtract", "none"]
+      "enum": [
+        "selection2link",
+        "selectionExtract",
+        "none"
+      ]
     },
     "DendronGraphConfig": {
       "type": "object",
@@ -910,13 +1003,21 @@
           "description": "If true, create a note if it hasn't been created already when clicked on a graph node"
         }
       },
-      "required": ["zoomSpeed", "createStub"],
+      "required": [
+        "zoomSpeed",
+        "createStub"
+      ],
       "additionalProperties": false,
       "description": "Namespace for all graph related configurations."
     },
     "VaultSyncMode": {
       "type": "string",
-      "enum": ["skip", "noPush", "noCommit", "sync"]
+      "enum": [
+        "skip",
+        "noPush",
+        "noCommit",
+        "sync"
+      ]
     },
     "DendronPreviewConfig": {
       "type": "object",
@@ -964,7 +1065,11 @@
     },
     "Theme": {
       "type": "string",
-      "enum": ["dark", "light", "custom"]
+      "enum": [
+        "dark",
+        "light",
+        "custom"
+      ]
     },
     "DendronPublishingConfig": {
       "type": "object",
@@ -1138,7 +1243,10 @@
         },
         "value": {}
       },
-      "required": ["key", "value"],
+      "required": [
+        "key",
+        "value"
+      ],
       "additionalProperties": false
     },
     "DuplicateNoteBehavior": {
@@ -1154,7 +1262,10 @@
           "$ref": "#/definitions/DuplicateNoteActionPayload"
         }
       },
-      "required": ["action", "payload"],
+      "required": [
+        "action",
+        "payload"
+      ],
       "additionalProperties": false
     },
     "DuplicateNoteAction": {
@@ -1173,7 +1284,9 @@
               "$ref": "#/definitions/DVault"
             }
           },
-          "required": ["vault"],
+          "required": [
+            "vault"
+          ],
           "additionalProperties": false
         },
         {
@@ -1216,7 +1329,10 @@
           "type": "string"
         }
       },
-      "required": ["url", "alt"],
+      "required": [
+        "url",
+        "alt"
+      ],
       "additionalProperties": false
     },
     "GithubConfig": {
@@ -1241,13 +1357,18 @@
           "type": "string"
         }
       },
-      "required": ["enableEditLink"],
+      "required": [
+        "enableEditLink"
+      ],
       "additionalProperties": false,
       "description": "Namespace for publishing related github configs"
     },
     "GithubEditViewMode": {
       "type": "string",
-      "enum": ["tree", "edit"]
+      "enum": [
+        "tree",
+        "edit"
+      ]
     }
   }
 }

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -220,10 +220,6 @@ export const WORKSPACE: DendronConfigEntryCollection<DendronWorkspaceConfig> = {
     label: "Enable FullHierarchyNoteTitle mode",
     desc: "When enabled, the full hierarchy position of a note is used to generate the note title",
   },
-  enableSmartRefs: {
-    label: "Enable smart references",
-    desc: "When enabled, note references that include a header will transclude said header and all sub headers",
-  },
   metadataStore: {
     label: "Storage engine for metadata",
     desc: "values: sqlite|json",

--- a/packages/common-all/src/types/configs/workspace/workspace.ts
+++ b/packages/common-all/src/types/configs/workspace/workspace.ts
@@ -35,7 +35,6 @@ export type DendronWorkspaceConfig = {
   maxPreviewsCached: number;
   maxNoteLength: number;
   enableEditorDecorations: boolean;
-  enableSmartRefs?: boolean;
   //
   feedback?: boolean;
   apiEndpoint?: string;
@@ -77,6 +76,5 @@ export function genDefaultWorkspaceConfig(): DendronWorkspaceConfig {
     maxPreviewsCached: 10,
     maxNoteLength: 204800,
     enableFullHierarchyNoteTitle: false,
-    enableSmartRefs: false,
   };
 }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -592,7 +592,7 @@ export class ConfigUtils {
         version: 5,
         ...common,
         commands: genDefaultCommandConfig(),
-        workspace: { ...genDefaultWorkspaceConfig(), enableSmartRefs: true },
+        workspace: { ...genDefaultWorkspaceConfig() },
         preview: genDefaultPreviewConfig(),
         publishing: genDefaultPublishingConfig(),
       } as StrictConfigV5,

--- a/packages/dendron-plugin-views/src/utils/dendronConfig.ts
+++ b/packages/dendron-plugin-views/src/utils/dendronConfig.ts
@@ -185,10 +185,6 @@ export const dendronConfig: { [key: string]: Config } = {
     type: "boolean",
     group: "workspace",
   },
-  "workspace.enableSmartRefs": {
-    type: "boolean",
-    group: "workspace",
-  },
   "preview.enableFMTitle": {
     type: "boolean",
     group: "preview",

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -91,7 +91,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds:
         dendron.foo: {}
 preview:
@@ -246,7 +245,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds:
         dendron.foo:
             site:
@@ -391,7 +389,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -503,7 +500,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -632,7 +628,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -85,7 +85,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds:
         dendron.foo: {}
 preview:
@@ -240,7 +239,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds:
         dendron.foo:
             site:
@@ -385,7 +383,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -497,7 +494,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -626,7 +622,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: true
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
@@ -762,7 +757,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds: {}
 preview:
     enableFMTitle: true
@@ -884,7 +878,6 @@ workspace:
     maxPreviewsCached: 10
     maxNoteLength: 204800
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
     seeds: {}
 preview:
     enableFMTitle: true

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -83,13 +83,6 @@ VFile {
 
 body 1.1
 
-## Header 2
-
-body 2.2
-end section
-
-## Header 3
-
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -106,11 +99,6 @@ VFile {
 ## Header 1
 
 body 1.1
-
-## Header 2
-
-body 2.2
-end section
 
 
 ",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/noteRefv2.spec.ts.snap
@@ -83,6 +83,13 @@ VFile {
 
 body 1.1
 
+## Header 2
+
+body 2.2
+end section
+
+## Header 3
+
 
 ",
   "cwd": "<PROJECT_ROOT>",
@@ -99,6 +106,11 @@ VFile {
 ## Header 1
 
 body 1.1
+
+## Header 2
+
+body 2.2
+end section
 
 
 ",

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -329,13 +329,13 @@ describe("noteRefV2", () => {
       );
     });
 
-    describe.skip("AND note has beginning section", () => {
+    describe("AND note has beginning section", () => {
       runTestCases(
         createProcCompileTests({
           name: "THEN parse beginning section",
           fname: "foo",
           setup: async (opts) => {
-            const text = "![[foo#header-1:^end]]";
+            const text = "![[foo#header-1:#^end]]";
             const { proc } = getOpts(opts);
             const resp = await proc.process(text);
             return { resp, proc };
@@ -354,13 +354,13 @@ describe("noteRefV2", () => {
       );
     });
 
-    describe.skip("AND note ends on a header", () => {
+    describe("AND note ends on a header", () => {
       runTestCases(
         createProcCompileTests({
           name: "THEN parse beginning section",
           fname: "foo",
           setup: async (opts) => {
-            const text = "![[foo#header-1:^end]]";
+            const text = "![[foo#header-1:#^end]]";
             const { proc } = getOpts(opts);
             const resp = await proc.process(text);
             return { resp, proc };

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/noteRefv2.spec.ts
@@ -87,10 +87,6 @@ describe("noteRefV2", () => {
   describe("WHEN parse header", () => {
     const preSetupHookForHeaders: PreSetupHookFunction = async (opts) => {
       await ANCHOR_WITH_SPACE_PRE_SETUP(opts);
-      TestConfigUtils.withConfig((config) => {
-        config.workspace.enableSmartRefs = true;
-        return config;
-      }, opts);
     };
     describe("AND parse from start header", () => {
       runTestCases(
@@ -333,7 +329,7 @@ describe("noteRefV2", () => {
       );
     });
 
-    describe("AND note has beginning section", () => {
+    describe.skip("AND note has beginning section", () => {
       runTestCases(
         createProcCompileTests({
           name: "THEN parse beginning section",
@@ -358,7 +354,7 @@ describe("noteRefV2", () => {
       );
     });
 
-    describe("AND note ends on a header", () => {
+    describe.skip("AND note ends on a header", () => {
       runTestCases(
         createProcCompileTests({
           name: "THEN parse beginning section",

--- a/packages/plugin-core/src/commands/CopyNoteRef.ts
+++ b/packages/plugin-core/src/commands/CopyNoteRef.ts
@@ -58,7 +58,6 @@ export class CopyNoteRefCommand extends BasicCommand<
     note: NoteProps;
     useVaultPrefix?: boolean;
     editor: TextEditor;
-    enableSmartRefs?: boolean;
   }) {
     const { note, useVaultPrefix, editor } = opts;
     const { fname, vault } = note;
@@ -77,22 +76,10 @@ export class CopyNoteRefCommand extends BasicCommand<
       if (!_.isUndefined(startAnchor) && !isBlockAnchor(startAnchor)) {
         // if a header is selected, skip the header itself
         linkData.anchorStart = slugger.slug(startAnchor);
-        if (!opts.enableSmartRefs) {
-          linkData.anchorStartOffset = 1;
-        }
       }
       linkData.anchorEnd = endAnchor;
       if (!_.isUndefined(endAnchor) && !isBlockAnchor(endAnchor)) {
         linkData.anchorEnd = slugger.slug(endAnchor);
-      }
-      if (
-        _.isUndefined(endAnchor) &&
-        !_.isUndefined(startAnchor) &&
-        this.hasNextHeader({ selection }) &&
-        !opts.enableSmartRefs
-      ) {
-        // if a header is selected for the start, and nothing for the end, and there's a next anchor, then use the wildcard
-        linkData.anchorEnd = "*";
       }
     }
     const link: DNoteRefLink = {
@@ -115,8 +102,7 @@ export class CopyNoteRefCommand extends BasicCommand<
     const editor = VSCodeUtils.getActiveTextEditor() as TextEditor;
     const fname = NoteUtils.uri2Fname(editor.document.uri);
     const vault = PickerUtilsV2.getVaultForOpenEditor();
-    const { config, engine } = ExtensionProvider.getDWorkspace();
-    const enableSmartRefs = config.workspace.enableSmartRefs;
+    const { engine } = ExtensionProvider.getDWorkspace();
     const note = NoteUtils.getNoteByFnameFromEngine({
       fname,
       engine,
@@ -128,7 +114,6 @@ export class CopyNoteRefCommand extends BasicCommand<
         note,
         useVaultPrefix,
         editor,
-        enableSmartRefs,
       });
       try {
         clipboard.writeText(link);

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -5,7 +5,7 @@ import {
   NoteTestUtilsV4,
   PreSetupHookFunction,
 } from "@dendronhq/common-test-utils";
-import { ENGINE_HOOKS, TestConfigUtils } from "@dendronhq/engine-test-utils";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import { describe } from "mocha";
 import path from "path";
@@ -19,193 +19,177 @@ import { describeMultiWS } from "../testUtilsV3";
 
 suite("CopyNoteRef", function () {
   describe("WHEN referencing a header", () => {
-    [true, false].forEach((enableSmartRef) => {
-      const preSetupHook: PreSetupHookFunction = async (opts) => {
-        await ENGINE_HOOKS.setupBasic(opts);
-        const rootName = "bar";
-        await NoteTestUtilsV4.createNote({
-          fname: `${rootName}`,
-          body: "## Foo\nfoo text\n## Header\n Header text",
-          vault: opts.vaults[0],
-          props: {
-            id: `${rootName}`,
-          },
-          wsRoot: opts.wsRoot,
-        });
-      };
-      const postSetupHook = async (opts: { wsRoot: string }) => {
-        TestConfigUtils.withConfig((config) => {
-          config.workspace.enableSmartRefs = enableSmartRef;
-          return config;
-        }, opts);
-      };
-      let suffix = enableSmartRef ? "" : ",1:#*";
-
-      describe("WHEN enableSmartRef is " + enableSmartRef, () => {
-        describeMultiWS(
-          "AND WHEN with header selected",
-          {
-            preSetupHook,
-            preActivateHook: postSetupHook,
-            timeout: 5e3,
-          },
-          () => {
-            test("THEN generate note ref", async () => {
-              const engine = ExtensionProvider.getEngine();
-              const note = engine.notes["bar"];
-              const editor = await WSUtils.openNote(note);
-              editor.selection = new vscode.Selection(7, 0, 7, 12);
-              const link = await new CopyNoteRefCommand().run();
-              expect(link).toEqual(`![[bar#foo${suffix}]]`);
-            });
-          }
-        );
-
-        describeMultiWS(
-          "AND WHEN with partial selection",
-          {
-            preSetupHook,
-            preActivateHook: postSetupHook,
-            timeout: 5e3,
-          },
-          () => {
-            test("THEN generate note ref", async () => {
-              const engine = ExtensionProvider.getEngine();
-              const note = engine.notes["bar"];
-              const editor = await WSUtils.openNote(note);
-              editor.selection = new vscode.Selection(7, 0, 7, 4);
-              const link = await new CopyNoteRefCommand().run();
-              expect(link).toEqual(`![[bar#foo${suffix}]]`);
-            });
-          }
-        );
-
-        describeMultiWS(
-          "AND WHEN no next header",
-          {
-            preSetupHook: async (opts) => {
-              await ENGINE_HOOKS.setupBasic(opts);
-              const rootName = "bar";
-              await NoteTestUtilsV4.createNote({
-                fname: `${rootName}`,
-                body: "## Foo\nfoo text\n",
-                vault: opts.vaults[0],
-                props: {
-                  id: `${rootName}`,
-                },
-                wsRoot: opts.wsRoot,
-              });
-            },
-            preActivateHook: postSetupHook,
-            timeout: 5e3,
-          },
-          () => {
-            test("THEN generate note ref", async () => {
-              const engine = ExtensionProvider.getEngine();
-              const note = engine.notes["bar"];
-              const editor = await WSUtils.openNote(note);
-              editor.selection = new vscode.Selection(7, 0, 7, 12);
-              const link = await new CopyNoteRefCommand().run();
-              suffix = enableSmartRef ? "" : ",1";
-              expect(link).toEqual(`![[bar#foo${suffix}]]`);
-            });
-          }
-        );
-
-        describeMultiWS(
-          "AND WHEN existing block anchor selection",
-          {
-            preSetupHook: async (opts) => {
-              await ENGINE_HOOKS.setupBasic(opts);
-              const rootName = "bar";
-              await NoteTestUtilsV4.createNote({
-                fname: `${rootName}`,
-                body: [
-                  "Sint est quis sint sed.",
-                  "Dicta vel nihil tempora. ^test-anchor",
-                  "",
-                  "A est alias unde quia quas.",
-                  "Laborum corrupti porro iure.",
-                  "",
-                  "Id perspiciatis est adipisci.",
-                ].join("\n"),
-                vault: opts.vaults[0],
-                props: {
-                  id: `${rootName}`,
-                },
-                wsRoot: opts.wsRoot,
-              });
-            },
-            preActivateHook: postSetupHook,
-            timeout: 5e3,
-          },
-          () => {
-            test("THEN generate note ref", async () => {
-              const engine = ExtensionProvider.getEngine();
-              const note = engine.notes["bar"];
-              const editor = await WSUtils.openNote(note);
-              editor.selection = new vscode.Selection(8, 0, 8, 0);
-              const link = await new CopyNoteRefCommand().run();
-              expect(link).toEqual("![[bar#^test-anchor]]");
-            });
-          }
-        );
-
-        describeMultiWS(
-          "AND WHEN generated block anchors",
-          {
-            preSetupHook: async (opts) => {
-              await ENGINE_HOOKS.setupBasic(opts);
-              const rootName = "bar";
-              await NoteTestUtilsV4.createNote({
-                fname: `${rootName}`,
-                body: [
-                  "Sint est quis sint sed.",
-                  "Dicta vel nihil tempora. ^test-anchor",
-                  "",
-                  "A est alias unde quia quas.",
-                  "Laborum corrupti porro iure.",
-                  "",
-                  "Id perspiciatis est adipisci.",
-                ].join("\n"),
-                vault: opts.vaults[0],
-                props: {
-                  id: `${rootName}`,
-                },
-                wsRoot: opts.wsRoot,
-              });
-            },
-            preActivateHook: postSetupHook,
-            timeout: 5e3,
-          },
-          () => {
-            test("THEN generate note ref", async () => {
-              const engine = ExtensionProvider.getEngine();
-              const note = engine.notes["bar"];
-              const editor = await WSUtils.openNote(note);
-              editor.selection = new vscode.Selection(8, 0, 11, 0);
-              const link = await new CopyNoteRefCommand().run();
-
-              // make sure the link is correct
-              expect(link!.startsWith("![[bar#^test-anchor:#^"));
-              expect(link!.endsWith("]]"));
-
-              // make sure we only added 1 block anchor (there should be 2 now)
-              AssertUtils.assertTimesInString({
-                body: editor.document.getText(),
-                match: [[2, /\^[a-zA-Z0-9-_]+/]],
-              });
-
-              // make sure the anchor in the link has been inserted into the document
-              const anchor = getAnchorsFromLink(link!, 2)[1];
-              AssertUtils.assertTimesInString({
-                body: editor.document.getText(),
-                match: [[1, anchor]],
-              });
-            });
-          }
-        );
+    const preSetupHook: PreSetupHookFunction = async (opts) => {
+      await ENGINE_HOOKS.setupBasic(opts);
+      const rootName = "bar";
+      await NoteTestUtilsV4.createNote({
+        fname: `${rootName}`,
+        body: "## Foo\nfoo text\n## Header\n Header text",
+        vault: opts.vaults[0],
+        props: {
+          id: `${rootName}`,
+        },
+        wsRoot: opts.wsRoot,
       });
+    };
+    describe("WHEN enableSmartRef is true by default", () => {
+      describeMultiWS(
+        "AND WHEN with header selected",
+        {
+          preSetupHook,
+          timeout: 5e3,
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(7, 0, 7, 12);
+            const link = await new CopyNoteRefCommand().run();
+            expect(link).toEqual(`![[bar#foo]]`);
+          });
+        }
+      );
+
+      describeMultiWS(
+        "AND WHEN with partial selection",
+        {
+          preSetupHook,
+          timeout: 5e3,
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(7, 0, 7, 4);
+            const link = await new CopyNoteRefCommand().run();
+            expect(link).toEqual(`![[bar#foo]]`);
+          });
+        }
+      );
+
+      describeMultiWS(
+        "AND WHEN no next header",
+        {
+          preSetupHook: async (opts) => {
+            await ENGINE_HOOKS.setupBasic(opts);
+            const rootName = "bar";
+            await NoteTestUtilsV4.createNote({
+              fname: `${rootName}`,
+              body: "## Foo\nfoo text\n",
+              vault: opts.vaults[0],
+              props: {
+                id: `${rootName}`,
+              },
+              wsRoot: opts.wsRoot,
+            });
+          },
+          timeout: 5e3,
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(7, 0, 7, 12);
+            const link = await new CopyNoteRefCommand().run();
+            expect(link).toEqual(`![[bar#foo]]`);
+          });
+        }
+      );
+
+      describeMultiWS(
+        "AND WHEN existing block anchor selection",
+        {
+          preSetupHook: async (opts) => {
+            await ENGINE_HOOKS.setupBasic(opts);
+            const rootName = "bar";
+            await NoteTestUtilsV4.createNote({
+              fname: `${rootName}`,
+              body: [
+                "Sint est quis sint sed.",
+                "Dicta vel nihil tempora. ^test-anchor",
+                "",
+                "A est alias unde quia quas.",
+                "Laborum corrupti porro iure.",
+                "",
+                "Id perspiciatis est adipisci.",
+              ].join("\n"),
+              vault: opts.vaults[0],
+              props: {
+                id: `${rootName}`,
+              },
+              wsRoot: opts.wsRoot,
+            });
+          },
+          timeout: 5e3,
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(8, 0, 8, 0);
+            const link = await new CopyNoteRefCommand().run();
+            expect(link).toEqual("![[bar#^test-anchor]]");
+          });
+        }
+      );
+
+      describeMultiWS(
+        "AND WHEN generated block anchors",
+        {
+          preSetupHook: async (opts) => {
+            await ENGINE_HOOKS.setupBasic(opts);
+            const rootName = "bar";
+            await NoteTestUtilsV4.createNote({
+              fname: `${rootName}`,
+              body: [
+                "Sint est quis sint sed.",
+                "Dicta vel nihil tempora. ^test-anchor",
+                "",
+                "A est alias unde quia quas.",
+                "Laborum corrupti porro iure.",
+                "",
+                "Id perspiciatis est adipisci.",
+              ].join("\n"),
+              vault: opts.vaults[0],
+              props: {
+                id: `${rootName}`,
+              },
+              wsRoot: opts.wsRoot,
+            });
+          },
+          timeout: 5e3,
+        },
+        () => {
+          test("THEN generate note ref", async () => {
+            const engine = ExtensionProvider.getEngine();
+            const note = engine.notes["bar"];
+            const editor = await WSUtils.openNote(note);
+            editor.selection = new vscode.Selection(8, 0, 11, 0);
+            const link = await new CopyNoteRefCommand().run();
+
+            // make sure the link is correct
+            expect(link!.startsWith("![[bar#^test-anchor:#^"));
+            expect(link!.endsWith("]]"));
+
+            // make sure we only added 1 block anchor (there should be 2 now)
+            AssertUtils.assertTimesInString({
+              body: editor.document.getText(),
+              match: [[2, /\^[a-zA-Z0-9-_]+/]],
+            });
+
+            // make sure the anchor in the link has been inserted into the document
+            const anchor = getAnchorsFromLink(link!, 2)[1];
+            AssertUtils.assertTimesInString({
+              body: editor.document.getText(),
+              match: [[1, anchor]],
+            });
+          });
+        }
+      );
     });
   });
 
@@ -299,7 +283,7 @@ suite("CopyNoteRef", function () {
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
             const link = await new CopyNoteRefCommand().run();
-            expect(link).toEqual("![[bar#foo,1:#*]]");
+            expect(link).toEqual("![[bar#foo]]");
           });
         }
       );

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -96,7 +96,6 @@ export class WorkspaceTestUtils {
         maxPreviewsCached: 10,
         maxNoteLength: 204800,
         enableFullHierarchyNoteTitle: false,
-        enableSmartRefs: true,
       },
       preview: {
         enableFMTitle: true,

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -591,7 +591,6 @@ function prepareNoteRefIndices<T>({
   anchorEnd,
   bodyAST,
   makeErrorData,
-  enableSmartRef,
 }: {
   anchorStart?: string;
   anchorEnd?: string;
@@ -673,7 +672,7 @@ function prepareNoteRefIndices<T>({
   if (
     !anchorEnd &&
     // smart header ref
-    ((start.type === "header" && enableSmartRef) ||
+    (start.type === "header" ||
       // smart block
       start.type === "block-begin") &&
     start.node
@@ -732,7 +731,7 @@ function convertNoteRefHelperAST(
 ): Required<RespV2<Parent>> {
   const { proc, refLvl, link, note } = opts;
   let noteRefProc: Processor;
-  const { engine, config } = MDUtilsV5.getProcData(proc);
+  const { engine } = MDUtilsV5.getProcData(proc);
 
   // Create a new proc to parse the reference; set the fname accordingly.
   // NOTE: a new proc is created here instead of using the proc() copy
@@ -763,7 +762,6 @@ function convertNoteRefHelperAST(
 
   const { start, end, data, error } = prepareNoteRefIndices({
     anchorStart,
-    enableSmartRef: ConfigUtils.getWorkspace(config).enableSmartRefs,
     anchorEnd,
     bodyAST,
     makeErrorData: (msg) => {

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -596,7 +596,6 @@ function prepareNoteRefIndices<T>({
   anchorEnd?: string;
   bodyAST: DendronASTNode;
   makeErrorData: (msg: string) => T;
-  enableSmartRef?: boolean;
 }): {
   start: FindAnchorResult;
   end: FindAnchorResult;

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -4,85 +4,80 @@ dev:
   enableExportPodV2: true
   enableSelfContainedVaults: true
 commands:
-    lookup:
-        note:
-            selectionMode: extract
-            confirmVaultOnCreate: true
-            leaveTrace: false
-            bubbleUpCreateNew: true
-            vaultSelectionModeOnCreate: smart
-            fuzzThreshold: 0.2
-    insertNoteLink:
-        aliasMode: none
-        enableMultiSelect: false
-    insertNoteIndex:
-        enableMarker: false
-    randomNote: {}
-    copyNoteLink:
-        aliasMode: title
-    templateHierarchy: template
+  lookup:
+    note:
+      selectionMode: extract
+      confirmVaultOnCreate: true
+      leaveTrace: false
+      bubbleUpCreateNew: true
+      vaultSelectionModeOnCreate: smart
+      fuzzThreshold: 0.2
+  insertNoteLink:
+    aliasMode: none
+    enableMultiSelect: false
+  insertNoteIndex:
+    enableMarker: false
+  randomNote: {}
+  copyNoteLink:
+    aliasMode: title
+  templateHierarchy: template
 workspace:
-    dendronVersion: 0.83.0
-    vaults:
-        -
-            fsPath: dependencies/localhost/vault3
-            selfContained: true
-            name: vault3
-        -
-            fsPath: vault2
-            visibility: private
-            siteUrl: https://vault2.com
-        -
-            fsPath: vault
-        -
-            fsPath: assets
-    journal:
-        dailyDomain: daily
-        name: journal
-        dateFormat: y.MM.dd
-        addBehavior: childOfCurrent
-    scratch:
-        name: scratch
-        dateFormat: y.MM.dd.HHmmss
-        addBehavior: asOwnDomain
-    graph:
-        zoomSpeed: 1
-        createStub: false
-    enableAutoCreateOnDefinition: false
-    enableXVaultWikiLink: false
-    enableRemoteVaultInit: true
-    workspaceVaultSyncMode: noCommit
-    enableAutoFoldFrontmatter: false
-    maxPreviewsCached: 10
-    maxNoteLength: 204800
-    task:
-        name: ''
-        dateFormat: ''
-        addBehavior: childOfCurrent
-        statusSymbols:
-            '': ' '
-            wip: w
-            done: x
-            assigned: a
-            moved: m
-            blocked: b
-            delegated: l
-            dropped: d
-            pending: 'y'
-        prioritySymbols:
-            H: high
-            M: medium
-            L: low
-        todoIntegration: false
-        createTaskSelectionType: selection2link
-        taskCompleteStatus:
-            - x
-            - done
-    enableUserTags: true
-    enableHashTags: true
-    enableEditorDecorations: true
-    enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
+  dendronVersion: 0.83.0
+  vaults:
+    - fsPath: dependencies/localhost/vault3
+      selfContained: true
+      name: vault3
+    - fsPath: vault2
+      visibility: private
+      siteUrl: https://vault2.com
+    - fsPath: vault
+    - fsPath: assets
+  journal:
+    dailyDomain: daily
+    name: journal
+    dateFormat: y.MM.dd
+    addBehavior: childOfCurrent
+  scratch:
+    name: scratch
+    dateFormat: y.MM.dd.HHmmss
+    addBehavior: asOwnDomain
+  graph:
+    zoomSpeed: 1
+    createStub: false
+  enableAutoCreateOnDefinition: false
+  enableXVaultWikiLink: false
+  enableRemoteVaultInit: true
+  workspaceVaultSyncMode: noCommit
+  enableAutoFoldFrontmatter: false
+  maxPreviewsCached: 10
+  maxNoteLength: 204800
+  task:
+    name: ""
+    dateFormat: ""
+    addBehavior: childOfCurrent
+    statusSymbols:
+      "": " "
+      wip: w
+      done: x
+      assigned: a
+      moved: m
+      blocked: b
+      delegated: l
+      dropped: d
+      pending: "y"
+    prioritySymbols:
+      H: high
+      M: medium
+      L: low
+    todoIntegration: false
+    createTaskSelectionType: selection2link
+    taskCompleteStatus:
+      - x
+      - done
+  enableUserTags: true
+  enableHashTags: true
+  enableEditorDecorations: true
+  enableFullHierarchyNoteTitle: false
 preview:
   enableFMTitle: true
   enableNoteTitleForLink: true


### PR DESCRIPTION
This PR aims to remove `enableSmartRefs` config from `workspace` scope.

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [x] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)