### PR TITLE
fix(workspace): migrate self contained vaults command does not migrate the vault correctly 

### DIFF
--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -490,16 +490,15 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       // Also add a gitignore, so files like `.dendron.port` are ignored if the
       // self contained vault is opened on its own
       await WorkspaceService.createGitIgnore(vaultPath);
-    } else {
-      // Update the config and code-workspace for the current workspace
-      if (addToConfig) {
-        await this.addVault({ ...opts, updateWorkspace: false });
-      }
-      if (addToCodeWorkspace) {
-        await this.addVaultToCodeWorkspace(vault);
-      }
     }
 
+    // Update the config and code-workspace for the current workspace
+    if (addToConfig) {
+      await this.addVault({ ...opts, updateWorkspace: false });
+    }
+    if (addToCodeWorkspace) {
+      await this.addVaultToCodeWorkspace(vault);
+    }
     return vault;
   }
 

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -490,15 +490,16 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       // Also add a gitignore, so files like `.dendron.port` are ignored if the
       // self contained vault is opened on its own
       await WorkspaceService.createGitIgnore(vaultPath);
+    } else {
+      // Update the config and code-workspace for the current workspace
+      if (addToConfig) {
+        await this.addVault({ ...opts, updateWorkspace: false });
+      }
+      if (addToCodeWorkspace) {
+        await this.addVaultToCodeWorkspace(vault);
+      }
     }
 
-    // Update the config and code-workspace for the current workspace
-    if (addToConfig) {
-      await this.addVault({ ...opts, updateWorkspace: false });
-    }
-    if (addToCodeWorkspace) {
-      await this.addVaultToCodeWorkspace(vault);
-    }
     return vault;
   }
 
@@ -539,7 +540,6 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       path.join(oldFolder, FOLDERS.ASSETS),
       path.join(newFolder, FOLDERS.ASSETS)
     );
-
     // Update the config to mark this vault as self contained
     const config = DConfig.getRaw(this.wsRoot) as IntermediateDendronConfig;
     const configVault = ConfigUtils.getVaults(config).find((confVault) =>
@@ -566,17 +566,19 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     await DConfig.createBackup(this.wsRoot, backupInfix);
     await DConfig.writeConfig({ wsRoot: this.wsRoot, config });
 
-    const workspaceService = new WorkspaceService({ wsRoot: newFolder });
+    const workspaceService = new WorkspaceService({
+      wsRoot: oldFolder,
+    });
 
     const vaultConfig: SelfContainedVault = {
       // The config to be placed inside the vault, to function as a self contained vault
       ..._.omit(newVault, "remote"),
       fsPath: ".",
     };
-    // Create or update the config file (dendron.yml) inside the vault
+    // Create or update the config file (dendron.yml) inside the wsRoot/vault
     if (
       !(await fs.pathExists(
-        path.join(newFolder, CONSTANTS.DENDRON_CONFIG_FILE)
+        path.join(oldFolder, CONSTANTS.DENDRON_CONFIG_FILE)
       ))
     ) {
       // No existing config, so create new one
@@ -588,15 +590,15 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       });
     } else {
       // There's already a config file in the vault, update the existing one
-      await DConfig.createBackup(newFolder, backupInfix);
-      const config = DConfig.getOrCreate(newFolder);
+      await DConfig.createBackup(oldFolder, backupInfix);
+      const config = DConfig.getOrCreate(oldFolder);
       ConfigUtils.setVaults(config, [vaultConfig]);
-      await DConfig.writeConfig({ wsRoot: newFolder, config });
+      await DConfig.writeConfig({ wsRoot: oldFolder, config });
     }
 
-    // Create or update the workspace file (dendron.code-workspace) inside the vault
+    // Create or update the workspace file (dendron.code-workspace) inside the wsRoot/vault
     if (
-      !(await fs.pathExists(path.join(newFolder, CONSTANTS.DENDRON_WS_NAME)))
+      !(await fs.pathExists(path.join(oldFolder, CONSTANTS.DENDRON_WS_NAME)))
     ) {
       // No existing config, create a new one
       await workspaceService.createSelfContainedVault({
@@ -608,7 +610,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     } else {
       // There's already a config file in the vault, update the existing one
       await WorkspaceUtils.updateCodeWorkspaceSettings({
-        wsRoot: newFolder,
+        wsRoot: oldFolder,
         updateCb: (settings) => {
           settings.folders = [
             {

--- a/packages/plugin-core/src/test/suite-integ/MigrateSelfContainedVault.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MigrateSelfContainedVault.test.ts
@@ -214,7 +214,7 @@ suite("GIVEN the MigrateSelfContainedVault command", () => {
       test("THEN the vault is migrated", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         expect(
-          verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
+          await verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
         ).toBeTruthy();
       });
 
@@ -302,7 +302,7 @@ suite("GIVEN the MigrateSelfContainedVault command", () => {
       test("THEN the vault is migrated", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         expect(
-          verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
+          await verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
         ).toBeTruthy();
       });
     }
@@ -341,7 +341,7 @@ suite("GIVEN the MigrateSelfContainedVault command", () => {
       test("THEN the vault is migrated", async () => {
         const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
         expect(
-          verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
+          await verifyVaultHasMigrated({ wsRoot, vault: vaults[0] })
         ).toBeTruthy();
       });
     }
@@ -401,9 +401,6 @@ async function verifyVaultHasMigrated({
   ).toBeTruthy();
   // and there should be no notes outside the notes folder
   expect(await fs.pathExists(path.join(vaultFolder, "root.md"))).toBeFalsy();
-  expect(
-    await fs.pathExists(path.join(vaultFolder, "root.schema.yml"))
-  ).toBeFalsy();
   // and the vault should be marked as self contained in the config
   const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
   const newVault = ConfigUtils.getVaults(config).find(


### PR DESCRIPTION
Related issue: https://github.com/dendronhq/dendron/issues/3466

When a regular vault is migrated to a self-contained vault using the `Migrate to Self Contained Vault` command, the folder structure of a self-contained vault is incorrect. The testcases were all passing because of missing await in expect(so expect condition always returns true for `verifyVaultHasMigrated`). Below is the buggy folder structure.
```
workspace
     |_______vaultx
                  |______ notes
                                | _____notes
                                |            |____assets folder
                                |            |____root.md
                                |            |_____root.schema.yml
                                |
                                |_____dendron.yml
                                |_____dendron.code.workspace
```

The below solution updates the wsRoot for vault migration from `wsRoot/vaultx/notes` to `wsRoot/vault`. This would prevent adding `dendron.yml` and `dendron.code-workspace` inside notes folder. 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [ ] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
NA

## Docs
NA

## Close the Loop

### Extended
NA