### PR TITLE
feat(workspace): copy codespace url command

### DIFF
--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -543,4 +543,17 @@ export class GitUtils {
       if (err?.code !== "ENOENT") throw err;
     }
   }
+
+  /**
+   *
+   * @param uri
+   * @param file
+   * @returns codespaces url for the note
+   */
+  static async getCodeSpacesURL(uri: string, file: string): Promise<string> {
+    const [owner, repo] = await this.getGitProviderOwnerAndRepository(uri);
+    const branch = await this.getCurrentBranch(uri);
+    const currentFile = file.replace(/^\//, "").replace(/^\\/, "");
+    return `https://github.dev/${owner}/${repo}/blob/${branch}/${currentFile}`;
+  }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -236,8 +236,8 @@
         "title": "Dendron: Copy To Clipboard"
       },
       {
-        "command": "dendron.copyCodeSpacesURL",
-        "title": "Dendron: Copy CodeSpaces URL"
+        "command": "dendron.copyCodeSpaceURL",
+        "title": "Dendron: Copy CodeSpace URL"
       },
       {
         "command": "dendron.delete",
@@ -648,7 +648,7 @@
           "when": "false"
         },
         {
-          "command": "dendron.copyCodeSpacesURL",
+          "command": "dendron.copyCodeSpaceURL",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -56,7 +56,7 @@
       },
       {
         "view": "dendron.treeView",
-        "contents": "Open a Dendron note to see the tree view."
+        "contents": "First open a Dendron note to see the tree view."
       }
     ],
     "viewsContainers": {
@@ -234,6 +234,10 @@
       {
         "command": "dendron.copyToClipboard",
         "title": "Dendron: Copy To Clipboard"
+      },
+      {
+        "command": "dendron.copyCodeSpacesURL",
+        "title": "Dendron: Copy CodeSpaces URL"
       },
       {
         "command": "dendron.delete",
@@ -642,6 +646,10 @@
         {
           "command": "dendron.copyToClipboard",
           "when": "false"
+        },
+        {
+          "command": "dendron.copyCodeSpacesURL",
+          "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
           "command": "dendron.delete",

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -236,8 +236,8 @@
         "title": "Dendron: Copy To Clipboard"
       },
       {
-        "command": "dendron.copyCodeSpaceURL",
-        "title": "Dendron: Copy CodeSpace URL"
+        "command": "dendron.copyCodespaceURL",
+        "title": "Dendron: Copy Codespace URL"
       },
       {
         "command": "dendron.delete",
@@ -648,7 +648,7 @@
           "when": "false"
         },
         {
-          "command": "dendron.copyCodeSpaceURL",
+          "command": "dendron.copyCodespaceURL",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/src/commands/CopyCodeSpaceURLCommand.ts
+++ b/packages/plugin-core/src/commands/CopyCodeSpaceURLCommand.ts
@@ -9,7 +9,7 @@ import { BasicCommand } from "./base";
 type CommandOpts = {};
 type CommandOutput = string | undefined;
 
-export class CopyCodeSpaceURLCommand extends BasicCommand<
+export class CopyCodespaceURLCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {

--- a/packages/plugin-core/src/commands/CopyCodeSpaceURLCommand.ts
+++ b/packages/plugin-core/src/commands/CopyCodeSpaceURLCommand.ts
@@ -9,11 +9,11 @@ import { BasicCommand } from "./base";
 type CommandOpts = {};
 type CommandOutput = string | undefined;
 
-export class CopyCodeSpacesURLCommand extends BasicCommand<
+export class CopyCodeSpaceURLCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
-  key = DENDRON_COMMANDS.COPY_CODESPACES_URL.key;
+  key = DENDRON_COMMANDS.COPY_CODESPACE_URL.key;
   async sanityCheck() {
     if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
       return "No document open";
@@ -23,9 +23,9 @@ export class CopyCodeSpacesURLCommand extends BasicCommand<
   async showFeedback(link: string) {
     const uri = vscode.Uri.parse(link);
     vscode.window
-      .showInformationMessage(`${link} copied`, ...["Open Codespaces"])
+      .showInformationMessage(`${link} copied`, ...["Open Codespace"])
       .then((resp) => {
-        if (resp === "Open Codespaces") {
+        if (resp === "Open Codespace") {
           vscode.commands.executeCommand("vscode.open", uri);
         }
       });
@@ -33,11 +33,14 @@ export class CopyCodeSpacesURLCommand extends BasicCommand<
 
   async execute(_opts: CommandOpts) {
     const editor = vscode.window.activeTextEditor;
+
     if (vscode.workspace.workspaceFolders && editor) {
       const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+
       if (!folder) {
         return;
       }
+
       const root = (await GitUtils.getGitRoot(folder.uri.fsPath)) || "";
       // get just the file
       const file = editor.document.fileName.substring(root.length);

--- a/packages/plugin-core/src/commands/CopyCodeSpacesURLCommand.ts
+++ b/packages/plugin-core/src/commands/CopyCodeSpacesURLCommand.ts
@@ -1,0 +1,54 @@
+import { GitUtils } from "@dendronhq/common-server";
+import _ from "lodash";
+import * as vscode from "vscode";
+import { DENDRON_COMMANDS } from "../constants";
+import { clipboard } from "../utils";
+import { VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {};
+type CommandOutput = string | undefined;
+
+export class CopyCodeSpacesURLCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.COPY_CODESPACES_URL.key;
+  async sanityCheck() {
+    if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
+      return "No document open";
+    }
+    return;
+  }
+  async showFeedback(link: string) {
+    const uri = vscode.Uri.parse(link);
+    vscode.window
+      .showInformationMessage(`${link} copied`, ...["Open Codespaces"])
+      .then((resp) => {
+        if (resp === "Open Codespaces") {
+          vscode.commands.executeCommand("vscode.open", uri);
+        }
+      });
+  }
+
+  async execute(_opts: CommandOpts) {
+    const editor = vscode.window.activeTextEditor;
+    if (vscode.workspace.workspaceFolders && editor) {
+      const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+      if (!folder) {
+        return;
+      }
+      const root = (await GitUtils.getGitRoot(folder.uri.fsPath)) || "";
+      // get just the file
+      const file = editor.document.fileName.substring(root.length);
+      const link = await GitUtils.getCodeSpacesURL(
+        folder.uri.fsPath,
+        file.replace(/\\/g, "/")
+      );
+      this.showFeedback(link);
+      clipboard.writeText(link);
+      return link;
+    }
+    return;
+  }
+}

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -85,6 +85,7 @@ import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
 import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
+import { CopyCodeSpacesURLCommand } from "./CopyCodeSpacesURLCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -177,6 +178,7 @@ const ALL_COMMANDS = [
   ValidateEngineCommand,
   MergeNoteCommand,
   CreateNoteCommand,
+  CopyCodeSpacesURLCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -85,7 +85,7 @@ import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
 import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
-import { CopyCodeSpacesURLCommand } from "./CopyCodeSpacesURLCommand";
+import { CopyCodeSpaceURLCommand } from "./CopyCodeSpaceURLCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -178,7 +178,7 @@ const ALL_COMMANDS = [
   ValidateEngineCommand,
   MergeNoteCommand,
   CreateNoteCommand,
-  CopyCodeSpacesURLCommand,
+  CopyCodeSpaceURLCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -85,7 +85,7 @@ import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
 import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
-import { CopyCodeSpaceURLCommand } from "./CopyCodeSpaceURLCommand";
+import { CopyCodespaceURLCommand } from "./CopyCodespaceURLCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -178,7 +178,7 @@ const ALL_COMMANDS = [
   ValidateEngineCommand,
   MergeNoteCommand,
   CreateNoteCommand,
-  CopyCodeSpaceURLCommand,
+  CopyCodespaceURLCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -498,6 +498,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Copy To Clipboard`,
     when: "false",
   },
+  COPY_CODESPACES_URL: {
+    key: "dendron.copyCodeSpacesURL",
+    title: `${CMD_PREFIX} Copy CodeSpaces URL`,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+  },
   DELETE: {
     key: "dendron.delete",
     title: `${CMD_PREFIX} Delete`,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -498,9 +498,9 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Copy To Clipboard`,
     when: "false",
   },
-  COPY_CODESPACES_URL: {
-    key: "dendron.copyCodeSpacesURL",
-    title: `${CMD_PREFIX} Copy CodeSpaces URL`,
+  COPY_CODESPACE_URL: {
+    key: "dendron.copyCodeSpaceURL",
+    title: `${CMD_PREFIX} Copy CodeSpace URL`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   DELETE: {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -499,8 +499,8 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     when: "false",
   },
   COPY_CODESPACE_URL: {
-    key: "dendron.copyCodeSpaceURL",
-    title: `${CMD_PREFIX} Copy CodeSpace URL`,
+    key: "dendron.copyCodespaceURL",
+    title: `${CMD_PREFIX} Copy Codespace URL`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   DELETE: {

--- a/packages/plugin-core/src/test/suite-integ/CopyCodeSpaceURLCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyCodeSpaceURLCommand.test.ts
@@ -1,0 +1,40 @@
+import { GitUtils, tmpDir, vault2Path } from "@dendronhq/common-server";
+import { GitTestUtils } from "@dendronhq/engine-test-utils";
+import path from "path";
+import sinon from "sinon";
+import { CopyCodeSpaceURLCommand } from "../../commands/CopyCodeSpaceURLCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS } from "../testUtilsV3";
+import * as vscode from "vscode";
+
+describeSingleWS(
+  "When Copy CodeSpace URL is run",
+  {
+    // these tests can run longer than 5s timeout;
+    timeout: 1e6,
+  },
+  () => {
+    test("THEN codespace url is copied to the clipboard", async () => {
+      const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+      sinon
+        .stub(GitUtils, "getGitProviderOwnerAndRepository")
+        .resolves(["dendronhq", "dendron"]);
+      const workspaces = vscode.workspace.workspaceFolders!;
+      sinon.stub(vscode.workspace, "getWorkspaceFolder").returns(workspaces[0]);
+      const remoteDir = tmpDir().name;
+      await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+      const cmd = new CopyCodeSpaceURLCommand();
+      const notePath = path.join(
+        vault2Path({ vault: vaults[0], wsRoot }),
+        "root.md"
+      );
+      await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
+      const resp = await cmd.execute({});
+      expect(resp).toContain(
+        "https://github.dev/dendronhq/dendron/blob/master"
+      );
+    });
+  }
+);

--- a/packages/plugin-core/src/test/suite-integ/CopyCodeSpaceURLCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyCodeSpaceURLCommand.test.ts
@@ -2,7 +2,7 @@ import { GitUtils, tmpDir, vault2Path } from "@dendronhq/common-server";
 import { GitTestUtils } from "@dendronhq/engine-test-utils";
 import path from "path";
 import sinon from "sinon";
-import { CopyCodeSpaceURLCommand } from "../../commands/CopyCodeSpaceURLCommand";
+import { CopyCodespaceURLCommand } from "../../commands/CopyCodespaceURLCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
@@ -10,7 +10,7 @@ import { describeSingleWS } from "../testUtilsV3";
 import * as vscode from "vscode";
 
 describeSingleWS(
-  "When Copy CodeSpace URL is run",
+  "When Copy Codespace URL is run",
   {
     // these tests can run longer than 5s timeout;
     timeout: 1e6,
@@ -25,7 +25,7 @@ describeSingleWS(
       sinon.stub(vscode.workspace, "getWorkspaceFolder").returns(workspaces[0]);
       const remoteDir = tmpDir().name;
       await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-      const cmd = new CopyCodeSpaceURLCommand();
+      const cmd = new CopyCodespaceURLCommand();
       const notePath = path.join(
         vault2Path({ vault: vaults[0], wsRoot }),
         "root.md"


### PR DESCRIPTION
This PR aims to create a new command `Copy CodeSpace URL` that would copy the github.dev URL to the clipboard.

# Dendron Extended PR Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [!] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [!] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)