### PR TITLE
fix: giscuss integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,936 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **edit:** prevent override of already existing frontmatter values when executing Apply Template ([#3407](https://github.com/dendronhq/dendron/issues/3407)) ([c3c6901](https://github.com/dendronhq/dendron/commit/c3c6901d1d3f7b99b7bd632aebeaaac5b881cf0f))
+* **lookup:** allow lookup accept for existing invalid hierarchy ([#3421](https://github.com/dendronhq/dendron/issues/3421)) ([cd5aad2](https://github.com/dendronhq/dendron/commit/cd5aad28af0a761edba05392efa604af63c3cd5a))
+* **publish:** deprecate Dendron: Publish Dev command ([#3368](https://github.com/dendronhq/dendron/issues/3368)) ([9556998](https://github.com/dendronhq/dendron/commit/9556998ae1e2c579337dfd4f65ffef191838af6a))
+* **schema:** correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub ([#3388](https://github.com/dendronhq/dendron/issues/3388)) ([3a9634e](https://github.com/dendronhq/dendron/commit/3a9634edc7fcd01f1e571822f9146d2754f7ba5d))
+* **sync:** nextjs export pod to fetch latest dendron config ([#3455](https://github.com/dendronhq/dendron/issues/3455)) ([00cbeea](https://github.com/dendronhq/dendron/commit/00cbeeacfbc6f8ae11b67fcd26eaa10cbc02271e))
+* **workspace:** noisy warnings in engine startup ([#3452](https://github.com/dendronhq/dendron/issues/3452)) ([e535afb](https://github.com/dendronhq/dendron/commit/e535afb2eee4c15b25da357085609b0c06428d35))
+* tree view init problem on web ([#3459](https://github.com/dendronhq/dendron/issues/3459)) ([3a80e4b](https://github.com/dendronhq/dendron/commit/3a80e4bcb8d479cbde10f2135e5445b5fa6b9634))
+* **views:** remove semicolon from preview ([#3383](https://github.com/dendronhq/dendron/issues/3383)) ([8156279](https://github.com/dendronhq/dendron/commit/8156279594d8652286db3dc38ce75b390f09cbdd))
+* **views:** resolve issues with preview lock button ([#3353](https://github.com/dendronhq/dendron/issues/3353)) ([5847284](https://github.com/dendronhq/dendron/commit/5847284cc1b38fa788d38c16410ef319d94747a0))
+* **views:** show whitespace for links in headers ([#3403](https://github.com/dendronhq/dendron/issues/3403)) ([5b37aaa](https://github.com/dendronhq/dendron/commit/5b37aaa3c6c6346e87fb86dac606eb0e37a7e740))
+* **workspace:** sqlite store properly update from cache when encountering existing notes ([#3451](https://github.com/dendronhq/dendron/issues/3451)) ([6d73898](https://github.com/dendronhq/dendron/commit/6d7389872b21b6be3988f8692f6855be116b468c))
+* updated visibility of copy note url command in codespaces ([#3447](https://github.com/dendronhq/dendron/issues/3447)) ([ce9fd82](https://github.com/dendronhq/dendron/commit/ce9fd82ee3c258688324bee561b09e9d6e26b4a6))
+* **workspace:** case insensitive tree view sorting ([#3420](https://github.com/dendronhq/dendron/issues/3420)) ([90f72b6](https://github.com/dendronhq/dendron/commit/90f72b648095d75dbb94504b87e50ceb6b237676))
+* **workspace:** correctly decorate begin and end anchors ([#3339](https://github.com/dendronhq/dendron/issues/3339)) ([fb1425c](https://github.com/dendronhq/dendron/commit/fb1425c62888f778733323c86a4a120dcb78224e))
+* **workspace:** correctly focus tree view on tutorial activation ([#3380](https://github.com/dendronhq/dendron/issues/3380)) ([39d89db](https://github.com/dendronhq/dendron/commit/39d89db25c2d3e4ba78e6c96380b14b0f80d1d0a))
+* **workspace:** don't throw during activation ([#3373](https://github.com/dendronhq/dendron/issues/3373)) ([69ac5de](https://github.com/dendronhq/dendron/commit/69ac5dea6295d3c45fa78f400020730f5af5da9f))
+* **workspace:** duplicate Dendron Delete command in contextual menu ([#3406](https://github.com/dendronhq/dendron/issues/3406)) ([f5e2155](https://github.com/dendronhq/dendron/commit/f5e2155e334a7495699a5e395decd476f57534b7))
+* **workspace:** proper visibility on views and commands for web ext ([#3423](https://github.com/dendronhq/dendron/issues/3423)) ([2bfaf4a](https://github.com/dendronhq/dendron/commit/2bfaf4a0c6c7f01dbb3a30eba3a89a4579e30788))
+* validate file name on note lookup ([#3312](https://github.com/dendronhq/dendron/issues/3312)) ([ec7b53c](https://github.com/dendronhq/dendron/commit/ec7b53cdb9b3b09a388363cf8dfaa81bcdf686fc))
+
+
+### Features Dendron
+
+* **publishing:** Enable Giscus widgets in published notes ([#3469](https://github.com/dendronhq/dendron/issues/3469)) ([d5072d3](https://github.com/dendronhq/dendron/commit/d5072d3b6bfee96e24df1e002fc886bbd50af805))
+* **workspace:** copy note url command for codespaces ([#3411](https://github.com/dendronhq/dendron/issues/3411)) ([823bab9](https://github.com/dendronhq/dendron/commit/823bab957253214769fc7debc080f82211997f46))
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+* **refactor:** merge note command ([#3349](https://github.com/dendronhq/dendron/issues/3349)) ([41d6189](https://github.com/dendronhq/dendron/commit/41d6189371aa7e40bd3faff55623787802a9aa8b))
+* **views:** UI to configure `dendron.yml` ([#3211](https://github.com/dendronhq/dendron/issues/3211)) ([0d9b606](https://github.com/dendronhq/dendron/commit/0d9b606be8fcc04679dfbbe2f0054f74e6a626d7))
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+* **workspace:** Create Note Command ([#3408](https://github.com/dendronhq/dendron/issues/3408)) ([32dc68a](https://github.com/dendronhq/dendron/commit/32dc68a8d5bfea95401a8988214af22079dff5bd))
+* **workspace:** tree view in web ext ([#3386](https://github.com/dendronhq/dendron/issues/3386)) ([b75a448](https://github.com/dendronhq/dendron/commit/b75a448aabc6918cead8ae14779ace83aa2a6ae5))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Bug Fixes
+
+* nested bullets in preview ([#3326](https://github.com/dendronhq/dendron/issues/3326)) ([a312edc](https://github.com/dendronhq/dendron/commit/a312edc7a602d99bf78e2ba1a0af73c79e0924f5))
+* resolve PR comments ([81b22cd](https://github.com/dendronhq/dendron/commit/81b22cdabd6d95e6a827ce9b4d8dc5312e4d6e85))
+* tree view steals focus of active editor when initially forced to reveal ([16b097a](https://github.com/dendronhq/dendron/commit/16b097a47b19a94751b131f47b96e02c8a5e4a29))
+* tree view steals focus of active editor when initially forced to reveal ([24e7427](https://github.com/dendronhq/dendron/commit/24e742746a69bf324bc386fa686f79f45594ea4a))
+
+
+### Features Dendron
+
+* **view:** add "Toggle PreviewLock"  command ([#3293](https://github.com/dendronhq/dendron/issues/3293)) ([368c938](https://github.com/dendronhq/dendron/commit/368c9389b23d5200b84928121a7157fe764df9b6)), closes [#2437](https://github.com/dendronhq/dendron/issues/2437)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **publish:** renders consitent layout on mobile and non-mobile ([#3272](https://github.com/dendronhq/dendron/issues/3272)) ([eeeef9e](https://github.com/dendronhq/dendron/commit/eeeef9e0ae645e1191beda2610ca157df21f8c9f)), closes [#2175](https://github.com/dendronhq/dendron/issues/2175) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [#2175](https://github.com/dendronhq/dendron/issues/2175)
+* **retrieve:** remove references of show preview ([9b5f9f6](https://github.com/dendronhq/dendron/commit/9b5f9f6d92eb880418dc9ec3627a5188b4e07472))
+* **views:** toggle preview to toggle off ([3f7be18](https://github.com/dendronhq/dendron/commit/3f7be1868a388065ca0c2a758bccbebc18098b04))
+* **workspace:** fix typos in getting started tutorial ([d238b2a](https://github.com/dendronhq/dendron/commit/d238b2a1225a9c12b80e803d60f723c3670069e7))
+* **workspace:** List dendron.dendron-markdown-preview-enhanced as unwanted ([#3281](https://github.com/dendronhq/dendron/issues/3281)) ([182e835](https://github.com/dendronhq/dendron/commit/182e83510574230e3c7a72650c388b3ce6058557))
+* **workspace:** remote vault not recognized by dendron for windows ([4fb2cf8](https://github.com/dendronhq/dendron/commit/4fb2cf878f09da0ac4432c75b01db00d558c142f))
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+### Bug Fixes
+
+* force a reveal when tree view is first shown ([9168a90](https://github.com/dendronhq/dendron/commit/9168a9075e70fba0ef4c8790b7ce0b12442476b4))
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* backlink tree item trimming all characters that are m and d from the end ([8a4b86b](https://github.com/dendronhq/dendron/commit/8a4b86b6502a10e4aa380e984f6652e4338785e7))
+* graph panel depth increase / decrease not working ([620a108](https://github.com/dendronhq/dendron/commit/620a108ae95eaa2b266f48cb89aed14060368652))
+* graph panel depth increase / decrease not working ([239147f](https://github.com/dendronhq/dendron/commit/239147fa0c07a01936b70a9c446b525104aa5237))
+* **views:** hide sidebar when clicking a non-submenu note on mobile ([#3253](https://github.com/dendronhq/dendron/issues/3253)) ([4132cd3](https://github.com/dendronhq/dendron/commit/4132cd35eb76bc2a19f5a8e0309cee755e9bf42e))
+* force a reveal when tree view is first shown ([feaa88c](https://github.com/dendronhq/dendron/commit/feaa88cb61653725067c6740b18fbe55a9889e7b))
+* **workspace:** workspace sync will maintain proper engine state ([#3233](https://github.com/dendronhq/dendron/issues/3233)) ([13f788c](https://github.com/dendronhq/dendron/commit/13f788cb9a46800edffe66dcac88062e33830a5c))
+* current menu item wont collapse in publish ([d36174f](https://github.com/dendronhq/dendron/commit/d36174f0685e1932d430a137337cb0b10f46a1da))
+* duplicate note id detection error handling for cases the path doesn't exist ([9a8442c](https://github.com/dendronhq/dendron/commit/9a8442cd8a99db628690bb1882863c8f18af44dc))
+* regression where publishing fails if note doesn't exist ([#3178](https://github.com/dendronhq/dendron/issues/3178)) ([36c894f](https://github.com/dendronhq/dendron/commit/36c894f3ea691ec08a9cabe4df24b1c67239b511))
+* resolve PR comment ([0483cc7](https://github.com/dendronhq/dendron/commit/0483cc72b048515cb93f8a0c24b7c661e91046c0))
+* **workspace:** information modal to uninstall dendron markdown links extension ([f31cb8b](https://github.com/dendronhq/dendron/commit/f31cb8bee39909492616e24ea7f176f479f14bf3))
+* resolve PR comment ([f064535](https://github.com/dendronhq/dendron/commit/f0645358a6401b39f407b9cf4b526a390d79e54e))
+* update bad frontmatter waning range ([f339803](https://github.com/dendronhq/dendron/commit/f3398035ab5ebecf870f57c48547c61c34fca4f3))
+* **retrieve:** bad parsing of xvault wikilink with space ([#3180](https://github.com/dendronhq/dendron/issues/3180)) ([8fa340c](https://github.com/dendronhq/dendron/commit/8fa340c6eb11a3d21b61e5ac349db358aa48318c))
+* **workspace:** fix init in workspace without workspace folders ([#3181](https://github.com/dendronhq/dendron/issues/3181)) ([014aa4f](https://github.com/dendronhq/dendron/commit/014aa4f8bf9cbbb06eb74a5ac21eb20592266f46))
+* **workspace:** proper handling of invalid data for write note ops ([#3137](https://github.com/dendronhq/dendron/issues/3137)) ([c6c7588](https://github.com/dendronhq/dendron/commit/c6c75881bec46bf701647b9d6b799e4de566edb7))
+
+
+### Features Dendron
+
+* **edit): support note references on beginning of a doc && fix(edit:** template gets applied twice if user undoes initial template  ([#3186](https://github.com/dendronhq/dendron/issues/3186)) ([88c7c5c](https://github.com/dendronhq/dendron/commit/88c7c5c85e470bdefaeaf371c60e2e950f25d16e))
+* **workspace:** command for local override config ([#3173](https://github.com/dendronhq/dendron/issues/3173)) ([ab41027](https://github.com/dendronhq/dendron/commit/ab410279506abc677a52e6b2b537c39c7faac0a8))
+* **workspace:** smart note refs ([#3174](https://github.com/dendronhq/dendron/issues/3174)) ([c0a6c60](https://github.com/dendronhq/dendron/commit/c0a6c6064193b3730fc0320d3c6d310434952561))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Bug Fixes
+
+* **publish:** compile error with no banner present([#3133](https://github.com/dendronhq/dendron/issues/3133)) ([8ef70c5](https://github.com/dendronhq/dendron/commit/8ef70c530bd653a3c74d26ede630df5e538d2118))
+* **structure:** hot reload in note traits + no template by default ([3904655](https://github.com/dendronhq/dendron/commit/390465552a6744495387aea6f49fa5392fb69b03))
+* **structure:** hot reload in note traits + no template by default ([#3154](https://github.com/dendronhq/dendron/issues/3154)) ([bcadd48](https://github.com/dendronhq/dendron/commit/bcadd487c706379f0384a6f3a8c728d606a2bba8))
+* **structure:** quickpick stuck issue for refactor hierarchy cmd ([#3152](https://github.com/dendronhq/dendron/issues/3152)) ([a0fec3b](https://github.com/dendronhq/dendron/commit/a0fec3ba6389a0dd6db144d75232ccbf3cf705e6))
+* **workspace:** duplicate note behavior is not updated when self contained vault is removed ([d69f02c](https://github.com/dendronhq/dendron/commit/d69f02c0857b4fc594ee8e3f494bd1e5465be2e8))
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+### Bug Fixes
+
+* **cli:** dendron publish --help to display full list of arguments ([#3127](https://github.com/dendronhq/dendron/issues/3127)) ([0707c16](https://github.com/dendronhq/dendron/commit/0707c167920ed16dfd7fe05c79403a02c0b511de))
+* address PR comments ([e847228](https://github.com/dendronhq/dendron/commit/e847228a6bbf122f80f9041b85026203ae3ed585))
+* resolved PR comments ([a299217](https://github.com/dendronhq/dendron/commit/a299217f2929e6ab15908137a60c841fdc5ee14f))
+* **publish:** slow rendering of sidebar ([60149c9](https://github.com/dendronhq/dendron/commit/60149c91f3bf51d76b0297589e3f9f93314b0389))
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* **2816:** improve phrasing of sync message ([d47a4bf](https://github.com/dendronhq/dendron/commit/d47a4bfe474c09192e07a300a4f8289a2a8f1e2a))
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([01be85f](https://github.com/dendronhq/dendron/commit/01be85f84ae6cdf182f2d43b9561decac44369e6))
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([decaccd](https://github.com/dendronhq/dendron/commit/decaccdc0af6072197405273e82750d8702d2262))
+* **publish:** issue publishing note with ref without a `code-worksapce` file ([#3114](https://github.com/dendronhq/dendron/issues/3114)) ([5a03d8f](https://github.com/dendronhq/dendron/commit/5a03d8fdaa289d7b5a7a79f85cad1da5de58c2ba))
+* adding existing remote vault creates workspace files in the vault ([6d43936](https://github.com/dendronhq/dendron/commit/6d439369d8e75150cc1ba582f337a6fded402a7b))
+* address PR comments ([c4ba612](https://github.com/dendronhq/dendron/commit/c4ba612a07fcdef1a98a86d245edab00e31ffc76))
+* separate hierarchichal and linked notes ([8b25a72](https://github.com/dendronhq/dendron/commit/8b25a7277f4c580c638fa11f1d625f8a40d0ab02))
+* **views:** double click issue on help and feedback panel ([#3089](https://github.com/dendronhq/dendron/issues/3089)) ([2dca2c2](https://github.com/dendronhq/dendron/commit/2dca2c226ea59485498a7fc689ca9c82d0c2f9cd))
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* **refactor:** updated refactor hierarchy success message ([1c021bb](https://github.com/dendronhq/dendron/commit/1c021bb358350ece9ff2037f5cff82e7948a1fb6))
+* address PR comment ([8ce91e9](https://github.com/dendronhq/dendron/commit/8ce91e90acd34139d5a69bd0a994c1f5bd04af73))
+* address PR comment and performance improvements ([62c2514](https://github.com/dendronhq/dendron/commit/62c25145bac45ed1954a45b22ed0e5cea1acd913))
+* email addresses are parsed as tags ([e85fb83](https://github.com/dendronhq/dendron/commit/e85fb83bf1ae07ae89eaf1e464fb5ccef4cb5cb9))
+
+
+### Features Dendron
+
+* **views:** Recent Workspaces Panel ([#3052](https://github.com/dendronhq/dendron/issues/3052)) ([5e52529](https://github.com/dendronhq/dendron/commit/5e525295ca0d1118782affdfb68c34e939b479c9))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* fix ci build error ([b8684ce](https://github.com/dendronhq/dendron/commit/b8684ce52598c9717f711ee7c8b204fa4dd53bef))
+* removed public from common assets ([923d6ad](https://github.com/dendronhq/dendron/commit/923d6ad5d4852f08ef7d4505c7c54fc11df35ff4))
+* **views:** added default initial theme for webviews ([#3013](https://github.com/dendronhq/dendron/issues/3013)) ([fcf29f0](https://github.com/dendronhq/dendron/commit/fcf29f0f554b0d3e30a42c80072dbb34bb4542e4))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([1bc7493](https://github.com/dendronhq/dendron/commit/1bc7493a76c8c2fcb58ef4ba5ef569675fca2a1d))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([4fa37a1](https://github.com/dendronhq/dendron/commit/4fa37a12423ae93215c765b27f5cd6f6c4ce698d))
+* **workspace:** fix duplicated panel titles ([#3016](https://github.com/dendronhq/dendron/issues/3016)) ([1587990](https://github.com/dendronhq/dendron/commit/15879909dedb81c26c971e6c4ae1314f37e2d4e5))
+* Images with encoded URI are not rendered in the Preview ([#3006](https://github.com/dendronhq/dendron/issues/3006)) ([e2172be](https://github.com/dendronhq/dendron/commit/e2172be363e2a3311c238c5fc841f5e498f66851))
+* remove '.' from list ([2e33981](https://github.com/dendronhq/dendron/commit/2e33981a1f0063a5c08ba650da8f72e6dbcc592f))
+* SegmentClient crashes all CLI commands ([af02445](https://github.com/dendronhq/dendron/commit/af02445b387cb39ec6f0810afc1234a6e94ac85c))
+* update snapshots ([bdb37f7](https://github.com/dendronhq/dendron/commit/bdb37f7f2c33f4d0af6c1f71622364e75c268a30))
+* **views:** bullet points missing in new theme-matching style ([#3023](https://github.com/dendronhq/dendron/issues/3023)) ([ab674d2](https://github.com/dendronhq/dendron/commit/ab674d2a8fc59da8ebfbf64ae88d918c5fb11c41))
+* **workspace:** Help and Feedback Panel shows info when not in Dendron WS ([#2974](https://github.com/dendronhq/dendron/issues/2974)) ([3c901bf](https://github.com/dendronhq/dendron/commit/3c901bf6cb58a6312e7496de41fe9866d48367a9))
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **edit:** template helpers ([#3029](https://github.com/dendronhq/dendron/issues/3029)) ([6881c97](https://github.com/dendronhq/dendron/commit/6881c97a6de3def469ac663b69289bb045a03502))
+* **navigate:** Backlink Panel with Hover ([#2904](https://github.com/dendronhq/dendron/issues/2904)) ([55c7fcd](https://github.com/dendronhq/dendron/commit/55c7fcdcd1135145b5385176e9bbdd18951f6d00))
+* **notes:** Auto generate template/schema for daily journal ([b8db57c](https://github.com/dendronhq/dendron/commit/b8db57caa89ec307ed17e8b0172e5a76439a0cec))
+* **notes:** Auto generate template/schema for daily journal ([0d812c1](https://github.com/dendronhq/dendron/commit/0d812c1266169d0683666f78e300966fd56638bb))
+* **notes:** Auto generate template/schema for daily journal ([a31e9c9](https://github.com/dendronhq/dendron/commit/a31e9c9e786cd146e9b251b9f33ee18de9c30eb1))
+* **notes:** Auto generate template/schema for daily journal ([37a2484](https://github.com/dendronhq/dendron/commit/37a24842a41a4bc134f612cef503a6901547b981))
+* **publish:** ability to exclude children in dendron side nav ([#2962](https://github.com/dendronhq/dendron/issues/2962)) ([f45029d](https://github.com/dendronhq/dendron/commit/f45029d808aaec457c606ad753f4fe9634958ad5))
+* **sync:** Obsidian Import Flow ([#3014](https://github.com/dendronhq/dendron/issues/3014)) ([669b200](https://github.com/dendronhq/dendron/commit/669b200509c7a3d1f339da62ecbca769974fb3fd))
+* **views:** Preview setting for light, dark, or custom themes ([294bf1e](https://github.com/dendronhq/dendron/commit/294bf1e18646cd74e6d656fd12964506d77a1a5c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Bug Fixes
+
+* **publish:** assetsPrefix breaks images ([e1e3000](https://github.com/dendronhq/dendron/commit/e1e300090cb734acea1f963722d3056a0fa18812))
+* **publish:** Export gets stuck if `logoPath` is set but the logo doesn't exist ([f820de2](https://github.com/dendronhq/dendron/commit/f820de2d2b116194b5874a90fcf35d1d317ff5d3))
+* configure enableHierarchyDisplay and hierarchyDisplayTitle ([bd11d92](https://github.com/dendronhq/dendron/commit/bd11d9259132f29184099a2cad6e745477c91783))
+* doctor removeStubs resulting in 'no data' prompt ([#2944](https://github.com/dendronhq/dendron/issues/2944)) ([5d1c7b3](https://github.com/dendronhq/dendron/commit/5d1c7b33728a7af8739446a3e024b6d8f08eaf3e))
+
+
+### Features Dendron
+
+* **markdown:** handlebar based templates ([#2954](https://github.com/dendronhq/dendron/issues/2954)) ([2af114a](https://github.com/dendronhq/dendron/commit/2af114afc85711f4ec4af26281e9235dcc33a062))
+* local graph view in the Dendron Side Panel ([#2901](https://github.com/dendronhq/dendron/issues/2901)) ([195a61a](https://github.com/dendronhq/dendron/commit/195a61ae7ed7158d97c1161aacc5d08a08d660e9))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+### Bug Fixes
+
+* block anchor after table crashes preview ([92812c3](https://github.com/dendronhq/dendron/commit/92812c3b946a2e881792d69d36932a782b2208d4))
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Bug Fixes
+
+* fix corrupt .dendron.ws version to unblock activation ([#2930](https://github.com/dendronhq/dendron/issues/2930)) ([4f25b16](https://github.com/dendronhq/dendron/commit/4f25b166f3874138e4c249aa3aa9c0655e78451f))
+* fix corrupt .dendron.ws version to unblock activation ([#2930](https://github.com/dendronhq/dendron/issues/2930)) ([68a2cba](https://github.com/dendronhq/dendron/commit/68a2cbab6609806b77219494d1538ffb8f7cb921))
+
+
+### Features Dendron
+
+* allow customization of tree view label / sorting to preserve old tree view behavior ([#2858](https://github.com/dendronhq/dendron/issues/2858)) ([987c802](https://github.com/dendronhq/dendron/commit/987c8021970de6c75f96a6d94e0df500b23eca0d))
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* CLI writes "cli" as the version into the meta file which breaks initialization ([#2871](https://github.com/dendronhq/dendron/issues/2871)) ([273df5c](https://github.com/dendronhq/dendron/commit/273df5cd756b1451d5bab19f808cd425c097c6b6))
+* highlighting misidentified capitalized header anchors on links as missing ([#2872](https://github.com/dendronhq/dendron/issues/2872)) ([92ded23](https://github.com/dendronhq/dendron/commit/92ded230eccec02947cb33221288591f2064866c)), closes [#2862](https://github.com/dendronhq/dendron/issues/2862)
+* self contained vaults get cloned into the wrong directory ([#2873](https://github.com/dendronhq/dendron/issues/2873)) ([9c7ac1c](https://github.com/dendronhq/dendron/commit/9c7ac1cfff4fb07bc689b42ea04677df5d2a927b))
+
+
+### Features Dendron
+
+* **chore:** germ stage implementation of config overrides ([#2794](https://github.com/dendronhq/dendron/issues/2794)) ([c3692ef](https://github.com/dendronhq/dendron/commit/c3692ef5073ab2454ee117d3ad72cb2af257e4be))
+* Add doctor command to remove deprecated config and prompt on upgrade ([#2841](https://github.com/dendronhq/dendron/issues/2841)) ([2cc71e0](https://github.com/dendronhq/dendron/commit/2cc71e0796c4cebc32817b2b930cf7b0a324485f))
+* add goto command ([#2852](https://github.com/dendronhq/dendron/issues/2852)) ([3586707](https://github.com/dendronhq/dendron/commit/3586707bd3e7ffd352797308ed8e9c0e31b6f3ef)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843) [#2845](https://github.com/dendronhq/dendron/issues/2845) [#2843](https://github.com/dendronhq/dendron/issues/2843)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+### Bug Fixes
+
+* bad wikilink is created with selection2link if selection is multi-line ([#2856](https://github.com/dendronhq/dendron/issues/2856)) ([8d708ac](https://github.com/dendronhq/dendron/commit/8d708ac0114e39cb00a15cc05baa4dcf954b5219)), closes [#2854](https://github.com/dendronhq/dendron/issues/2854)
+* insert note index `#undefined` in case missing tags ([#2789](https://github.com/dendronhq/dendron/issues/2789)) ([e025fd2](https://github.com/dendronhq/dendron/commit/e025fd2a31fd2743e4163ef589a526467584eefe))
+
+
+### Features Dendron
+
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([158ed1d](https://github.com/dendronhq/dendron/commit/158ed1d748448c611146900915c6299a0730bbf9))
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([0f89993](https://github.com/dendronhq/dendron/commit/0f899934e5e5eeacb7b2dd5643dbdb4e4caff267))
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* bad upgrade prompt ([#2845](https://github.com/dendronhq/dendron/issues/2845)) ([6e120a1](https://github.com/dendronhq/dendron/commit/6e120a1626c51e2b0580c43c386467e0cdb0ee9a)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843)
+* bad upgrade prompt ([#2845](https://github.com/dendronhq/dendron/issues/2845)) ([2ae6f2f](https://github.com/dendronhq/dendron/commit/2ae6f2fb417147069aa7b9ffdade34775c3c878c)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843)
+* correctly handle previous global and workspace version ([#2843](https://github.com/dendronhq/dendron/issues/2843)) ([ce528bf](https://github.com/dendronhq/dendron/commit/ce528bf44571e1d1d6e52cc3ed09125ef3d74471))
+* correctly handle previous global and workspace version ([#2843](https://github.com/dendronhq/dendron/issues/2843)) ([fb6c4c2](https://github.com/dendronhq/dendron/commit/fb6c4c2c881a65631329c0bd58cbed2d47fe9270))
+* **view:** broken preview for links with sub-hierarchy starting with .md ([#2781](https://github.com/dendronhq/dendron/issues/2781)) ([7eefd3a](https://github.com/dendronhq/dendron/commit/7eefd3ad776c76575c40503feaf5d704f97123da))
+* **view:** views don't update for new notes with self contained vaults ([#2790](https://github.com/dendronhq/dendron/issues/2790)) ([eac9b53](https://github.com/dendronhq/dendron/commit/eac9b53b5da3c9336b09c317caf56d800aacf4cc))
+* **views:** second pass of treeview v1 sync issue ([#2805](https://github.com/dendronhq/dendron/issues/2805)) ([64e0970](https://github.com/dendronhq/dendron/commit/64e0970382d11694bb52f65a50f4c7de8fdd0a0c))
+* **workspace:** hovering an asset link while holding `ctrl` opens it ([#2784](https://github.com/dendronhq/dendron/issues/2784)) ([30ab1d9](https://github.com/dendronhq/dendron/commit/30ab1d9f3525e9a657a4c2c92e37060da3176623))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* first pass of treeview v1 sync issue ([#2757](https://github.com/dendronhq/dendron/issues/2757)) ([f8f80ca](https://github.com/dendronhq/dendron/commit/f8f80cacb8b661b06df0d57b955b7e4529272a66))
+* **view:** apply current theme when vscode reduce motion setting is on ([#2749](https://github.com/dendronhq/dendron/issues/2749)) ([15c3f05](https://github.com/dendronhq/dendron/commit/15c3f050e6ebecb1aeaf34da5b01ac9917ae6e1e))
+* **view:** support custom styles for Note Graph ([#2760](https://github.com/dendronhq/dendron/issues/2760)) ([6d99e62](https://github.com/dendronhq/dendron/commit/6d99e6265078119239c461c0fa78be90d44039af))
+* don't write first install metadata if install is from new vscode instance ([05a507d](https://github.com/dendronhq/dendron/commit/05a507de5ee3dde210a77979578e14ceef63b3fa))
+* don't write first install metadata if install is from new vscode instance ([1929e81](https://github.com/dendronhq/dendron/commit/1929e8111d64e200a76a6dfca2e9473598e1a67e))
+* error when adding a self contained vault inside a native workspace ([#2660](https://github.com/dendronhq/dendron/issues/2660)) ([f2a9449](https://github.com/dendronhq/dendron/commit/f2a94491463396d0cce30dc7376898644622b908))
+* resolve PR comment ([1157b70](https://github.com/dendronhq/dendron/commit/1157b7058e3a1419cb2919f1300faa2cf40e74d1))
+* self contained vaults sync ([#2758](https://github.com/dendronhq/dendron/issues/2758)) ([ebb4658](https://github.com/dendronhq/dendron/commit/ebb46587ca0728e25bf69b5d94058d3cc3c2446c))
+* **airtable:** Exporting to airtable automatically saves current document ([#2696](https://github.com/dendronhq/dendron/issues/2696)) ([b8e8c97](https://github.com/dendronhq/dendron/commit/b8e8c9773fe11fe85610f99ba542267fa93a4b95))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([959d92f](https://github.com/dendronhq/dendron/commit/959d92fe6936cfac9561b39144a96563c916de6f))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([88aea8a](https://github.com/dendronhq/dendron/commit/88aea8a829af91671be93a7d266fc098d2ca5951))
+* **publish:** add luxon as dev dependency ([c42d9dd](https://github.com/dendronhq/dendron/commit/c42d9dd22df8a0e49f2fd4fbb728ed68212c96a8))
+* **workspace:** workspace vault support for self contained vaults ([#2728](https://github.com/dendronhq/dendron/issues/2728)) ([beb791f](https://github.com/dendronhq/dendron/commit/beb791f3f13aa81f6f5f325f70a21654c1b92e1d))
+* malformed _trackCommon arguments ([7e4bfa0](https://github.com/dendronhq/dendron/commit/7e4bfa0ea805ee74380052f560af21eee2c28169))
+* malformed _trackCommon arguments ([1e53681](https://github.com/dendronhq/dendron/commit/1e53681c9676c2878bb0d1f6f7140c15816d4d09))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([d3e9f78](https://github.com/dendronhq/dendron/commit/d3e9f7803b343be11f2001409f388b9f877adcd0))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([97abfae](https://github.com/dendronhq/dendron/commit/97abfae86fc95df513219efca346e938f253ff71))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([61f79d0](https://github.com/dendronhq/dendron/commit/61f79d0f925faee516525686e0457988becc79f7))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([b0f3e0d](https://github.com/dendronhq/dendron/commit/b0f3e0d1016cc1ee6bade48317c51c3a23c9557d))
+* error during init in non-Dendron workspaces due to `CopyNoteLink` ([6320278](https://github.com/dendronhq/dendron/commit/63202784a4d7fc042d8db50db776e4f4bbb2363b))
+* resolve PR comment ([03dc82a](https://github.com/dendronhq/dendron/commit/03dc82a561722465e73875c2537acbf786823645))
+* resolved PR comment ([4f4887b](https://github.com/dendronhq/dendron/commit/4f4887be9f9e72ef6337f2c0ab8fe0bbb7d5dc7e))
+* Text Document Service activates in non-Dendron workspaces ([f60515e](https://github.com/dendronhq/dendron/commit/f60515e97f0b9cdcfec9ea661370aa695d300ad1))
+* tree item sort order in treeview v1 to be on par with v2 in preparation for v2 deprecation ([#2665](https://github.com/dendronhq/dendron/issues/2665)) ([657a8ac](https://github.com/dendronhq/dendron/commit/657a8ac8f842506bdff97c80f00aba0880ab1cbc))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+* webview already registered problem with lookup panel ([28851d7](https://github.com/dendronhq/dendron/commit/28851d7c3855fb990fea82842d8f8d65427f31fc))
+* **views:** dendron-next-server to pass port-forwarded url ([01b957a](https://github.com/dendronhq/dendron/commit/01b957a285cd87aaadd79312c9019758a0fc5f79))
+* **views:** wrapping tree view calls in Sentry too ([2d57203](https://github.com/dendronhq/dendron/commit/2d5720314d4ebbde0c53e6d006e4d06462d396a7))
+* **workspace:** Fix issue with updated timestamp not updating properly on save ([#2651](https://github.com/dendronhq/dendron/issues/2651)) ([c8e75ff](https://github.com/dendronhq/dendron/commit/c8e75ff348e0ab0b88a094c1dd71824b66fdec8c))
+* **workspace:** preserve wikilink metadata on export ([#2676](https://github.com/dendronhq/dendron/issues/2676)) ([553a954](https://github.com/dendronhq/dendron/commit/553a954bccdf5a8f574b2908f17ccd25fe61cb65))
+
+
+### Features Dendron
+
+* **cli:** Add rename functionality to CLI ([#2408](https://github.com/dendronhq/dendron/issues/2408)) ([03a96f8](https://github.com/dendronhq/dendron/commit/03a96f88799d7e7850186af06f7a31acac7ee3f7))
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([8ea1d1b](https://github.com/dendronhq/dendron/commit/8ea1d1b8e6247fec3e636c26da3f98e047026a6b))
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([f87ca99](https://github.com/dendronhq/dendron/commit/f87ca996dc31588b42e35fa8613d95c2aaf49b2a))
+* detect and fill missing default configs to reliably introduce newly added configurations on extension upgrade ([#2602](https://github.com/dendronhq/dendron/issues/2602)) ([4f31fce](https://github.com/dendronhq/dendron/commit/4f31fce3da8d04d981e05a151040ddd28edfba29))
+* option to gen title using full hierarchy ([1c6e4a7](https://github.com/dendronhq/dendron/commit/1c6e4a76cb9689e759ea87f5dc50485abf0c18b2))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* consolidating button type enums ([c3c56bd](https://github.com/dendronhq/dendron/commit/c3c56bd23cc1b970126eb55ed96b397b9d5a2061))
+* PR Feedback; Various Bug Fixes ([0387120](https://github.com/dendronhq/dendron/commit/03871209a7b5abbcab9bd44de77702d942248a86))
+* **basics:** improve perf around reference rendering including hover ([bcc6bb4](https://github.com/dendronhq/dendron/commit/bcc6bb47498835226263fff18cb7c3605e1438b0))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([9050c79](https://github.com/dendronhq/dendron/commit/9050c79bccefbe7ed375e3221181c2fc736fbe61))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([9b48b9c](https://github.com/dendronhq/dendron/commit/9b48b9c652b38f7d78d51cdeb0d585f87f14b016))
+* **internal:** Engine updateNote not properly firing update events ([#2622](https://github.com/dendronhq/dendron/issues/2622)) ([97f0911](https://github.com/dendronhq/dendron/commit/97f091136c0d7606150631ab3be4d9eeb99aa4aa))
+* **markdown:** support parenthesis in the image URL ([#2634](https://github.com/dendronhq/dendron/issues/2634)) ([b05907d](https://github.com/dendronhq/dendron/commit/b05907d94aa1fecf0edcac61ad119d5ecd820736))
+* **retrieve:** issue with angle brackets syntax in mermaid  ([#2637](https://github.com/dendronhq/dendron/issues/2637)) ([0457f75](https://github.com/dendronhq/dendron/commit/0457f7521da53844cb1019c0a517f1ef959c04fa))
+* Re-enable inactive user survey and store prompt status in filesystem for prompt reliability. ([#2555](https://github.com/dendronhq/dendron/issues/2555)) ([3a4269f](https://github.com/dendronhq/dendron/commit/3a4269f4b5669f45eb257377abfcde7aad9e7bf4))
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+* typo in dendron.yml ([#2636](https://github.com/dendronhq/dendron/issues/2636)) ([faefa36](https://github.com/dendronhq/dendron/commit/faefa3608092cc6f3e89e7224f0d51f635e03cdd))
+* **lookup:** autocomplete causes notes to be created in wrong vault  ([#2623](https://github.com/dendronhq/dendron/issues/2623)) ([c0c9023](https://github.com/dendronhq/dendron/commit/c0c9023da067415078790eebe5df9de448ded34a))
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+* Backlinks will no longer disappear in preview upon editing ([#2608](https://github.com/dendronhq/dendron/issues/2608)) ([1ee16f9](https://github.com/dendronhq/dendron/commit/1ee16f9540173b2ec7558d0d120428e2d093d649))
+* **lookup:** lookup (without spaces) should be case-insensitive ([#2570](https://github.com/dendronhq/dendron/issues/2570)) ([a856347](https://github.com/dendronhq/dendron/commit/a856347d2d935f6764c79d068db9be0b83efb10a))
+* **publish:** customHeaderPath breaks publishing if value is set to anything except header.html ([#2565](https://github.com/dendronhq/dendron/issues/2565)) ([7f2c421](https://github.com/dendronhq/dendron/commit/7f2c421e7b78b0bdfed512e1584dc5c8f39ff22b))
+* **views:** unblock preview rendering when backlink is invalid ([#2586](https://github.com/dendronhq/dendron/issues/2586)) ([fe893b9](https://github.com/dendronhq/dendron/commit/fe893b9b3d827811b743cfb93afef6363470760b))
+* **workspace:** fix dropped keystrokes issue in lookup ([#2626](https://github.com/dendronhq/dendron/issues/2626)) ([a8deb1a](https://github.com/dendronhq/dendron/commit/a8deb1a3e87edb62d3af2ac422eec334996da1df))
+* block anchors showing up in the preview ([#2548](https://github.com/dendronhq/dendron/issues/2548)) ([44802b8](https://github.com/dendronhq/dendron/commit/44802b8a37ed38b94fbc22692a4c1f21ee83963f)), closes [#2531](https://github.com/dendronhq/dendron/issues/2531)
+* ensure note title is always a string to avoid errors ([#2551](https://github.com/dendronhq/dendron/issues/2551)) ([5d93bd1](https://github.com/dendronhq/dendron/commit/5d93bd16b0bdeb9d29323b659f154bdf0b2dfec9)), closes [#2329](https://github.com/dendronhq/dendron/issues/2329)
+* Prevent fatal errors in Open Backup Command and Run Migration Command in native workspaces ([#2607](https://github.com/dendronhq/dendron/issues/2607)) ([dce17fe](https://github.com/dendronhq/dendron/commit/dce17fe293cf73016797257fd18e5f85c625a6a2))
+* rendering issue in local note graph ([b1c7cd3](https://github.com/dendronhq/dendron/commit/b1c7cd3c8739944370c4367dd187540cebd6cd2b))
+* **pods:** Google Docs Export pod displays Bad Request error on export ([#2529](https://github.com/dendronhq/dendron/issues/2529)) ([2583a8e](https://github.com/dendronhq/dendron/commit/2583a8e8f9534b2b922fbb0caa3f6f682930e9d2))
+* **sync:** Better error message on Workspace Add and Commit ([4895ae8](https://github.com/dendronhq/dendron/commit/4895ae8d8ac47b6029a9e91dd5cc6a490d049ea7))
+* **workspace:** fix crash in updated fm field logic on doc save ([#2535](https://github.com/dendronhq/dendron/issues/2535)) ([752486c](https://github.com/dendronhq/dendron/commit/752486c5a4206b04bbc40ced4ef75c896346a292))
+* **workspace:** issue with notes not being saved on export ([#2574](https://github.com/dendronhq/dendron/issues/2574)) ([7467c17](https://github.com/dendronhq/dendron/commit/7467c1780ee8ff554adec14eb272bf55252d4c49))
+* **workspace:** race condition when backing up configuration  ([#2581](https://github.com/dendronhq/dendron/issues/2581)) ([efd3bb8](https://github.com/dendronhq/dendron/commit/efd3bb8880b963b912fbcc6bcd0c0595b4083273))
+* resolve PR comments ([51a3115](https://github.com/dendronhq/dendron/commit/51a311590157b0e626ec8c03d6f1584d75aac44a))
+
+
+### Features Dendron
+
+* add doctor command for a more reliable keybinding resolution ([#2578](https://github.com/dendronhq/dendron/issues/2578)) ([4737aa5](https://github.com/dendronhq/dendron/commit/4737aa5dda198e51728496a1243f7ad45f2450f0))
+* OpenBackupCommand ([57b7718](https://github.com/dendronhq/dendron/commit/57b77180de288026fca20f925386a0e248df7451))
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* **views:** fix race condition in tree view v2 initialization logic ([#2528](https://github.com/dendronhq/dendron/issues/2528)) ([c85a821](https://github.com/dendronhq/dendron/commit/c85a821a02bbe2669b6c0d7df10a6475a7526654))
+* add omitted migration entries ([#2519](https://github.com/dendronhq/dendron/issues/2519)) ([ae6ef64](https://github.com/dendronhq/dendron/commit/ae6ef64cb61b3aa4c229c77da5b94362e09d363d))
+* **views:** md parsing and preview perf improvements ([#2505](https://github.com/dendronhq/dendron/issues/2505)) ([282951f](https://github.com/dendronhq/dendron/commit/282951fbee192e97064595659fa31773249b6aa6))
+* remove comment ([00edd5a](https://github.com/dendronhq/dendron/commit/00edd5aa7a9d50776299f3db9fa0563f7823579c))
+* **vaults:** Use exact match when getting vault by dir path ([#2501](https://github.com/dendronhq/dendron/issues/2501)) ([99db974](https://github.com/dendronhq/dendron/commit/99db974a1fa47bb27c8ff5ca424b1fc495030235))
+* resolved PR comments ([7364405](https://github.com/dendronhq/dendron/commit/73644054523ed349bd3ddc73e581ec687e805391))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* add selection2link button for CreateScratchNoteCommand ([#2496](https://github.com/dendronhq/dendron/issues/2496)) ([a881757](https://github.com/dendronhq/dendron/commit/a881757607d71106c87804aa3464232eee0b3250))
+* **publish:** properly render mermaid and katex when published ([#2480](https://github.com/dendronhq/dendron/issues/2480)) ([2524589](https://github.com/dendronhq/dendron/commit/2524589cbf016dff694bcc308dbf1ec1b7390570))
+* don't refresh tree view if note visible ([#2487](https://github.com/dendronhq/dendron/issues/2487)) ([76459fc](https://github.com/dendronhq/dendron/commit/76459fcf88609683ce2b6ccfe62cc498b5b1ea5e))
+* **pods:** md export v2 to acknowledge wikiLinkToURL for links inside noteRefs ([32f5ae6](https://github.com/dendronhq/dendron/commit/32f5ae61eccd80195eb8e32700c4f48dc516b54b))
+* don't call reload index if action is findIncompatibleExtension ([#2458](https://github.com/dendronhq/dendron/issues/2458)) ([7141f17](https://github.com/dendronhq/dendron/commit/7141f17e8d36edfaf4c8dd9857666eefe4b8971d))
+* faster webviews by reducing engine sync operations ([#2472](https://github.com/dendronhq/dendron/issues/2472)) ([a34a3b0](https://github.com/dendronhq/dendron/commit/a34a3b024411b1c2097b330938ceb9c3fe8c401e))
+* **preview:** Code blocks and spans in preview are html encoded ([#2471](https://github.com/dendronhq/dendron/issues/2471)) ([4a29e46](https://github.com/dendronhq/dendron/commit/4a29e4678b55b13ecf43d57044a919ca105d1a90)), closes [#2301](https://github.com/dendronhq/dendron/issues/2301)
+* **publish:** Table of Contents is missing user tags, inline code, dashes and underline ([#2465](https://github.com/dendronhq/dendron/issues/2465)) ([79c6d9e](https://github.com/dendronhq/dendron/commit/79c6d9e801e5cec78acf0212fc8e4c1134e6f5d2)), closes [#2456](https://github.com/dendronhq/dendron/issues/2456)
+* resolved PR comments ([6b9c70c](https://github.com/dendronhq/dendron/commit/6b9c70c1ae24a1841c9400b193d8e1fb092ec692))
+* resolved PR comments ([53ca31e](https://github.com/dendronhq/dendron/commit/53ca31e954c1bf4e9aea9b6ff5dcf143a86a9e19))
+* skip addFrontmatter prompt ([3a302de](https://github.com/dendronhq/dendron/commit/3a302de3b4167d9a9de25eec3a466eb6e56399dd))
+* update testcases ([6bc1d66](https://github.com/dendronhq/dendron/commit/6bc1d66e56ba31b3e51582010d9cdb236a5e8d73))
+* **pods:** refreshToken to read correct dendron port file ([53734ab](https://github.com/dendronhq/dendron/commit/53734ab46dbd75a34974939fe1d47734b118de44))
+* properly set siteIndex when it's not explicitly set by config ([#2443](https://github.com/dendronhq/dendron/issues/2443)) ([43b4c3b](https://github.com/dendronhq/dendron/commit/43b4c3b8634f311ff14dc05b7dab9bc65c605b57))
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([d1057e5](https://github.com/dendronhq/dendron/commit/d1057e5948b742bed7b2a378f3db2f43cd2a91d6))
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([f0143e3](https://github.com/dendronhq/dendron/commit/f0143e3a0001dba9f775a4c50b2b87615b8f4a5f))
+
+
+### Features Dendron
+
+* pods v2 cli ([2e2bf8e](https://github.com/dendronhq/dendron/commit/2e2bf8e5e1189ed3e48e2e4e822c6fedf72142aa))
+
+
+### Reverts
+
+* remove source in import pod ([05a3084](https://github.com/dendronhq/dendron/commit/05a30842734d5745374577b9b025eb20439814d7))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **workspace:** Dendron will try to parse non-dendron files in `onFirstOpen` ([#2405](https://github.com/dendronhq/dendron/issues/2405)) ([d913a7f](https://github.com/dendronhq/dendron/commit/d913a7fe6e251f5e45925c591310ddd6e1031274))
+* **workspace:** error message to be readable in error toast ([25c74e8](https://github.com/dendronhq/dendron/commit/25c74e8aa2547a78c0d1e6399fcb2ffc72b06820))
+* emphasize no async fns on the describeWS Test functions ([9d7cf5f](https://github.com/dendronhq/dendron/commit/9d7cf5fe6290a7762bea433c287a72a9fdad31bf))
+* fixing journal title date formatting support ([5da910a](https://github.com/dendronhq/dendron/commit/5da910a4fac6c1bbef6515f88b44cd63507a823b))
+* journal command title and trait consistency issues ([3def810](https://github.com/dendronhq/dendron/commit/3def8104161a5779ae7abe47fce39d9f81bbc9c8))
+* remove circ deps between ILookupController and ILookupProvider ([798c2b9](https://github.com/dendronhq/dendron/commit/798c2b99e06eed4c0f07d8054e97c05a6effc152))
+* **dev:** correctly detect DENDRON_RELEASE_VERSION using both marketplace and package.json ([#2320](https://github.com/dendronhq/dendron/issues/2320)) ([cb342b2](https://github.com/dendronhq/dendron/commit/cb342b2fa7200e8b6df880bc3b9b9ef892d17c51))
+* **pod:** acknowledge cli args for publish pod ([#2352](https://github.com/dendronhq/dendron/issues/2352)) ([b5d1f15](https://github.com/dendronhq/dendron/commit/b5d1f157a2db15711099666a7e09abd08cbccdb9))
+* **pod:** markdown import to update asset references ([#2350](https://github.com/dendronhq/dendron/issues/2350)) ([c22a322](https://github.com/dendronhq/dendron/commit/c22a322ce904da4157260e06cc14ffd07728042d))
+* **publish:** CSS sidebar is off on smaller screens like iPad ([#2305](https://github.com/dendronhq/dendron/issues/2305)) ([d46c521](https://github.com/dendronhq/dendron/commit/d46c52124586d8d620d52d39395c62e460c11007))
+* **publish:** skip adding asset prefix to images with web url ([#2362](https://github.com/dendronhq/dendron/issues/2362)) ([11cf84c](https://github.com/dendronhq/dendron/commit/11cf84c61db4b83934048c7f8a46fbb969132816))
+* **publishing:** Search Bar Results to not stay anchored to the search bar when scrolling up ([#2292](https://github.com/dendronhq/dendron/issues/2292)) ([32b09b0](https://github.com/dendronhq/dendron/commit/32b09b0b2e7dcf099cba44b8639e1964a149d129))
+* **schemas:** Do not include stubs as part of template suggestions when applying a template ([#2357](https://github.com/dendronhq/dendron/issues/2357)) ([a746e9c](https://github.com/dendronhq/dendron/commit/a746e9cf6c8766fa66dc879d2bf07e9e157025c4))
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+* **views:** show preview doesn't display targeted files when using file explorer([#2327](https://github.com/dendronhq/dendron/issues/2327)) ([7ee340b](https://github.com/dendronhq/dendron/commit/7ee340b7194d5b48fc1d6c67d929dbd0beab9ad9))
+* **workspace:** avoid workspace watcher crashing if folder is deleted ([#2359](https://github.com/dendronhq/dendron/issues/2359)) ([9d0325f](https://github.com/dendronhq/dendron/commit/9d0325fc9d220a95d48a04716a5678dae0bebe79))
+* **workspace:** correct title generartion of notes with sub-hierarchy starting with md ([#2369](https://github.com/dendronhq/dendron/issues/2369)) ([562f2bd](https://github.com/dendronhq/dendron/commit/562f2bda3e7059408c6c5d46c7e4dfae463d49d0))
+* add omitted changes that causes type error ([43a0f71](https://github.com/dendronhq/dendron/commit/43a0f719daf2f54b2b652b797e81cbd6dd7e1b75))
+* decode urlencoded spaces in asset path before opening ([#2279](https://github.com/dendronhq/dendron/issues/2279)) ([c60743d](https://github.com/dendronhq/dendron/commit/c60743db7c93bdb44deb2e97c4fb80cfdf209994))
+* preview opens wrong path on Windows ([#2326](https://github.com/dendronhq/dendron/issues/2326)) ([6ae66bc](https://github.com/dendronhq/dendron/commit/6ae66bca93bddbcefd9efb930c8a2bbc97352dfa))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+* resolve PR comments ([f5769d0](https://github.com/dendronhq/dendron/commit/f5769d037e7b313a3c09aaf61a29c0f2a8e84131))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **lookup:** "Note does not exist. Create?" should read "Schema does not exist. Create?" in Schema Lookup ([#2253](https://github.com/dendronhq/dendron/issues/2253)) ([e12dd3a](https://github.com/dendronhq/dendron/commit/e12dd3ad4d6460fca238ece928fb3be81dc77a98))
+* add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score. ([3192d77](https://github.com/dendronhq/dendron/commit/3192d773588e9f1817eabbbb78e68042c201d213))
+* analytics for show preview ([90c5ed8](https://github.com/dendronhq/dendron/commit/90c5ed837f2de0d7f9503459f9b46f278944cdd2))
+* bug on start up observing automaticallyShowPreview flag + cr feedback ([1b87072](https://github.com/dendronhq/dendron/commit/1b870720e533d6358cb4a4483294eaa8248d3725))
+* compact bullet list on import ([a43cdd9](https://github.com/dendronhq/dendron/commit/a43cdd9c1305c31d0b6e6bb96acc5fb5aa28cd70))
+* cursor is moved when opening file through search interface ([87dcbd9](https://github.com/dendronhq/dendron/commit/87dcbd9aa2c0cc7f8f76c12f49e66cd883b94d91))
+* for handling diamond shape schema relationships ([ca2d5af](https://github.com/dendronhq/dendron/commit/ca2d5af94acbf62885e0230f0ef28f384395b6f8))
+* highlighting breaks when there's too much text ([#2163](https://github.com/dendronhq/dendron/issues/2163)) ([9d9579c](https://github.com/dendronhq/dendron/commit/9d9579cdab773131a5c8e0b1d6e130262d6a8164))
+* insert note index enablement ([b230a16](https://github.com/dendronhq/dendron/commit/b230a1669021949aea3f9af39d69c33c1b8fd26f))
+* move header issues ([#2040](https://github.com/dendronhq/dendron/issues/2040)) ([5e09abf](https://github.com/dendronhq/dendron/commit/5e09abff646d001c99f944a2e51254aa56379e0d))
+* numbered lists without content stack on top of each other ([63f49ed](https://github.com/dendronhq/dendron/commit/63f49ed86fdef495c3010bc89ec594c4f4e267f4))
+* PR comment resolve ([1d9e67a](https://github.com/dendronhq/dendron/commit/1d9e67ae45ed242c883a6b09a08e14815451cb71))
+* PR comments addressed ([5f2a11b](https://github.com/dendronhq/dendron/commit/5f2a11b36aa0a7ec3a64544c09f273fe7575306e))
+* Publishing dev server keeps running after exiting on Windows ([#2035](https://github.com/dendronhq/dendron/issues/2035)) ([134bcb3](https://github.com/dendronhq/dendron/commit/134bcb3b38c5a2136507d68660d85dd77f5f9791))
+* publishing pages fail ([#2199](https://github.com/dendronhq/dendron/issues/2199)) ([cfffd6a](https://github.com/dendronhq/dendron/commit/cfffd6a1988c372f7472bb2cd93126befd866a0d))
+* regression in windowwatcher ([9069c82](https://github.com/dendronhq/dendron/commit/9069c825a72b06a14b3aebe348f9dfbd53ed0479))
+* remove commented code ([44ca806](https://github.com/dendronhq/dendron/commit/44ca806a09fd741b5ec5010a925888160ffde7de))
+* removed runnable check from getAllPodConfig ([973ef22](https://github.com/dendronhq/dendron/commit/973ef2295a86a45bb594886d859cfa9bcc7e9201))
+* resolve PR comment ([114a8b7](https://github.com/dendronhq/dendron/commit/114a8b71a375d22abf392c968fa35ddbafdb1565))
+* resolve Pr comment and rebase ([95dbd69](https://github.com/dendronhq/dendron/commit/95dbd6920b733e422c1dab3e57eac7fd2500a7e8))
+* resolved pr comment and updated testcase ([746b330](https://github.com/dendronhq/dendron/commit/746b330578487ee2ffdde17967f6d9c84bfc40dc))
+* resolved PR comments ([7cf9b10](https://github.com/dendronhq/dendron/commit/7cf9b10fd8c78cb962563cc25f24e82b8bef29b3))
+* resolved PR comments ([85d91f4](https://github.com/dendronhq/dendron/commit/85d91f4881a7c9b7f21cbff458c885b13b7eeff9))
+* title wrap and hamburged offset on mobile ([#2183](https://github.com/dendronhq/dendron/issues/2183)) ([3828b8b](https://github.com/dendronhq/dendron/commit/3828b8b2241211427c3d274b418ecb5058fab0b5))
+* update PR comments ([41739fb](https://github.com/dendronhq/dendron/commit/41739fbb2219b0bbc1e9e40c55a79a78d5096daa))
+* updated pod to check values from config ([c1285f4](https://github.com/dendronhq/dendron/commit/c1285f487d289eab69ec1ce7532bb6e9351f384f))
+* **analytics:** inactive survey issues ([#2110](https://github.com/dendronhq/dendron/issues/2110)) ([36a3b2f](https://github.com/dendronhq/dendron/commit/36a3b2f6f69e1637c111503ce9455bf370558845))
+* **cli:** using `--noBuild` with export from CLI will cause command to hang ([#2109](https://github.com/dendronhq/dendron/issues/2109)) ([2a0f184](https://github.com/dendronhq/dendron/commit/2a0f184a3358312f34a3f3e879738e3a2c295421))
+* **commands:** paste-link-title-trim ([#1961](https://github.com/dendronhq/dendron/issues/1961)) ([07f5137](https://github.com/dendronhq/dendron/commit/07f5137d33f8fbc96e161229ec133a9d1039d0e3))
+* **commands:** renamed command from goto note to go to note ([#2187](https://github.com/dendronhq/dendron/issues/2187)) ([c4ef88e](https://github.com/dendronhq/dendron/commit/c4ef88e077442db6ecb9584d134beebe039e7757))
+* **lookup:** Remove redundant broken test ([b4979ec](https://github.com/dendronhq/dendron/commit/b4979ecf519e8851fcad55dc072670206cb92efb))
+* **lookup:** Remove redundant broken test ([b5648c0](https://github.com/dendronhq/dendron/commit/b5648c031cf1fd61ac75e8a1d7f681c72380792d))
+* **markdown:** Exclude parenthesis from tags ([#2182](https://github.com/dendronhq/dendron/issues/2182)) ([04fe9f8](https://github.com/dendronhq/dendron/commit/04fe9f896000e1254403d1ead49d209a9fda7b95))
+* **pod:** issue with linkedRecord not getting correct airtable id ([cb0b0e1](https://github.com/dendronhq/dendron/commit/cb0b0e153ff1a2745cdd51b3155230941b9eb505))
+* **publish:** logo doesn't respect assetsPrefix ([#2189](https://github.com/dendronhq/dendron/issues/2189)) ([763c797](https://github.com/dendronhq/dendron/commit/763c797c4c2f7821ef747376c980e4a4b0eace8e))
+* **schema:** Use string replace instead of lodash for date variable substitution ([75a6111](https://github.com/dendronhq/dendron/commit/75a6111ab322139ab504cc769010510a0e972069))
+* **views:** enable copy plaintext from preview ([#2152](https://github.com/dendronhq/dendron/issues/2152)) ([a54b63b](https://github.com/dendronhq/dendron/commit/a54b63bb0c66b8e4dc31dbe5c9c51835b4fd4ec9))
+* **workspace:** stop link candidate logic when disabled ([#2136](https://github.com/dendronhq/dendron/issues/2136)) ([110941c](https://github.com/dendronhq/dendron/commit/110941cd268aaca43bc99a07d5670c52271aa95c))
+* resolved PR comment and conflict ([1d8b895](https://github.com/dendronhq/dendron/commit/1d8b8959e5c66e1dc7f6d7a487300040c11bca1c))
+* Show Preview does nothing if used from command prompt ([f18d66b](https://github.com/dendronhq/dendron/commit/f18d66bbbf23e8dca5e61bf400023367c30410c3))
+* **publish:** compile error when publishing ([c045c3a](https://github.com/dendronhq/dendron/commit/c045c3a3ab358b710c2d937aaf9f879f0ac218c1))
+* **views:** tree view refresh and circ dependency removal ([#2082](https://github.com/dendronhq/dendron/issues/2082)) ([a614731](https://github.com/dendronhq/dendron/commit/a614731e92f1ccba623a32ce1939ce48ff3102c2))
+* skipping single notelookupcommand test ([3102f4f](https://github.com/dendronhq/dendron/commit/3102f4f87d528a4698b6a360c5bd843b506fe07d))
+* test updates ([fb066b2](https://github.com/dendronhq/dendron/commit/fb066b2277a8620b62385281235359ad5ccde874))
+* updated test ([31aaa1c](https://github.com/dendronhq/dendron/commit/31aaa1c8a9c21dce3013804b4d4a25e7aea71cb5))
+* **schema:** Ensure month/day/time has two digits when doing data variable substitution ([#2064](https://github.com/dendronhq/dendron/issues/2064)) ([20f807e](https://github.com/dendronhq/dendron/commit/20f807e3f1be3ba082a01dda527fa653cf30b433))
+
+
+### Features Dendron
+
+* lookup view ([#1977](https://github.com/dendronhq/dendron/issues/1977)) ([dad85f6](https://github.com/dendronhq/dendron/commit/dad85f6e1964b5cf21bc0a1007c229c504e17eb5))
+
+
+
+# 0.76.0 (2022-01-04)
+
+
+### Bug Fixes
+
+* regression on onTriggerButton not scoping properly ([#2037](https://github.com/dendronhq/dendron/issues/2037)) ([d0e5fcd](https://github.com/dendronhq/dendron/commit/d0e5fcd99a51dd81309fc5faf46addef80f0267c))
+* **workspace:** don't show calendar view unless dendron tree view is active ([#2017](https://github.com/dendronhq/dendron/issues/2017)) ([5132e83](https://github.com/dendronhq/dendron/commit/5132e8309d2b66585aed50983bf431b221c16c0d))
+* compiler issue with nextjs ([60e9107](https://github.com/dendronhq/dendron/commit/60e9107155eabacb41a6d92e0076df88b701f121))
+* rename operations modify unnecessary files ([1330785](https://github.com/dendronhq/dendron/commit/1330785011d57150d18728fa7a14f7a58a6ca7fb))
+* resolved PR comments ([126034e](https://github.com/dendronhq/dendron/commit/126034ee21767c91b62e0e82c6efcec7d5826753))
+* warn for frontmatter issues even if the frontmatter is not visible ([bfe027e](https://github.com/dendronhq/dendron/commit/bfe027eb40ef1cdc7b214a6ff8ab3b1e6b32d453))
+* **commands:** seed commands broken by refactor ([#1997](https://github.com/dendronhq/dendron/issues/1997)) ([2a3f5e4](https://github.com/dendronhq/dendron/commit/2a3f5e4ff0528ece188485d4d4f12f9b11d8eab2))
+* **docs:** Replaced instances of 'spwan' with 'spawn'. ([#1792](https://github.com/dendronhq/dendron/issues/1792)) ([6b0b609](https://github.com/dendronhq/dendron/commit/6b0b6096fef3e36daa0b81121cedd83fe5fd0a91))
+* **lookup:** full length word matches should be case insensitive ([#1990](https://github.com/dendronhq/dendron/issues/1990)) ([03deb56](https://github.com/dendronhq/dendron/commit/03deb5699c81627b64350e7fdb7a0634810af3f4))
+* **markdown:** lag in the editor when there's a x-vault link to a non-existent vault ([#1941](https://github.com/dendronhq/dendron/issues/1941)) ([0ae4325](https://github.com/dendronhq/dendron/commit/0ae43256c0d81683ec8c92bff66f69ed97e04102))
+* **note:** frontmatter tags are not highlighted ([#2001](https://github.com/dendronhq/dendron/issues/2001)) ([5eae3b7](https://github.com/dendronhq/dendron/commit/5eae3b7ae1efa8f4c0c790c6d30bf8f55617d7a7))
+* **publish:** excluding the domain of a published hierarchy will cause publishing to throw an error ([#1964](https://github.com/dendronhq/dendron/issues/1964)) ([07dc882](https://github.com/dendronhq/dendron/commit/07dc8820c6d6b4a023ef531128093cf38ec20bb2))
+* **publish:** hamburger display in wrong position ([#1965](https://github.com/dendronhq/dendron/issues/1965)) ([6ef6a90](https://github.com/dendronhq/dendron/commit/6ef6a909e71ab208903335a8d1fde6497b00eea5))
+* **server:** specify localhost when starting server ([c57972a](https://github.com/dendronhq/dendron/commit/c57972a4afe3ea5ce98c464ba6a46fc173a7d514))
+* **views:** update tree order when a note changes order ([#2014](https://github.com/dendronhq/dendron/issues/2014)) ([b66032f](https://github.com/dendronhq/dendron/commit/b66032fef1b8cb5f7a6fa522a5e0ad14ac4d8388))
+* **workspace:** correct message in convert vault ([#1999](https://github.com/dendronhq/dendron/issues/1999)) ([3d3ac8f](https://github.com/dendronhq/dendron/commit/3d3ac8f2e4c8c6f48440e6c3d2de9ba987b7a466))
+* correctly offset frontmatter line count in doctor preview for `findBrokenLinks` ([#1959](https://github.com/dendronhq/dendron/issues/1959)) ([21255b3](https://github.com/dendronhq/dendron/commit/21255b30f3310e2cd897cfafc4764d04d553bd22))
+* delete npmrc ([defd215](https://github.com/dendronhq/dendron/commit/defd215900101aa3110f1e94e932c44fc83b0cff))
+* infinite looping active note change when note graph is open ([#1980](https://github.com/dendronhq/dendron/issues/1980)) ([3a42ab7](https://github.com/dendronhq/dendron/commit/3a42ab78416019b716b842c08de247e7df22376c))
+* move auto completable command registration to be done centrally ([#1891](https://github.com/dendronhq/dendron/issues/1891)) ([239eea2](https://github.com/dendronhq/dendron/commit/239eea2c882a686a5dfe98b52be98003a21cae88))
+* note traits not working after webpack ([#1889](https://github.com/dendronhq/dendron/issues/1889)) ([48087e4](https://github.com/dendronhq/dendron/commit/48087e44fd6a746b90771589f23c5aa88f32fc39))
+* update interface for batch api calls ([81d8e9c](https://github.com/dendronhq/dendron/commit/81d8e9cbb1e33453b0d615b75bca9a0bce6eed25))
+* **refactor:** refactor crashes when captured note is a stub ([#1910](https://github.com/dendronhq/dendron/issues/1910)) ([24cf219](https://github.com/dendronhq/dendron/commit/24cf219d267ba63b0f9c140f19173898bece75b3))
+* **workspace:** autocomplete deletes text following wikilink with no closing brackets ([#1909](https://github.com/dendronhq/dendron/issues/1909)) ([8fd0ef8](https://github.com/dendronhq/dendron/commit/8fd0ef8cd7710b8e6f5e74261d24c606e3c38f13)), closes [#1834](https://github.com/dendronhq/dendron/issues/1834)
+* **workspace:** extension crash in non-Dendron workspaces when there's a large number of files ([#1913](https://github.com/dendronhq/dendron/issues/1913)) ([2840aa4](https://github.com/dendronhq/dendron/commit/2840aa47448cbf25a36bb10322da5e66d2c1bffc)), closes [#1312](https://github.com/dendronhq/dendron/issues/1312)
+* use patterns when ids are auto generated and there is no manually set title for a schema ([c54e2bb](https://github.com/dendronhq/dendron/commit/c54e2bb90beac6d384ca0d6929cbf5a202808c63))
+* **workspace:** simplify InitializeWorkspace command ([#1886](https://github.com/dendronhq/dendron/issues/1886)) ([27f4c53](https://github.com/dendronhq/dendron/commit/27f4c53f34ee89700df3d53b31b016f393cdf282))
+* revert match text default value to active note name ([#1892](https://github.com/dendronhq/dendron/issues/1892)) ([8f823e8](https://github.com/dendronhq/dendron/commit/8f823e8e48b4700ba3cb68b063a783f5122c64c2))
+* **workspace:** tutorial initializer with existing ws in default paths ([#1873](https://github.com/dendronhq/dendron/issues/1873)) ([434a857](https://github.com/dendronhq/dendron/commit/434a85793c7eadb3e2ab0332e1c1da5984632a69))
+* double open link from preview ([827e911](https://github.com/dendronhq/dendron/commit/827e911be8a457ff221dc51cff1d25d05ed47467))
+
+
+### Features Dendron
+
+* open preview buttons for context menus ([#1906](https://github.com/dendronhq/dendron/issues/1906)) ([8b9160c](https://github.com/dendronhq/dendron/commit/8b9160c250cad2465dbfb77c785ab022b31cd88b))
+* **commands:** find broken links ([#1847](https://github.com/dendronhq/dendron/issues/1847)) ([0f23a79](https://github.com/dendronhq/dendron/commit/0f23a79e5473afa2afb1c5c0e274e2bd3f134554))
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+* **navigation:** implement goto definition for non-note files ([#1888](https://github.com/dendronhq/dendron/issues/1888)) ([19e8070](https://github.com/dendronhq/dendron/commit/19e8070ede4bc5c827ff92cdeac31dd6ab000a74))
+* **navigation:** non-note file enhancements ([#1895](https://github.com/dendronhq/dendron/issues/1895)) ([90e083b](https://github.com/dendronhq/dendron/commit/90e083b5e10073acbc8967ad9649c0008aae381c))
+* **notes:** Note Trait System Prototype (Phase 1) ([#1658](https://github.com/dendronhq/dendron/issues/1658)) ([0d5d187](https://github.com/dendronhq/dendron/commit/0d5d187a9aaaaebfc32fa9c7c5b5faa5c3b38eb3))
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+* **refactor:** convert link command ([#1933](https://github.com/dendronhq/dendron/issues/1933)) ([e4cba18](https://github.com/dendronhq/dendron/commit/e4cba184382f7d8c1d2a6820e85305e1191a54c2))
+* **refactoring:** add rename provider ([#1879](https://github.com/dendronhq/dendron/issues/1879)) ([988e18b](https://github.com/dendronhq/dendron/commit/988e18b8e03cb952898cb1cba9caf998b2e994f5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **views:** update webview title name ([16d1f0c](https://github.com/dendronhq/dendron/commit/16d1f0c2454e4056d56d988aa909c2ea70cf18b1))
+* corner cases for auto complete ([#1843](https://github.com/dendronhq/dendron/issues/1843)) ([d6c51f3](https://github.com/dendronhq/dendron/commit/d6c51f3fd352412d9a763af8f60f34a2c0ebabda))
+* **cli:** workspace info prints message to CLI ([6d512e2](https://github.com/dendronhq/dendron/commit/6d512e21f2542515b802a188fcf5edc75e21f8fd))
+* **lookup:** disappearing vaults in vault selection quickpick ([#1717](https://github.com/dendronhq/dendron/issues/1717)) ([7e2333a](https://github.com/dendronhq/dendron/commit/7e2333ae8b6dd5bcd10f29d6bf61931e206830ec))
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **lookup:** re-enable lookup commands ([e780cd1](https://github.com/dendronhq/dendron/commit/e780cd10f7c6ae17b1ad83666322677329b34f32))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **note:** correctly handle note titles containing international characters ([#1801](https://github.com/dendronhq/dendron/issues/1801)) ([03b05f4](https://github.com/dendronhq/dendron/commit/03b05f4aa7887577365059f5bb22d8c3585afe40))
+* **pods:** github import pod handle deleted authors ([#1660](https://github.com/dendronhq/dendron/issues/1660)) ([eb11440](https://github.com/dendronhq/dendron/commit/eb11440e255b889e546cd7f67fcb970692c52989))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** minor error in airtable v2 export pod ([#1846](https://github.com/dendronhq/dendron/issues/1846)) ([4550d93](https://github.com/dendronhq/dendron/commit/4550d9371c55ddb6a48be4a6b21c03585bc89592))
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** issue with cypress dependency ([9a18336](https://github.com/dendronhq/dendron/commit/9a18336131711d3115568a4e7a40732e37e0e89d)), closes [#19102](https://github.com/dendronhq/dendron/issues/19102)
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** remove duplicate CSS ([#1707](https://github.com/dendronhq/dendron/issues/1707)) ([9574009](https://github.com/dendronhq/dendron/commit/9574009f03441abae6209920f4c076ed46af73ad))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **schema:** When applying a schema template, do not override the body but append to the end to it ([#1812](https://github.com/dendronhq/dendron/issues/1812)) ([0a48123](https://github.com/dendronhq/dendron/commit/0a481230c29aee08493937772f1f4d57be511615))
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* **views:** re-introduce preview command enablement ([#1806](https://github.com/dendronhq/dendron/issues/1806)) ([a16e34a](https://github.com/dendronhq/dendron/commit/a16e34ade8a3a7e296848940f00820e7a725788c))
+* **views:** tree view not initializing on load ([5590a3c](https://github.com/dendronhq/dendron/commit/5590a3c0aa7476e8984a1e9193697d9984ab00ee))
+* **views:** update web uis on note creation ([55a7ecd](https://github.com/dendronhq/dendron/commit/55a7ecd787461062f969804ef44b287af1cd05f5)), closes [/github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md#L103](https://github.com//github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md/issues/L103)
+* ajv warning messages printed to console ([#1722](https://github.com/dendronhq/dendron/issues/1722)) ([1aae27b](https://github.com/dendronhq/dendron/commit/1aae27bb0924f649af131ca7664da3f914044c31))
+* allow assets to open from preview view ([#1771](https://github.com/dendronhq/dendron/issues/1771)) ([f362bda](https://github.com/dendronhq/dendron/commit/f362bda9726c9dde2c96aa1954aa549c1f013136))
+* Change Workspace command recognizes native workspaces ([#1621](https://github.com/dendronhq/dendron/issues/1621)) ([d120934](https://github.com/dendronhq/dendron/commit/d1209348577437d6df1780ff2955849dabf7fbc9))
+* cli migration now handles JSONC for wsConfig ([#1825](https://github.com/dendronhq/dendron/issues/1825)) ([fd88d06](https://github.com/dendronhq/dendron/commit/fd88d06266a8aa73e5f7ba9402b7b31984b22f69))
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* **workspace:** remove trailing whitespace in note ([#1736](https://github.com/dendronhq/dendron/issues/1736)) ([d1f0117](https://github.com/dendronhq/dendron/commit/d1f01177390e206fe75f235caa7ef10eebe43732))
+* circular dependency with logger ([5f3f958](https://github.com/dendronhq/dendron/commit/5f3f9587516a6abfd0cde4810839b900cb0ff0b9))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* mistyped analytics event name ([#1678](https://github.com/dendronhq/dendron/issues/1678)) ([13086c2](https://github.com/dendronhq/dendron/commit/13086c2c9dc995f7feeea3cfed66fddb54ca52a9))
+* **commands:** allow creation of new notes when move header destination doesn't exist yet ([#1646](https://github.com/dendronhq/dendron/issues/1646)) ([90a47e4](https://github.com/dendronhq/dendron/commit/90a47e4779b0d9209aa95f209688a42f20497990))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** table of contents layout ([#1649](https://github.com/dendronhq/dendron/issues/1649)) ([dbae739](https://github.com/dendronhq/dendron/commit/dbae739ad0650c75a72dd51821b3a5d4ab556839))
+* **server:** improving error response on api server ([#1645](https://github.com/dendronhq/dendron/issues/1645)) ([8936fb6](https://github.com/dendronhq/dendron/commit/8936fb690045022487fb46aafd661581b60deab1))
+* file watcher updates backlinks ([#1618](https://github.com/dendronhq/dendron/issues/1618)) ([1e0b776](https://github.com/dendronhq/dendron/commit/1e0b776c8fe9af90f56a0df4a57002982a4d834c))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* lock ua-parser-js to 0.7.28 due to https://github.com/faisalman/ua-parser-js/issues/536 ([7b697d2](https://github.com/dendronhq/dendron/commit/7b697d26be6fe3912ed51c1ca0753b0cac8e8c70))
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* **commands:** move header command modifying unrelated note content ([#1574](https://github.com/dendronhq/dendron/issues/1574)) ([46cad20](https://github.com/dendronhq/dendron/commit/46cad20c089fd4bcc22513a2dfc60bed8197e7f6))
+* **dev:** fix some typos in the GitHub templates ([#1546](https://github.com/dendronhq/dendron/issues/1546)) ([87dd69c](https://github.com/dendronhq/dendron/commit/87dd69cd15b81655cc5e407e616f7a0d2211ec0b))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** remove .next dir if it exists in publish init ([#1548](https://github.com/dendronhq/dendron/issues/1548)) ([3ffd87a](https://github.com/dendronhq/dendron/commit/3ffd87a606d2251991319e81ba7292989dac427f))
+* **publish:** Title parts duplicated in Next publishing search ([#1573](https://github.com/dendronhq/dendron/issues/1573)) ([59de1a4](https://github.com/dendronhq/dendron/commit/59de1a486be980c1e6b16753478c62b03c38e018))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* handle undefined and null properties of old command configs in migration ([#1508](https://github.com/dendronhq/dendron/issues/1508)) ([6782b54](https://github.com/dendronhq/dendron/commit/6782b54231e30c6fc6298f1c3a826469dd6548ec))
+* notes getting edited issue ([#1559](https://github.com/dendronhq/dendron/issues/1559)) ([6810a9a](https://github.com/dendronhq/dendron/commit/6810a9a1564750b2fd31da7b6ab44f062ed779f5))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* require statement path ([#1561](https://github.com/dendronhq/dendron/issues/1561)) ([6a7be61](https://github.com/dendronhq/dendron/commit/6a7be61db3ec7e6fab61871b30ec215c47f1cb59))
+* **publish:** optimize nextjs publishing search ([#1519](https://github.com/dendronhq/dendron/issues/1519)) ([d06dd25](https://github.com/dendronhq/dendron/commit/d06dd25e292532a4ea66d1aa469a27c00b424ad6))
+* **publish:** unslugify titles in toc ([292a46b](https://github.com/dendronhq/dendron/commit/292a46b14287f2e649a7929516ed97144e9fd2d6))
+* **publish:** verbose logging when building notes ([136cbec](https://github.com/dendronhq/dendron/commit/136cbec7c10d6c42b79ecce0f21955d546ba1f9e))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **workspace:** error when init native workspace ([e74d492](https://github.com/dendronhq/dendron/commit/e74d492186489d06aa584dd9c78d82ad27017e85))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+* **workspace:** possible error if open note is changed quickly after edit ([#1486](https://github.com/dendronhq/dendron/issues/1486)) ([e21f92e](https://github.com/dendronhq/dendron/commit/e21f92e528f19ad44643fb63fe0e817f33bffea7))
+
+
+### Features Dendron
+
+* **lookup:** add auto complete to note lookup ([#1781](https://github.com/dendronhq/dendron/issues/1781)) ([ea5ad5c](https://github.com/dendronhq/dendron/commit/ea5ad5c6672aa0c812aa7e852d5c28c3cea0e1b1))
+* **pods:** Export Pod V2 ([#1772](https://github.com/dendronhq/dendron/issues/1772)) ([2dac9df](https://github.com/dendronhq/dendron/commit/2dac9dfb13525af984c3fd2f938283cba33cef7b))
+* decorator improvements ([#1770](https://github.com/dendronhq/dendron/issues/1770)) ([a7227fd](https://github.com/dendronhq/dendron/commit/a7227fd4d8991e44729989c821a22560dcb8348b))
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **workspace:** added contextual ui menu option for wrapping link ([#1677](https://github.com/dendronhq/dendron/issues/1677)) ([732108c](https://github.com/dendronhq/dendron/commit/732108c848eb05e5f2c9cf1fc8ecdd02fa377c6e))
+* add Dendron preview button ([db092e3](https://github.com/dendronhq/dendron/commit/db092e33cb6295b4d90e60bd4267d2f83f824e7a))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** hide default markdown preview button ([#1636](https://github.com/dendronhq/dendron/issues/1636)) ([ce182b2](https://github.com/dendronhq/dendron/commit/ce182b278008ded4ffe0de02b12b70ef4f948dc4))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+### Reverts
+
+* Revert "fix: add workspace root to workspace folders for Code Workspaces" ([09b3ad5](https://github.com/dendronhq/dendron/commit/09b3ad58fb3c872acfa7a71c64e7e9c9b27a8ded))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* fix journal note creation ([#1465](https://github.com/dendronhq/dendron/issues/1465)) ([18a5f27](https://github.com/dendronhq/dendron/commit/18a5f273183cd084a1eaf288ed2c48ad7a092a1e))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+* **commands:** move header command compile noterefs ([#1458](https://github.com/dendronhq/dendron/issues/1458)) ([acc15d6](https://github.com/dendronhq/dendron/commit/acc15d6614194404dc5610d2ae9ffbe689013fc0))
+* **lookup:** vault selection use wrong label ([#1463](https://github.com/dendronhq/dendron/issues/1463)) ([2767be7](https://github.com/dendronhq/dendron/commit/2767be78a458548c72d0ada194abb15263b52a1f))
+* **publish:** bad seo props setter ([373d933](https://github.com/dendronhq/dendron/commit/373d9331aba3b3385632f01661dd6c80835ec5ac))
+* **publish:** nextjs search note snippets ([#1433](https://github.com/dendronhq/dendron/issues/1433)) ([0cb8f38](https://github.com/dendronhq/dendron/commit/0cb8f38fc9cb5e45af682fc5524ff5eb7ba44ce7))
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* **workspace:** highlighting for wildcard note refs with header offsets ([#1460](https://github.com/dendronhq/dendron/issues/1460)) ([a4722da](https://github.com/dendronhq/dendron/commit/a4722daaff33b25667c0b431cc919f898401ca31))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* add ovsx dev dep ([0080b8f](https://github.com/dendronhq/dendron/commit/0080b8fa0faf1c63630ea72fa78d2e4afb0fdf22))
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+* **lookup:** picked schema matching name was not creating the expected note ([#1425](https://github.com/dendronhq/dendron/issues/1425)) ([76cf5e1](https://github.com/dendronhq/dendron/commit/76cf5e1b2e7929a65fcdcf060e52242abc6991fa))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* **publish:** footer show on first load ([#1413](https://github.com/dendronhq/dendron/issues/1413)) ([00d32cc](https://github.com/dendronhq/dendron/commit/00d32cc830ca6da3160a9cee86386e50b3a35fd6))
+* no-op on hover provider if dendron non active ([#1398](https://github.com/dendronhq/dendron/issues/1398)) ([61949f1](https://github.com/dendronhq/dendron/commit/61949f187d1a6c5a1d3ed3f63f9695b51bacdc7a))
+* **workspace:** next gen views in remote workspaces ([#1401](https://github.com/dendronhq/dendron/issues/1401)) ([c9cb2e0](https://github.com/dendronhq/dendron/commit/c9cb2e0381c258b34e355bb89d53b3624ff3962e))
+
+
+### Features Dendron
+
+* **publish:** add popover for long title in menu ([#1408](https://github.com/dendronhq/dendron/issues/1408)) ([b94b223](https://github.com/dendronhq/dendron/commit/b94b2235f337b2e54bcbf8658e5f4f371804c5f9))
+* **publish:** mobile navigation ([#1407](https://github.com/dendronhq/dendron/issues/1407)) ([3487213](https://github.com/dendronhq/dendron/commit/34872138131f030f460dc4cd8e81c65fe7654524))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+* **workspace:** notes added outside Dendron are missed ([#1406](https://github.com/dendronhq/dendron/issues/1406)) ([1a34940](https://github.com/dendronhq/dendron/commit/1a349407718d65e94dfdc86104af587e00344264))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** prevent malformed keybinding.json ([#1403](https://github.com/dendronhq/dendron/issues/1403)) ([2a221ab](https://github.com/dendronhq/dendron/commit/2a221ab5ad2ddd9cf93b27edf4a145941fca1915))
+* **workspace:** regression with hover preview ([5e8079a](https://github.com/dendronhq/dendron/commit/5e8079a9532d0dbc395ea9a7aaab640b6212b368))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* no-op completion provider when dendron isn't active ([#1392](https://github.com/dendronhq/dendron/issues/1392)) ([8136b9c](https://github.com/dendronhq/dendron/commit/8136b9c6bad293ac77aae78a9426c3b27c4d38d3))
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+* selection2link doesn't update note with link ([#1383](https://github.com/dendronhq/dendron/issues/1383)) ([737d584](https://github.com/dendronhq/dendron/commit/737d584c42a8033131437085ff5b2e4db3f18e8a))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+* **preview:** button for toggle local/global graph ([#1386](https://github.com/dendronhq/dendron/issues/1386)) ([31d905b](https://github.com/dendronhq/dendron/commit/31d905bb57294e268aa64c28b3a0a176d4839b41))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** add force close timeout ([ebbe51f](https://github.com/dendronhq/dendron/commit/ebbe51f0aad37e5ecf4b319405e6c719f1e14dc5))
+* **publish:** dangling connection when publishing via 11ty using github action ([c08117d](https://github.com/dendronhq/dendron/commit/c08117dd41fe250b6aa9f29f1b61879a7f9b56ce))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* creating scratch when text is selected within a note SHOULD not match scratches just due to prefix ([#1292](https://github.com/dendronhq/dendron/issues/1292)) ([cea4568](https://github.com/dendronhq/dendron/commit/cea456809b0da327bff5e06c1a796323d3eb257f))
+* decorations for erased tags persist ([#1291](https://github.com/dendronhq/dendron/issues/1291)) ([e3284f6](https://github.com/dendronhq/dendron/commit/e3284f6449fe36edb81deb2ae4c97612fdf2b8de))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* disallow toggling of vault selection behavior in move note ([#1296](https://github.com/dendronhq/dendron/issues/1296)) ([4dc7ca4](https://github.com/dendronhq/dendron/commit/4dc7ca4547bc0c7bcb8eb3e27f64ad7236ef4fd5))
+* do not show multi select button on note rename ([#1293](https://github.com/dendronhq/dendron/issues/1293)) ([bd283c1](https://github.com/dendronhq/dendron/commit/bd283c1427f5b1f611885dd8499b2bd5b5bf98c3))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* fix move note to have exact match ([#1331](https://github.com/dendronhq/dendron/issues/1331)) ([a5f4f9b](https://github.com/dendronhq/dendron/commit/a5f4f9b5220d67621e508a68ad2386cd481db21f))
+* fixing cmd tab typo in tutorial.2 ([#1234](https://github.com/dendronhq/dendron/issues/1234)) ([6e0543d](https://github.com/dendronhq/dendron/commit/6e0543d5077d40f2e9fc12325d3e111cad7e9a01))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* highlight same file wikilinks, wildcard references, links with anchors ([#1306](https://github.com/dendronhq/dendron/issues/1306)) ([956aa2a](https://github.com/dendronhq/dendron/commit/956aa2a7079eaa93acd2a66ace3c44f3f874c0f8))
+* hover provider shouldn't recommend Ctrl+click for missing notes unless configured ([#1276](https://github.com/dendronhq/dendron/issues/1276)) ([cc037b6](https://github.com/dendronhq/dendron/commit/cc037b6e53c21389be8507e8088dc65bff0d7259))
+* Ignore lookupConfirm if dailyVault is set ([#1311](https://github.com/dendronhq/dendron/issues/1311)) ([1c734da](https://github.com/dendronhq/dendron/commit/1c734daa45cc1e655638d754267c6bdf5bdcab90))
+* issue with init workspace ([94d05c8](https://github.com/dendronhq/dendron/commit/94d05c8f1b6856c769d0cd2964d1dece9decb37c))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+* make package public ([#1225](https://github.com/dendronhq/dendron/issues/1225)) ([b6832ce](https://github.com/dendronhq/dendron/commit/b6832ceab281826c5009a451df63f9607366b72d))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+* unhandled error in insert note link ([#1192](https://github.com/dendronhq/dendron/issues/1192)) ([a73420c](https://github.com/dendronhq/dendron/commit/a73420cd0f3d9f933256be43b839226b15b1e837))
+* update links on frontmatter tags changes ([#1214](https://github.com/dendronhq/dendron/issues/1214)) ([4d344fe](https://github.com/dendronhq/dendron/commit/4d344fe40701a259e3ac4399899dab4099c8614f))
+* update vs code compat version + husky hook check ([#1346](https://github.com/dendronhq/dendron/issues/1346)) ([1ae3fc6](https://github.com/dendronhq/dendron/commit/1ae3fc6da41084adc1e19f4c09b3a75d00ca0cb3))
+* workspace fix ([4f4bfab](https://github.com/dendronhq/dendron/commit/4f4bfab336862b43da226aa75db9f446e60ba1a2))
+
+
+### Features Dendron
+
+* **publish:** notice for dev mode ([#1354](https://github.com/dendronhq/dendron/issues/1354)) ([e3f9fc9](https://github.com/dendronhq/dendron/commit/e3f9fc9d81dc51fbaec5f4bbccb2f6c1dffb1afb))
+* Add smart vault selection to NoteLookupCommand ([#1174](https://github.com/dendronhq/dendron/issues/1174)) ([742cab6](https://github.com/dendronhq/dendron/commit/742cab6c683bb14b6baff6c786957a5cc7228894))
+* additional styling for nextjs ([f8e7972](https://github.com/dendronhq/dendron/commit/f8e797231b586c20ac4d2e1fa1813982cc282375))
+* consolidate dendron configs ([#1295](https://github.com/dendronhq/dendron/issues/1295)) ([177ac92](https://github.com/dendronhq/dendron/commit/177ac925a5442471f041ce5d991da52cecee6c9b))
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* run migration command ([#1177](https://github.com/dendronhq/dendron/issues/1177)) ([98bd000](https://github.com/dendronhq/dendron/commit/98bd000236e8c3a7def6b6895fa8d24315c54cf2))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+* tag colors in graph ([#1227](https://github.com/dendronhq/dendron/issues/1227)) ([cc95d0a](https://github.com/dendronhq/dendron/commit/cc95d0a1ae1f611f9162149db6163660b06fdfeb))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* force update picker item on button trigger even when value hasn't changed ([#1176](https://github.com/dendronhq/dendron/issues/1176)) ([46449a4](https://github.com/dendronhq/dendron/commit/46449a44009913af6340b26660fd5b5b2a79d57f))
+* horizontal rule not rendering ([#1156](https://github.com/dendronhq/dendron/issues/1156)) ([a95b615](https://github.com/dendronhq/dendron/commit/a95b6157512cda56ce98fd3944dc439570182e5b))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+### Features Dendron
+
+* make breadcrumbs clickable ([#1164](https://github.com/dendronhq/dendron/issues/1164)) ([a386fc3](https://github.com/dendronhq/dendron/commit/a386fc3dd42769207f58259f292216be51f0a15b))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* properly log error stack ([485e220](https://github.com/dendronhq/dendron/commit/485e220f8ffa6cd63210e106e846ff305b920b77))
+* regression with move note command ([5e357b8](https://github.com/dendronhq/dendron/commit/5e357b8995ff335aa36ad48777a96ee56b196c01))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* accept splitType argument in lookup v2 ([#1102](https://github.com/dendronhq/dendron/issues/1102)) ([a1120e4](https://github.com/dendronhq/dendron/commit/a1120e449af9776a14d2bcbb47f8d877ebd1227b))
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* CopyNoteRef respects noXVaultWikiLink option ([#1085](https://github.com/dendronhq/dendron/issues/1085)) ([b4b3da3](https://github.com/dendronhq/dendron/commit/b4b3da3306e2c5621c3c79a53b9f6e4cc31856c6)), closes [#1072](https://github.com/dendronhq/dendron/issues/1072)
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* extension readme getting started link ([#1084](https://github.com/dendronhq/dendron/issues/1084)) ([d3f5b7d](https://github.com/dendronhq/dendron/commit/d3f5b7dc49873cbbb9e44ce1ff473cd4d95e1214))
+* FM tags with quoted strings & with spaces ([1a16689](https://github.com/dendronhq/dendron/commit/1a1668914f70b48a4e74a218bd43521df226de38))
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+* highlighting is not displayed ([#1083](https://github.com/dendronhq/dendron/issues/1083)) ([86ead9b](https://github.com/dendronhq/dendron/commit/86ead9b7ec66a51712a265f263a515c624f2861c))
+* issue with direct child filter partially omitting values in quickpick ([#1123](https://github.com/dendronhq/dendron/issues/1123)) ([fbabab4](https://github.com/dendronhq/dendron/commit/fbabab4b61c91f3ebbe62def339efb32e1815178))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+* lookupv3 selection issue ([#1130](https://github.com/dendronhq/dendron/issues/1130)) ([c807e88](https://github.com/dendronhq/dendron/commit/c807e88a82217e5a04dfddb5a24259a50bea4813))
+* patch `getOrCreate` to inherit from default values ([#1126](https://github.com/dendronhq/dendron/issues/1126)) ([512b476](https://github.com/dendronhq/dendron/commit/512b476e8ac986887f25bc9a21bf7b189ea19ce9))
+* **calendar-view:** header selection throws error ([#1122](https://github.com/dendronhq/dendron/issues/1122)) ([5bc8ca1](https://github.com/dendronhq/dendron/commit/5bc8ca1a256328bd6d05f7d351e2c7ae7042580c)), closes [/ant.design/changelog#4](https://github.com//ant.design/changelog/issues/4)
+* properly debounce picker update ([#1111](https://github.com/dendronhq/dendron/issues/1111)) ([ae12e1e](https://github.com/dendronhq/dendron/commit/ae12e1ec39e6d75c9c47e27eff7f96418984da4a))
+* renaming frontmatter tags adds # ([223d9f5](https://github.com/dendronhq/dendron/commit/223d9f50430569b440e45567ffc71a7fff81f96f))
+* skip delayed decoration update if note is closed ([2d91164](https://github.com/dendronhq/dendron/commit/2d9116489b2d1f4d5ccd6d22c022af2da9984817))
+* undefined tags breaks note serialization ([b1d784c](https://github.com/dendronhq/dendron/commit/b1d784c8df18b3b45999f01c14793436ff669a3f))
+* uninstall hook force flush ([#1087](https://github.com/dendronhq/dendron/issues/1087)) ([386aac2](https://github.com/dendronhq/dendron/commit/386aac2b8036cd58c190da99609cef2d3ed2467f))
+
+
+### Features Dendron
+
+* add journal title override to NoteLookupCommand ([#1140](https://github.com/dendronhq/dendron/issues/1140)) ([173b0c9](https://github.com/dendronhq/dendron/commit/173b0c95d7ca9593e72e2cd1c39e4fdcf31fa64a))
+* **calendar:** enable webui by default ([#1127](https://github.com/dendronhq/dendron/issues/1127)) ([3ce8be0](https://github.com/dendronhq/dendron/commit/3ce8be05f50c0fef784eef1b6d02e4816e1bf44a))
+* add remaining modifiers to NoteLookup ([#1056](https://github.com/dendronhq/dendron/issues/1056)) ([49c6005](https://github.com/dendronhq/dendron/commit/49c6005d2a2c8fd422eb653977e926084e743d6a)), closes [#1045](https://github.com/dendronhq/dendron/issues/1045) [#1046](https://github.com/dendronhq/dendron/issues/1046)
+* add schema suggestion to NoteLookupCommand ([#1113](https://github.com/dendronhq/dendron/issues/1113)) ([7dbd03f](https://github.com/dendronhq/dendron/commit/7dbd03f20586d5174c13a40ed50eecfd8b4c788d))
+* add schema templating feature to NoteLookupCommand ([#1118](https://github.com/dendronhq/dendron/issues/1118)) ([8a4cd2b](https://github.com/dendronhq/dendron/commit/8a4cd2b337521abcc25df61e145ef6868c50ea0f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* re-engage lapsed users with prompt ([#1086](https://github.com/dendronhq/dendron/issues/1086)) ([f4e6dc5](https://github.com/dendronhq/dendron/commit/f4e6dc563aafdfc0b46966e74d9b38920aee1207))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* render frontmatter tags in HTML ([86f798a](https://github.com/dendronhq/dendron/commit/86f798a3c72ca405922945b835119aa0e0b1c3d9))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package root

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "0.110.0"
+  "version": "0.110.1"
 }

--- a/packages/api-server/CHANGELOG.md
+++ b/packages/api-server/CHANGELOG.md
@@ -3,6 +3,169 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* **workspace:** workspace sync will maintain proper engine state ([#3233](https://github.com/dendronhq/dendron/issues/3233)) ([13f788c](https://github.com/dendronhq/dendron/commit/13f788cb9a46800edffe66dcac88062e33830a5c))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* highlighting breaks when there's too much text ([#2163](https://github.com/dendronhq/dendron/issues/2163)) ([9d9579c](https://github.com/dendronhq/dendron/commit/9d9579cdab773131a5c8e0b1d6e130262d6a8164))
+* **server:** specify localhost when starting server ([c57972a](https://github.com/dendronhq/dendron/commit/c57972a4afe3ea5ce98c464ba6a46fc173a7d514))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **server:** improving error response on api server ([#1645](https://github.com/dendronhq/dendron/issues/1645)) ([8936fb6](https://github.com/dendronhq/dendron/commit/8936fb690045022487fb46aafd661581b60deab1))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/api-server

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/api-server",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
-    "@dendronhq/unified": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
+    "@dendronhq/unified": "^0.110.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "cors": "^2.8.5",

--- a/packages/common-all/CHANGELOG.md
+++ b/packages/common-all/CHANGELOG.md
@@ -3,6 +3,453 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **schema:** correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub ([#3388](https://github.com/dendronhq/dendron/issues/3388)) ([3a9634e](https://github.com/dendronhq/dendron/commit/3a9634edc7fcd01f1e571822f9146d2754f7ba5d))
+* **workspace:** case insensitive tree view sorting ([#3420](https://github.com/dendronhq/dendron/issues/3420)) ([90f72b6](https://github.com/dendronhq/dendron/commit/90f72b648095d75dbb94504b87e50ceb6b237676))
+* **workspace:** noisy warnings in engine startup ([#3452](https://github.com/dendronhq/dendron/issues/3452)) ([e535afb](https://github.com/dendronhq/dendron/commit/e535afb2eee4c15b25da357085609b0c06428d35))
+* validate file name on note lookup ([#3312](https://github.com/dendronhq/dendron/issues/3312)) ([ec7b53c](https://github.com/dendronhq/dendron/commit/ec7b53cdb9b3b09a388363cf8dfaa81bcdf686fc))
+
+
+### Features Dendron
+
+* **publishing:** Enable Giscus widgets in published notes ([#3469](https://github.com/dendronhq/dendron/issues/3469)) ([d5072d3](https://github.com/dendronhq/dendron/commit/d5072d3b6bfee96e24df1e002fc886bbd50af805))
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+* **views:** UI to configure `dendron.yml` ([#3211](https://github.com/dendronhq/dendron/issues/3211)) ([0d9b606](https://github.com/dendronhq/dendron/commit/0d9b606be8fcc04679dfbbe2f0054f74e6a626d7))
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+* **workspace:** tree view in web ext ([#3386](https://github.com/dendronhq/dendron/issues/3386)) ([b75a448](https://github.com/dendronhq/dendron/commit/b75a448aabc6918cead8ae14779ace83aa2a6ae5))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Bug Fixes
+
+* resolve PR comments ([81b22cd](https://github.com/dendronhq/dendron/commit/81b22cdabd6d95e6a827ce9b4d8dc5312e4d6e85))
+
+
+### Features Dendron
+
+* **view:** add "Toggle PreviewLock"  command ([#3293](https://github.com/dendronhq/dendron/issues/3293)) ([368c938](https://github.com/dendronhq/dendron/commit/368c9389b23d5200b84928121a7157fe764df9b6)), closes [#2437](https://github.com/dendronhq/dendron/issues/2437)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **workspace:** remote vault not recognized by dendron for windows ([4fb2cf8](https://github.com/dendronhq/dendron/commit/4fb2cf878f09da0ac4432c75b01db00d558c142f))
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* **retrieve:** bad parsing of xvault wikilink with space ([#3180](https://github.com/dendronhq/dendron/issues/3180)) ([8fa340c](https://github.com/dendronhq/dendron/commit/8fa340c6eb11a3d21b61e5ac349db358aa48318c))
+* **workspace:** proper handling of invalid data for write note ops ([#3137](https://github.com/dendronhq/dendron/issues/3137)) ([c6c7588](https://github.com/dendronhq/dendron/commit/c6c75881bec46bf701647b9d6b799e4de566edb7))
+* **workspace:** workspace sync will maintain proper engine state ([#3233](https://github.com/dendronhq/dendron/issues/3233)) ([13f788c](https://github.com/dendronhq/dendron/commit/13f788cb9a46800edffe66dcac88062e33830a5c))
+
+
+### Features Dendron
+
+* **workspace:** smart note refs ([#3174](https://github.com/dendronhq/dendron/issues/3174)) ([c0a6c60](https://github.com/dendronhq/dendron/commit/c0a6c6064193b3730fc0320d3c6d310434952561))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* address PR comments ([c4ba612](https://github.com/dendronhq/dendron/commit/c4ba612a07fcdef1a98a86d245edab00e31ffc76))
+* **workspace:** try to patch `EPERM` issues for windows ([17dd870](https://github.com/dendronhq/dendron/commit/17dd870cf6aa85bc01e97998de4be15c44d182f3))
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Features Dendron
+
+* **views:** Recent Workspaces Panel ([#3052](https://github.com/dendronhq/dendron/issues/3052)) ([5e52529](https://github.com/dendronhq/dendron/commit/5e525295ca0d1118782affdfb68c34e939b479c9))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **navigate:** Backlink Panel with Hover ([#2904](https://github.com/dendronhq/dendron/issues/2904)) ([55c7fcd](https://github.com/dendronhq/dendron/commit/55c7fcdcd1135145b5385176e9bbdd18951f6d00))
+* **notes:** Auto generate template/schema for daily journal ([37a2484](https://github.com/dendronhq/dendron/commit/37a24842a41a4bc134f612cef503a6901547b981))
+* **publish:** ability to exclude children in dendron side nav ([#2962](https://github.com/dendronhq/dendron/issues/2962)) ([f45029d](https://github.com/dendronhq/dendron/commit/f45029d808aaec457c606ad753f4fe9634958ad5))
+* **views:** Preview setting for light, dark, or custom themes ([294bf1e](https://github.com/dendronhq/dendron/commit/294bf1e18646cd74e6d656fd12964506d77a1a5c))
+* **views:** Preview uses your VSCode theme colors, and supports custom themes ([c14c6f0](https://github.com/dendronhq/dendron/commit/c14c6f0703eab185de280c4a7bc3f4cecd2bdb4c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Bug Fixes
+
+* configure enableHierarchyDisplay and hierarchyDisplayTitle ([bd11d92](https://github.com/dendronhq/dendron/commit/bd11d9259132f29184099a2cad6e745477c91783))
+
+
+### Features Dendron
+
+* **markdown:** handlebar based templates ([#2954](https://github.com/dendronhq/dendron/issues/2954)) ([2af114a](https://github.com/dendronhq/dendron/commit/2af114afc85711f4ec4af26281e9235dcc33a062))
+* **views:** display task note status when linking to task notes in publishing and in preview ([dbc16ff](https://github.com/dendronhq/dendron/commit/dbc16ffdd1a66cff9252b3d88e2e2d44bf59a060))
+* local graph view in the Dendron Side Panel ([#2901](https://github.com/dendronhq/dendron/issues/2901)) ([195a61a](https://github.com/dendronhq/dendron/commit/195a61ae7ed7158d97c1161aacc5d08a08d660e9))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Features Dendron
+
+* allow customization of tree view label / sorting to preserve old tree view behavior ([#2858](https://github.com/dendronhq/dendron/issues/2858)) ([987c802](https://github.com/dendronhq/dendron/commit/987c8021970de6c75f96a6d94e0df500b23eca0d))
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Features Dendron
+
+* **chore:** germ stage implementation of config overrides ([#2794](https://github.com/dendronhq/dendron/issues/2794)) ([c3692ef](https://github.com/dendronhq/dendron/commit/c3692ef5073ab2454ee117d3ad72cb2af257e4be))
+* Add doctor command to remove deprecated config and prompt on upgrade ([#2841](https://github.com/dendronhq/dendron/issues/2841)) ([2cc71e0](https://github.com/dendronhq/dendron/commit/2cc71e0796c4cebc32817b2b930cf7b0a324485f))
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+### Bug Fixes
+
+* insert note index `#undefined` in case missing tags ([#2789](https://github.com/dendronhq/dendron/issues/2789)) ([e025fd2](https://github.com/dendronhq/dendron/commit/e025fd2a31fd2743e4163ef589a526467584eefe))
+
+
+### Features Dendron
+
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([158ed1d](https://github.com/dendronhq/dendron/commit/158ed1d748448c611146900915c6299a0730bbf9))
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([0f89993](https://github.com/dendronhq/dendron/commit/0f899934e5e5eeacb7b2dd5643dbdb4e4caff267))
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **view:** broken preview for links with sub-hierarchy starting with .md ([#2781](https://github.com/dendronhq/dendron/issues/2781)) ([7eefd3a](https://github.com/dendronhq/dendron/commit/7eefd3ad776c76575c40503feaf5d704f97123da))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* first pass of treeview v1 sync issue ([#2757](https://github.com/dendronhq/dendron/issues/2757)) ([f8f80ca](https://github.com/dendronhq/dendron/commit/f8f80cacb8b661b06df0d57b955b7e4529272a66))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([97abfae](https://github.com/dendronhq/dendron/commit/97abfae86fc95df513219efca346e938f253ff71))
+* **view:** support custom styles for Note Graph ([#2760](https://github.com/dendronhq/dendron/issues/2760)) ([6d99e62](https://github.com/dendronhq/dendron/commit/6d99e6265078119239c461c0fa78be90d44039af))
+* tree item sort order in treeview v1 to be on par with v2 in preparation for v2 deprecation ([#2665](https://github.com/dendronhq/dendron/issues/2665)) ([657a8ac](https://github.com/dendronhq/dendron/commit/657a8ac8f842506bdff97c80f00aba0880ab1cbc))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+* **workspace:** Fix issue with updated timestamp not updating properly on save ([#2651](https://github.com/dendronhq/dendron/issues/2651)) ([c8e75ff](https://github.com/dendronhq/dendron/commit/c8e75ff348e0ab0b88a094c1dd71824b66fdec8c))
+* **workspace:** preserve wikilink metadata on export ([#2676](https://github.com/dendronhq/dendron/issues/2676)) ([553a954](https://github.com/dendronhq/dendron/commit/553a954bccdf5a8f574b2908f17ccd25fe61cb65))
+
+
+### Features Dendron
+
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([8ea1d1b](https://github.com/dendronhq/dendron/commit/8ea1d1b8e6247fec3e636c26da3f98e047026a6b))
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([f87ca99](https://github.com/dendronhq/dendron/commit/f87ca996dc31588b42e35fa8613d95c2aaf49b2a))
+* detect and fill missing default configs to reliably introduce newly added configurations on extension upgrade ([#2602](https://github.com/dendronhq/dendron/issues/2602)) ([4f31fce](https://github.com/dendronhq/dendron/commit/4f31fce3da8d04d981e05a151040ddd28edfba29))
+* option to gen title using full hierarchy ([1c6e4a7](https://github.com/dendronhq/dendron/commit/1c6e4a76cb9689e759ea87f5dc50485abf0c18b2))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* consolidating button type enums ([c3c56bd](https://github.com/dendronhq/dendron/commit/c3c56bd23cc1b970126eb55ed96b397b9d5a2061))
+* typo in dendron.yml ([#2636](https://github.com/dendronhq/dendron/issues/2636)) ([faefa36](https://github.com/dendronhq/dendron/commit/faefa3608092cc6f3e89e7224f0d51f635e03cdd))
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+* Backlinks will no longer disappear in preview upon editing ([#2608](https://github.com/dendronhq/dendron/issues/2608)) ([1ee16f9](https://github.com/dendronhq/dendron/commit/1ee16f9540173b2ec7558d0d120428e2d093d649))
+* **internal:** Engine updateNote not properly firing update events ([#2622](https://github.com/dendronhq/dendron/issues/2622)) ([97f0911](https://github.com/dendronhq/dendron/commit/97f091136c0d7606150631ab3be4d9eeb99aa4aa))
+* **workspace:** race condition when backing up configuration  ([#2581](https://github.com/dendronhq/dendron/issues/2581)) ([efd3bb8](https://github.com/dendronhq/dendron/commit/efd3bb8880b963b912fbcc6bcd0c0595b4083273))
+
+
+### Features Dendron
+
+* add doctor command for a more reliable keybinding resolution ([#2578](https://github.com/dendronhq/dendron/issues/2578)) ([4737aa5](https://github.com/dendronhq/dendron/commit/4737aa5dda198e51728496a1243f7ad45f2450f0))
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* **vaults:** Use exact match when getting vault by dir path ([#2501](https://github.com/dendronhq/dendron/issues/2501)) ([99db974](https://github.com/dendronhq/dendron/commit/99db974a1fa47bb27c8ff5ca424b1fc495030235))
+* **views:** md parsing and preview perf improvements ([#2505](https://github.com/dendronhq/dendron/issues/2505)) ([282951f](https://github.com/dendronhq/dendron/commit/282951fbee192e97064595659fa31773249b6aa6))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([81c6586](https://github.com/dendronhq/dendron/commit/81c6586c49f2ea22f6036b0bd1d05bf6a642c051)), closes [#2429](https://github.com/dendronhq/dendron/issues/2429)
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([d1057e5](https://github.com/dendronhq/dendron/commit/d1057e5948b742bed7b2a378f3db2f43cd2a91d6))
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([f0143e3](https://github.com/dendronhq/dendron/commit/f0143e3a0001dba9f775a4c50b2b87615b8f4a5f))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* fixing journal title date formatting support ([5da910a](https://github.com/dendronhq/dendron/commit/5da910a4fac6c1bbef6515f88b44cd63507a823b))
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+* **workspace:** correct title generartion of notes with sub-hierarchy starting with md ([#2369](https://github.com/dendronhq/dendron/issues/2369)) ([562f2bd](https://github.com/dendronhq/dendron/commit/562f2bda3e7059408c6c5d46c7e4dfae463d49d0))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* cursor moves to top when opening file through the search ([cd5004e](https://github.com/dendronhq/dendron/commit/cd5004ec2fff3529ab05d58e000365903566b2ae))
+* publishing pages fail ([#2199](https://github.com/dendronhq/dendron/issues/2199)) ([cfffd6a](https://github.com/dendronhq/dendron/commit/cfffd6a1988c372f7472bb2cd93126befd866a0d))
+* **analytics:** inactive survey issues ([#2110](https://github.com/dendronhq/dendron/issues/2110)) ([36a3b2f](https://github.com/dendronhq/dendron/commit/36a3b2f6f69e1637c111503ce9455bf370558845))
+* **lookup:** full length word matches should be case insensitive ([#1990](https://github.com/dendronhq/dendron/issues/1990)) ([03deb56](https://github.com/dendronhq/dendron/commit/03deb5699c81627b64350e7fdb7a0634810af3f4))
+* **publish:** logo doesn't respect assetsPrefix ([#2189](https://github.com/dendronhq/dendron/issues/2189)) ([763c797](https://github.com/dendronhq/dendron/commit/763c797c4c2f7821ef747376c980e4a4b0eace8e))
+* **refactor:** refactor crashes when captured note is a stub ([#1910](https://github.com/dendronhq/dendron/issues/1910)) ([24cf219](https://github.com/dendronhq/dendron/commit/24cf219d267ba63b0f9c140f19173898bece75b3))
+* **schema:** Use string replace instead of lodash for date variable substitution ([75a6111](https://github.com/dendronhq/dendron/commit/75a6111ab322139ab504cc769010510a0e972069))
+* add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score. ([3192d77](https://github.com/dendronhq/dendron/commit/3192d773588e9f1817eabbbb78e68042c201d213))
+* highlighting breaks when there's too much text ([#2163](https://github.com/dendronhq/dendron/issues/2163)) ([9d9579c](https://github.com/dendronhq/dendron/commit/9d9579cdab773131a5c8e0b1d6e130262d6a8164))
+* **schema:** Ensure month/day/time has two digits when doing data variable substitution ([#2064](https://github.com/dendronhq/dendron/issues/2064)) ([20f807e](https://github.com/dendronhq/dendron/commit/20f807e3f1be3ba082a01dda527fa653cf30b433))
+* warn for frontmatter issues even if the frontmatter is not visible ([bfe027e](https://github.com/dendronhq/dendron/commit/bfe027eb40ef1cdc7b214a6ff8ab3b1e6b32d453))
+* **workspace:** autocomplete deletes text following wikilink with no closing brackets ([#1909](https://github.com/dendronhq/dendron/issues/1909)) ([8fd0ef8](https://github.com/dendronhq/dendron/commit/8fd0ef8cd7710b8e6f5e74261d24c606e3c38f13)), closes [#1834](https://github.com/dendronhq/dendron/issues/1834)
+
+
+### Features Dendron
+
+* lookup view ([#1977](https://github.com/dendronhq/dendron/issues/1977)) ([dad85f6](https://github.com/dendronhq/dendron/commit/dad85f6e1964b5cf21bc0a1007c229c504e17eb5))
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+* **navigation:** non-note file enhancements ([#1895](https://github.com/dendronhq/dendron/issues/1895)) ([90e083b](https://github.com/dendronhq/dendron/commit/90e083b5e10073acbc8967ad9649c0008aae381c))
+* **notes:** Note Trait System Prototype (Phase 1) ([#1658](https://github.com/dendronhq/dendron/issues/1658)) ([0d5d187](https://github.com/dendronhq/dendron/commit/0d5d187a9aaaaebfc32fa9c7c5b5faa5c3b38eb3))
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+* **refactoring:** add rename provider ([#1879](https://github.com/dendronhq/dendron/issues/1879)) ([988e18b](https://github.com/dendronhq/dendron/commit/988e18b8e03cb952898cb1cba9caf998b2e994f5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **views:** tree view not initializing on load ([5590a3c](https://github.com/dendronhq/dendron/commit/5590a3c0aa7476e8984a1e9193697d9984ab00ee))
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **note:** correctly handle note titles containing international characters ([#1801](https://github.com/dendronhq/dendron/issues/1801)) ([03b05f4](https://github.com/dendronhq/dendron/commit/03b05f4aa7887577365059f5bb22d8c3585afe40))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **schema:** When applying a schema template, do not override the body but append to the end to it ([#1812](https://github.com/dendronhq/dendron/issues/1812)) ([0a48123](https://github.com/dendronhq/dendron/commit/0a481230c29aee08493937772f1f4d57be511615))
+* allow assets to open from preview view ([#1771](https://github.com/dendronhq/dendron/issues/1771)) ([f362bda](https://github.com/dendronhq/dendron/commit/f362bda9726c9dde2c96aa1954aa549c1f013136))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+
+
+### Features Dendron
+
+* decorator improvements ([#1770](https://github.com/dendronhq/dendron/issues/1770)) ([a7227fd](https://github.com/dendronhq/dendron/commit/a7227fd4d8991e44729989c821a22560dcb8348b))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* **publish:** bad seo props setter ([373d933](https://github.com/dendronhq/dendron/commit/373d9331aba3b3385632f01661dd6c80835ec5ac))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+
+
+### Features Dendron
+
+* consolidate dendron configs ([#1295](https://github.com/dendronhq/dendron/issues/1295)) ([177ac92](https://github.com/dendronhq/dendron/commit/177ac925a5442471f041ce5d991da52cecee6c9b))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* properly log error stack ([485e220](https://github.com/dendronhq/dendron/commit/485e220f8ffa6cd63210e106e846ff305b920b77))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* undefined tags breaks note serialization ([b1d784c](https://github.com/dendronhq/dendron/commit/b1d784c8df18b3b45999f01c14793436ff669a3f))
+
+
+### Features Dendron
+
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/common-all

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-all",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "common-all",
   "license": "GPLv3",
   "repository": {

--- a/packages/common-assets/CHANGELOG.md
+++ b/packages/common-assets/CHANGELOG.md
@@ -3,6 +3,127 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **views:** show whitespace for links in headers ([#3403](https://github.com/dendronhq/dendron/issues/3403)) ([5b37aaa](https://github.com/dendronhq/dendron/commit/5b37aaa3c6c6346e87fb86dac606eb0e37a7e740))
+
+
+### Features Dendron
+
+* **views:** UI to configure `dendron.yml` ([#3211](https://github.com/dendronhq/dendron/issues/3211)) ([0d9b606](https://github.com/dendronhq/dendron/commit/0d9b606be8fcc04679dfbbe2f0054f74e6a626d7))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* address PR comment ([8ce91e9](https://github.com/dendronhq/dendron/commit/8ce91e90acd34139d5a69bd0a994c1f5bd04af73))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* fix ci build error ([b8684ce](https://github.com/dendronhq/dendron/commit/b8684ce52598c9717f711ee7c8b204fa4dd53bef))
+* removed public from common assets ([923d6ad](https://github.com/dendronhq/dendron/commit/923d6ad5d4852f08ef7d4505c7c54fc11df35ff4))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/common-assets

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-assets",
   "private": true,
-  "version": "0.110.0",
+  "version": "0.110.1",
   "main": "index.js",
   "license": "GPLv3",
   "scripts": {

--- a/packages/common-frontend/CHANGELOG.md
+++ b/packages/common-frontend/CHANGELOG.md
@@ -3,6 +3,241 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Features Dendron
+
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Features Dendron
+
+* **view:** add "Toggle PreviewLock"  command ([#3293](https://github.com/dendronhq/dendron/issues/3293)) ([368c938](https://github.com/dendronhq/dendron/commit/368c9389b23d5200b84928121a7157fe764df9b6)), closes [#2437](https://github.com/dendronhq/dendron/issues/2437)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **publish:** renders consitent layout on mobile and non-mobile ([#3272](https://github.com/dendronhq/dendron/issues/3272)) ([eeeef9e](https://github.com/dendronhq/dendron/commit/eeeef9e0ae645e1191beda2610ca157df21f8c9f)), closes [#2175](https://github.com/dendronhq/dendron/issues/2175) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [#2175](https://github.com/dendronhq/dendron/issues/2175)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **view:** views don't update for new notes with self contained vaults ([#2790](https://github.com/dendronhq/dendron/issues/2790)) ([eac9b53](https://github.com/dendronhq/dendron/commit/eac9b53b5da3c9336b09c317caf56d800aacf4cc))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+* ensure note title is always a string to avoid errors ([#2551](https://github.com/dendronhq/dendron/issues/2551)) ([5d93bd1](https://github.com/dendronhq/dendron/commit/5d93bd16b0bdeb9d29323b659f154bdf0b2dfec9)), closes [#2329](https://github.com/dendronhq/dendron/issues/2329)
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **publish:** properly render mermaid and katex when published ([#2480](https://github.com/dendronhq/dendron/issues/2480)) ([2524589](https://github.com/dendronhq/dendron/commit/2524589cbf016dff694bcc308dbf1ec1b7390570))
+* faster webviews by reducing engine sync operations ([#2472](https://github.com/dendronhq/dendron/issues/2472)) ([a34a3b0](https://github.com/dendronhq/dendron/commit/a34a3b024411b1c2097b330938ceb9c3fe8c401e))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **views:** update tree order when a note changes order ([#2014](https://github.com/dendronhq/dendron/issues/2014)) ([b66032f](https://github.com/dendronhq/dendron/commit/b66032fef1b8cb5f7a6fa522a5e0ad14ac4d8388))
+
+
+### Features Dendron
+
+* lookup view ([#1977](https://github.com/dendronhq/dendron/issues/1977)) ([dad85f6](https://github.com/dendronhq/dendron/commit/dad85f6e1964b5cf21bc0a1007c229c504e17eb5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** enable katex on published site ([7189cd8](https://github.com/dendronhq/dendron/commit/7189cd840e12d7aadf6f78b9e3281180bca903af))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **views:** tree view not initializing on load ([5590a3c](https://github.com/dendronhq/dendron/commit/5590a3c0aa7476e8984a1e9193697d9984ab00ee))
+* **views:** update web uis on note creation ([55a7ecd](https://github.com/dendronhq/dendron/commit/55a7ecd787461062f969804ef44b287af1cd05f5)), closes [/github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md#L103](https://github.com//github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md/issues/L103)
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+### Features Dendron
+
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Features Dendron
+
+* colored tags in tree view & tags at bottom ([#1119](https://github.com/dendronhq/dendron/issues/1119)) ([2577e01](https://github.com/dendronhq/dendron/commit/2577e0189e3ba0d813823bc4d81a340d91db440d))
+* **calendar-view:** allow journal settings deviating from defaults ([#1088](https://github.com/dendronhq/dendron/issues/1088)) ([74ce384](https://github.com/dendronhq/dendron/commit/74ce384f1b833abf68d3b145cbed55fe02fa8e1f))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/common-frontend

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-frontend",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "common-frontend",
   "license": "GPLv3",
   "repository": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
-    "@dendronhq/common-all": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
     "@reduxjs/toolkit": "^1.5.1",
     "antd": "^4.15.4",
     "lodash": "^4.17.20",

--- a/packages/common-server/CHANGELOG.md
+++ b/packages/common-server/CHANGELOG.md
@@ -3,6 +3,250 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **edit:** prevent override of already existing frontmatter values when executing Apply Template ([#3407](https://github.com/dendronhq/dendron/issues/3407)) ([c3c6901](https://github.com/dendronhq/dendron/commit/c3c6901d1d3f7b99b7bd632aebeaaac5b881cf0f))
+
+
+### Features Dendron
+
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Bug Fixes
+
+* nested bullets in preview ([#3326](https://github.com/dendronhq/dendron/issues/3326)) ([a312edc](https://github.com/dendronhq/dendron/commit/a312edc7a602d99bf78e2ba1a0af73c79e0924f5))
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Features Dendron
+
+* **edit): support note references on beginning of a doc && fix(edit:** template gets applied twice if user undoes initial template  ([#3186](https://github.com/dendronhq/dendron/issues/3186)) ([88c7c5c](https://github.com/dendronhq/dendron/commit/88c7c5c85e470bdefaeaf371c60e2e950f25d16e))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* **views:** bullet points missing in new theme-matching style ([#3023](https://github.com/dendronhq/dendron/issues/3023)) ([ab674d2](https://github.com/dendronhq/dendron/commit/ab674d2a8fc59da8ebfbf64ae88d918c5fb11c41))
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **edit:** template helpers ([#3029](https://github.com/dendronhq/dendron/issues/3029)) ([6881c97](https://github.com/dendronhq/dendron/commit/6881c97a6de3def469ac663b69289bb045a03502))
+* **views:** Preview setting for light, dark, or custom themes ([294bf1e](https://github.com/dendronhq/dendron/commit/294bf1e18646cd74e6d656fd12964506d77a1a5c))
+* **views:** Preview uses your VSCode theme colors, and supports custom themes ([c14c6f0](https://github.com/dendronhq/dendron/commit/c14c6f0703eab185de280c4a7bc3f4cecd2bdb4c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* self contained vaults get cloned into the wrong directory ([#2873](https://github.com/dendronhq/dendron/issues/2873)) ([9c7ac1c](https://github.com/dendronhq/dendron/commit/9c7ac1cfff4fb07bc689b42ea04677df5d2a927b))
+
+
+### Features Dendron
+
+* add goto command ([#2852](https://github.com/dendronhq/dendron/issues/2852)) ([3586707](https://github.com/dendronhq/dendron/commit/3586707bd3e7ffd352797308ed8e9c0e31b6f3ef)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843) [#2845](https://github.com/dendronhq/dendron/issues/2845) [#2843](https://github.com/dendronhq/dendron/issues/2843)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **views:** second pass of treeview v1 sync issue ([#2805](https://github.com/dendronhq/dendron/issues/2805)) ([64e0970](https://github.com/dendronhq/dendron/commit/64e0970382d11694bb52f65a50f4c7de8fdd0a0c))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* **view:** apply current theme when vscode reduce motion setting is on ([#2749](https://github.com/dendronhq/dendron/issues/2749)) ([15c3f05](https://github.com/dendronhq/dendron/commit/15c3f050e6ebecb1aeaf34da5b01ac9917ae6e1e))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **preview:** Code blocks and spans in preview are html encoded ([#2471](https://github.com/dendronhq/dendron/issues/2471)) ([4a29e46](https://github.com/dendronhq/dendron/commit/4a29e4678b55b13ecf43d57044a919ca105d1a90)), closes [#2301](https://github.com/dendronhq/dendron/issues/2301)
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **workspace:** Dendron will try to parse non-dendron files in `onFirstOpen` ([#2405](https://github.com/dendronhq/dendron/issues/2405)) ([d913a7f](https://github.com/dendronhq/dendron/commit/d913a7fe6e251f5e45925c591310ddd6e1031274))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* for handling diamond shape schema relationships ([ca2d5af](https://github.com/dendronhq/dendron/commit/ca2d5af94acbf62885e0230f0ef28f384395b6f8))
+* **views:** enable copy plaintext from preview ([#2152](https://github.com/dendronhq/dendron/issues/2152)) ([a54b63b](https://github.com/dendronhq/dendron/commit/a54b63bb0c66b8e4dc31dbe5c9c51835b4fd4ec9))
+
+
+### Features Dendron
+
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+* **navigation:** non-note file enhancements ([#1895](https://github.com/dendronhq/dendron/issues/1895)) ([90e083b](https://github.com/dendronhq/dendron/commit/90e083b5e10073acbc8967ad9649c0008aae381c))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* ajv warning messages printed to console ([#1722](https://github.com/dendronhq/dendron/issues/1722)) ([1aae27b](https://github.com/dendronhq/dendron/commit/1aae27bb0924f649af131ca7664da3f914044c31))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+
+
+### Features Dendron
+
+* decorator improvements ([#1770](https://github.com/dendronhq/dendron/issues/1770)) ([a7227fd](https://github.com/dendronhq/dendron/commit/a7227fd4d8991e44729989c821a22560dcb8348b))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/common-server

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-server",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "common-server",
   "license": "GPLv3",
   "repository": {
@@ -35,7 +35,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "ajv": "^8.6.0",

--- a/packages/common-test-utils/CHANGELOG.md
+++ b/packages/common-test-utils/CHANGELOG.md
@@ -3,6 +3,209 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Features Dendron
+
+* allow customization of tree view label / sorting to preserve old tree view behavior ([#2858](https://github.com/dendronhq/dendron/issues/2858)) ([987c802](https://github.com/dendronhq/dendron/commit/987c8021970de6c75f96a6d94e0df500b23eca0d))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Features Dendron
+
+* add goto command ([#2852](https://github.com/dendronhq/dendron/issues/2852)) ([3586707](https://github.com/dendronhq/dendron/commit/3586707bd3e7ffd352797308ed8e9c0e31b6f3ef)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843) [#2845](https://github.com/dendronhq/dendron/issues/2845) [#2843](https://github.com/dendronhq/dendron/issues/2843)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* tree item sort order in treeview v1 to be on par with v2 in preparation for v2 deprecation ([#2665](https://github.com/dendronhq/dendron/issues/2665)) ([657a8ac](https://github.com/dendronhq/dendron/commit/657a8ac8f842506bdff97c80f00aba0880ab1cbc))
+* **workspace:** preserve wikilink metadata on export ([#2676](https://github.com/dendronhq/dendron/issues/2676)) ([553a954](https://github.com/dendronhq/dendron/commit/553a954bccdf5a8f574b2908f17ccd25fe61cb65))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([9b48b9c](https://github.com/dendronhq/dendron/commit/9b48b9c652b38f7d78d51cdeb0d585f87f14b016))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **schema:** Use string replace instead of lodash for date variable substitution ([75a6111](https://github.com/dendronhq/dendron/commit/75a6111ab322139ab504cc769010510a0e972069))
+
+
+### Features Dendron
+
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* allow assets to open from preview view ([#1771](https://github.com/dendronhq/dendron/issues/1771)) ([f362bda](https://github.com/dendronhq/dendron/commit/f362bda9726c9dde2c96aa1954aa549c1f013136))
+* corner cases for auto complete ([#1843](https://github.com/dendronhq/dendron/issues/1843)) ([d6c51f3](https://github.com/dendronhq/dendron/commit/d6c51f3fd352412d9a763af8f60f34a2c0ebabda))
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+
+
+### Features Dendron
+
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/common-test-utils

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-test-utils",
   "private": true,
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/pods-core": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/pods-core": "^0.110.1",
     "@types/sinon": "^9.0.9",
     "fs-extra": "^9.0.1",
     "jest": "^28.1.0",

--- a/packages/dendron-cli/CHANGELOG.md
+++ b/packages/dendron-cli/CHANGELOG.md
@@ -3,6 +3,272 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Features Dendron
+
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+### Bug Fixes
+
+* **cli:** dendron publish --help to display full list of arguments ([#3127](https://github.com/dendronhq/dendron/issues/3127)) ([0707c16](https://github.com/dendronhq/dendron/commit/0707c167920ed16dfd7fe05c79403a02c0b511de))
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* adding existing remote vault creates workspace files in the vault ([6d43936](https://github.com/dendronhq/dendron/commit/6d439369d8e75150cc1ba582f337a6fded402a7b))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* SegmentClient crashes all CLI commands ([af02445](https://github.com/dendronhq/dendron/commit/af02445b387cb39ec6f0810afc1234a6e94ac85c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* CLI writes "cli" as the version into the meta file which breaks initialization ([#2871](https://github.com/dendronhq/dendron/issues/2871)) ([273df5c](https://github.com/dendronhq/dendron/commit/273df5cd756b1451d5bab19f808cd425c097c6b6))
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Features Dendron
+
+* **cli:** Add rename functionality to CLI ([#2408](https://github.com/dendronhq/dendron/issues/2408)) ([03a96f8](https://github.com/dendronhq/dendron/commit/03a96f88799d7e7850186af06f7a31acac7ee3f7))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* add omitted migration entries ([#2519](https://github.com/dendronhq/dendron/issues/2519)) ([ae6ef64](https://github.com/dendronhq/dendron/commit/ae6ef64cb61b3aa4c229c77da5b94362e09d363d))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **publish:** properly render mermaid and katex when published ([#2480](https://github.com/dendronhq/dendron/issues/2480)) ([2524589](https://github.com/dendronhq/dendron/commit/2524589cbf016dff694bcc308dbf1ec1b7390570))
+* resolved PR comments ([6b9c70c](https://github.com/dendronhq/dendron/commit/6b9c70c1ae24a1841c9400b193d8e1fb092ec692))
+* resolved PR comments ([53ca31e](https://github.com/dendronhq/dendron/commit/53ca31e954c1bf4e9aea9b6ff5dcf143a86a9e19))
+* **pods:** refreshToken to read correct dendron port file ([53734ab](https://github.com/dendronhq/dendron/commit/53734ab46dbd75a34974939fe1d47734b118de44))
+
+
+### Features Dendron
+
+* pods v2 cli ([2e2bf8e](https://github.com/dendronhq/dendron/commit/2e2bf8e5e1189ed3e48e2e4e822c6fedf72142aa))
+
+
+### Reverts
+
+* remove source in import pod ([05a3084](https://github.com/dendronhq/dendron/commit/05a30842734d5745374577b9b025eb20439814d7))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **pod:** acknowledge cli args for publish pod ([#2352](https://github.com/dendronhq/dendron/issues/2352)) ([b5d1f15](https://github.com/dendronhq/dendron/commit/b5d1f157a2db15711099666a7e09abd08cbccdb9))
+* **publish:** skip adding asset prefix to images with web url ([#2362](https://github.com/dendronhq/dendron/issues/2362)) ([11cf84c](https://github.com/dendronhq/dendron/commit/11cf84c61db4b83934048c7f8a46fbb969132816))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **cli:** using `--noBuild` with export from CLI will cause command to hang ([#2109](https://github.com/dendronhq/dendron/issues/2109)) ([2a0f184](https://github.com/dendronhq/dendron/commit/2a0f184a3358312f34a3f3e879738e3a2c295421))
+* Publishing dev server keeps running after exiting on Windows ([#2035](https://github.com/dendronhq/dendron/issues/2035)) ([134bcb3](https://github.com/dendronhq/dendron/commit/134bcb3b38c5a2136507d68660d85dd77f5f9791))
+* **docs:** Replaced instances of 'spwan' with 'spawn'. ([#1792](https://github.com/dendronhq/dendron/issues/1792)) ([6b0b609](https://github.com/dendronhq/dendron/commit/6b0b6096fef3e36daa0b81121cedd83fe5fd0a91))
+
+
+### Features Dendron
+
+* **commands:** find broken links ([#1847](https://github.com/dendronhq/dendron/issues/1847)) ([0f23a79](https://github.com/dendronhq/dendron/commit/0f23a79e5473afa2afb1c5c0e274e2bd3f134554))
+* **notes:** Note Trait System Prototype (Phase 1) ([#1658](https://github.com/dendronhq/dendron/issues/1658)) ([0d5d187](https://github.com/dendronhq/dendron/commit/0d5d187a9aaaaebfc32fa9c7c5b5faa5c3b38eb3))
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* cli migration now handles JSONC for wsConfig ([#1825](https://github.com/dendronhq/dendron/issues/1825)) ([fd88d06](https://github.com/dendronhq/dendron/commit/fd88d06266a8aa73e5f7ba9402b7b31984b22f69))
+* **cli:** workspace info prints message to CLI ([6d512e2](https://github.com/dendronhq/dendron/commit/6d512e21f2542515b802a188fcf5edc75e21f8fd))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* **publish:** remove .next dir if it exists in publish init ([#1548](https://github.com/dendronhq/dendron/issues/1548)) ([3ffd87a](https://github.com/dendronhq/dendron/commit/3ffd87a606d2251991319e81ba7292989dac427f))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+
+
+### Features Dendron
+
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** add force close timeout ([ebbe51f](https://github.com/dendronhq/dendron/commit/ebbe51f0aad37e5ecf4b319405e6c719f1e14dc5))
+* **publish:** dangling connection when publishing via 11ty using github action ([c08117d](https://github.com/dendronhq/dendron/commit/c08117dd41fe250b6aa9f29f1b61879a7f9b56ce))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* issue with webpack devCLI ([a4ff4c9](https://github.com/dendronhq/dendron/commit/a4ff4c9ae28ff31ab6f9483c339ae78b5144e185))
+
+
+### Features Dendron
+
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+
+
+### Features Dendron
+
+* generate json schema from config ([#1100](https://github.com/dendronhq/dendron/issues/1100)) ([53b189e](https://github.com/dendronhq/dendron/commit/53b189ec973a8d3d3ccf300a0e59908197f4efb1))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/dendron-cli

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-cli",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "dendron-cli",
   "license": "GPLv3",
   "repository": {
@@ -41,12 +41,12 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.110.0",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/dendron-viz": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
-    "@dendronhq/pods-core": "^0.110.0",
+    "@dendronhq/api-server": "^0.110.1",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/dendron-viz": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
+    "@dendronhq/pods-core": "^0.110.1",
     "@jcoreio/async-throttle": "^1.3.2",
     "@types/prompts": "^2.0.14",
     "clipboardy": "2.3.0",

--- a/packages/dendron-plugin-views/CHANGELOG.md
+++ b/packages/dendron-plugin-views/CHANGELOG.md
@@ -3,6 +3,193 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **views:** remove semicolon from preview ([#3383](https://github.com/dendronhq/dendron/issues/3383)) ([8156279](https://github.com/dendronhq/dendron/commit/8156279594d8652286db3dc38ce75b390f09cbdd))
+* **views:** resolve issues with preview lock button ([#3353](https://github.com/dendronhq/dendron/issues/3353)) ([5847284](https://github.com/dendronhq/dendron/commit/5847284cc1b38fa788d38c16410ef319d94747a0))
+
+
+### Features Dendron
+
+* **views:** UI to configure `dendron.yml` ([#3211](https://github.com/dendronhq/dendron/issues/3211)) ([0d9b606](https://github.com/dendronhq/dendron/commit/0d9b606be8fcc04679dfbbe2f0054f74e6a626d7))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Features Dendron
+
+* **view:** add "Toggle PreviewLock"  command ([#3293](https://github.com/dendronhq/dendron/issues/3293)) ([368c938](https://github.com/dendronhq/dendron/commit/368c9389b23d5200b84928121a7157fe764df9b6)), closes [#2437](https://github.com/dendronhq/dendron/issues/2437)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* address PR comments ([c4ba612](https://github.com/dendronhq/dendron/commit/c4ba612a07fcdef1a98a86d245edab00e31ffc76))
+* separate hierarchichal and linked notes ([8b25a72](https://github.com/dendronhq/dendron/commit/8b25a7277f4c580c638fa11f1d625f8a40d0ab02))
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* address PR comment ([8ce91e9](https://github.com/dendronhq/dendron/commit/8ce91e90acd34139d5a69bd0a994c1f5bd04af73))
+* address PR comment and performance improvements ([62c2514](https://github.com/dendronhq/dendron/commit/62c25145bac45ed1954a45b22ed0e5cea1acd913))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Features Dendron
+
+* local graph view in the Dendron Side Panel ([#2901](https://github.com/dendronhq/dendron/issues/2901)) ([195a61a](https://github.com/dendronhq/dendron/commit/195a61ae7ed7158d97c1161aacc5d08a08d660e9))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **view:** views don't update for new notes with self contained vaults ([#2790](https://github.com/dendronhq/dendron/issues/2790)) ([eac9b53](https://github.com/dendronhq/dendron/commit/eac9b53b5da3c9336b09c317caf56d800aacf4cc))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* **view:** support custom styles for Note Graph ([#2760](https://github.com/dendronhq/dendron/issues/2760)) ([6d99e62](https://github.com/dendronhq/dendron/commit/6d99e6265078119239c461c0fa78be90d44039af))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **retrieve:** issue with angle brackets syntax in mermaid  ([#2637](https://github.com/dendronhq/dendron/issues/2637)) ([0457f75](https://github.com/dendronhq/dendron/commit/0457f7521da53844cb1019c0a517f1ef959c04fa))
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* **views:** fix race condition in tree view v2 initialization logic ([#2528](https://github.com/dendronhq/dendron/issues/2528)) ([c85a821](https://github.com/dendronhq/dendron/commit/c85a821a02bbe2669b6c0d7df10a6475a7526654))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* faster webviews by reducing engine sync operations ([#2472](https://github.com/dendronhq/dendron/issues/2472)) ([a34a3b0](https://github.com/dendronhq/dendron/commit/a34a3b024411b1c2097b330938ceb9c3fe8c401e))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **views:** update tree order when a note changes order ([#2014](https://github.com/dendronhq/dendron/issues/2014)) ([b66032f](https://github.com/dendronhq/dendron/commit/b66032fef1b8cb5f7a6fa522a5e0ad14ac4d8388))
+
+
+### Features Dendron
+
+* lookup view ([#1977](https://github.com/dendronhq/dendron/issues/1977)) ([dad85f6](https://github.com/dendronhq/dendron/commit/dad85f6e1964b5cf21bc0a1007c229c504e17eb5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **views:** tree view not initializing on load ([5590a3c](https://github.com/dendronhq/dendron/commit/5590a3c0aa7476e8984a1e9193697d9984ab00ee))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/dendron-plugin-views

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-plugin-views",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "private": true,
   "workspaces": {
     "nohoist": [
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-frontend": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-frontend": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/dendron-viz/CHANGELOG.md
+++ b/packages/dendron-viz/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/dendron-viz

--- a/packages/dendron-viz/package.json
+++ b/packages/dendron-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-viz",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "dendron-viz",
   "license": "GPLv3",
   "repository": {
@@ -32,8 +32,8 @@
     "watch": "yarn copyNonTSFiles && yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
     "d3": "^7.0.0",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.4",

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -3,6 +3,489 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **workspace:** correctly decorate begin and end anchors ([#3339](https://github.com/dendronhq/dendron/issues/3339)) ([fb1425c](https://github.com/dendronhq/dendron/commit/fb1425c62888f778733323c86a4a120dcb78224e))
+* **workspace:** noisy warnings in engine startup ([#3452](https://github.com/dendronhq/dendron/issues/3452)) ([e535afb](https://github.com/dendronhq/dendron/commit/e535afb2eee4c15b25da357085609b0c06428d35))
+* **workspace:** sqlite store properly update from cache when encountering existing notes ([#3451](https://github.com/dendronhq/dendron/issues/3451)) ([6d73898](https://github.com/dendronhq/dendron/commit/6d7389872b21b6be3988f8692f6855be116b468c))
+
+
+### Features Dendron
+
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+* **refactor:** merge note command ([#3349](https://github.com/dendronhq/dendron/issues/3349)) ([41d6189](https://github.com/dendronhq/dendron/commit/41d6189371aa7e40bd3faff55623787802a9aa8b))
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+* **workspace:** tree view in web ext ([#3386](https://github.com/dendronhq/dendron/issues/3386)) ([b75a448](https://github.com/dendronhq/dendron/commit/b75a448aabc6918cead8ae14779ace83aa2a6ae5))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **workspace:** List dendron.dendron-markdown-preview-enhanced as unwanted ([#3281](https://github.com/dendronhq/dendron/issues/3281)) ([182e835](https://github.com/dendronhq/dendron/commit/182e83510574230e3c7a72650c388b3ce6058557))
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* **workspace:** workspace sync will maintain proper engine state ([#3233](https://github.com/dendronhq/dendron/issues/3233)) ([13f788c](https://github.com/dendronhq/dendron/commit/13f788cb9a46800edffe66dcac88062e33830a5c))
+* update bad frontmatter waning range ([f339803](https://github.com/dendronhq/dendron/commit/f3398035ab5ebecf870f57c48547c61c34fca4f3))
+* **retrieve:** bad parsing of xvault wikilink with space ([#3180](https://github.com/dendronhq/dendron/issues/3180)) ([8fa340c](https://github.com/dendronhq/dendron/commit/8fa340c6eb11a3d21b61e5ac349db358aa48318c))
+* **workspace:** proper handling of invalid data for write note ops ([#3137](https://github.com/dendronhq/dendron/issues/3137)) ([c6c7588](https://github.com/dendronhq/dendron/commit/c6c75881bec46bf701647b9d6b799e4de566edb7))
+* regression where publishing fails if note doesn't exist ([#3178](https://github.com/dendronhq/dendron/issues/3178)) ([36c894f](https://github.com/dendronhq/dendron/commit/36c894f3ea691ec08a9cabe4df24b1c67239b511))
+* **workspace:** removing vault with a name different than their `fsPath` doesn't remove them from `duplicateNoteBehavior` ([d0cb52f](https://github.com/dendronhq/dendron/commit/d0cb52f00f318f6dd1f30d0533a55115e42d8a71))
+
+
+### Features Dendron
+
+* **edit): support note references on beginning of a doc && fix(edit:** template gets applied twice if user undoes initial template  ([#3186](https://github.com/dendronhq/dendron/issues/3186)) ([88c7c5c](https://github.com/dendronhq/dendron/commit/88c7c5c85e470bdefaeaf371c60e2e950f25d16e))
+* **workspace:** smart note refs ([#3174](https://github.com/dendronhq/dendron/issues/3174)) ([c0a6c60](https://github.com/dendronhq/dendron/commit/c0a6c6064193b3730fc0320d3c6d310434952561))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Bug Fixes
+
+* **structure:** hot reload in note traits + no template by default ([3904655](https://github.com/dendronhq/dendron/commit/390465552a6744495387aea6f49fa5392fb69b03))
+* **structure:** hot reload in note traits + no template by default ([#3154](https://github.com/dendronhq/dendron/issues/3154)) ([bcadd48](https://github.com/dendronhq/dendron/commit/bcadd487c706379f0384a6f3a8c728d606a2bba8))
+* **workspace:** duplicate note behavior is not updated when self contained vault is removed ([d69f02c](https://github.com/dendronhq/dendron/commit/d69f02c0857b4fc594ee8e3f494bd1e5465be2e8))
+* **workspace:** Sync fails in shared workspaces if users update workspace config first before syncing migrated vaults ([969b83c](https://github.com/dendronhq/dendron/commit/969b83c598401251fa7ff69e62586a6b7627d0c1))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([01be85f](https://github.com/dendronhq/dendron/commit/01be85f84ae6cdf182f2d43b9561decac44369e6))
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([decaccd](https://github.com/dendronhq/dendron/commit/decaccdc0af6072197405273e82750d8702d2262))
+* **publish:** issue publishing note with ref without a `code-worksapce` file ([#3114](https://github.com/dendronhq/dendron/issues/3114)) ([5a03d8f](https://github.com/dendronhq/dendron/commit/5a03d8fdaa289d7b5a7a79f85cad1da5de58c2ba))
+* address PR comments ([c4ba612](https://github.com/dendronhq/dendron/commit/c4ba612a07fcdef1a98a86d245edab00e31ffc76))
+* **workspace:** try to patch `EPERM` issues for windows ([17dd870](https://github.com/dendronhq/dendron/commit/17dd870cf6aa85bc01e97998de4be15c44d182f3))
+* adding existing remote vault creates workspace files in the vault ([6d43936](https://github.com/dendronhq/dendron/commit/6d439369d8e75150cc1ba582f337a6fded402a7b))
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* **edit:** email addresses and hash symbols inside words are parsed as tags ([5579820](https://github.com/dendronhq/dendron/commit/5579820701816095cc5bb882373cef2f69898927))
+* **workspace:** Migrate to Self Contained Vault causes EBUSY errors on Windows ([8ed95f3](https://github.com/dendronhq/dendron/commit/8ed95f3e1597204860b0a0789e733eda76838df7))
+* email addresses are parsed as tags ([e85fb83](https://github.com/dendronhq/dendron/commit/e85fb83bf1ae07ae89eaf1e464fb5ccef4cb5cb9))
+
+
+### Features Dendron
+
+* **views:** Recent Workspaces Panel ([#3052](https://github.com/dendronhq/dendron/issues/3052)) ([5e52529](https://github.com/dendronhq/dendron/commit/5e525295ca0d1118782affdfb68c34e939b479c9))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([1bc7493](https://github.com/dendronhq/dendron/commit/1bc7493a76c8c2fcb58ef4ba5ef569675fca2a1d))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([4fa37a1](https://github.com/dendronhq/dendron/commit/4fa37a12423ae93215c765b27f5cd6f6c4ce698d))
+* Images with encoded URI are not rendered in the Preview ([#3006](https://github.com/dendronhq/dendron/issues/3006)) ([e2172be](https://github.com/dendronhq/dendron/commit/e2172be363e2a3311c238c5fc841f5e498f66851))
+* **publish:** assetsPrefix breaks images ([bc611d2](https://github.com/dendronhq/dendron/commit/bc611d2d42b46eef80a945bbd2360b82e7e52af5))
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **navigate:** Backlink Panel with Hover ([#2904](https://github.com/dendronhq/dendron/issues/2904)) ([55c7fcd](https://github.com/dendronhq/dendron/commit/55c7fcdcd1135145b5385176e9bbdd18951f6d00))
+* **notes:** Auto generate template/schema for daily journal ([37a2484](https://github.com/dendronhq/dendron/commit/37a24842a41a4bc134f612cef503a6901547b981))
+* **sync:** Obsidian Import Flow ([#3014](https://github.com/dendronhq/dendron/issues/3014)) ([669b200](https://github.com/dendronhq/dendron/commit/669b200509c7a3d1f339da62ecbca769974fb3fd))
+* **views:** Preview uses your VSCode theme colors, and supports custom themes ([c14c6f0](https://github.com/dendronhq/dendron/commit/c14c6f0703eab185de280c4a7bc3f4cecd2bdb4c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Bug Fixes
+
+* **publish:** assetsPrefix breaks images ([e1e3000](https://github.com/dendronhq/dendron/commit/e1e300090cb734acea1f963722d3056a0fa18812))
+* block anchor after table crashes preview ([c3eb688](https://github.com/dendronhq/dendron/commit/c3eb68811f63be909ca89fcfa87ff4f27d2a9db6))
+* configure enableHierarchyDisplay and hierarchyDisplayTitle ([bd11d92](https://github.com/dendronhq/dendron/commit/bd11d9259132f29184099a2cad6e745477c91783))
+* doctor removeStubs resulting in 'no data' prompt ([#2944](https://github.com/dendronhq/dendron/issues/2944)) ([5d1c7b3](https://github.com/dendronhq/dendron/commit/5d1c7b33728a7af8739446a3e024b6d8f08eaf3e))
+
+
+### Features Dendron
+
+* **views:** display task note status when linking to task notes in publishing and in preview ([dbc16ff](https://github.com/dendronhq/dendron/commit/dbc16ffdd1a66cff9252b3d88e2e2d44bf59a060))
+* **workspace:** Add a command to migrate regular vaults into self contained vaults ([9710511](https://github.com/dendronhq/dendron/commit/9710511a2f2a040be3f10d820da8cc562a54d738))
+* local graph view in the Dendron Side Panel ([#2901](https://github.com/dendronhq/dendron/issues/2901)) ([195a61a](https://github.com/dendronhq/dendron/commit/195a61ae7ed7158d97c1161aacc5d08a08d660e9))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+### Bug Fixes
+
+* block anchor after table crashes preview ([92812c3](https://github.com/dendronhq/dendron/commit/92812c3b946a2e881792d69d36932a782b2208d4))
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Features Dendron
+
+* allow customization of tree view label / sorting to preserve old tree view behavior ([#2858](https://github.com/dendronhq/dendron/issues/2858)) ([987c802](https://github.com/dendronhq/dendron/commit/987c8021970de6c75f96a6d94e0df500b23eca0d))
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* highlighting misidentified capitalized header anchors on links as missing ([#2872](https://github.com/dendronhq/dendron/issues/2872)) ([92ded23](https://github.com/dendronhq/dendron/commit/92ded230eccec02947cb33221288591f2064866c)), closes [#2862](https://github.com/dendronhq/dendron/issues/2862)
+* self contained vaults get cloned into the wrong directory ([#2873](https://github.com/dendronhq/dendron/issues/2873)) ([9c7ac1c](https://github.com/dendronhq/dendron/commit/9c7ac1cfff4fb07bc689b42ea04677df5d2a927b))
+
+
+### Features Dendron
+
+* **chore:** germ stage implementation of config overrides ([#2794](https://github.com/dendronhq/dendron/issues/2794)) ([c3692ef](https://github.com/dendronhq/dendron/commit/c3692ef5073ab2454ee117d3ad72cb2af257e4be))
+* Add doctor command to remove deprecated config and prompt on upgrade ([#2841](https://github.com/dendronhq/dendron/issues/2841)) ([2cc71e0](https://github.com/dendronhq/dendron/commit/2cc71e0796c4cebc32817b2b930cf7b0a324485f))
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+### Features Dendron
+
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([158ed1d](https://github.com/dendronhq/dendron/commit/158ed1d748448c611146900915c6299a0730bbf9))
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([0f89993](https://github.com/dendronhq/dendron/commit/0f899934e5e5eeacb7b2dd5643dbdb4e4caff267))
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **view:** views don't update for new notes with self contained vaults ([#2790](https://github.com/dendronhq/dendron/issues/2790)) ([eac9b53](https://github.com/dendronhq/dendron/commit/eac9b53b5da3c9336b09c317caf56d800aacf4cc))
+* **views:** second pass of treeview v1 sync issue ([#2805](https://github.com/dendronhq/dendron/issues/2805)) ([64e0970](https://github.com/dendronhq/dendron/commit/64e0970382d11694bb52f65a50f4c7de8fdd0a0c))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* first pass of treeview v1 sync issue ([#2757](https://github.com/dendronhq/dendron/issues/2757)) ([f8f80ca](https://github.com/dendronhq/dendron/commit/f8f80cacb8b661b06df0d57b955b7e4529272a66))
+* self contained vaults sync ([#2758](https://github.com/dendronhq/dendron/issues/2758)) ([ebb4658](https://github.com/dendronhq/dendron/commit/ebb46587ca0728e25bf69b5d94058d3cc3c2446c))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([88aea8a](https://github.com/dendronhq/dendron/commit/88aea8a829af91671be93a7d266fc098d2ca5951))
+* error when adding a self contained vault inside a native workspace ([#2660](https://github.com/dendronhq/dendron/issues/2660)) ([f2a9449](https://github.com/dendronhq/dendron/commit/f2a94491463396d0cce30dc7376898644622b908))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+
+
+### Features Dendron
+
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([8ea1d1b](https://github.com/dendronhq/dendron/commit/8ea1d1b8e6247fec3e636c26da3f98e047026a6b))
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([f87ca99](https://github.com/dendronhq/dendron/commit/f87ca996dc31588b42e35fa8613d95c2aaf49b2a))
+* detect and fill missing default configs to reliably introduce newly added configurations on extension upgrade ([#2602](https://github.com/dendronhq/dendron/issues/2602)) ([4f31fce](https://github.com/dendronhq/dendron/commit/4f31fce3da8d04d981e05a151040ddd28edfba29))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* Backlinks will no longer disappear in preview upon editing ([#2608](https://github.com/dendronhq/dendron/issues/2608)) ([1ee16f9](https://github.com/dendronhq/dendron/commit/1ee16f9540173b2ec7558d0d120428e2d093d649))
+* **internal:** Engine updateNote not properly firing update events ([#2622](https://github.com/dendronhq/dendron/issues/2622)) ([97f0911](https://github.com/dendronhq/dendron/commit/97f091136c0d7606150631ab3be4d9eeb99aa4aa))
+* **markdown:** support parenthesis in the image URL ([#2634](https://github.com/dendronhq/dendron/issues/2634)) ([b05907d](https://github.com/dendronhq/dendron/commit/b05907d94aa1fecf0edcac61ad119d5ecd820736))
+* **views:** unblock preview rendering when backlink is invalid ([#2586](https://github.com/dendronhq/dendron/issues/2586)) ([fe893b9](https://github.com/dendronhq/dendron/commit/fe893b9b3d827811b743cfb93afef6363470760b))
+* block anchors showing up in the preview ([#2548](https://github.com/dendronhq/dendron/issues/2548)) ([44802b8](https://github.com/dendronhq/dendron/commit/44802b8a37ed38b94fbc22692a4c1f21ee83963f)), closes [#2531](https://github.com/dendronhq/dendron/issues/2531)
+* Re-enable inactive user survey and store prompt status in filesystem for prompt reliability. ([#2555](https://github.com/dendronhq/dendron/issues/2555)) ([3a4269f](https://github.com/dendronhq/dendron/commit/3a4269f4b5669f45eb257377abfcde7aad9e7bf4))
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+* **workspace:** race condition when backing up configuration  ([#2581](https://github.com/dendronhq/dendron/issues/2581)) ([efd3bb8](https://github.com/dendronhq/dendron/commit/efd3bb8880b963b912fbcc6bcd0c0595b4083273))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* add omitted migration entries ([#2519](https://github.com/dendronhq/dendron/issues/2519)) ([ae6ef64](https://github.com/dendronhq/dendron/commit/ae6ef64cb61b3aa4c229c77da5b94362e09d363d))
+* **views:** md parsing and preview perf improvements ([#2505](https://github.com/dendronhq/dendron/issues/2505)) ([282951f](https://github.com/dendronhq/dendron/commit/282951fbee192e97064595659fa31773249b6aa6))
+* remove comment ([00edd5a](https://github.com/dendronhq/dendron/commit/00edd5aa7a9d50776299f3db9fa0563f7823579c))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **pods:** md export v2 to acknowledge wikiLinkToURL for links inside noteRefs ([32f5ae6](https://github.com/dendronhq/dendron/commit/32f5ae61eccd80195eb8e32700c4f48dc516b54b))
+* **publish:** properly render mermaid and katex when published ([#2480](https://github.com/dendronhq/dendron/issues/2480)) ([2524589](https://github.com/dendronhq/dendron/commit/2524589cbf016dff694bcc308dbf1ec1b7390570))
+* **publish:** Table of Contents is missing user tags, inline code, dashes and underline ([#2465](https://github.com/dendronhq/dendron/issues/2465)) ([79c6d9e](https://github.com/dendronhq/dendron/commit/79c6d9e801e5cec78acf0212fc8e4c1134e6f5d2)), closes [#2456](https://github.com/dendronhq/dendron/issues/2456)
+* properly set siteIndex when it's not explicitly set by config ([#2443](https://github.com/dendronhq/dendron/issues/2443)) ([43b4c3b](https://github.com/dendronhq/dendron/commit/43b4c3b8634f311ff14dc05b7dab9bc65c605b57))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **publish:** skip adding asset prefix to images with web url ([#2362](https://github.com/dendronhq/dendron/issues/2362)) ([11cf84c](https://github.com/dendronhq/dendron/commit/11cf84c61db4b83934048c7f8a46fbb969132816))
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+* **workspace:** avoid workspace watcher crashing if folder is deleted ([#2359](https://github.com/dendronhq/dendron/issues/2359)) ([9d0325f](https://github.com/dendronhq/dendron/commit/9d0325fc9d220a95d48a04716a5678dae0bebe79))
+* **workspace:** Dendron will try to parse non-dendron files in `onFirstOpen` ([#2405](https://github.com/dendronhq/dendron/issues/2405)) ([d913a7f](https://github.com/dendronhq/dendron/commit/d913a7fe6e251f5e45925c591310ddd6e1031274))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **markdown:** Exclude parenthesis from tags ([#2182](https://github.com/dendronhq/dendron/issues/2182)) ([04fe9f8](https://github.com/dendronhq/dendron/commit/04fe9f896000e1254403d1ead49d209a9fda7b95))
+* **workspace:** stop link candidate logic when disabled ([#2136](https://github.com/dendronhq/dendron/issues/2136)) ([110941c](https://github.com/dendronhq/dendron/commit/110941cd268aaca43bc99a07d5670c52271aa95c))
+* add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score. ([3192d77](https://github.com/dendronhq/dendron/commit/3192d773588e9f1817eabbbb78e68042c201d213))
+* correctly offset frontmatter line count in doctor preview for `findBrokenLinks` ([#1959](https://github.com/dendronhq/dendron/issues/1959)) ([21255b3](https://github.com/dendronhq/dendron/commit/21255b30f3310e2cd897cfafc4764d04d553bd22))
+* rename operations modify unnecessary files ([83d0469](https://github.com/dendronhq/dendron/commit/83d04699656160f01634375782c1f26f9a8b67be)), closes [#2015](https://github.com/dendronhq/dendron/issues/2015)
+* test updates ([fb066b2](https://github.com/dendronhq/dendron/commit/fb066b2277a8620b62385281235359ad5ccde874))
+* **workspace:** don't show calendar view unless dendron tree view is active ([#2017](https://github.com/dendronhq/dendron/issues/2017)) ([5132e83](https://github.com/dendronhq/dendron/commit/5132e8309d2b66585aed50983bf431b221c16c0d))
+* rename operations modify unnecessary files ([1330785](https://github.com/dendronhq/dendron/commit/1330785011d57150d18728fa7a14f7a58a6ca7fb))
+* warn for frontmatter issues even if the frontmatter is not visible ([bfe027e](https://github.com/dendronhq/dendron/commit/bfe027eb40ef1cdc7b214a6ff8ab3b1e6b32d453))
+* **markdown:** lag in the editor when there's a x-vault link to a non-existent vault ([#1941](https://github.com/dendronhq/dendron/issues/1941)) ([0ae4325](https://github.com/dendronhq/dendron/commit/0ae43256c0d81683ec8c92bff66f69ed97e04102))
+* **note:** frontmatter tags are not highlighted ([#2001](https://github.com/dendronhq/dendron/issues/2001)) ([5eae3b7](https://github.com/dendronhq/dendron/commit/5eae3b7ae1efa8f4c0c790c6d30bf8f55617d7a7))
+* **workspace:** simplify InitializeWorkspace command ([#1886](https://github.com/dendronhq/dendron/issues/1886)) ([27f4c53](https://github.com/dendronhq/dendron/commit/27f4c53f34ee89700df3d53b31b016f393cdf282))
+
+
+### Features Dendron
+
+* open preview buttons for context menus ([#1906](https://github.com/dendronhq/dendron/issues/1906)) ([8b9160c](https://github.com/dendronhq/dendron/commit/8b9160c250cad2465dbfb77c785ab022b31cd88b))
+* **commands:** find broken links ([#1847](https://github.com/dendronhq/dendron/issues/1847)) ([0f23a79](https://github.com/dendronhq/dendron/commit/0f23a79e5473afa2afb1c5c0e274e2bd3f134554))
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+* **navigation:** non-note file enhancements ([#1895](https://github.com/dendronhq/dendron/issues/1895)) ([90e083b](https://github.com/dendronhq/dendron/commit/90e083b5e10073acbc8967ad9649c0008aae381c))
+* **notes:** Note Trait System Prototype (Phase 1) ([#1658](https://github.com/dendronhq/dendron/issues/1658)) ([0d5d187](https://github.com/dendronhq/dendron/commit/0d5d187a9aaaaebfc32fa9c7c5b5faa5c3b38eb3))
+* **refactor:** convert link command ([#1933](https://github.com/dendronhq/dendron/issues/1933)) ([e4cba18](https://github.com/dendronhq/dendron/commit/e4cba184382f7d8c1d2a6820e85305e1191a54c2))
+* **refactoring:** add rename provider ([#1879](https://github.com/dendronhq/dendron/issues/1879)) ([988e18b](https://github.com/dendronhq/dendron/commit/988e18b8e03cb952898cb1cba9caf998b2e994f5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** verbose logging when building notes ([136cbec](https://github.com/dendronhq/dendron/commit/136cbec7c10d6c42b79ecce0f21955d546ba1f9e))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* **workspace:** remove trailing whitespace in note ([#1736](https://github.com/dendronhq/dendron/issues/1736)) ([d1f0117](https://github.com/dendronhq/dendron/commit/d1f01177390e206fe75f235caa7ef10eebe43732))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* handle undefined and null properties of old command configs in migration ([#1508](https://github.com/dendronhq/dendron/issues/1508)) ([6782b54](https://github.com/dendronhq/dendron/commit/6782b54231e30c6fc6298f1c3a826469dd6548ec))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+
+
+### Features Dendron
+
+* decorator improvements ([#1770](https://github.com/dendronhq/dendron/issues/1770)) ([a7227fd](https://github.com/dendronhq/dendron/commit/a7227fd4d8991e44729989c821a22560dcb8348b))
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+### Reverts
+
+* Revert "fix: add workspace root to workspace folders for Code Workspaces" ([09b3ad5](https://github.com/dendronhq/dendron/commit/09b3ad58fb3c872acfa7a71c64e7e9c9b27a8ded))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+
+
+### Features Dendron
+
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** regression with hover preview ([5e8079a](https://github.com/dendronhq/dendron/commit/5e8079a9532d0dbc395ea9a7aaab640b6212b368))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* workspace fix ([4f4bfab](https://github.com/dendronhq/dendron/commit/4f4bfab336862b43da226aa75db9f446e60ba1a2))
+
+
+### Features Dendron
+
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+* patch `getOrCreate` to inherit from default values ([#1126](https://github.com/dendronhq/dendron/issues/1126)) ([512b476](https://github.com/dendronhq/dendron/commit/512b476e8ac986887f25bc9a21bf7b189ea19ce9))
+* renaming frontmatter tags adds # ([223d9f5](https://github.com/dendronhq/dendron/commit/223d9f50430569b440e45567ffc71a7fff81f96f))
+
+
+### Features Dendron
+
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* render frontmatter tags in HTML ([86f798a](https://github.com/dendronhq/dendron/commit/86f798a3c72ca405922945b835119aa0e0b1c3d9))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/engine-server

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/engine-server",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "dendron-engine",
   "license": "GPLv3",
   "repository": {
@@ -35,10 +35,10 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
     "@dendronhq/remark-mermaid": "^0.3.0",
-    "@dendronhq/unified": "^0.110.0",
+    "@dendronhq/unified": "^0.110.1",
     "@jcoreio/async-throttle": "^1.4.3",
     "@mapbox/rehype-prism": "^0.5.0",
     "@prisma/client": "^4.1.1",

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -3,6 +3,435 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **schema:** correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub ([#3388](https://github.com/dendronhq/dendron/issues/3388)) ([3a9634e](https://github.com/dendronhq/dendron/commit/3a9634edc7fcd01f1e571822f9146d2754f7ba5d))
+
+
+### Features Dendron
+
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* **retrieve:** bad parsing of xvault wikilink with space ([#3180](https://github.com/dendronhq/dendron/issues/3180)) ([8fa340c](https://github.com/dendronhq/dendron/commit/8fa340c6eb11a3d21b61e5ac349db358aa48318c))
+* **workspace:** proper handling of invalid data for write note ops ([#3137](https://github.com/dendronhq/dendron/issues/3137)) ([c6c7588](https://github.com/dendronhq/dendron/commit/c6c75881bec46bf701647b9d6b799e4de566edb7))
+* **workspace:** removing vault with a name different than their `fsPath` doesn't remove them from `duplicateNoteBehavior` ([d0cb52f](https://github.com/dendronhq/dendron/commit/d0cb52f00f318f6dd1f30d0533a55115e42d8a71))
+
+
+### Features Dendron
+
+* **edit): support note references on beginning of a doc && fix(edit:** template gets applied twice if user undoes initial template  ([#3186](https://github.com/dendronhq/dendron/issues/3186)) ([88c7c5c](https://github.com/dendronhq/dendron/commit/88c7c5c85e470bdefaeaf371c60e2e950f25d16e))
+* **workspace:** smart note refs ([#3174](https://github.com/dendronhq/dendron/issues/3174)) ([c0a6c60](https://github.com/dendronhq/dendron/commit/c0a6c6064193b3730fc0320d3c6d310434952561))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Bug Fixes
+
+* **workspace:** Sync fails in shared workspaces if users update workspace config first before syncing migrated vaults ([969b83c](https://github.com/dendronhq/dendron/commit/969b83c598401251fa7ff69e62586a6b7627d0c1))
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* **edit:** email addresses and hash symbols inside words are parsed as tags ([5579820](https://github.com/dendronhq/dendron/commit/5579820701816095cc5bb882373cef2f69898927))
+* email addresses are parsed as tags ([e85fb83](https://github.com/dendronhq/dendron/commit/e85fb83bf1ae07ae89eaf1e464fb5ccef4cb5cb9))
+
+
+### Features Dendron
+
+* **views:** Recent Workspaces Panel ([#3052](https://github.com/dendronhq/dendron/issues/3052)) ([5e52529](https://github.com/dendronhq/dendron/commit/5e525295ca0d1118782affdfb68c34e939b479c9))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([1bc7493](https://github.com/dendronhq/dendron/commit/1bc7493a76c8c2fcb58ef4ba5ef569675fca2a1d))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([4fa37a1](https://github.com/dendronhq/dendron/commit/4fa37a12423ae93215c765b27f5cd6f6c4ce698d))
+* update snapshots ([bdb37f7](https://github.com/dendronhq/dendron/commit/bdb37f7f2c33f4d0af6c1f71622364e75c268a30))
+* **publish:** assetsPrefix breaks images ([bc611d2](https://github.com/dendronhq/dendron/commit/bc611d2d42b46eef80a945bbd2360b82e7e52af5))
+* **publish:** Export gets stuck if `logoPath` is set but the logo doesn't exist ([4d8453b](https://github.com/dendronhq/dendron/commit/4d8453bc1c764dbf1d25e1bc932865159a4fd575))
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **edit:** template helpers ([#3029](https://github.com/dendronhq/dendron/issues/3029)) ([6881c97](https://github.com/dendronhq/dendron/commit/6881c97a6de3def469ac663b69289bb045a03502))
+* **navigate:** Backlink Panel with Hover ([#2904](https://github.com/dendronhq/dendron/issues/2904)) ([55c7fcd](https://github.com/dendronhq/dendron/commit/55c7fcdcd1135145b5385176e9bbdd18951f6d00))
+* **publish:** ability to exclude children in dendron side nav ([#2962](https://github.com/dendronhq/dendron/issues/2962)) ([f45029d](https://github.com/dendronhq/dendron/commit/f45029d808aaec457c606ad753f4fe9634958ad5))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Bug Fixes
+
+* **publish:** assetsPrefix breaks images ([e1e3000](https://github.com/dendronhq/dendron/commit/e1e300090cb734acea1f963722d3056a0fa18812))
+* **publish:** Export gets stuck if `logoPath` is set but the logo doesn't exist ([f820de2](https://github.com/dendronhq/dendron/commit/f820de2d2b116194b5874a90fcf35d1d317ff5d3))
+* block anchor after table crashes preview ([c3eb688](https://github.com/dendronhq/dendron/commit/c3eb68811f63be909ca89fcfa87ff4f27d2a9db6))
+* configure enableHierarchyDisplay and hierarchyDisplayTitle ([bd11d92](https://github.com/dendronhq/dendron/commit/bd11d9259132f29184099a2cad6e745477c91783))
+
+
+### Features Dendron
+
+* **markdown:** handlebar based templates ([#2954](https://github.com/dendronhq/dendron/issues/2954)) ([2af114a](https://github.com/dendronhq/dendron/commit/2af114afc85711f4ec4af26281e9235dcc33a062))
+* **views:** display task note status when linking to task notes in publishing and in preview ([dbc16ff](https://github.com/dendronhq/dendron/commit/dbc16ffdd1a66cff9252b3d88e2e2d44bf59a060))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+### Bug Fixes
+
+* block anchor after table crashes preview ([92812c3](https://github.com/dendronhq/dendron/commit/92812c3b946a2e881792d69d36932a782b2208d4))
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* self contained vaults get cloned into the wrong directory ([#2873](https://github.com/dendronhq/dendron/issues/2873)) ([9c7ac1c](https://github.com/dendronhq/dendron/commit/9c7ac1cfff4fb07bc689b42ea04677df5d2a927b))
+
+
+### Features Dendron
+
+* **chore:** germ stage implementation of config overrides ([#2794](https://github.com/dendronhq/dendron/issues/2794)) ([c3692ef](https://github.com/dendronhq/dendron/commit/c3692ef5073ab2454ee117d3ad72cb2af257e4be))
+* Add doctor command to remove deprecated config and prompt on upgrade ([#2841](https://github.com/dendronhq/dendron/issues/2841)) ([2cc71e0](https://github.com/dendronhq/dendron/commit/2cc71e0796c4cebc32817b2b930cf7b0a324485f))
+* add goto command ([#2852](https://github.com/dendronhq/dendron/issues/2852)) ([3586707](https://github.com/dendronhq/dendron/commit/3586707bd3e7ffd352797308ed8e9c0e31b6f3ef)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843) [#2845](https://github.com/dendronhq/dendron/issues/2845) [#2843](https://github.com/dendronhq/dendron/issues/2843)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* **views:** second pass of treeview v1 sync issue ([#2805](https://github.com/dendronhq/dendron/issues/2805)) ([64e0970](https://github.com/dendronhq/dendron/commit/64e0970382d11694bb52f65a50f4c7de8fdd0a0c))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* first pass of treeview v1 sync issue ([#2757](https://github.com/dendronhq/dendron/issues/2757)) ([f8f80ca](https://github.com/dendronhq/dendron/commit/f8f80cacb8b661b06df0d57b955b7e4529272a66))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+
+
+### Features Dendron
+
+* **cli:** Add rename functionality to CLI ([#2408](https://github.com/dendronhq/dendron/issues/2408)) ([03a96f8](https://github.com/dendronhq/dendron/commit/03a96f88799d7e7850186af06f7a31acac7ee3f7))
+* detect and fill missing default configs to reliably introduce newly added configurations on extension upgrade ([#2602](https://github.com/dendronhq/dendron/issues/2602)) ([4f31fce](https://github.com/dendronhq/dendron/commit/4f31fce3da8d04d981e05a151040ddd28edfba29))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **internal:** Engine updateNote not properly firing update events ([#2622](https://github.com/dendronhq/dendron/issues/2622)) ([97f0911](https://github.com/dendronhq/dendron/commit/97f091136c0d7606150631ab3be4d9eeb99aa4aa))
+* **markdown:** support parenthesis in the image URL ([#2634](https://github.com/dendronhq/dendron/issues/2634)) ([b05907d](https://github.com/dendronhq/dendron/commit/b05907d94aa1fecf0edcac61ad119d5ecd820736))
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+* **views:** unblock preview rendering when backlink is invalid ([#2586](https://github.com/dendronhq/dendron/issues/2586)) ([fe893b9](https://github.com/dendronhq/dendron/commit/fe893b9b3d827811b743cfb93afef6363470760b))
+* block anchors showing up in the preview ([#2548](https://github.com/dendronhq/dendron/issues/2548)) ([44802b8](https://github.com/dendronhq/dendron/commit/44802b8a37ed38b94fbc22692a4c1f21ee83963f)), closes [#2531](https://github.com/dendronhq/dendron/issues/2531)
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* **vaults:** Use exact match when getting vault by dir path ([#2501](https://github.com/dendronhq/dendron/issues/2501)) ([99db974](https://github.com/dendronhq/dendron/commit/99db974a1fa47bb27c8ff5ca424b1fc495030235))
+* resolved PR comments ([7364405](https://github.com/dendronhq/dendron/commit/73644054523ed349bd3ddc73e581ec687e805391))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **pods:** md export v2 to acknowledge wikiLinkToURL for links inside noteRefs ([32f5ae6](https://github.com/dendronhq/dendron/commit/32f5ae61eccd80195eb8e32700c4f48dc516b54b))
+* **publish:** Table of Contents is missing user tags, inline code, dashes and underline ([#2465](https://github.com/dendronhq/dendron/issues/2465)) ([79c6d9e](https://github.com/dendronhq/dendron/commit/79c6d9e801e5cec78acf0212fc8e4c1134e6f5d2)), closes [#2456](https://github.com/dendronhq/dendron/issues/2456)
+* properly set siteIndex when it's not explicitly set by config ([#2443](https://github.com/dendronhq/dendron/issues/2443)) ([43b4c3b](https://github.com/dendronhq/dendron/commit/43b4c3b8634f311ff14dc05b7dab9bc65c605b57))
+* resolved PR comments ([6b9c70c](https://github.com/dendronhq/dendron/commit/6b9c70c1ae24a1841c9400b193d8e1fb092ec692))
+* resolved PR comments ([53ca31e](https://github.com/dendronhq/dendron/commit/53ca31e954c1bf4e9aea9b6ff5dcf143a86a9e19))
+* update testcases ([6bc1d66](https://github.com/dendronhq/dendron/commit/6bc1d66e56ba31b3e51582010d9cdb236a5e8d73))
+
+
+### Reverts
+
+* remove source in import pod ([05a3084](https://github.com/dendronhq/dendron/commit/05a30842734d5745374577b9b025eb20439814d7))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **workspace:** Dendron will try to parse non-dendron files in `onFirstOpen` ([#2405](https://github.com/dendronhq/dendron/issues/2405)) ([d913a7f](https://github.com/dendronhq/dendron/commit/d913a7fe6e251f5e45925c591310ddd6e1031274))
+* fixing journal title date formatting support ([5da910a](https://github.com/dendronhq/dendron/commit/5da910a4fac6c1bbef6515f88b44cd63507a823b))
+* **pod:** markdown import to update asset references ([#2350](https://github.com/dendronhq/dendron/issues/2350)) ([c22a322](https://github.com/dendronhq/dendron/commit/c22a322ce904da4157260e06cc14ffd07728042d))
+* **publish:** skip adding asset prefix to images with web url ([#2362](https://github.com/dendronhq/dendron/issues/2362)) ([11cf84c](https://github.com/dendronhq/dendron/commit/11cf84c61db4b83934048c7f8a46fbb969132816))
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* for handling diamond shape schema relationships ([ca2d5af](https://github.com/dendronhq/dendron/commit/ca2d5af94acbf62885e0230f0ef28f384395b6f8))
+* **markdown:** Exclude parenthesis from tags ([#2182](https://github.com/dendronhq/dendron/issues/2182)) ([04fe9f8](https://github.com/dendronhq/dendron/commit/04fe9f896000e1254403d1ead49d209a9fda7b95))
+* **publish:** logo doesn't respect assetsPrefix ([#2189](https://github.com/dendronhq/dendron/issues/2189)) ([763c797](https://github.com/dendronhq/dendron/commit/763c797c4c2f7821ef747376c980e4a4b0eace8e))
+* **schema:** Use string replace instead of lodash for date variable substitution ([75a6111](https://github.com/dendronhq/dendron/commit/75a6111ab322139ab504cc769010510a0e972069))
+* add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score. ([3192d77](https://github.com/dendronhq/dendron/commit/3192d773588e9f1817eabbbb78e68042c201d213))
+* removed runnable check from getAllPodConfig ([973ef22](https://github.com/dendronhq/dendron/commit/973ef2295a86a45bb594886d859cfa9bcc7e9201))
+* rename operations modify unnecessary files ([83d0469](https://github.com/dendronhq/dendron/commit/83d04699656160f01634375782c1f26f9a8b67be)), closes [#2015](https://github.com/dendronhq/dendron/issues/2015)
+* resolve Pr comment and rebase ([95dbd69](https://github.com/dendronhq/dendron/commit/95dbd6920b733e422c1dab3e57eac7fd2500a7e8))
+* resolved PR comment and conflict ([1d8b895](https://github.com/dendronhq/dendron/commit/1d8b8959e5c66e1dc7f6d7a487300040c11bca1c))
+* resolved PR comments ([85d91f4](https://github.com/dendronhq/dendron/commit/85d91f4881a7c9b7f21cbff458c885b13b7eeff9))
+* **schema:** Ensure month/day/time has two digits when doing data variable substitution ([#2064](https://github.com/dendronhq/dendron/issues/2064)) ([20f807e](https://github.com/dendronhq/dendron/commit/20f807e3f1be3ba082a01dda527fa653cf30b433))
+* resolved PR comments ([126034e](https://github.com/dendronhq/dendron/commit/126034ee21767c91b62e0e82c6efcec7d5826753))
+* **lookup:** full length word matches should be case insensitive ([#1990](https://github.com/dendronhq/dendron/issues/1990)) ([03deb56](https://github.com/dendronhq/dendron/commit/03deb5699c81627b64350e7fdb7a0634810af3f4))
+* **workspace:** simplify InitializeWorkspace command ([#1886](https://github.com/dendronhq/dendron/issues/1886)) ([27f4c53](https://github.com/dendronhq/dendron/commit/27f4c53f34ee89700df3d53b31b016f393cdf282))
+
+
+### Features Dendron
+
+* **commands:** find broken links ([#1847](https://github.com/dendronhq/dendron/issues/1847)) ([0f23a79](https://github.com/dendronhq/dendron/commit/0f23a79e5473afa2afb1c5c0e274e2bd3f134554))
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **views:** update web uis on note creation ([55a7ecd](https://github.com/dendronhq/dendron/commit/55a7ecd787461062f969804ef44b287af1cd05f5)), closes [/github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md#L103](https://github.com//github.com/dendronhq/dendron-docs/blob/main/vault/pkg.dendron-plugin-views.dev.cook.md/issues/L103)
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **markdown:** footnote definitions including links are rendered incorrectly ([#1704](https://github.com/dendronhq/dendron/issues/1704)) ([f500583](https://github.com/dendronhq/dendron/commit/f500583ab5d274d8120cbbab0a786e1c115e7bb7)), closes [#1001](https://github.com/dendronhq/dendron/issues/1001)
+* **markdown:** footnote links move view in publishing & preview ([#1568](https://github.com/dendronhq/dendron/issues/1568)) ([fbe659d](https://github.com/dendronhq/dendron/commit/fbe659d2be3d1f2534d7437d585e9fa38f1684da))
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **schema:** When applying a schema template, do not override the body but append to the end to it ([#1812](https://github.com/dendronhq/dendron/issues/1812)) ([0a48123](https://github.com/dendronhq/dendron/commit/0a481230c29aee08493937772f1f4d57be511615))
+* **schemas:** yaml expansions in schemas ([#1726](https://github.com/dendronhq/dendron/issues/1726)) ([0bd94bb](https://github.com/dendronhq/dendron/commit/0bd94bb86489aa23ce970b1b0c9bfe224d77d1ff))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* frontmatter variable substitution not rendering in preview V2 ([#1567](https://github.com/dendronhq/dendron/issues/1567)) ([0282c17](https://github.com/dendronhq/dendron/commit/0282c1703643995b6675ee6ee64ca7c7b7500fd2))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* **publish:** wikilinks inside note references don't have right link ([59468c3](https://github.com/dendronhq/dendron/commit/59468c3e4d691dba3d5e5e486524ed779c0620aa))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* workaround for user tags & hashtags inside links ([ef8c859](https://github.com/dendronhq/dendron/commit/ef8c8590e2f7238129ee7c3ac5d7719cfee09d41))
+
+
+### Features Dendron
+
+* **pods:** Export Pod V2 ([#1772](https://github.com/dendronhq/dendron/issues/1772)) ([2dac9df](https://github.com/dendronhq/dendron/commit/2dac9dfb13525af984c3fd2f938283cba33cef7b))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **publish:** add `dendron publish dev` command ([4be800b](https://github.com/dendronhq/dendron/commit/4be800bdba6c11e1f69fc49212406f86d4d3bd1e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **preview:** multiple ref notes back to back rendering. ([#1471](https://github.com/dendronhq/dendron/issues/1471)) ([382a7b1](https://github.com/dendronhq/dendron/commit/382a7b15c655e5cee29321259924695ef136d2e7))
+* preview caching invalidation when notes with ![[ref]] links change ([#1385](https://github.com/dendronhq/dendron/issues/1385)) ([efeef86](https://github.com/dendronhq/dendron/commit/efeef8662ec52e64ba33cae9b1196bba6cc82f95))
+* tree view order ([#1459](https://github.com/dendronhq/dendron/issues/1459)) ([b7955a2](https://github.com/dendronhq/dendron/commit/b7955a2cc43b383b05f7e39dde504a6b3e05ec2e)), closes [#440](https://github.com/dendronhq/dendron/issues/440)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **publish:** fix links in note reference --no-verify ([319d59b](https://github.com/dendronhq/dendron/commit/319d59b6930eaf44b7533b6fcc0939f2550d475d))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+* single letter look up matches ([#1388](https://github.com/dendronhq/dendron/issues/1388)) ([7de9a71](https://github.com/dendronhq/dendron/commit/7de9a7195a02399b1285b51ef08d6853b1f390f6))
+
+
+### Features Dendron
+
+* **cli:** initialize workspace from CLI ([31a734d](https://github.com/dendronhq/dendron/commit/31a734dbd48c2a75bdb85a1e2e299d4b77311d65))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* block anchor in list with single top level element ([#1242](https://github.com/dendronhq/dendron/issues/1242)) ([1ce3a21](https://github.com/dendronhq/dendron/commit/1ce3a216047d5a1a1638509cdc92e36e7ec86a1c)), closes [#1235](https://github.com/dendronhq/dendron/issues/1235)
+* block anchors attached to code blocks in publishing ([#1267](https://github.com/dendronhq/dendron/issues/1267)) ([6b3c71c](https://github.com/dendronhq/dendron/commit/6b3c71cd6728dfee7eaa74db9f9b8168ad7a2e39))
+* wrong assetPrefix in 11ty ([e5cb251](https://github.com/dendronhq/dendron/commit/e5cb251afbd6b76cbb52ab5046e7ca4ac816e06c))
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* correctly render cross-vault note references in preview v2 ([#1310](https://github.com/dendronhq/dendron/issues/1310)) ([1198449](https://github.com/dendronhq/dendron/commit/11984494ca7c889790a0c0288fe97b8687398e4f))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* exclude private vault backlinks ([#1301](https://github.com/dendronhq/dendron/issues/1301)) ([837c50e](https://github.com/dendronhq/dendron/commit/837c50efad4d80d4a41d73a39287053b7ff7e365))
+* Frontmatter tags display similar to Children ([#1285](https://github.com/dendronhq/dendron/issues/1285)) ([a0ce014](https://github.com/dendronhq/dendron/commit/a0ce01469bd0de17768d1aff2711807425027d87))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+
+
+### Features Dendron
+
+* dendron publishing with nextjs commands ([#1266](https://github.com/dendronhq/dendron/issues/1266)) ([fb90e98](https://github.com/dendronhq/dendron/commit/fb90e98999c1073b58480eb7364f6a70e31a6903))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* extended images for custom CSS properties ([#1315](https://github.com/dendronhq/dendron/issues/1315)) ([f9ed88f](https://github.com/dendronhq/dendron/commit/f9ed88ff91916c444607d7842027c79085d077ae)), closes [#1273](https://github.com/dendronhq/dendron/issues/1273)
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* don't insert title when rendering note refs in preview ([#1157](https://github.com/dendronhq/dendron/issues/1157)) ([9d447af](https://github.com/dendronhq/dendron/commit/9d447af8ad7381bb8d3078fc44d4a188618acdfd))
+* wrong internal links in nextjs publishing ([#1165](https://github.com/dendronhq/dendron/issues/1165)) ([59a949d](https://github.com/dendronhq/dendron/commit/59a949d2b5b541efb283e851060636b108eb5a98))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* add new vaults from CLI to code workspace ([#1094](https://github.com/dendronhq/dendron/issues/1094)) ([2cde108](https://github.com/dendronhq/dendron/commit/2cde108b4c88a5c9d13b8eb6370f69879d6c9a62))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+* leading slash in markdown export pod ([#1136](https://github.com/dendronhq/dendron/issues/1136)) ([0f8ebbf](https://github.com/dendronhq/dendron/commit/0f8ebbf228f7af1bbbf677c9fea38989f87c635e))
+
+
+### Features Dendron
+
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* option to disable frontmatter tag rendering ([7985e23](https://github.com/dendronhq/dendron/commit/7985e2323950f16f2c5afa55c115a1af52e82b07))
+* remove frontmatter tags if tag is moved outside `tags.` ([1bce9af](https://github.com/dendronhq/dendron/commit/1bce9af293a60fd453389a907fc3043fe173330c))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/engine-test-utils

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/engine-test-utils",
   "private": true,
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -47,15 +47,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.110.0",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-frontend": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/common-test-utils": "^0.110.0",
-    "@dendronhq/dendron-cli": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
-    "@dendronhq/pods-core": "^0.110.0",
-    "@dendronhq/unified": "^0.110.0",
+    "@dendronhq/api-server": "^0.110.1",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-frontend": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/common-test-utils": "^0.110.1",
+    "@dendronhq/dendron-cli": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
+    "@dendronhq/pods-core": "^0.110.1",
+    "@dendronhq/unified": "^0.110.1",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",

--- a/packages/nextjs-template/CHANGELOG.md
+++ b/packages/nextjs-template/CHANGELOG.md
@@ -3,6 +3,285 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Features Dendron
+
+* **publishing:** Enable Giscus widgets in published notes ([#3469](https://github.com/dendronhq/dendron/issues/3469)) ([d5072d3](https://github.com/dendronhq/dendron/commit/d5072d3b6bfee96e24df1e002fc886bbd50af805))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **publish:** renders consitent layout on mobile and non-mobile ([#3272](https://github.com/dendronhq/dendron/issues/3272)) ([eeeef9e](https://github.com/dendronhq/dendron/commit/eeeef9e0ae645e1191beda2610ca157df21f8c9f)), closes [#2175](https://github.com/dendronhq/dendron/issues/2175) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [Layout#hier-2](https://github.com/Layout/issues/hier-2) [#2175](https://github.com/dendronhq/dendron/issues/2175)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* **views:** hide sidebar when clicking a non-submenu note on mobile ([#3253](https://github.com/dendronhq/dendron/issues/3253)) ([4132cd3](https://github.com/dendronhq/dendron/commit/4132cd35eb76bc2a19f5a8e0309cee755e9bf42e))
+* current menu item wont collapse in publish ([d36174f](https://github.com/dendronhq/dendron/commit/d36174f0685e1932d430a137337cb0b10f46a1da))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Bug Fixes
+
+* **publish:** compile error with no banner present([#3133](https://github.com/dendronhq/dendron/issues/3133)) ([8ef70c5](https://github.com/dendronhq/dendron/commit/8ef70c530bd653a3c74d26ede630df5e538d2118))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+### Bug Fixes
+
+* address PR comments ([e847228](https://github.com/dendronhq/dendron/commit/e847228a6bbf122f80f9041b85026203ae3ed585))
+* **publish:** slow rendering of sidebar ([60149c9](https://github.com/dendronhq/dendron/commit/60149c91f3bf51d76b0297589e3f9f93314b0389))
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Features Dendron
+
+* **publish:** ability to exclude children in dendron side nav ([#2962](https://github.com/dendronhq/dendron/issues/2962)) ([f45029d](https://github.com/dendronhq/dendron/commit/f45029d808aaec457c606ad753f4fe9634958ad5))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Features Dendron
+
+* **views:** display task note status when linking to task notes in publishing and in preview ([dbc16ff](https://github.com/dendronhq/dendron/commit/dbc16ffdd1a66cff9252b3d88e2e2d44bf59a060))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Features Dendron
+
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* **publish:** add luxon as dev dependency ([c42d9dd](https://github.com/dendronhq/dendron/commit/c42d9dd22df8a0e49f2fd4fbb728ed68212c96a8))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* **publish:** customHeaderPath breaks publishing if value is set to anything except header.html ([#2565](https://github.com/dendronhq/dendron/issues/2565)) ([7f2c421](https://github.com/dendronhq/dendron/commit/7f2c421e7b78b0bdfed512e1584dc5c8f39ff22b))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **publish:** properly render mermaid and katex when published ([#2480](https://github.com/dendronhq/dendron/issues/2480)) ([2524589](https://github.com/dendronhq/dendron/commit/2524589cbf016dff694bcc308dbf1ec1b7390570))
+* **publish:** Table of Contents is missing user tags, inline code, dashes and underline ([#2465](https://github.com/dendronhq/dendron/issues/2465)) ([79c6d9e](https://github.com/dendronhq/dendron/commit/79c6d9e801e5cec78acf0212fc8e4c1134e6f5d2)), closes [#2456](https://github.com/dendronhq/dendron/issues/2456)
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **publish:** CSS sidebar is off on smaller screens like iPad ([#2305](https://github.com/dendronhq/dendron/issues/2305)) ([d46c521](https://github.com/dendronhq/dendron/commit/d46c52124586d8d620d52d39395c62e460c11007))
+* **publishing:** Search Bar Results to not stay anchored to the search bar when scrolling up ([#2292](https://github.com/dendronhq/dendron/issues/2292)) ([32b09b0](https://github.com/dendronhq/dendron/commit/32b09b0b2e7dcf099cba44b8639e1964a149d129))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* numbered lists without content stack on top of each other ([63f49ed](https://github.com/dendronhq/dendron/commit/63f49ed86fdef495c3010bc89ec594c4f4e267f4))
+* title wrap and hamburged offset on mobile ([#2183](https://github.com/dendronhq/dendron/issues/2183)) ([3828b8b](https://github.com/dendronhq/dendron/commit/3828b8b2241211427c3d274b418ecb5058fab0b5))
+* **publish:** compile error when publishing ([c045c3a](https://github.com/dendronhq/dendron/commit/c045c3a3ab358b710c2d937aaf9f879f0ac218c1))
+* **publish:** excluding the domain of a published hierarchy will cause publishing to throw an error ([#1964](https://github.com/dendronhq/dendron/issues/1964)) ([07dc882](https://github.com/dendronhq/dendron/commit/07dc8820c6d6b4a023ef531128093cf38ec20bb2))
+* **publish:** logo doesn't respect assetsPrefix ([#2189](https://github.com/dendronhq/dendron/issues/2189)) ([763c797](https://github.com/dendronhq/dendron/commit/763c797c4c2f7821ef747376c980e4a4b0eace8e))
+* compiler issue with nextjs ([60e9107](https://github.com/dendronhq/dendron/commit/60e9107155eabacb41a6d92e0076df88b701f121))
+* **publish:** hamburger display in wrong position ([#1965](https://github.com/dendronhq/dendron/issues/1965)) ([6ef6a90](https://github.com/dendronhq/dendron/commit/6ef6a909e71ab208903335a8d1fde6497b00eea5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **markdown:** footnote rendering in note references ([#1520](https://github.com/dendronhq/dendron/issues/1520)) ([c4056f5](https://github.com/dendronhq/dendron/commit/c4056f5c4fc4c02dbc14cd4564032caa3619eae5))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **publish:** enable mermaid support ([fc84c74](https://github.com/dendronhq/dendron/commit/fc84c74c35ce09fe9acde8cc21204d4191a8f80a))
+* **publish:** issue with cypress dependency ([9a18336](https://github.com/dendronhq/dendron/commit/9a18336131711d3115568a4e7a40732e37e0e89d)), closes [#19102](https://github.com/dendronhq/dendron/issues/19102)
+* **publish:** make mermaid work consistently on published sites ([2f648e0](https://github.com/dendronhq/dendron/commit/2f648e0a34c95095e86e8535a1fa8ec9ac4de39c))
+* **publish:** optimize nextjs publishing search ([#1519](https://github.com/dendronhq/dendron/issues/1519)) ([d06dd25](https://github.com/dendronhq/dendron/commit/d06dd25e292532a4ea66d1aa469a27c00b424ad6))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **publish:** table of contents layout ([#1649](https://github.com/dendronhq/dendron/issues/1649)) ([dbae739](https://github.com/dendronhq/dendron/commit/dbae739ad0650c75a72dd51821b3a5d4ab556839))
+* **publish:** Title parts duplicated in Next publishing search ([#1573](https://github.com/dendronhq/dendron/issues/1573)) ([59de1a4](https://github.com/dendronhq/dendron/commit/59de1a486be980c1e6b16753478c62b03c38e018))
+* **publish:** unslugify titles in toc ([292a46b](https://github.com/dendronhq/dendron/commit/292a46b14287f2e649a7929516ed97144e9fd2d6))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+
+
+### Features Dendron
+
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* **publish:** nextjs search note snippets ([#1433](https://github.com/dendronhq/dendron/issues/1433)) ([0cb8f38](https://github.com/dendronhq/dendron/commit/0cb8f38fc9cb5e45af682fc5524ff5eb7ba44ce7))
+
+
+### Features Dendron
+
+* **publish:** add table of contents ([#1428](https://github.com/dendronhq/dendron/issues/1428)) ([df4b05b](https://github.com/dendronhq/dendron/commit/df4b05ba8526dc32362d6a59543d880f253f02fc))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* **publish:** footer show on first load ([#1413](https://github.com/dendronhq/dendron/issues/1413)) ([00d32cc](https://github.com/dendronhq/dendron/commit/00d32cc830ca6da3160a9cee86386e50b3a35fd6))
+
+
+### Features Dendron
+
+* **publish:** add popover for long title in menu ([#1408](https://github.com/dendronhq/dendron/issues/1408)) ([b94b223](https://github.com/dendronhq/dendron/commit/b94b2235f337b2e54bcbf8658e5f4f371804c5f9))
+* **publish:** mobile navigation ([#1407](https://github.com/dendronhq/dendron/issues/1407)) ([3487213](https://github.com/dendronhq/dendron/commit/34872138131f030f460dc4cd8e81c65fe7654524))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* handle single domain hierarchies gracefully ([10dc5ec](https://github.com/dendronhq/dendron/commit/10dc5ec2ab3ebf767ae7e913cb90ba48e9651447))
+* links at top/bottom of reference aren't clickable ([#1282](https://github.com/dendronhq/dendron/issues/1282)) ([b2a00cc](https://github.com/dendronhq/dendron/commit/b2a00cc564299cdb17ae6060154b7616c04e630c))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+
+
+### Features Dendron
+
+* **publish:** notice for dev mode ([#1354](https://github.com/dendronhq/dendron/issues/1354)) ([e3f9fc9](https://github.com/dendronhq/dendron/commit/e3f9fc9d81dc51fbaec5f4bbccb2f6c1dffb1afb))
+* additional styling for nextjs ([f8e7972](https://github.com/dendronhq/dendron/commit/f8e797231b586c20ac4d2e1fa1813982cc282375))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+* support canonicalBaseURL ([f64e97c](https://github.com/dendronhq/dendron/commit/f64e97ca4afa8b953a410874089630c29152863a))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Features Dendron
+
+* make breadcrumbs clickable ([#1164](https://github.com/dendronhq/dendron/issues/1164)) ([a386fc3](https://github.com/dendronhq/dendron/commit/a386fc3dd42769207f58259f292216be51f0a15b))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/nextjs-template

--- a/packages/nextjs-template/components/DendronNoteGiscusWidget.tsx
+++ b/packages/nextjs-template/components/DendronNoteGiscusWidget.tsx
@@ -1,7 +1,7 @@
 import {
   ConfigUtils,
   IntermediateDendronConfig,
-  NoteProps,
+  NoteProps
 } from "@dendronhq/common-all";
 import Giscus, { GiscusProps, Repo } from "@giscus/react";
 import _ from "lodash";
@@ -19,6 +19,7 @@ export const DendronNoteGiscusWidget = ({
   config: IntermediateDendronConfig;
 }) => {
   const giscusConfig = ConfigUtils.getGiscusConfig(config);
+  const page = note.id;
   if (giscusConfig === undefined) {
     return null;
   }
@@ -32,8 +33,9 @@ export const DendronNoteGiscusWidget = ({
     const cleanGiscusConfig: GiscusProps = {
       ...giscusConfig,
       repo: repoString,
+      term: page,
     };
-    return <Giscus {...cleanGiscusConfig} />;
+    return <Giscus {...cleanGiscusConfig } />;
   } else {
     return null;
   }

--- a/packages/nextjs-template/package-lock.json
+++ b/packages/nextjs-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "license": "Apache-2.0",
   "private": true,
   "repository": {
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^1.6.7",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-frontend": "^0.110.1",
     "@giscus/react": "^2.2.0",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-frontend": "^0.110.0",
     "antd": "^4.15.5",
     "fs-extra": "^10.0.0",
     "html-react-parser": "^1.3.0",

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -3,6 +3,709 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* tree view init problem on web ([#3459](https://github.com/dendronhq/dendron/issues/3459)) ([3a80e4b](https://github.com/dendronhq/dendron/commit/3a80e4bcb8d479cbde10f2135e5445b5fa6b9634))
+* updated visibility of copy note url command in codespaces ([#3447](https://github.com/dendronhq/dendron/issues/3447)) ([ce9fd82](https://github.com/dendronhq/dendron/commit/ce9fd82ee3c258688324bee561b09e9d6e26b4a6))
+* **edit:** prevent override of already existing frontmatter values when executing Apply Template ([#3407](https://github.com/dendronhq/dendron/issues/3407)) ([c3c6901](https://github.com/dendronhq/dendron/commit/c3c6901d1d3f7b99b7bd632aebeaaac5b881cf0f))
+* **lookup:** allow lookup accept for existing invalid hierarchy ([#3421](https://github.com/dendronhq/dendron/issues/3421)) ([cd5aad2](https://github.com/dendronhq/dendron/commit/cd5aad28af0a761edba05392efa604af63c3cd5a))
+* **publish:** deprecate Dendron: Publish Dev command ([#3368](https://github.com/dendronhq/dendron/issues/3368)) ([9556998](https://github.com/dendronhq/dendron/commit/9556998ae1e2c579337dfd4f65ffef191838af6a))
+* **schema:** correctly match namespace schema nodes, and correctly apply schema to new note when note existed as stub ([#3388](https://github.com/dendronhq/dendron/issues/3388)) ([3a9634e](https://github.com/dendronhq/dendron/commit/3a9634edc7fcd01f1e571822f9146d2754f7ba5d))
+* **views:** resolve issues with preview lock button ([#3353](https://github.com/dendronhq/dendron/issues/3353)) ([5847284](https://github.com/dendronhq/dendron/commit/5847284cc1b38fa788d38c16410ef319d94747a0))
+* **workspace:** case insensitive tree view sorting ([#3420](https://github.com/dendronhq/dendron/issues/3420)) ([90f72b6](https://github.com/dendronhq/dendron/commit/90f72b648095d75dbb94504b87e50ceb6b237676))
+* **workspace:** correctly decorate begin and end anchors ([#3339](https://github.com/dendronhq/dendron/issues/3339)) ([fb1425c](https://github.com/dendronhq/dendron/commit/fb1425c62888f778733323c86a4a120dcb78224e))
+* **workspace:** correctly focus tree view on tutorial activation ([#3380](https://github.com/dendronhq/dendron/issues/3380)) ([39d89db](https://github.com/dendronhq/dendron/commit/39d89db25c2d3e4ba78e6c96380b14b0f80d1d0a))
+* **workspace:** don't throw during activation ([#3373](https://github.com/dendronhq/dendron/issues/3373)) ([69ac5de](https://github.com/dendronhq/dendron/commit/69ac5dea6295d3c45fa78f400020730f5af5da9f))
+* **workspace:** duplicate Dendron Delete command in contextual menu ([#3406](https://github.com/dendronhq/dendron/issues/3406)) ([f5e2155](https://github.com/dendronhq/dendron/commit/f5e2155e334a7495699a5e395decd476f57534b7))
+* **workspace:** proper visibility on views and commands for web ext ([#3423](https://github.com/dendronhq/dendron/issues/3423)) ([2bfaf4a](https://github.com/dendronhq/dendron/commit/2bfaf4a0c6c7f01dbb3a30eba3a89a4579e30788))
+* validate file name on note lookup ([#3312](https://github.com/dendronhq/dendron/issues/3312)) ([ec7b53c](https://github.com/dendronhq/dendron/commit/ec7b53cdb9b3b09a388363cf8dfaa81bcdf686fc))
+
+
+### Features Dendron
+
+* **workspace:** copy note url command for codespaces ([#3411](https://github.com/dendronhq/dendron/issues/3411)) ([823bab9](https://github.com/dendronhq/dendron/commit/823bab957253214769fc7debc080f82211997f46))
+* introduce sqlite as a plugabble metadata store ([#3401](https://github.com/dendronhq/dendron/issues/3401)) ([82896af](https://github.com/dendronhq/dendron/commit/82896aff47cbf5303895f6ffca25d719352b34a4))
+* **refactor:** merge note command ([#3349](https://github.com/dendronhq/dendron/issues/3349)) ([41d6189](https://github.com/dendronhq/dendron/commit/41d6189371aa7e40bd3faff55623787802a9aa8b))
+* **views:** UI to configure `dendron.yml` ([#3211](https://github.com/dendronhq/dendron/issues/3211)) ([0d9b606](https://github.com/dendronhq/dendron/commit/0d9b606be8fcc04679dfbbe2f0054f74e6a626d7))
+* **workspace:** code workspaces support ([#3343](https://github.com/dendronhq/dendron/issues/3343)) ([ac62ab7](https://github.com/dendronhq/dendron/commit/ac62ab71be81b61bcb14281b0c24c222c22f7232))
+* **workspace:** Create Note Command ([#3408](https://github.com/dendronhq/dendron/issues/3408)) ([32dc68a](https://github.com/dendronhq/dendron/commit/32dc68a8d5bfea95401a8988214af22079dff5bd))
+* **workspace:** tree view in web ext ([#3386](https://github.com/dendronhq/dendron/issues/3386)) ([b75a448](https://github.com/dendronhq/dendron/commit/b75a448aabc6918cead8ae14779ace83aa2a6ae5))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+### Bug Fixes
+
+* tree view steals focus of active editor when initially forced to reveal ([16b097a](https://github.com/dendronhq/dendron/commit/16b097a47b19a94751b131f47b96e02c8a5e4a29))
+* tree view steals focus of active editor when initially forced to reveal ([24e7427](https://github.com/dendronhq/dendron/commit/24e742746a69bf324bc386fa686f79f45594ea4a))
+
+
+### Features Dendron
+
+* **view:** add "Toggle PreviewLock"  command ([#3293](https://github.com/dendronhq/dendron/issues/3293)) ([368c938](https://github.com/dendronhq/dendron/commit/368c9389b23d5200b84928121a7157fe764df9b6)), closes [#2437](https://github.com/dendronhq/dendron/issues/2437)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+### Bug Fixes
+
+* **retrieve:** remove references of show preview ([9b5f9f6](https://github.com/dendronhq/dendron/commit/9b5f9f6d92eb880418dc9ec3627a5188b4e07472))
+* **views:** toggle preview to toggle off ([3f7be18](https://github.com/dendronhq/dendron/commit/3f7be1868a388065ca0c2a758bccbebc18098b04))
+* **workspace:** fix typos in getting started tutorial ([d238b2a](https://github.com/dendronhq/dendron/commit/d238b2a1225a9c12b80e803d60f723c3670069e7))
+* **workspace:** List dendron.dendron-markdown-preview-enhanced as unwanted ([#3281](https://github.com/dendronhq/dendron/issues/3281)) ([182e835](https://github.com/dendronhq/dendron/commit/182e83510574230e3c7a72650c388b3ce6058557))
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+### Bug Fixes
+
+* force a reveal when tree view is first shown ([9168a90](https://github.com/dendronhq/dendron/commit/9168a9075e70fba0ef4c8790b7ce0b12442476b4))
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+### Bug Fixes
+
+* force a reveal when tree view is first shown ([feaa88c](https://github.com/dendronhq/dendron/commit/feaa88cb61653725067c6740b18fbe55a9889e7b))
+* graph panel depth increase / decrease not working ([620a108](https://github.com/dendronhq/dendron/commit/620a108ae95eaa2b266f48cb89aed14060368652))
+* graph panel depth increase / decrease not working ([239147f](https://github.com/dendronhq/dendron/commit/239147fa0c07a01936b70a9c446b525104aa5237))
+* **workspace:** fix init in workspace without workspace folders ([#3181](https://github.com/dendronhq/dendron/issues/3181)) ([014aa4f](https://github.com/dendronhq/dendron/commit/014aa4f8bf9cbbb06eb74a5ac21eb20592266f46))
+* **workspace:** proper handling of invalid data for write note ops ([#3137](https://github.com/dendronhq/dendron/issues/3137)) ([c6c7588](https://github.com/dendronhq/dendron/commit/c6c75881bec46bf701647b9d6b799e4de566edb7))
+* **workspace:** removing vault with a name different than their `fsPath` doesn't remove them from `duplicateNoteBehavior` ([d0cb52f](https://github.com/dendronhq/dendron/commit/d0cb52f00f318f6dd1f30d0533a55115e42d8a71))
+* **workspace:** workspace sync will maintain proper engine state ([#3233](https://github.com/dendronhq/dendron/issues/3233)) ([13f788c](https://github.com/dendronhq/dendron/commit/13f788cb9a46800edffe66dcac88062e33830a5c))
+* resolve PR comment ([0483cc7](https://github.com/dendronhq/dendron/commit/0483cc72b048515cb93f8a0c24b7c661e91046c0))
+* **workspace:** information modal to uninstall dendron markdown links extension ([f31cb8b](https://github.com/dendronhq/dendron/commit/f31cb8bee39909492616e24ea7f176f479f14bf3))
+* backlink tree item trimming all characters that are m and d from the end ([8a4b86b](https://github.com/dendronhq/dendron/commit/8a4b86b6502a10e4aa380e984f6652e4338785e7))
+* duplicate note id detection error handling for cases the path doesn't exist ([9a8442c](https://github.com/dendronhq/dendron/commit/9a8442cd8a99db628690bb1882863c8f18af44dc))
+* resolve PR comment ([f064535](https://github.com/dendronhq/dendron/commit/f0645358a6401b39f407b9cf4b526a390d79e54e))
+
+
+### Features Dendron
+
+* **edit): support note references on beginning of a doc && fix(edit:** template gets applied twice if user undoes initial template  ([#3186](https://github.com/dendronhq/dendron/issues/3186)) ([88c7c5c](https://github.com/dendronhq/dendron/commit/88c7c5c85e470bdefaeaf371c60e2e950f25d16e))
+* **workspace:** command for local override config ([#3173](https://github.com/dendronhq/dendron/issues/3173)) ([ab41027](https://github.com/dendronhq/dendron/commit/ab410279506abc677a52e6b2b537c39c7faac0a8))
+* **workspace:** smart note refs ([#3174](https://github.com/dendronhq/dendron/issues/3174)) ([c0a6c60](https://github.com/dendronhq/dendron/commit/c0a6c6064193b3730fc0320d3c6d310434952561))
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Bug Fixes
+
+* **structure:** hot reload in note traits + no template by default ([3904655](https://github.com/dendronhq/dendron/commit/390465552a6744495387aea6f49fa5392fb69b03))
+* **structure:** hot reload in note traits + no template by default ([#3154](https://github.com/dendronhq/dendron/issues/3154)) ([bcadd48](https://github.com/dendronhq/dendron/commit/bcadd487c706379f0384a6f3a8c728d606a2bba8))
+* **structure:** quickpick stuck issue for refactor hierarchy cmd ([#3152](https://github.com/dendronhq/dendron/issues/3152)) ([a0fec3b](https://github.com/dendronhq/dendron/commit/a0fec3ba6389a0dd6db144d75232ccbf3cf705e6))
+* **workspace:** duplicate note behavior is not updated when self contained vault is removed ([d69f02c](https://github.com/dendronhq/dendron/commit/d69f02c0857b4fc594ee8e3f494bd1e5465be2e8))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+### Bug Fixes
+
+* **workspace:** error when native workspaces are initializing ([d327119](https://github.com/dendronhq/dendron/commit/d32711980116bd0993a497d3886ee6a35dfed9c7))
+* resolved PR comments ([a299217](https://github.com/dendronhq/dendron/commit/a299217f2929e6ab15908137a60c841fdc5ee14f))
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+### Bug Fixes
+
+* **2816:** improve phrasing of sync message ([d47a4bf](https://github.com/dendronhq/dendron/commit/d47a4bfe474c09192e07a300a4f8289a2a8f1e2a))
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([01be85f](https://github.com/dendronhq/dendron/commit/01be85f84ae6cdf182f2d43b9561decac44369e6))
+* **edit:** autocomplete issues with tags and mentions ([#3107](https://github.com/dendronhq/dendron/issues/3107)) ([decaccd](https://github.com/dendronhq/dendron/commit/decaccdc0af6072197405273e82750d8702d2262))
+* **views:** double click issue on help and feedback panel ([#3089](https://github.com/dendronhq/dendron/issues/3089)) ([2dca2c2](https://github.com/dendronhq/dendron/commit/2dca2c226ea59485498a7fc689ca9c82d0c2f9cd))
+* **workspace:** improve phrasing of sync message ([c3742ef](https://github.com/dendronhq/dendron/commit/c3742ef760495be1c4831fff81a3fe56f2da1c7c))
+* adding existing remote vault creates workspace files in the vault ([6d43936](https://github.com/dendronhq/dendron/commit/6d439369d8e75150cc1ba582f337a6fded402a7b))
+* address PR comments ([c4ba612](https://github.com/dendronhq/dendron/commit/c4ba612a07fcdef1a98a86d245edab00e31ffc76))
+* **workspace:** try to patch `EPERM` issues for windows ([17dd870](https://github.com/dendronhq/dendron/commit/17dd870cf6aa85bc01e97998de4be15c44d182f3))
+
+
+### Features Dendron
+
+* **views:** depth for local graph ([494b648](https://github.com/dendronhq/dendron/commit/494b648dee70cc92caf7f490781e2a14bda3c297))
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+### Bug Fixes
+
+* **refactor:** updated refactor hierarchy success message ([1c021bb](https://github.com/dendronhq/dendron/commit/1c021bb358350ece9ff2037f5cff82e7948a1fb6))
+
+
+### Features Dendron
+
+* **views:** Recent Workspaces Panel ([#3052](https://github.com/dendronhq/dendron/issues/3052)) ([5e52529](https://github.com/dendronhq/dendron/commit/5e525295ca0d1118782affdfb68c34e939b479c9))
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* **views:** added default initial theme for webviews ([#3013](https://github.com/dendronhq/dendron/issues/3013)) ([fcf29f0](https://github.com/dendronhq/dendron/commit/fcf29f0f554b0d3e30a42c80072dbb34bb4542e4))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([1bc7493](https://github.com/dendronhq/dendron/commit/1bc7493a76c8c2fcb58ef4ba5ef569675fca2a1d))
+* **views:** Backlinks Panel Tweaks ([#3031](https://github.com/dendronhq/dendron/issues/3031)) ([4fa37a1](https://github.com/dendronhq/dendron/commit/4fa37a12423ae93215c765b27f5cd6f6c4ce698d))
+* **workspace:** fix duplicated panel titles ([#3016](https://github.com/dendronhq/dendron/issues/3016)) ([1587990](https://github.com/dendronhq/dendron/commit/15879909dedb81c26c971e6c4ae1314f37e2d4e5))
+* Images with encoded URI are not rendered in the Preview ([#3006](https://github.com/dendronhq/dendron/issues/3006)) ([e2172be](https://github.com/dendronhq/dendron/commit/e2172be363e2a3311c238c5fc841f5e498f66851))
+* **workspace:** Help and Feedback Panel shows info when not in Dendron WS ([#2974](https://github.com/dendronhq/dendron/issues/2974)) ([3c901bf](https://github.com/dendronhq/dendron/commit/3c901bf6cb58a6312e7496de41fe9866d48367a9))
+
+
+### Features Dendron
+
+* **edit:** introduce apply template command ([#2982](https://github.com/dendronhq/dendron/issues/2982)) ([c57ab3d](https://github.com/dendronhq/dendron/commit/c57ab3dda91082f544e53e12aa201aa72f6b30e4))
+* **edit:** template helpers ([#3029](https://github.com/dendronhq/dendron/issues/3029)) ([6881c97](https://github.com/dendronhq/dendron/commit/6881c97a6de3def469ac663b69289bb045a03502))
+* **navigate:** Backlink Panel with Hover ([#2904](https://github.com/dendronhq/dendron/issues/2904)) ([55c7fcd](https://github.com/dendronhq/dendron/commit/55c7fcdcd1135145b5385176e9bbdd18951f6d00))
+* **notes:** Auto generate template/schema for daily journal ([b8db57c](https://github.com/dendronhq/dendron/commit/b8db57caa89ec307ed17e8b0172e5a76439a0cec))
+* **notes:** Auto generate template/schema for daily journal ([0d812c1](https://github.com/dendronhq/dendron/commit/0d812c1266169d0683666f78e300966fd56638bb))
+* **notes:** Auto generate template/schema for daily journal ([a31e9c9](https://github.com/dendronhq/dendron/commit/a31e9c9e786cd146e9b251b9f33ee18de9c30eb1))
+* **notes:** Auto generate template/schema for daily journal ([37a2484](https://github.com/dendronhq/dendron/commit/37a24842a41a4bc134f612cef503a6901547b981))
+* **structure:** Set Task Status and Complete Task commands ([f3db5a5](https://github.com/dendronhq/dendron/commit/f3db5a5f3e3a3a70ac5b08c7397f64f8201cd4c8))
+* **sync:** Obsidian Import Flow ([#3014](https://github.com/dendronhq/dendron/issues/3014)) ([669b200](https://github.com/dendronhq/dendron/commit/669b200509c7a3d1f339da62ecbca769974fb3fd))
+* **views:** Preview setting for light, dark, or custom themes ([294bf1e](https://github.com/dendronhq/dendron/commit/294bf1e18646cd74e6d656fd12964506d77a1a5c))
+* **views:** Preview uses your VSCode theme colors, and supports custom themes ([c14c6f0](https://github.com/dendronhq/dendron/commit/c14c6f0703eab185de280c4a7bc3f4cecd2bdb4c))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Features Dendron
+
+* **markdown:** handlebar based templates ([#2954](https://github.com/dendronhq/dendron/issues/2954)) ([2af114a](https://github.com/dendronhq/dendron/commit/2af114afc85711f4ec4af26281e9235dcc33a062))
+* **views:** display task note status when linking to task notes in publishing and in preview ([dbc16ff](https://github.com/dendronhq/dendron/commit/dbc16ffdd1a66cff9252b3d88e2e2d44bf59a060))
+* **workspace:** Add a command to migrate regular vaults into self contained vaults ([9710511](https://github.com/dendronhq/dendron/commit/9710511a2f2a040be3f10d820da8cc562a54d738))
+* local graph view in the Dendron Side Panel ([#2901](https://github.com/dendronhq/dendron/issues/2901)) ([195a61a](https://github.com/dendronhq/dendron/commit/195a61ae7ed7158d97c1161aacc5d08a08d660e9))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Bug Fixes
+
+* fix corrupt .dendron.ws version to unblock activation ([#2930](https://github.com/dendronhq/dendron/issues/2930)) ([4f25b16](https://github.com/dendronhq/dendron/commit/4f25b166f3874138e4c249aa3aa9c0655e78451f))
+* fix corrupt .dendron.ws version to unblock activation ([#2930](https://github.com/dendronhq/dendron/issues/2930)) ([68a2cba](https://github.com/dendronhq/dendron/commit/68a2cbab6609806b77219494d1538ffb8f7cb921))
+
+
+### Features Dendron
+
+* allow customization of tree view label / sorting to preserve old tree view behavior ([#2858](https://github.com/dendronhq/dendron/issues/2858)) ([987c802](https://github.com/dendronhq/dendron/commit/987c8021970de6c75f96a6d94e0df500b23eca0d))
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+### Bug Fixes
+
+* highlighting misidentified capitalized header anchors on links as missing ([#2872](https://github.com/dendronhq/dendron/issues/2872)) ([92ded23](https://github.com/dendronhq/dendron/commit/92ded230eccec02947cb33221288591f2064866c)), closes [#2862](https://github.com/dendronhq/dendron/issues/2862)
+
+
+### Features Dendron
+
+* **chore:** germ stage implementation of config overrides ([#2794](https://github.com/dendronhq/dendron/issues/2794)) ([c3692ef](https://github.com/dendronhq/dendron/commit/c3692ef5073ab2454ee117d3ad72cb2af257e4be))
+* Add doctor command to remove deprecated config and prompt on upgrade ([#2841](https://github.com/dendronhq/dendron/issues/2841)) ([2cc71e0](https://github.com/dendronhq/dendron/commit/2cc71e0796c4cebc32817b2b930cf7b0a324485f))
+* add goto command ([#2852](https://github.com/dendronhq/dendron/issues/2852)) ([3586707](https://github.com/dendronhq/dendron/commit/3586707bd3e7ffd352797308ed8e9c0e31b6f3ef)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843) [#2845](https://github.com/dendronhq/dendron/issues/2845) [#2843](https://github.com/dendronhq/dendron/issues/2843)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+### Bug Fixes
+
+* bad wikilink is created with selection2link if selection is multi-line ([#2856](https://github.com/dendronhq/dendron/issues/2856)) ([8d708ac](https://github.com/dendronhq/dendron/commit/8d708ac0114e39cb00a15cc05baa4dcf954b5219)), closes [#2854](https://github.com/dendronhq/dendron/issues/2854)
+* insert note index `#undefined` in case missing tags ([#2789](https://github.com/dendronhq/dendron/issues/2789)) ([e025fd2](https://github.com/dendronhq/dendron/commit/e025fd2a31fd2743e4163ef589a526467584eefe))
+
+
+### Features Dendron
+
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([158ed1d](https://github.com/dendronhq/dendron/commit/158ed1d748448c611146900915c6299a0730bbf9))
+* **views:** Dendron Side Panel ([#2832](https://github.com/dendronhq/dendron/issues/2832)) ([0f89993](https://github.com/dendronhq/dendron/commit/0f899934e5e5eeacb7b2dd5643dbdb4e4caff267))
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+### Bug Fixes
+
+* bad upgrade prompt ([#2845](https://github.com/dendronhq/dendron/issues/2845)) ([6e120a1](https://github.com/dendronhq/dendron/commit/6e120a1626c51e2b0580c43c386467e0cdb0ee9a)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843)
+* bad upgrade prompt ([#2845](https://github.com/dendronhq/dendron/issues/2845)) ([2ae6f2f](https://github.com/dendronhq/dendron/commit/2ae6f2fb417147069aa7b9ffdade34775c3c878c)), closes [#2843](https://github.com/dendronhq/dendron/issues/2843)
+* correctly handle previous global and workspace version ([#2843](https://github.com/dendronhq/dendron/issues/2843)) ([ce528bf](https://github.com/dendronhq/dendron/commit/ce528bf44571e1d1d6e52cc3ed09125ef3d74471))
+* correctly handle previous global and workspace version ([#2843](https://github.com/dendronhq/dendron/issues/2843)) ([fb6c4c2](https://github.com/dendronhq/dendron/commit/fb6c4c2c881a65631329c0bd58cbed2d47fe9270))
+* **view:** broken preview for links with sub-hierarchy starting with .md ([#2781](https://github.com/dendronhq/dendron/issues/2781)) ([7eefd3a](https://github.com/dendronhq/dendron/commit/7eefd3ad776c76575c40503feaf5d704f97123da))
+* **views:** second pass of treeview v1 sync issue ([#2805](https://github.com/dendronhq/dendron/issues/2805)) ([64e0970](https://github.com/dendronhq/dendron/commit/64e0970382d11694bb52f65a50f4c7de8fdd0a0c))
+* **workspace:** hovering an asset link while holding `ctrl` opens it ([#2784](https://github.com/dendronhq/dendron/issues/2784)) ([30ab1d9](https://github.com/dendronhq/dendron/commit/30ab1d9f3525e9a657a4c2c92e37060da3176623))
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+### Bug Fixes
+
+* first pass of treeview v1 sync issue ([#2757](https://github.com/dendronhq/dendron/issues/2757)) ([f8f80ca](https://github.com/dendronhq/dendron/commit/f8f80cacb8b661b06df0d57b955b7e4529272a66))
+* **view:** apply current theme when vscode reduce motion setting is on ([#2749](https://github.com/dendronhq/dendron/issues/2749)) ([15c3f05](https://github.com/dendronhq/dendron/commit/15c3f050e6ebecb1aeaf34da5b01ac9917ae6e1e))
+* **view:** support custom styles for Note Graph ([#2760](https://github.com/dendronhq/dendron/issues/2760)) ([6d99e62](https://github.com/dendronhq/dendron/commit/6d99e6265078119239c461c0fa78be90d44039af))
+* don't write first install metadata if install is from new vscode instance ([1929e81](https://github.com/dendronhq/dendron/commit/1929e8111d64e200a76a6dfca2e9473598e1a67e))
+* self contained vaults sync ([#2758](https://github.com/dendronhq/dendron/issues/2758)) ([ebb4658](https://github.com/dendronhq/dendron/commit/ebb46587ca0728e25bf69b5d94058d3cc3c2446c))
+* **airtable:** Exporting to airtable automatically saves current document ([#2696](https://github.com/dendronhq/dendron/issues/2696)) ([b8e8c97](https://github.com/dendronhq/dendron/commit/b8e8c9773fe11fe85610f99ba542267fa93a4b95))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([959d92f](https://github.com/dendronhq/dendron/commit/959d92fe6936cfac9561b39144a96563c916de6f))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([d3e9f78](https://github.com/dendronhq/dendron/commit/d3e9f7803b343be11f2001409f388b9f877adcd0))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([97abfae](https://github.com/dendronhq/dendron/commit/97abfae86fc95df513219efca346e938f253ff71))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([61f79d0](https://github.com/dendronhq/dendron/commit/61f79d0f925faee516525686e0457988becc79f7))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([b0f3e0d](https://github.com/dendronhq/dendron/commit/b0f3e0d1016cc1ee6bade48317c51c3a23c9557d))
+* **views:** wrapping tree view calls in Sentry too ([2d57203](https://github.com/dendronhq/dendron/commit/2d5720314d4ebbde0c53e6d006e4d06462d396a7))
+* **workspace:** Fix issue with updated timestamp not updating properly on save ([#2651](https://github.com/dendronhq/dendron/issues/2651)) ([c8e75ff](https://github.com/dendronhq/dendron/commit/c8e75ff348e0ab0b88a094c1dd71824b66fdec8c))
+* **workspace:** workspace vault support for self contained vaults ([#2728](https://github.com/dendronhq/dendron/issues/2728)) ([beb791f](https://github.com/dendronhq/dendron/commit/beb791f3f13aa81f6f5f325f70a21654c1b92e1d))
+* error during init in non-Dendron workspaces due to `CopyNoteLink` ([6320278](https://github.com/dendronhq/dendron/commit/63202784a4d7fc042d8db50db776e4f4bbb2363b))
+* malformed _trackCommon arguments ([1e53681](https://github.com/dendronhq/dendron/commit/1e53681c9676c2878bb0d1f6f7140c15816d4d09))
+* **internal:** Clean up copynotelink and BacklinksTreeDataProvider tests ([88aea8a](https://github.com/dendronhq/dendron/commit/88aea8a829af91671be93a7d266fc098d2ca5951))
+* error when adding a self contained vault inside a native workspace ([#2660](https://github.com/dendronhq/dendron/issues/2660)) ([f2a9449](https://github.com/dendronhq/dendron/commit/f2a94491463396d0cce30dc7376898644622b908))
+* resolve PR comment ([03dc82a](https://github.com/dendronhq/dendron/commit/03dc82a561722465e73875c2537acbf786823645))
+* Text Document Service activates in non-Dendron workspaces ([f60515e](https://github.com/dendronhq/dendron/commit/f60515e97f0b9cdcfec9ea661370aa695d300ad1))
+* tree item sort order in treeview v1 to be on par with v2 in preparation for v2 deprecation ([#2665](https://github.com/dendronhq/dendron/issues/2665)) ([657a8ac](https://github.com/dendronhq/dendron/commit/657a8ac8f842506bdff97c80f00aba0880ab1cbc))
+* typo "hierarchy", "should" ([#2699](https://github.com/dendronhq/dendron/issues/2699)) ([a3b2eff](https://github.com/dendronhq/dendron/commit/a3b2eff276892ea344c7bc0552af9ab5030aaed5))
+* webview already registered problem with lookup panel ([28851d7](https://github.com/dendronhq/dendron/commit/28851d7c3855fb990fea82842d8f8d65427f31fc))
+* **workspace:** preserve wikilink metadata on export ([#2676](https://github.com/dendronhq/dendron/issues/2676)) ([553a954](https://github.com/dendronhq/dendron/commit/553a954bccdf5a8f574b2908f17ccd25fe61cb65))
+
+
+### Features Dendron
+
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([8ea1d1b](https://github.com/dendronhq/dendron/commit/8ea1d1b8e6247fec3e636c26da3f98e047026a6b))
+* **workspace:** Meeting Notes ([#2727](https://github.com/dendronhq/dendron/issues/2727)) ([f87ca99](https://github.com/dendronhq/dendron/commit/f87ca996dc31588b42e35fa8613d95c2aaf49b2a))
+* detect and fill missing default configs to reliably introduce newly added configurations on extension upgrade ([#2602](https://github.com/dendronhq/dendron/issues/2602)) ([4f31fce](https://github.com/dendronhq/dendron/commit/4f31fce3da8d04d981e05a151040ddd28edfba29))
+* option to gen title using full hierarchy ([1c6e4a7](https://github.com/dendronhq/dendron/commit/1c6e4a76cb9689e759ea87f5dc50485abf0c18b2))
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* consolidating button type enums ([c3c56bd](https://github.com/dendronhq/dendron/commit/c3c56bd23cc1b970126eb55ed96b397b9d5a2061))
+* PR Feedback; Various Bug Fixes ([0387120](https://github.com/dendronhq/dendron/commit/03871209a7b5abbcab9bd44de77702d942248a86))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([9050c79](https://github.com/dendronhq/dendron/commit/9050c79bccefbe7ed375e3221181c2fc736fbe61))
+* **copynotelink:** Allow user to run copyNoteLink without needing to save first ([9b48b9c](https://github.com/dendronhq/dendron/commit/9b48b9c652b38f7d78d51cdeb0d585f87f14b016))
+* **lookup:** autocomplete causes notes to be created in wrong vault  ([#2623](https://github.com/dendronhq/dendron/issues/2623)) ([c0c9023](https://github.com/dendronhq/dendron/commit/c0c9023da067415078790eebe5df9de448ded34a))
+* **views:** Pass in a port-forwarded URL to preview for remote workspaces ([#2624](https://github.com/dendronhq/dendron/issues/2624)) ([d2f460b](https://github.com/dendronhq/dendron/commit/d2f460b36d836ed187e9da9a67d9ca2d48102b87)), closes [#2606](https://github.com/dendronhq/dendron/issues/2606)
+* Backlinks will no longer disappear in preview upon editing ([#2608](https://github.com/dendronhq/dendron/issues/2608)) ([1ee16f9](https://github.com/dendronhq/dendron/commit/1ee16f9540173b2ec7558d0d120428e2d093d649))
+* **workspace:** fix dropped keystrokes issue in lookup ([#2626](https://github.com/dendronhq/dendron/issues/2626)) ([a8deb1a](https://github.com/dendronhq/dendron/commit/a8deb1a3e87edb62d3af2ac422eec334996da1df))
+* block anchors showing up in the preview ([#2548](https://github.com/dendronhq/dendron/issues/2548)) ([44802b8](https://github.com/dendronhq/dendron/commit/44802b8a37ed38b94fbc22692a4c1f21ee83963f)), closes [#2531](https://github.com/dendronhq/dendron/issues/2531)
+* Prevent fatal errors in Open Backup Command and Run Migration Command in native workspaces ([#2607](https://github.com/dendronhq/dendron/issues/2607)) ([dce17fe](https://github.com/dendronhq/dendron/commit/dce17fe293cf73016797257fd18e5f85c625a6a2))
+* Re-enable inactive user survey and store prompt status in filesystem for prompt reliability. ([#2555](https://github.com/dendronhq/dendron/issues/2555)) ([3a4269f](https://github.com/dendronhq/dendron/commit/3a4269f4b5669f45eb257377abfcde7aad9e7bf4))
+* rendering issue in local note graph ([b1c7cd3](https://github.com/dendronhq/dendron/commit/b1c7cd3c8739944370c4367dd187540cebd6cd2b))
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+* **workspace:** race condition when backing up configuration  ([#2581](https://github.com/dendronhq/dendron/issues/2581)) ([efd3bb8](https://github.com/dendronhq/dendron/commit/efd3bb8880b963b912fbcc6bcd0c0595b4083273))
+
+
+### Features Dendron
+
+* add doctor command for a more reliable keybinding resolution ([#2578](https://github.com/dendronhq/dendron/issues/2578)) ([4737aa5](https://github.com/dendronhq/dendron/commit/4737aa5dda198e51728496a1243f7ad45f2450f0))
+
+
+### Reverts
+
+* Revert "Pass in a port-forwarded URL to preview for remote workspaces" ([64f0cf6](https://github.com/dendronhq/dendron/commit/64f0cf678e0db7ac4e5533e24cfad8a6153ee9bf))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* add omitted migration entries ([#2519](https://github.com/dendronhq/dendron/issues/2519)) ([ae6ef64](https://github.com/dendronhq/dendron/commit/ae6ef64cb61b3aa4c229c77da5b94362e09d363d))
+* **views:** md parsing and preview perf improvements ([#2505](https://github.com/dendronhq/dendron/issues/2505)) ([282951f](https://github.com/dendronhq/dendron/commit/282951fbee192e97064595659fa31773249b6aa6))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* add selection2link button for CreateScratchNoteCommand ([#2496](https://github.com/dendronhq/dendron/issues/2496)) ([a881757](https://github.com/dendronhq/dendron/commit/a881757607d71106c87804aa3464232eee0b3250))
+* don't call reload index if action is findIncompatibleExtension ([#2458](https://github.com/dendronhq/dendron/issues/2458)) ([7141f17](https://github.com/dendronhq/dendron/commit/7141f17e8d36edfaf4c8dd9857666eefe4b8971d))
+* don't refresh tree view if note visible ([#2487](https://github.com/dendronhq/dendron/issues/2487)) ([76459fc](https://github.com/dendronhq/dendron/commit/76459fcf88609683ce2b6ccfe62cc498b5b1ea5e))
+* resolved PR comments ([6b9c70c](https://github.com/dendronhq/dendron/commit/6b9c70c1ae24a1841c9400b193d8e1fb092ec692))
+* resolved PR comments ([53ca31e](https://github.com/dendronhq/dendron/commit/53ca31e954c1bf4e9aea9b6ff5dcf143a86a9e19))
+* skip addFrontmatter prompt ([3a302de](https://github.com/dendronhq/dendron/commit/3a302de3b4167d9a9de25eec3a466eb6e56399dd))
+* update testcases ([6bc1d66](https://github.com/dendronhq/dendron/commit/6bc1d66e56ba31b3e51582010d9cdb236a5e8d73))
+* **pods:** refreshToken to read correct dendron port file ([53734ab](https://github.com/dendronhq/dendron/commit/53734ab46dbd75a34974939fe1d47734b118de44))
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([81c6586](https://github.com/dendronhq/dendron/commit/81c6586c49f2ea22f6036b0bd1d05bf6a642c051)), closes [#2429](https://github.com/dendronhq/dendron/issues/2429)
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([d1057e5](https://github.com/dendronhq/dendron/commit/d1057e5948b742bed7b2a378f3db2f43cd2a91d6))
+* **schema:** Apply schema template for goto-note-command if template is in different vault ([f0143e3](https://github.com/dendronhq/dendron/commit/f0143e3a0001dba9f775a4c50b2b87615b8f4a5f))
+
+
+### Features Dendron
+
+* pods v2 cli ([2e2bf8e](https://github.com/dendronhq/dendron/commit/2e2bf8e5e1189ed3e48e2e4e822c6fedf72142aa))
+
+
+### Reverts
+
+* remove source in import pod ([05a3084](https://github.com/dendronhq/dendron/commit/05a30842734d5745374577b9b025eb20439814d7))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **workspace:** Dendron will try to parse non-dendron files in `onFirstOpen` ([#2405](https://github.com/dendronhq/dendron/issues/2405)) ([d913a7f](https://github.com/dendronhq/dendron/commit/d913a7fe6e251f5e45925c591310ddd6e1031274))
+* **workspace:** error message to be readable in error toast ([25c74e8](https://github.com/dendronhq/dendron/commit/25c74e8aa2547a78c0d1e6399fcb2ffc72b06820))
+* add omitted changes that causes type error ([43a0f71](https://github.com/dendronhq/dendron/commit/43a0f719daf2f54b2b652b797e81cbd6dd7e1b75))
+* decode urlencoded spaces in asset path before opening ([#2279](https://github.com/dendronhq/dendron/issues/2279)) ([c60743d](https://github.com/dendronhq/dendron/commit/c60743db7c93bdb44deb2e97c4fb80cfdf209994))
+* emphasize no async fns on the describeWS Test functions ([9d7cf5f](https://github.com/dendronhq/dendron/commit/9d7cf5fe6290a7762bea433c287a72a9fdad31bf))
+* fixing journal title date formatting support ([5da910a](https://github.com/dendronhq/dendron/commit/5da910a4fac6c1bbef6515f88b44cd63507a823b))
+* journal command title and trait consistency issues ([3def810](https://github.com/dendronhq/dendron/commit/3def8104161a5779ae7abe47fce39d9f81bbc9c8))
+* preview opens wrong path on Windows ([#2326](https://github.com/dendronhq/dendron/issues/2326)) ([6ae66bc](https://github.com/dendronhq/dendron/commit/6ae66bca93bddbcefd9efb930c8a2bbc97352dfa))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+* remove circ deps between ILookupController and ILookupProvider ([798c2b9](https://github.com/dendronhq/dendron/commit/798c2b99e06eed4c0f07d8054e97c05a6effc152))
+* **schemas:** Do not include stubs as part of template suggestions when applying a template ([#2357](https://github.com/dendronhq/dendron/issues/2357)) ([a746e9c](https://github.com/dendronhq/dendron/commit/a746e9cf6c8766fa66dc879d2bf07e9e157025c4))
+* **views:** engine events; update DendronTreeView reliably ([#2269](https://github.com/dendronhq/dendron/issues/2269)) ([147cce8](https://github.com/dendronhq/dendron/commit/147cce8ba31576cccb2f98c3c355ef2fdb2cb683))
+* **views:** show preview doesn't display targeted files when using file explorer([#2327](https://github.com/dendronhq/dendron/issues/2327)) ([7ee340b](https://github.com/dendronhq/dendron/commit/7ee340b7194d5b48fc1d6c67d929dbd0beab9ad9))
+* **workspace:** avoid workspace watcher crashing if folder is deleted ([#2359](https://github.com/dendronhq/dendron/issues/2359)) ([9d0325f](https://github.com/dendronhq/dendron/commit/9d0325fc9d220a95d48a04716a5678dae0bebe79))
+* **workspace:** correct title generartion of notes with sub-hierarchy starting with md ([#2369](https://github.com/dendronhq/dendron/issues/2369)) ([562f2bd](https://github.com/dendronhq/dendron/commit/562f2bda3e7059408c6c5d46c7e4dfae463d49d0))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* **lookup:** "Note does not exist. Create?" should read "Schema does not exist. Create?" in Schema Lookup ([#2253](https://github.com/dendronhq/dendron/issues/2253)) ([e12dd3a](https://github.com/dendronhq/dendron/commit/e12dd3ad4d6460fca238ece928fb3be81dc77a98))
+* add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score. ([3192d77](https://github.com/dendronhq/dendron/commit/3192d773588e9f1817eabbbb78e68042c201d213))
+* analytics for show preview ([90c5ed8](https://github.com/dendronhq/dendron/commit/90c5ed837f2de0d7f9503459f9b46f278944cdd2))
+* bug on start up observing automaticallyShowPreview flag + cr feedback ([1b87072](https://github.com/dendronhq/dendron/commit/1b870720e533d6358cb4a4483294eaa8248d3725))
+* correctly offset frontmatter line count in doctor preview for `findBrokenLinks` ([#1959](https://github.com/dendronhq/dendron/issues/1959)) ([21255b3](https://github.com/dendronhq/dendron/commit/21255b30f3310e2cd897cfafc4764d04d553bd22))
+* cursor is moved when opening file through search interface ([87dcbd9](https://github.com/dendronhq/dendron/commit/87dcbd9aa2c0cc7f8f76c12f49e66cd883b94d91))
+* cursor moves to top when opening file through the search ([cd5004e](https://github.com/dendronhq/dendron/commit/cd5004ec2fff3529ab05d58e000365903566b2ae))
+* double open link from preview ([827e911](https://github.com/dendronhq/dendron/commit/827e911be8a457ff221dc51cff1d25d05ed47467))
+* infinite looping active note change when note graph is open ([#1980](https://github.com/dendronhq/dendron/issues/1980)) ([3a42ab7](https://github.com/dendronhq/dendron/commit/3a42ab78416019b716b842c08de247e7df22376c))
+* insert note index enablement ([b230a16](https://github.com/dendronhq/dendron/commit/b230a1669021949aea3f9af39d69c33c1b8fd26f))
+* move auto completable command registration to be done centrally ([#1891](https://github.com/dendronhq/dendron/issues/1891)) ([239eea2](https://github.com/dendronhq/dendron/commit/239eea2c882a686a5dfe98b52be98003a21cae88))
+* move header issues ([#2040](https://github.com/dendronhq/dendron/issues/2040)) ([5e09abf](https://github.com/dendronhq/dendron/commit/5e09abff646d001c99f944a2e51254aa56379e0d))
+* note traits not working after webpack ([#1889](https://github.com/dendronhq/dendron/issues/1889)) ([48087e4](https://github.com/dendronhq/dendron/commit/48087e44fd6a746b90771589f23c5aa88f32fc39))
+* PR comments addressed ([5f2a11b](https://github.com/dendronhq/dendron/commit/5f2a11b36aa0a7ec3a64544c09f273fe7575306e))
+* regression in windowwatcher ([9069c82](https://github.com/dendronhq/dendron/commit/9069c825a72b06a14b3aebe348f9dfbd53ed0479))
+* regression on onTriggerButton not scoping properly ([#2037](https://github.com/dendronhq/dendron/issues/2037)) ([d0e5fcd](https://github.com/dendronhq/dendron/commit/d0e5fcd99a51dd81309fc5faf46addef80f0267c))
+* rename operations modify unnecessary files ([83d0469](https://github.com/dendronhq/dendron/commit/83d04699656160f01634375782c1f26f9a8b67be)), closes [#2015](https://github.com/dendronhq/dendron/issues/2015)
+* resolved PR comment and conflict ([1d8b895](https://github.com/dendronhq/dendron/commit/1d8b8959e5c66e1dc7f6d7a487300040c11bca1c))
+* resolved PR comments ([85d91f4](https://github.com/dendronhq/dendron/commit/85d91f4881a7c9b7f21cbff458c885b13b7eeff9))
+* resolved PR comments ([126034e](https://github.com/dendronhq/dendron/commit/126034ee21767c91b62e0e82c6efcec7d5826753))
+* revert match text default value to active note name ([#1892](https://github.com/dendronhq/dendron/issues/1892)) ([8f823e8](https://github.com/dendronhq/dendron/commit/8f823e8e48b4700ba3cb68b063a783f5122c64c2))
+* skipping single notelookupcommand test ([3102f4f](https://github.com/dendronhq/dendron/commit/3102f4f87d528a4698b6a360c5bd843b506fe07d))
+* test updates ([fb066b2](https://github.com/dendronhq/dendron/commit/fb066b2277a8620b62385281235359ad5ccde874))
+* update interface for batch api calls ([81d8e9c](https://github.com/dendronhq/dendron/commit/81d8e9cbb1e33453b0d615b75bca9a0bce6eed25))
+* update PR comments ([41739fb](https://github.com/dendronhq/dendron/commit/41739fbb2219b0bbc1e9e40c55a79a78d5096daa))
+* updated pod to check values from config ([c1285f4](https://github.com/dendronhq/dendron/commit/c1285f487d289eab69ec1ce7532bb6e9351f384f))
+* **analytics:** inactive survey issues ([#2110](https://github.com/dendronhq/dendron/issues/2110)) ([36a3b2f](https://github.com/dendronhq/dendron/commit/36a3b2f6f69e1637c111503ce9455bf370558845))
+* **commands:** paste-link-title-trim ([#1961](https://github.com/dendronhq/dendron/issues/1961)) ([07f5137](https://github.com/dendronhq/dendron/commit/07f5137d33f8fbc96e161229ec133a9d1039d0e3))
+* **commands:** renamed command from goto note to go to note ([#2187](https://github.com/dendronhq/dendron/issues/2187)) ([c4ef88e](https://github.com/dendronhq/dendron/commit/c4ef88e077442db6ecb9584d134beebe039e7757))
+* **commands:** seed commands broken by refactor ([#1997](https://github.com/dendronhq/dendron/issues/1997)) ([2a3f5e4](https://github.com/dendronhq/dendron/commit/2a3f5e4ff0528ece188485d4d4f12f9b11d8eab2))
+* **lookup:** Remove redundant broken test ([b5648c0](https://github.com/dendronhq/dendron/commit/b5648c031cf1fd61ac75e8a1d7f681c72380792d))
+* **markdown:** lag in the editor when there's a x-vault link to a non-existent vault ([#1941](https://github.com/dendronhq/dendron/issues/1941)) ([0ae4325](https://github.com/dendronhq/dendron/commit/0ae43256c0d81683ec8c92bff66f69ed97e04102))
+* **note:** frontmatter tags are not highlighted ([#2001](https://github.com/dendronhq/dendron/issues/2001)) ([5eae3b7](https://github.com/dendronhq/dendron/commit/5eae3b7ae1efa8f4c0c790c6d30bf8f55617d7a7))
+* **refactor:** refactor crashes when captured note is a stub ([#1910](https://github.com/dendronhq/dendron/issues/1910)) ([24cf219](https://github.com/dendronhq/dendron/commit/24cf219d267ba63b0f9c140f19173898bece75b3))
+* **schema:** Ensure month/day/time has two digits when doing data variable substitution ([#2064](https://github.com/dendronhq/dendron/issues/2064)) ([20f807e](https://github.com/dendronhq/dendron/commit/20f807e3f1be3ba082a01dda527fa653cf30b433))
+* **views:** update tree order when a note changes order ([#2014](https://github.com/dendronhq/dendron/issues/2014)) ([b66032f](https://github.com/dendronhq/dendron/commit/b66032fef1b8cb5f7a6fa522a5e0ad14ac4d8388))
+* **workspace:** autocomplete deletes text following wikilink with no closing brackets ([#1909](https://github.com/dendronhq/dendron/issues/1909)) ([8fd0ef8](https://github.com/dendronhq/dendron/commit/8fd0ef8cd7710b8e6f5e74261d24c606e3c38f13)), closes [#1834](https://github.com/dendronhq/dendron/issues/1834)
+* **workspace:** correct message in convert vault ([#1999](https://github.com/dendronhq/dendron/issues/1999)) ([3d3ac8f](https://github.com/dendronhq/dendron/commit/3d3ac8f2e4c8c6f48440e6c3d2de9ba987b7a466))
+* **workspace:** stop link candidate logic when disabled ([#2136](https://github.com/dendronhq/dendron/issues/2136)) ([110941c](https://github.com/dendronhq/dendron/commit/110941cd268aaca43bc99a07d5670c52271aa95c))
+* resolved pr comment and updated testcase ([746b330](https://github.com/dendronhq/dendron/commit/746b330578487ee2ffdde17967f6d9c84bfc40dc))
+* Show Preview does nothing if used from command prompt ([f18d66b](https://github.com/dendronhq/dendron/commit/f18d66bbbf23e8dca5e61bf400023367c30410c3))
+* **lookup:** Remove redundant broken test ([b4979ec](https://github.com/dendronhq/dendron/commit/b4979ecf519e8851fcad55dc072670206cb92efb))
+* **views:** tree view refresh and circ dependency removal ([#2082](https://github.com/dendronhq/dendron/issues/2082)) ([a614731](https://github.com/dendronhq/dendron/commit/a614731e92f1ccba623a32ce1939ce48ff3102c2))
+* updated test ([31aaa1c](https://github.com/dendronhq/dendron/commit/31aaa1c8a9c21dce3013804b4d4a25e7aea71cb5))
+* **workspace:** don't show calendar view unless dendron tree view is active ([#2017](https://github.com/dendronhq/dendron/issues/2017)) ([5132e83](https://github.com/dendronhq/dendron/commit/5132e8309d2b66585aed50983bf431b221c16c0d))
+* warn for frontmatter issues even if the frontmatter is not visible ([bfe027e](https://github.com/dendronhq/dendron/commit/bfe027eb40ef1cdc7b214a6ff8ab3b1e6b32d453))
+* **workspace:** extension crash in non-Dendron workspaces when there's a large number of files ([#1913](https://github.com/dendronhq/dendron/issues/1913)) ([2840aa4](https://github.com/dendronhq/dendron/commit/2840aa47448cbf25a36bb10322da5e66d2c1bffc)), closes [#1312](https://github.com/dendronhq/dendron/issues/1312)
+* **workspace:** simplify InitializeWorkspace command ([#1886](https://github.com/dendronhq/dendron/issues/1886)) ([27f4c53](https://github.com/dendronhq/dendron/commit/27f4c53f34ee89700df3d53b31b016f393cdf282))
+* **workspace:** tutorial initializer with existing ws in default paths ([#1873](https://github.com/dendronhq/dendron/issues/1873)) ([434a857](https://github.com/dendronhq/dendron/commit/434a85793c7eadb3e2ab0332e1c1da5984632a69))
+
+
+### Features Dendron
+
+* lookup view ([#1977](https://github.com/dendronhq/dendron/issues/1977)) ([dad85f6](https://github.com/dendronhq/dendron/commit/dad85f6e1964b5cf21bc0a1007c229c504e17eb5))
+* open preview buttons for context menus ([#1906](https://github.com/dendronhq/dendron/issues/1906)) ([8b9160c](https://github.com/dendronhq/dendron/commit/8b9160c250cad2465dbfb77c785ab022b31cd88b))
+* **commands:** find broken links ([#1847](https://github.com/dendronhq/dendron/issues/1847)) ([0f23a79](https://github.com/dendronhq/dendron/commit/0f23a79e5473afa2afb1c5c0e274e2bd3f134554))
+* **navigation:** Goto Note can open links to non-note files ([#1844](https://github.com/dendronhq/dendron/issues/1844)) ([4223303](https://github.com/dendronhq/dendron/commit/4223303213731b341a45a73d9e2e55d53392630a))
+* **navigation:** implement goto definition for non-note files ([#1888](https://github.com/dendronhq/dendron/issues/1888)) ([19e8070](https://github.com/dendronhq/dendron/commit/19e8070ede4bc5c827ff92cdeac31dd6ab000a74))
+* **navigation:** non-note file enhancements ([#1895](https://github.com/dendronhq/dendron/issues/1895)) ([90e083b](https://github.com/dendronhq/dendron/commit/90e083b5e10073acbc8967ad9649c0008aae381c))
+* **notes:** Note Trait System Prototype (Phase 1) ([#1658](https://github.com/dendronhq/dendron/issues/1658)) ([0d5d187](https://github.com/dendronhq/dendron/commit/0d5d187a9aaaaebfc32fa9c7c5b5faa5c3b38eb3))
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+* **refactor:** convert link command ([#1933](https://github.com/dendronhq/dendron/issues/1933)) ([e4cba18](https://github.com/dendronhq/dendron/commit/e4cba184382f7d8c1d2a6820e85305e1191a54c2))
+* **refactoring:** add rename provider ([#1879](https://github.com/dendronhq/dendron/issues/1879)) ([988e18b](https://github.com/dendronhq/dendron/commit/988e18b8e03cb952898cb1cba9caf998b2e994f5))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **views:** update webview title name ([16d1f0c](https://github.com/dendronhq/dendron/commit/16d1f0c2454e4056d56d988aa909c2ea70cf18b1))
+* corner cases for auto complete ([#1843](https://github.com/dendronhq/dendron/issues/1843)) ([d6c51f3](https://github.com/dendronhq/dendron/commit/d6c51f3fd352412d9a763af8f60f34a2c0ebabda))
+* **commands:** allow creation of new notes when move header destination doesn't exist yet ([#1646](https://github.com/dendronhq/dendron/issues/1646)) ([90a47e4](https://github.com/dendronhq/dendron/commit/90a47e4779b0d9209aa95f209688a42f20497990))
+* **lookup:** disappearing vaults in vault selection quickpick ([#1717](https://github.com/dendronhq/dendron/issues/1717)) ([7e2333a](https://github.com/dendronhq/dendron/commit/7e2333ae8b6dd5bcd10f29d6bf61931e206830ec))
+* **lookup:** have schema exact match suggestion in lookup show up at the top of the list ([#1720](https://github.com/dendronhq/dendron/issues/1720)) ([41b07b9](https://github.com/dendronhq/dendron/commit/41b07b98612dbe29e0d82426fc6fa5ac40812973))
+* **lookup:** hierarchy look up when inside parts of the hierarchy are omitted ([#1522](https://github.com/dendronhq/dendron/issues/1522)) ([6c30af5](https://github.com/dendronhq/dendron/commit/6c30af5e5b76297334f15a435fd1f9ad09941e06))
+* **lookup:** re-enable lookup commands ([e780cd1](https://github.com/dendronhq/dendron/commit/e780cd10f7c6ae17b1ad83666322677329b34f32))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** minor error in airtable v2 export pod ([#1846](https://github.com/dendronhq/dendron/issues/1846)) ([4550d93](https://github.com/dendronhq/dendron/commit/4550d9371c55ddb6a48be4a6b21c03585bc89592))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **views:** re-introduce preview command enablement ([#1806](https://github.com/dendronhq/dendron/issues/1806)) ([a16e34a](https://github.com/dendronhq/dendron/commit/a16e34ade8a3a7e296848940f00820e7a725788c))
+* **views:** tree view not initializing on load ([5590a3c](https://github.com/dendronhq/dendron/commit/5590a3c0aa7476e8984a1e9193697d9984ab00ee))
+* allow assets to open from preview view ([#1771](https://github.com/dendronhq/dendron/issues/1771)) ([f362bda](https://github.com/dendronhq/dendron/commit/f362bda9726c9dde2c96aa1954aa549c1f013136))
+* circular dependency with logger ([5f3f958](https://github.com/dendronhq/dendron/commit/5f3f9587516a6abfd0cde4810839b900cb0ff0b9))
+* decorator lag problems ([#1822](https://github.com/dendronhq/dendron/issues/1822)) ([239bbdc](https://github.com/dendronhq/dendron/commit/239bbdc074e7bfde065a4210084002a0685471e5))
+* **workspace:** apply enableUser/HashTags to broken wikilinks code action ([#1712](https://github.com/dendronhq/dendron/issues/1712)) ([1ea4f9d](https://github.com/dendronhq/dendron/commit/1ea4f9dbb24074519e90e2f5fc2d96bfdda65be5))
+* **workspace:** checks against fnames with all lowercase ([#1739](https://github.com/dendronhq/dendron/issues/1739)) ([8e3f8ec](https://github.com/dendronhq/dendron/commit/8e3f8ec061e0ce7d249a7e92902bb48e7c520793))
+* **workspace:** vault add avoids adding duplicate lines & vault remove cleans up gitignore lines ([#1689](https://github.com/dendronhq/dendron/issues/1689)) ([2a79fdd](https://github.com/dendronhq/dendron/commit/2a79fdd6ebedb0c312dca5d0b2f465a22be0f953))
+* backward compatibility of id matching adding '_' to id regex match. ([#1504](https://github.com/dendronhq/dendron/issues/1504)) ([4bbae40](https://github.com/dendronhq/dendron/commit/4bbae40d81ea064612f605c6f4e18ae8d34ba0de))
+* Change Workspace command recognizes native workspaces ([#1621](https://github.com/dendronhq/dendron/issues/1621)) ([d120934](https://github.com/dendronhq/dendron/commit/d1209348577437d6df1780ff2955849dabf7fbc9))
+* file watcher updates backlinks ([#1618](https://github.com/dendronhq/dendron/issues/1618)) ([1e0b776](https://github.com/dendronhq/dendron/commit/1e0b776c8fe9af90f56a0df4a57002982a4d834c))
+* hover & goto note should respect enableUser/HashTags ([#1620](https://github.com/dendronhq/dendron/issues/1620)) ([1943171](https://github.com/dendronhq/dendron/commit/1943171f6cf614250cc157d13e210c83fa985348)), closes [#1503](https://github.com/dendronhq/dendron/issues/1503)
+* mistyped analytics event name ([#1678](https://github.com/dendronhq/dendron/issues/1678)) ([13086c2](https://github.com/dendronhq/dendron/commit/13086c2c9dc995f7feeea3cfed66fddb54ca52a9))
+* notes getting edited issue ([#1559](https://github.com/dendronhq/dendron/issues/1559)) ([6810a9a](https://github.com/dendronhq/dendron/commit/6810a9a1564750b2fd31da7b6ab44f062ed779f5))
+* recursive null value cleanup not properly working during migration ([#1564](https://github.com/dendronhq/dendron/issues/1564)) ([660c86e](https://github.com/dendronhq/dendron/commit/660c86e9ef0ea702eb20fa754378e5de6dbf84b6))
+* replace auto generated ids (coming from inline schemas) with patterns ([#1632](https://github.com/dendronhq/dendron/issues/1632)) ([af28cf6](https://github.com/dendronhq/dendron/commit/af28cf6ef1d085d22069695e9df128477c024d1b))
+* **commands:** move header command modifying unrelated note content ([#1574](https://github.com/dendronhq/dendron/issues/1574)) ([46cad20](https://github.com/dendronhq/dendron/commit/46cad20c089fd4bcc22513a2dfc60bed8197e7f6))
+* **markdown:** email parsed as user tag & option to disable user tags and hashtags ([#1562](https://github.com/dendronhq/dendron/issues/1562)) ([fd56f7e](https://github.com/dendronhq/dendron/commit/fd56f7ece1651ea6433ebf481f2c54386ab6fb16))
+* **publish:** make 11ty publishing compatible with config version 3 ([#1556](https://github.com/dendronhq/dendron/issues/1556)) ([bc76028](https://github.com/dendronhq/dendron/commit/bc760288b757375eef1c787541b31097e86842be))
+* require statement path ([#1561](https://github.com/dendronhq/dendron/issues/1561)) ([6a7be61](https://github.com/dendronhq/dendron/commit/6a7be61db3ec7e6fab61871b30ec215c47f1cb59))
+* **workspace:** error when init native workspace ([e74d492](https://github.com/dendronhq/dendron/commit/e74d492186489d06aa584dd9c78d82ad27017e85))
+* **workspace:** making changes to fontmatter title also update the preview ([#1513](https://github.com/dendronhq/dendron/issues/1513)) ([a54848d](https://github.com/dendronhq/dendron/commit/a54848d787b0298b2fac696b0c6b3e4d144efe05))
+* **workspace:** possible error if open note is changed quickly after edit ([#1486](https://github.com/dendronhq/dendron/issues/1486)) ([e21f92e](https://github.com/dendronhq/dendron/commit/e21f92e528f19ad44643fb63fe0e817f33bffea7))
+
+
+### Features Dendron
+
+* **lookup:** add auto complete to note lookup ([#1781](https://github.com/dendronhq/dendron/issues/1781)) ([ea5ad5c](https://github.com/dendronhq/dendron/commit/ea5ad5c6672aa0c812aa7e852d5c28c3cea0e1b1))
+* **pods:** Export Pod V2 ([#1772](https://github.com/dendronhq/dendron/issues/1772)) ([2dac9df](https://github.com/dendronhq/dendron/commit/2dac9dfb13525af984c3fd2f938283cba33cef7b))
+* decorator improvements ([#1770](https://github.com/dendronhq/dendron/issues/1770)) ([a7227fd](https://github.com/dendronhq/dendron/commit/a7227fd4d8991e44729989c821a22560dcb8348b))
+* **workspace:** added contextual ui menu option for wrapping link ([#1677](https://github.com/dendronhq/dendron/issues/1677)) ([732108c](https://github.com/dendronhq/dendron/commit/732108c848eb05e5f2c9cf1fc8ecdd02fa377c6e))
+* add Dendron preview button ([db092e3](https://github.com/dendronhq/dendron/commit/db092e33cb6295b4d90e60bd4267d2f83f824e7a))
+* **notes:** task notes (create modifier & editor highlighting) ([#1583](https://github.com/dendronhq/dendron/issues/1583)) ([e785efa](https://github.com/dendronhq/dendron/commit/e785efa8e2ce55bc39fb90cf34984d55035dd6ca))
+* **workspace:** Initialize Workspace command can create native workspaces ([#1701](https://github.com/dendronhq/dendron/issues/1701)) ([5b59038](https://github.com/dendronhq/dendron/commit/5b590388c57e92b3e801bbe8463fe8ba052e79ed))
+* Native workspace enhancements ([#1670](https://github.com/dendronhq/dendron/issues/1670)) ([7a392bb](https://github.com/dendronhq/dendron/commit/7a392bb47c69b562d54fa15479a184f1441e129e))
+* **schemas:** adding new command - create schema from hierarchy ([#1673](https://github.com/dendronhq/dendron/issues/1673)) ([14732ec](https://github.com/dendronhq/dendron/commit/14732ecbdd42511337ddaaf3fc91bde288c3036d))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+* **workspace:** convert vault command ([#1542](https://github.com/dendronhq/dendron/issues/1542)) ([c265e9d](https://github.com/dendronhq/dendron/commit/c265e9d2c238b5a6b3761f4c073140b1a0debe3a))
+* **workspace:** hide default markdown preview button ([#1636](https://github.com/dendronhq/dendron/issues/1636)) ([ce182b2](https://github.com/dendronhq/dendron/commit/ce182b278008ded4ffe0de02b12b70ef4f948dc4))
+* **workspace:** native workspaces ([#1482](https://github.com/dendronhq/dendron/issues/1482)) ([c2febc9](https://github.com/dendronhq/dendron/commit/c2febc9ec328d723b933177fc2659326638ac059))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+### Bug Fixes
+
+* template doesn't copy FM tags ([#1488](https://github.com/dendronhq/dendron/issues/1488)) ([0317699](https://github.com/dendronhq/dendron/commit/0317699ef9bfd4d77b1d3d05f8093e725ea5b2c3)), closes [#1481](https://github.com/dendronhq/dendron/issues/1481)
+* **lookup:** move header command shouldn't update note references that don't match the moved header's anchor ([#1480](https://github.com/dendronhq/dendron/issues/1480)) ([f3bb62e](https://github.com/dendronhq/dendron/commit/f3bb62e284dd26aee5d531a4d7f0d12231fd1750))
+* fix journal note creation ([#1465](https://github.com/dendronhq/dendron/issues/1465)) ([18a5f27](https://github.com/dendronhq/dendron/commit/18a5f273183cd084a1eaf288ed2c48ad7a092a1e))
+* **commands:** move header command compile noterefs ([#1458](https://github.com/dendronhq/dendron/issues/1458)) ([acc15d6](https://github.com/dendronhq/dendron/commit/acc15d6614194404dc5610d2ae9ffbe689013fc0))
+* **lookup:** vault selection use wrong label ([#1463](https://github.com/dendronhq/dendron/issues/1463)) ([2767be7](https://github.com/dendronhq/dendron/commit/2767be78a458548c72d0ada194abb15263b52a1f))
+* **view:** enable anchor links to work in preview ([#1375](https://github.com/dendronhq/dendron/issues/1375)) ([f27cfb0](https://github.com/dendronhq/dendron/commit/f27cfb07d612e28fd0d6dd08019d772767900bba))
+* **workspace:** highlighting for wildcard note refs with header offsets ([#1460](https://github.com/dendronhq/dendron/issues/1460)) ([a4722da](https://github.com/dendronhq/dendron/commit/a4722daaff33b25667c0b431cc919f898401ca31))
+* initialization for native workspaces ([#1449](https://github.com/dendronhq/dendron/issues/1449)) ([d9eafde](https://github.com/dendronhq/dendron/commit/d9eafdeb3e7db4af847aba6628d9e69c0b3c624a))
+
+
+### Features Dendron
+
+* Lapsed user survey ([#1446](https://github.com/dendronhq/dendron/issues/1446)) ([8094d2b](https://github.com/dendronhq/dendron/commit/8094d2bb1972fecf4fde74e8c5644aeba3eec119)), closes [#1349](https://github.com/dendronhq/dendron/issues/1349)
+* **command:** move header command ([#1349](https://github.com/dendronhq/dendron/issues/1349)) ([71c20f0](https://github.com/dendronhq/dendron/commit/71c20f07eef155775cab3b5bdff59a854170cb02))
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* add ovsx dev dep ([0080b8f](https://github.com/dendronhq/dendron/commit/0080b8fa0faf1c63630ea72fa78d2e4afb0fdf22))
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+* support activation for older vscode version ([#1426](https://github.com/dendronhq/dendron/issues/1426)) ([5a1c7ed](https://github.com/dendronhq/dendron/commit/5a1c7ed9b45df2f00e61229c0776dad41cc29aba))
+* **lookup:** picked schema matching name was not creating the expected note ([#1425](https://github.com/dendronhq/dendron/issues/1425)) ([76cf5e1](https://github.com/dendronhq/dendron/commit/76cf5e1b2e7929a65fcdcf060e52242abc6991fa))
+
+
+### Features Dendron
+
+* **workspace:** add survey for new users([#1409](https://github.com/dendronhq/dendron/issues/1409)) ([e2b1754](https://github.com/dendronhq/dendron/commit/e2b17548fbbe3dffef961eb393f82a6a876940e7))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+### Bug Fixes
+
+* no-op on hover provider if dendron non active ([#1398](https://github.com/dendronhq/dendron/issues/1398)) ([61949f1](https://github.com/dendronhq/dendron/commit/61949f187d1a6c5a1d3ed3f63f9695b51bacdc7a))
+* **workspace:** next gen views in remote workspaces ([#1401](https://github.com/dendronhq/dendron/issues/1401)) ([c9cb2e0](https://github.com/dendronhq/dendron/commit/c9cb2e0381c258b34e355bb89d53b3624ff3962e))
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** notes added outside Dendron are missed ([#1406](https://github.com/dendronhq/dendron/issues/1406)) ([1a34940](https://github.com/dendronhq/dendron/commit/1a349407718d65e94dfdc86104af587e00344264))
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* **workspace:** prevent malformed keybinding.json ([#1403](https://github.com/dendronhq/dendron/issues/1403)) ([2a221ab](https://github.com/dendronhq/dendron/commit/2a221ab5ad2ddd9cf93b27edf4a145941fca1915))
+* hashtags not at the start of line don't autocomplete ([#1370](https://github.com/dendronhq/dendron/issues/1370)) ([83f7a56](https://github.com/dendronhq/dendron/commit/83f7a56bb76336c3192c29dc03619e9ea2bcff85)), closes [#1352](https://github.com/dendronhq/dendron/issues/1352)
+* no-op completion provider when dendron isn't active ([#1392](https://github.com/dendronhq/dendron/issues/1392)) ([8136b9c](https://github.com/dendronhq/dendron/commit/8136b9c6bad293ac77aae78a9426c3b27c4d38d3))
+* pesky error popup when schema lookup is closed ([#1389](https://github.com/dendronhq/dendron/issues/1389)) ([4d2bb40](https://github.com/dendronhq/dendron/commit/4d2bb401b17e926dc2eaa11957536f0c75a1e538))
+* selection2link doesn't update note with link ([#1383](https://github.com/dendronhq/dendron/issues/1383)) ([737d584](https://github.com/dendronhq/dendron/commit/737d584c42a8033131437085ff5b2e4db3f18e8a))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **commands:** rename note leaves incorrect metadata if parent is a stub ([#1348](https://github.com/dendronhq/dendron/issues/1348)) ([d432cc9](https://github.com/dendronhq/dendron/commit/d432cc9e20ff8b9f6cefd7cc4c3a42b567ed9bc5))
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* **workspace:** disable certain decorations for long notes to avoid performance hit ([#1337](https://github.com/dendronhq/dendron/issues/1337)) ([f1c46f9](https://github.com/dendronhq/dendron/commit/f1c46f95c228ada2126ec7212cede3bf5acc773d))
+* creating scratch when text is selected within a note SHOULD not match scratches just due to prefix ([#1292](https://github.com/dendronhq/dendron/issues/1292)) ([cea4568](https://github.com/dendronhq/dendron/commit/cea456809b0da327bff5e06c1a796323d3eb257f))
+* decorations for erased tags persist ([#1291](https://github.com/dendronhq/dendron/issues/1291)) ([e3284f6](https://github.com/dendronhq/dendron/commit/e3284f6449fe36edb81deb2ae4c97612fdf2b8de))
+* direct children query ([#1303](https://github.com/dendronhq/dendron/issues/1303)) ([bcf0dea](https://github.com/dendronhq/dendron/commit/bcf0deae422406564cd9a56c1765f90dd2e66215))
+* disallow toggling of vault selection behavior in move note ([#1296](https://github.com/dendronhq/dendron/issues/1296)) ([4dc7ca4](https://github.com/dendronhq/dendron/commit/4dc7ca4547bc0c7bcb8eb3e27f64ad7236ef4fd5))
+* do not show multi select button on note rename ([#1293](https://github.com/dendronhq/dendron/issues/1293)) ([bd283c1](https://github.com/dendronhq/dendron/commit/bd283c1427f5b1f611885dd8499b2bd5b5bf98c3))
+* fix move note to have exact match ([#1331](https://github.com/dendronhq/dendron/issues/1331)) ([a5f4f9b](https://github.com/dendronhq/dendron/commit/a5f4f9b5220d67621e508a68ad2386cd481db21f))
+* fixing cmd tab typo in tutorial.2 ([#1234](https://github.com/dendronhq/dendron/issues/1234)) ([6e0543d](https://github.com/dendronhq/dendron/commit/6e0543d5077d40f2e9fc12325d3e111cad7e9a01))
+* highlight same file wikilinks, wildcard references, links with anchors ([#1306](https://github.com/dendronhq/dendron/issues/1306)) ([956aa2a](https://github.com/dendronhq/dendron/commit/956aa2a7079eaa93acd2a66ace3c44f3f874c0f8))
+* hover provider shouldn't recommend Ctrl+click for missing notes unless configured ([#1276](https://github.com/dendronhq/dendron/issues/1276)) ([cc037b6](https://github.com/dendronhq/dendron/commit/cc037b6e53c21389be8507e8088dc65bff0d7259))
+* Ignore lookupConfirm if dailyVault is set ([#1311](https://github.com/dendronhq/dendron/issues/1311)) ([1c734da](https://github.com/dendronhq/dendron/commit/1c734daa45cc1e655638d754267c6bdf5bdcab90))
+* issue with init workspace ([94d05c8](https://github.com/dendronhq/dendron/commit/94d05c8f1b6856c769d0cd2964d1dece9decb37c))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* show all root results and their children on empty query ([#1333](https://github.com/dendronhq/dendron/issues/1333)) ([6ad6fd8](https://github.com/dendronhq/dendron/commit/6ad6fd87d7a8a6fd7791cf7d2166ea59dc3b0982))
+* stop calendar from auto expanding when the last note is closed ([#1299](https://github.com/dendronhq/dendron/issues/1299)) ([9c8f853](https://github.com/dendronhq/dendron/commit/9c8f8533da5027c122e0d003ce4c61dc866735f5))
+* unhandled error in insert note link ([#1192](https://github.com/dendronhq/dendron/issues/1192)) ([a73420c](https://github.com/dendronhq/dendron/commit/a73420cd0f3d9f933256be43b839226b15b1e837))
+* update links on frontmatter tags changes ([#1214](https://github.com/dendronhq/dendron/issues/1214)) ([4d344fe](https://github.com/dendronhq/dendron/commit/4d344fe40701a259e3ac4399899dab4099c8614f))
+* update vs code compat version + husky hook check ([#1346](https://github.com/dendronhq/dendron/issues/1346)) ([1ae3fc6](https://github.com/dendronhq/dendron/commit/1ae3fc6da41084adc1e19f4c09b3a75d00ca0cb3))
+
+
+### Features Dendron
+
+* Add smart vault selection to NoteLookupCommand ([#1174](https://github.com/dendronhq/dendron/issues/1174)) ([742cab6](https://github.com/dendronhq/dendron/commit/742cab6c683bb14b6baff6c786957a5cc7228894))
+* enable usePrettyRefs for nextJS publishing and preview ([#1239](https://github.com/dendronhq/dendron/issues/1239)) ([8a456a9](https://github.com/dendronhq/dendron/commit/8a456a910c45e927c8413d881324bd28401e2aca))
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* run migration command ([#1177](https://github.com/dendronhq/dendron/issues/1177)) ([98bd000](https://github.com/dendronhq/dendron/commit/98bd000236e8c3a7def6b6895fa8d24315c54cf2))
+* seed browser initial revision ([#1166](https://github.com/dendronhq/dendron/issues/1166)) ([588fba0](https://github.com/dendronhq/dendron/commit/588fba05bbd9e3dabadd5e02d9fde72d80ed8148))
+* support collection options in nextjs publishing ([#1277](https://github.com/dendronhq/dendron/issues/1277)) ([ddaedd4](https://github.com/dendronhq/dendron/commit/ddaedd40cfa9490a752d1d45e9680cf55d76c51f))
+* user tag autocomplete & user tags updated on rename ([#1278](https://github.com/dendronhq/dendron/issues/1278)) ([9719f99](https://github.com/dendronhq/dendron/commit/9719f99550a2c51c1a22f6fb21ff750bb4115f89))
+* user tags ([#1228](https://github.com/dendronhq/dendron/issues/1228)) ([98c0106](https://github.com/dendronhq/dendron/commit/98c0106367e384c130a927484b9ea294eb6f84fa))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+### Bug Fixes
+
+* force update picker item on button trigger even when value hasn't changed ([#1176](https://github.com/dendronhq/dendron/issues/1176)) ([46449a4](https://github.com/dendronhq/dendron/commit/46449a44009913af6340b26660fd5b5b2a79d57f))
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Bug Fixes
+
+* hiding quickpick doesn't dispose of picker ([781923a](https://github.com/dendronhq/dendron/commit/781923a679426ec4f29bd4600e29437ce1902d6f))
+* multiple issues with lookupv3 ([1fdd9eb](https://github.com/dendronhq/dendron/commit/1fdd9eb3242b43539572a1993fefd174640c6d83))
+* regression with move note command ([5e357b8](https://github.com/dendronhq/dendron/commit/5e357b8995ff335aa36ad48777a96ee56b196c01))
+
+
+### Features Dendron
+
+* Insert Note Index command ([#1142](https://github.com/dendronhq/dendron/issues/1142)) ([c140015](https://github.com/dendronhq/dendron/commit/c140015c19a942cf4696d596e818fd89905eea25))
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* accept splitType argument in lookup v2 ([#1102](https://github.com/dendronhq/dendron/issues/1102)) ([a1120e4](https://github.com/dendronhq/dendron/commit/a1120e449af9776a14d2bcbb47f8d877ebd1227b))
+* CopyNoteLink copies footnotes as anchors ([#1117](https://github.com/dendronhq/dendron/issues/1117)) ([2168991](https://github.com/dendronhq/dendron/commit/21689914d0c84735d243b988dcceb276df97380f))
+* CopyNoteRef respects noXVaultWikiLink option ([#1085](https://github.com/dendronhq/dendron/issues/1085)) ([b4b3da3](https://github.com/dendronhq/dendron/commit/b4b3da3306e2c5621c3c79a53b9f6e4cc31856c6)), closes [#1072](https://github.com/dendronhq/dendron/issues/1072)
+* Doctor `regenerateNoteId` action error ([#1097](https://github.com/dendronhq/dendron/issues/1097)) ([f0480c7](https://github.com/dendronhq/dendron/commit/f0480c7306eb07a2d40ea2b4278757d6c8dd26bb))
+* extension readme getting started link ([#1084](https://github.com/dendronhq/dendron/issues/1084)) ([d3f5b7d](https://github.com/dendronhq/dendron/commit/d3f5b7dc49873cbbb9e44ce1ff473cd4d95e1214))
+* FM tags with quoted strings & with spaces ([1a16689](https://github.com/dendronhq/dendron/commit/1a1668914f70b48a4e74a218bd43521df226de38))
+* highlighting is not displayed ([#1083](https://github.com/dendronhq/dendron/issues/1083)) ([86ead9b](https://github.com/dendronhq/dendron/commit/86ead9b7ec66a51712a265f263a515c624f2861c))
+* issue with direct child filter partially omitting values in quickpick ([#1123](https://github.com/dendronhq/dendron/issues/1123)) ([fbabab4](https://github.com/dendronhq/dendron/commit/fbabab4b61c91f3ebbe62def339efb32e1815178))
+* lookupv3 selection issue ([#1130](https://github.com/dendronhq/dendron/issues/1130)) ([c807e88](https://github.com/dendronhq/dendron/commit/c807e88a82217e5a04dfddb5a24259a50bea4813))
+* properly debounce picker update ([#1111](https://github.com/dendronhq/dendron/issues/1111)) ([ae12e1e](https://github.com/dendronhq/dendron/commit/ae12e1ec39e6d75c9c47e27eff7f96418984da4a))
+* skip delayed decoration update if note is closed ([2d91164](https://github.com/dendronhq/dendron/commit/2d9116489b2d1f4d5ccd6d22c022af2da9984817))
+* uninstall hook force flush ([#1087](https://github.com/dendronhq/dendron/issues/1087)) ([386aac2](https://github.com/dendronhq/dendron/commit/386aac2b8036cd58c190da99609cef2d3ed2467f))
+
+
+### Features Dendron
+
+* add journal title override to NoteLookupCommand ([#1140](https://github.com/dendronhq/dendron/issues/1140)) ([173b0c9](https://github.com/dendronhq/dendron/commit/173b0c95d7ca9593e72e2cd1c39e4fdcf31fa64a))
+* **calendar:** enable webui by default ([#1127](https://github.com/dendronhq/dendron/issues/1127)) ([3ce8be0](https://github.com/dendronhq/dendron/commit/3ce8be05f50c0fef784eef1b6d02e4816e1bf44a))
+* add remaining modifiers to NoteLookup ([#1056](https://github.com/dendronhq/dendron/issues/1056)) ([49c6005](https://github.com/dendronhq/dendron/commit/49c6005d2a2c8fd422eb653977e926084e743d6a)), closes [#1045](https://github.com/dendronhq/dendron/issues/1045) [#1046](https://github.com/dendronhq/dendron/issues/1046)
+* add schema suggestion to NoteLookupCommand ([#1113](https://github.com/dendronhq/dendron/issues/1113)) ([7dbd03f](https://github.com/dendronhq/dendron/commit/7dbd03f20586d5174c13a40ed50eecfd8b4c788d))
+* add schema templating feature to NoteLookupCommand ([#1118](https://github.com/dendronhq/dendron/issues/1118)) ([8a4cd2b](https://github.com/dendronhq/dendron/commit/8a4cd2b337521abcc25df61e145ef6868c50ea0f))
+* Add SchemaLookupCommand ([#1082](https://github.com/dendronhq/dendron/issues/1082)) ([fe11a0e](https://github.com/dendronhq/dendron/commit/fe11a0ea1e0214823dd01842b941456df164bc70))
+* basic frontmatter tag support ([2fe8ea5](https://github.com/dendronhq/dendron/commit/2fe8ea5733cdf6c047c39b8b9865cb7e5fdb541b))
+* custom tag coloring ([#1069](https://github.com/dendronhq/dendron/issues/1069)) ([5fe0a3c](https://github.com/dendronhq/dendron/commit/5fe0a3c7c62608f3796c58e4b807061498199168))
+* goto definition & hover support for frontmatter tags ([18faa1e](https://github.com/dendronhq/dendron/commit/18faa1e1549d2ed6a29118a0fb5a888c7e92f927))
+* GotoNote support for frontmatter tags ([4b3ba55](https://github.com/dendronhq/dendron/commit/4b3ba55ceb8459652b09f8be1f79e842d90213d9))
+* provide YAML validator & suggest YAML extension ([#1116](https://github.com/dendronhq/dendron/issues/1116)) ([b46f091](https://github.com/dendronhq/dendron/commit/b46f0916f9f01fdd7b71b6b5120c38a71d58b113))
+* re-engage lapsed users with prompt ([#1086](https://github.com/dendronhq/dendron/issues/1086)) ([f4e6dc5](https://github.com/dendronhq/dendron/commit/f4e6dc563aafdfc0b46966e74d9b38920aee1207))
+* rename header updates default link aliases ([1f0e405](https://github.com/dendronhq/dendron/commit/1f0e405d2c67a547fdecc41d76f062251a7cae01))
+* resolve vim keybinding conflict on initial install ([#1103](https://github.com/dendronhq/dendron/issues/1103)) ([2278c66](https://github.com/dendronhq/dendron/commit/2278c6616c8297cc414ad02d5323bff5c45072e4))
+* seed cmds in plugin ([#1080](https://github.com/dendronhq/dendron/issues/1080)) ([e07a092](https://github.com/dendronhq/dendron/commit/e07a092b1a75548574f2ea45f1b465490b2091f3))
+* tag colors in parents cascade to children ([3c77c06](https://github.com/dendronhq/dendron/commit/3c77c06daad5e32d3d72a4b329632100f7345460))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/plugin-core

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchal note taking tool that grows as you do. ",
   "publisher": "dendron",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "sponsor": {
     "url": "https://accounts.dendron.so/account/subscribe"
   },
@@ -1418,8 +1418,8 @@
     "test-in-browser": "mkdir -p testOutput && vscode-test-web --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/index.js --headless testOutput"
   },
   "devDependencies": {
-    "@dendronhq/common-test-utils": "^0.110.0",
-    "@dendronhq/engine-test-utils": "^0.110.0",
+    "@dendronhq/common-test-utils": "^0.110.1",
+    "@dendronhq/engine-test-utils": "^0.110.1",
     "@sentry/webpack-plugin": "^1.17.1",
     "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0.1",
@@ -1461,11 +1461,11 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.110.0",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
-    "@dendronhq/pods-core": "^0.110.0",
+    "@dendronhq/api-server": "^0.110.1",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
+    "@dendronhq/pods-core": "^0.110.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "@types/vscode": "1.62.0",

--- a/packages/pods-core/CHANGELOG.md
+++ b/packages/pods-core/CHANGELOG.md
@@ -3,6 +3,270 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+
+### Bug Fixes
+
+* **sync:** nextjs export pod to fetch latest dendron config ([#3455](https://github.com/dendronhq/dendron/issues/3455)) ([00cbeea](https://github.com/dendronhq/dendron/commit/00cbeeacfbc6f8ae11b67fcd26eaa10cbc02271e))
+
+
+
+# 0.106.0 (2022-08-02)
+
+
+
+## 0.105.2 (2022-07-28)
+
+
+
+## 0.104.1 (2022-07-21)
+
+
+
+# 0.104.0 (2022-07-19)
+
+
+
+# 0.101.0 (2022-06-28)
+
+
+### Features Dendron
+
+* **cli:** add a cli command that generates a packed-circles visualization of workspace ([#3057](https://github.com/dendronhq/dendron/issues/3057)) ([fe2b98b](https://github.com/dendronhq/dendron/commit/fe2b98b93594635fa7650b9daa9082bf63b0cd66))
+
+
+
+## 0.100.1 (2022-06-23)
+
+
+
+# 0.100.0 (2022-06-21)
+
+
+
+# 0.99.0 (2022-06-14)
+
+
+
+# 0.98.0 (2022-06-07)
+
+
+### Bug Fixes
+
+* **publish:** Export gets stuck if `logoPath` is set but the logo doesn't exist ([4d8453b](https://github.com/dendronhq/dendron/commit/4d8453bc1c764dbf1d25e1bc932865159a4fd575))
+
+
+
+# 0.96.0 (2022-05-24)
+
+
+### Bug Fixes
+
+* **publish:** Export gets stuck if `logoPath` is set but the logo doesn't exist ([f820de2](https://github.com/dendronhq/dendron/commit/f820de2d2b116194b5874a90fcf35d1d317ff5d3))
+
+
+
+## 0.95.1 (2022-05-18)
+
+
+
+# 0.95.0 (2022-05-17)
+
+
+### Features Dendron
+
+* **publish:** Custom theme support ([#2887](https://github.com/dendronhq/dendron/issues/2887)) ([8dd5023](https://github.com/dendronhq/dendron/commit/8dd50239347fae84b65622f204bf3add38fc20d6))
+
+
+
+# 0.94.0 (2022-05-10)
+
+
+
+# 0.93.0 (2022-05-03)
+
+
+
+## 0.92.1 (2022-04-28)
+
+
+
+# 0.91.0 (2022-04-19)
+
+
+
+# 0.88.0 (2022-03-29)
+
+
+### Bug Fixes
+
+* resolve PR comments ([cadea31](https://github.com/dendronhq/dendron/commit/cadea31039b8bdf973e52662c9438d734a64fcc5))
+* **pods:** Google Docs Export pod displays Bad Request error on export ([#2529](https://github.com/dendronhq/dendron/issues/2529)) ([2583a8e](https://github.com/dendronhq/dendron/commit/2583a8e8f9534b2b922fbb0caa3f6f682930e9d2))
+
+
+
+# 0.85.0 (2022-03-08)
+
+
+### Bug Fixes
+
+* **views:** md parsing and preview perf improvements ([#2505](https://github.com/dendronhq/dendron/issues/2505)) ([282951f](https://github.com/dendronhq/dendron/commit/282951fbee192e97064595659fa31773249b6aa6))
+
+
+
+# 0.84.0 (2022-03-01)
+
+
+### Bug Fixes
+
+* **pods:** md export v2 to acknowledge wikiLinkToURL for links inside noteRefs ([32f5ae6](https://github.com/dendronhq/dendron/commit/32f5ae61eccd80195eb8e32700c4f48dc516b54b))
+* resolved PR comments ([53ca31e](https://github.com/dendronhq/dendron/commit/53ca31e954c1bf4e9aea9b6ff5dcf143a86a9e19))
+* update testcases ([6bc1d66](https://github.com/dendronhq/dendron/commit/6bc1d66e56ba31b3e51582010d9cdb236a5e8d73))
+* **pods:** refreshToken to read correct dendron port file ([53734ab](https://github.com/dendronhq/dendron/commit/53734ab46dbd75a34974939fe1d47734b118de44))
+
+
+### Features Dendron
+
+* pods v2 cli ([2e2bf8e](https://github.com/dendronhq/dendron/commit/2e2bf8e5e1189ed3e48e2e4e822c6fedf72142aa))
+
+
+### Reverts
+
+* remove source in import pod ([05a3084](https://github.com/dendronhq/dendron/commit/05a30842734d5745374577b9b025eb20439814d7))
+
+
+
+# 0.82.0 (2022-02-15)
+
+
+### Bug Fixes
+
+* **pod:** markdown import to update asset references ([#2350](https://github.com/dendronhq/dendron/issues/2350)) ([c22a322](https://github.com/dendronhq/dendron/commit/c22a322ce904da4157260e06cc14ffd07728042d))
+* re-apply windows hover preview image fix & improve hover preview performance ([#2312](https://github.com/dendronhq/dendron/issues/2312)) ([103655e](https://github.com/dendronhq/dendron/commit/103655ece34b67f5c86d254aded9200435fe5166)), closes [#2047](https://github.com/dendronhq/dendron/issues/2047)
+* resolve PR comments ([f5769d0](https://github.com/dendronhq/dendron/commit/f5769d037e7b313a3c09aaf61a29c0f2a8e84131))
+
+
+
+# 0.79.0 (2022-01-25)
+
+
+### Bug Fixes
+
+* compact bullet list on import ([a43cdd9](https://github.com/dendronhq/dendron/commit/a43cdd9c1305c31d0b6e6bb96acc5fb5aa28cd70))
+* Publishing dev server keeps running after exiting on Windows ([#2035](https://github.com/dendronhq/dendron/issues/2035)) ([134bcb3](https://github.com/dendronhq/dendron/commit/134bcb3b38c5a2136507d68660d85dd77f5f9791))
+* publishing pages fail ([#2199](https://github.com/dendronhq/dendron/issues/2199)) ([cfffd6a](https://github.com/dendronhq/dendron/commit/cfffd6a1988c372f7472bb2cd93126befd866a0d))
+* remove commented code ([44ca806](https://github.com/dendronhq/dendron/commit/44ca806a09fd741b5ec5010a925888160ffde7de))
+* removed runnable check from getAllPodConfig ([973ef22](https://github.com/dendronhq/dendron/commit/973ef2295a86a45bb594886d859cfa9bcc7e9201))
+* resolve PR comment ([114a8b7](https://github.com/dendronhq/dendron/commit/114a8b71a375d22abf392c968fa35ddbafdb1565))
+* resolved pr comment and updated testcase ([746b330](https://github.com/dendronhq/dendron/commit/746b330578487ee2ffdde17967f6d9c84bfc40dc))
+* resolved PR comments ([7cf9b10](https://github.com/dendronhq/dendron/commit/7cf9b10fd8c78cb962563cc25f24e82b8bef29b3))
+* resolved PR comments ([85d91f4](https://github.com/dendronhq/dendron/commit/85d91f4881a7c9b7f21cbff458c885b13b7eeff9))
+* resolved PR comments ([126034e](https://github.com/dendronhq/dendron/commit/126034ee21767c91b62e0e82c6efcec7d5826753))
+* update interface for batch api calls ([81d8e9c](https://github.com/dendronhq/dendron/commit/81d8e9cbb1e33453b0d615b75bca9a0bce6eed25))
+* updated pod to check values from config ([c1285f4](https://github.com/dendronhq/dendron/commit/c1285f487d289eab69ec1ce7532bb6e9351f384f))
+* **pod:** issue with linkedRecord not getting correct airtable id ([cb0b0e1](https://github.com/dendronhq/dendron/commit/cb0b0e153ff1a2745cdd51b3155230941b9eb505))
+* **publish:** logo doesn't respect assetsPrefix ([#2189](https://github.com/dendronhq/dendron/issues/2189)) ([763c797](https://github.com/dendronhq/dendron/commit/763c797c4c2f7821ef747376c980e4a4b0eace8e))
+
+
+### Features Dendron
+
+* **pod:** orbit import pod ([#1637](https://github.com/dendronhq/dendron/issues/1637)) ([66a5b14](https://github.com/dendronhq/dendron/commit/66a5b14019e542ade95f4cd2cb7b5cd3763d3b59))
+
+
+
+# 0.72.0 (2021-12-07)
+
+
+### Bug Fixes
+
+* **pods:** github import pod handle deleted authors ([#1660](https://github.com/dendronhq/dendron/issues/1660)) ([eb11440](https://github.com/dendronhq/dendron/commit/eb11440e255b889e546cd7f67fcb970692c52989))
+* **pods:** invalid configuration error ([398a599](https://github.com/dendronhq/dendron/commit/398a5995fc594566131eb283ff989a877ca9c995))
+* **pods:** minor error in airtable v2 export pod ([#1846](https://github.com/dendronhq/dendron/issues/1846)) ([4550d93](https://github.com/dendronhq/dendron/commit/4550d9371c55ddb6a48be4a6b21c03585bc89592))
+* **pods:** resolve same level dir wikilinks in markdown import([#1615](https://github.com/dendronhq/dendron/issues/1615)) ([3c82e14](https://github.com/dendronhq/dendron/commit/3c82e147a33ed5d6cff3c2508aec1f66eca2d20c))
+* **publish:** syntax highlighting for code blocks ([8ece4e2](https://github.com/dendronhq/dendron/commit/8ece4e28ae0c60d314498f6ed11a7974086f8f80))
+* **viwes:** `nav_order` property not respected in tree view ([fd328a1](https://github.com/dendronhq/dendron/commit/fd328a17478a063c2ea3d51e00fbc26c7e7e1b26))
+* markdown publish to hide block reference anchors ([#1577](https://github.com/dendronhq/dendron/issues/1577)) ([43fe1a7](https://github.com/dendronhq/dendron/commit/43fe1a7d4437136ebe6ba3cb91ca835b93c7a831))
+
+
+### Features Dendron
+
+* **pods:** Export Pod V2 ([#1772](https://github.com/dendronhq/dendron/issues/1772)) ([2dac9df](https://github.com/dendronhq/dendron/commit/2dac9dfb13525af984c3fd2f938283cba33cef7b))
+* **workspace:** better note previews ([#1666](https://github.com/dendronhq/dendron/issues/1666)) ([5cf7067](https://github.com/dendronhq/dendron/commit/5cf70672a24a62d528440f38b44813bfa627fb88))
+
+
+
+## 0.62.3 (2021-10-09)
+
+
+
+# 0.61.0 (2021-09-28)
+
+
+### Bug Fixes
+
+* **workspace:** use correct keybinding when using vim+dendron in same workspace ([e1180e6](https://github.com/dendronhq/dendron/commit/e1180e66e8ac29c82f34cf1e6797f1ab473ef510))
+
+
+
+## 0.60.2 (2021-09-25)
+
+
+
+## 0.60.2-alpha.0 (2021-09-24)
+
+
+
+## 0.60.1 (2021-09-24)
+
+
+### Bug Fixes
+
+* resolve relative links on import ([#1371](https://github.com/dendronhq/dendron/issues/1371)) ([d4cee4c](https://github.com/dendronhq/dendron/commit/d4cee4c978ddcc56ad13a17ec0988be1420f789c))
+
+
+
+# 0.60.0 (2021-09-21)
+
+
+### Bug Fixes
+
+* **publish:** versioning issues with next 11 ([76d7042](https://github.com/dendronhq/dendron/commit/76d7042a444dabc98069aaac1e40d692ee18f5a1))
+* reload index to be silent by default ([#1269](https://github.com/dendronhq/dendron/issues/1269)) ([2c0bf03](https://github.com/dendronhq/dendron/commit/2c0bf03d997ee3abc1f802f80e4b177feb44ae8b))
+* slugify github issue title ([#1218](https://github.com/dendronhq/dendron/issues/1218)) ([e6c2638](https://github.com/dendronhq/dendron/commit/e6c26380abd68f076dbe1d8ed542327c3ff558f3))
+
+
+### Features Dendron
+
+* github publish to create new issue ([#1206](https://github.com/dendronhq/dendron/issues/1206)) ([67abef0](https://github.com/dendronhq/dendron/commit/67abef02c5615385a8a7f82fe290c8a443605a7f))
+* nextjs publishing fulltext search ([#1334](https://github.com/dendronhq/dendron/issues/1334)) ([68f8473](https://github.com/dendronhq/dendron/commit/68f8473badf22494c8d0758f8195e377235321f6))
+
+
+
+## 0.55.2 (2021-08-21)
+
+
+
+## 0.55.1 (2021-08-17)
+
+
+### Features Dendron
+
+* **pubv3:** add more features to new publishing ([28a8a4f](https://github.com/dendronhq/dendron/commit/28a8a4f0ec8a02e6d6946833dec11c0117a3f783))
+
+
+
+## 0.54.1 (2021-08-13)
+
+
+### Bug Fixes
+
+* frontmatter tags ([#1104](https://github.com/dendronhq/dendron/issues/1104)) ([e4c022f](https://github.com/dendronhq/dendron/commit/e4c022f422b1ce020215d59d2658218f10c75250))
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/pods-core

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/pods-core",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "pods-core",
   "license": "GPLv3",
   "repository": {
@@ -51,10 +51,10 @@
   },
   "dependencies": {
     "@dendronhq/airtable": "^0.11.1",
-    "@dendronhq/common-all": "^0.110.0",
-    "@dendronhq/common-server": "^0.110.0",
-    "@dendronhq/engine-server": "^0.110.0",
-    "@dendronhq/unified": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
+    "@dendronhq/common-server": "^0.110.1",
+    "@dendronhq/engine-server": "^0.110.1",
+    "@dendronhq/unified": "^0.110.1",
     "@instantish/martian": "1.0.3",
     "@notionhq/client": "^0.1.9",
     "@octokit/graphql": "^4.6.4",

--- a/packages/unified/CHANGELOG.md
+++ b/packages/unified/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.110.1](https://github.com/dendronhq/dendron/compare/v0.53.0...v0.110.1) (2022-08-31)
+
+**Note:** Version bump only for package @dendronhq/unified
+
+
+
+
+
 # 0.110.0 (2022-08-30)
 
 **Note:** Version bump only for package @dendronhq/unified

--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/unified",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "Unified parser utilities for Dendron",
   "license": "GPLv3",
   "repository": {
@@ -31,7 +31,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.110.0",
+    "@dendronhq/common-all": "^0.110.1",
     "mdast": "^3.0.0",
     "mdast-builder": "^1.1.1",
     "mdast-util-compact": "^2.0.1",


### PR DESCRIPTION
fix: giscuss integration

Two fixes for the giscus integration:

- nextjs-template required a change in common-all that wasn't available, ended up bumping up the patch version of lerna to `0.110.1` and publishing the new common-all packages
- explicityl pass in the term property based on note id (otherwise giscuss would re-use the same path for all pages) - see https://github.com/dendronhq/dendron/pull/3474/files#diff-06608bb6c886eb23d44682f2302083810e4a26aceb141f69d9bd537c1054d46d