### PR TITLE
chore(workspace): validate filename that are illegal in SQLite

### DIFF
--- a/packages/common-all/src/constants/lookup.ts
+++ b/packages/common-all/src/constants/lookup.ts
@@ -18,3 +18,9 @@ export const MODIFIER_DESCRIPTIONS: {
   multiSelect: "Select multiple notes at once",
   copyNoteLink: "Add selected notes to the clipboard as wikilinks",
 };
+
+export enum InvalidFilenameReason {
+  EMPTY_HIERARCHY = "Hierarchies cannot be empty strings",
+  LEADING_OR_TRAILING_WHITESPACE = "Hierarchies cannot contain leading or trailing whitespaces",
+  ILLEGAL_CHARACTER = `Hierarchy strings cannot contain parentheses, commas, or single quotes`,
+}

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1177,12 +1177,12 @@ export class NoteUtils {
     );
     const hierarchies = fnameAfterReplace.split(".");
     const cleanedFname = hierarchies
-      // cut out empty hierarchies
-      .filter((value) => value !== "")
       // trim leading / trailing whitespace
       .map((value) => {
         return _.trim(value, " ");
       })
+      // cut out empty hierarchies
+      .filter((value) => value !== "")
       .join(".");
     return cleanedFname;
   }

--- a/packages/dendron-cli/src/commands/base.ts
+++ b/packages/dendron-cli/src/commands/base.ts
@@ -107,6 +107,8 @@ export abstract class CLICommand<
     this.L.info({ msg: `Telemetry is disabled? ${segment.hasOptedOut}` });
   }
 
+  addAnalyticsPayload?(opts?: TOpts, out?: TOut): any;
+
   async validateConfig(opts: { wsRoot: string }) {
     const { wsRoot } = opts;
 
@@ -179,7 +181,15 @@ export abstract class CLICommand<
   }
 
   addArgsToPayload(data: any) {
-    _.set(this._analyticsPayload, "args", data);
+    this.addToPayload({
+      key: "args",
+      value: data,
+    });
+  }
+
+  addToPayload(opts: { key: string; value: any }) {
+    const { key, value } = opts;
+    _.set(this._analyticsPayload, key, value);
   }
 
   /**

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -77,15 +77,40 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     return { data: { ...args, ...engineArgs } };
   }
 
+  /**
+   * Given opts and out,
+   * prepare the analytics payload that should be included to the
+   * tracked event.
+   *
+   * Implement {@link DoctorService.executeDoctorActions} so that
+   * it outputs the necessary information,
+   * and prepare / add it here.
+   *
+   * Only the cases implemented will add a payload.
+   */
+  async addAnalyticsPayload(opts: CommandOpts, out: CommandOutput) {
+    switch (opts.action) {
+      case DoctorActionsEnum.FIX_INVALID_FILENAMES: {
+        const payload = out.resp;
+        if (payload) {
+          _.entries(payload).forEach((entry) => {
+            const [key, value] = entry;
+            this.addToPayload({ key, value });
+          });
+        }
+        break;
+      }
+      default: {
+        // no-op.
+        break;
+      }
+    }
+  }
+
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const ds = new DoctorService();
     const out = await ds.executeDoctorActions(opts);
-    if (out.resp) {
-      this._analyticsPayload = {
-        ...this._analyticsPayload,
-        ...out.resp,
-      };
-    }
+    await this.addAnalyticsPayload(opts, out);
     ds.dispose();
     return out;
   }

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -108,7 +108,7 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   }
 
   async execute(opts: CommandOpts): Promise<CommandOutput> {
-    const ds = new DoctorService();
+    const ds = new DoctorService({ printFunc: this.print.bind(this) });
     const out = await ds.executeDoctorActions(opts);
     await this.addAnalyticsPayload(opts, out);
     ds.dispose();

--- a/packages/dendron-cli/src/commands/doctor.ts
+++ b/packages/dendron-cli/src/commands/doctor.ts
@@ -80,6 +80,12 @@ export class DoctorCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const ds = new DoctorService();
     const out = await ds.executeDoctorActions(opts);
+    if (out.resp) {
+      this._analyticsPayload = {
+        ...this._analyticsPayload,
+        ...out.resp,
+      };
+    }
     ds.dispose();
     return out;
   }

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -627,7 +627,6 @@ export class DoctorService implements Disposable {
           changes = await this.fixInvalidFileNames({
             canRename,
             engine,
-            quiet: opts.quiet,
           });
         }
 
@@ -756,9 +755,8 @@ export class DoctorService implements Disposable {
       resp: ValidateFnameResp;
     }[];
     engine: DEngineClient;
-    quiet?: boolean;
   }) {
-    const { canRename, engine, quiet } = opts;
+    const { canRename, engine } = opts;
     let changes: NoteChangeEntry[] = [];
     if (canRename.length > 0) {
       await asyncLoopOneAtATime(canRename, async (item) => {

--- a/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
@@ -1,0 +1,106 @@
+import {
+  InvalidFilenameReason,
+  NoteUtils,
+  ThemeMessageType,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+
+const validFnames = ["foo", "bar", "foo.bar", "foo bar"];
+const invalidFnamesAndReasons = {
+  "foo.": InvalidFilenameReason.EMPTY_HIERARCHY,
+  "foo..": InvalidFilenameReason.EMPTY_HIERARCHY,
+  ".foo": InvalidFilenameReason.EMPTY_HIERARCHY,
+  "..foo": InvalidFilenameReason.EMPTY_HIERARCHY,
+  " foo": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "  foo": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo ": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo  ": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  " foo ": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "  foo  ": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo..bar": InvalidFilenameReason.EMPTY_HIERARCHY,
+  "foo...bar": InvalidFilenameReason.EMPTY_HIERARCHY,
+  "foo. .bar": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo.bar .baz": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo. bar.baz": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "foo. bar .baz": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  " foo . . bar . . baz ": InvalidFilenameReason.LEADING_OR_TRAILING_WHITESPACE,
+  "(foo)": InvalidFilenameReason.ILLEGAL_CHARACTER,
+  "foo, and bar": InvalidFilenameReason.ILLEGAL_CHARACTER,
+  "'foo' and 'bar'": InvalidFilenameReason.ILLEGAL_CHARACTER,
+};
+const invalidFnamesAndCleaned = {
+  "foo.": "foo",
+  "foo..": "foo",
+  ".foo": "foo",
+  "..foo": "foo",
+  " foo": "foo",
+  "  foo": "foo",
+  "foo ": "foo",
+  "foo  ": "foo",
+  " foo ": "foo",
+  "  foo  ": "foo",
+  "foo..bar": "foo.bar",
+  "foo...bar": "foo.bar",
+  "foo. .bar": "foo.bar",
+  "foo.bar .baz": "foo.bar.baz",
+  "foo. bar.baz": "foo.bar.baz",
+  "foo. bar .baz": "foo.bar.baz",
+  " foo . . bar . . baz ": "foo.bar.baz",
+  "(foo)": "foo",
+  "foo, and bar": "foo  and bar",
+  "'foo' and 'bar'": "foo  and  bar",
+};
+
+describe("NoteUtils", () => {
+  describe("validateFname", () => {
+    describe("GIVEN valid file names", () => {
+      describe("WHEN validated", () => {
+        test("THEN correctly validates file name", () => {
+          validFnames.forEach((fname) => {
+            const resp = NoteUtils.validateFname(fname);
+            expect(resp.isValid).toBeTruthy();
+            expect(resp.reason).toBeUndefined();
+          });
+        });
+      });
+    });
+    describe("GIVEN invalid file names", () => {
+      describe("WHEN validated", () => {
+        test("THEN correctly invalidates file name and return correct reason", () => {
+          _.entries(invalidFnamesAndReasons).forEach((item) => {
+            const [fname, reason] = item;
+            const resp = NoteUtils.validateFname(fname);
+            expect(resp.isValid).toBeFalsy();
+            expect(resp.reason).toEqual(reason);
+          });
+        });
+      });
+    });
+  });
+  describe("cleanFname", () => {
+    describe("GIVEN valid file names", () => {
+      describe("WHEN cleaned", () => {
+        test("THEN outputs the same file name", () => {
+          validFnames.forEach((fname) => {
+            const cleanedFname = NoteUtils.cleanFname({
+              fname,
+            });
+            expect(cleanedFname).toEqual(fname);
+          });
+        });
+      });
+    });
+    describe("GIVEN invalid file names", () => {
+      describe("WHEN cleaned", () => {
+        test("THEN outputs cleaned file name", () => {
+          _.entries(invalidFnamesAndCleaned).forEach((item) => {
+            const [fname, cleaned] = item;
+            const cleanedFname = NoteUtils.cleanFname({ fname });
+            expect(cleanedFname).toEqual(cleaned);
+            expect(NoteUtils.validateFname(cleanedFname).isValid).toBeTruthy();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
@@ -1,8 +1,4 @@
-import {
-  InvalidFilenameReason,
-  NoteUtils,
-  ThemeMessageType,
-} from "@dendronhq/common-all";
+import { InvalidFilenameReason, NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 
 const validFnames = ["foo", "bar", "foo.bar", "foo bar"];

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/doctor.spec.ts
@@ -102,6 +102,15 @@ const setupWithAliasedWikilink = async (opts: WorkspaceOpts) => {
   });
 };
 
+const setupWithInvalidFilename = async (opts: WorkspaceOpts) => {
+  const { wsRoot, vaults } = opts;
+  await NoteTestUtilsV4.createNote({
+    wsRoot,
+    vault: vaults[0],
+    fname: "bar..('foo',)",
+  });
+};
+
 const setupWithXVaultWikilink = async (opts: WorkspaceOpts) => {
   const { wsRoot, vaults } = opts;
   await NoteTestUtilsV4.createNote({
@@ -973,6 +982,30 @@ describe("GIVEN removeDeprecatedConfigs", () => {
           }
         },
         {
+          expect,
+        }
+      );
+    });
+  });
+});
+
+describe("GIVEN fixInvalidFilenames", () => {
+  const action = DoctorActionsEnum.FIX_INVALID_FILENAMES;
+  describe("WHEN workspace with note that has invalid filename", () => {
+    test("THEN invalid file name is automatically fixed", async () => {
+      await runEngineTestV5(
+        async ({ wsRoot, engine }) => {
+          await runDoctor({
+            wsRoot,
+            engine,
+            action,
+          });
+          const getNoteResp = await engine.getNote("bar..('foo',)");
+          expect(getNoteResp.data).toBeTruthy();
+          expect(getNoteResp.data?.fname).toEqual("bar.foo");
+        },
+        {
+          preSetupHook: setupWithInvalidFilename,
           expect,
         }
       );

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -415,11 +415,25 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }
 
   addAnalyticsPayload(opts: CommandOpts, out: CommandOutput) {
-    return {
+    let payload = {
       action: opts.action,
       scope: opts.scope,
-      ...out.extra,
     };
+    if (out.extra) {
+      switch (opts.action) {
+        case DoctorActionsEnum.FIX_INVALID_FILENAMES: {
+          payload = {
+            ...payload,
+            ...out.extra,
+          };
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+    return payload;
   }
 
   async execute(opts: CommandOpts) {

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -679,7 +679,6 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
               changes = await ds.fixInvalidFileNames({
                 canRename,
                 engine,
-                quiet: true,
               });
               const maybeReminder =
                 cantRename.length > 0

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -135,12 +135,12 @@ export class DoctorUtils {
 
     if (!note) return true;
 
-    const isValid = NoteUtils.validateFname(filename);
+    const result = NoteUtils.validateFname(filename);
 
-    if (isValid) return true;
+    if (result.isValid) return true;
 
     const error = new DendronError({
-      message: `"${filename}" is not a valid hierarchy. Please rename the note so that every hierarchy is non-empty and doesn't contain leading or trailing whitespaces`,
+      message: `"${filename}" is not a valid hierarchy. Please rename it so that it follows the `,
     });
     VSCodeUtils.showMessage(
       MessageSeverity.WARN,

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -11,7 +11,6 @@ import { DoctorActionsEnum } from "@dendronhq/engine-server";
 import path from "path";
 import * as vscode from "vscode";
 import { DoctorCommand } from "../../commands/Doctor";
-import { RenameNoteCommand } from "../../commands/RenameNoteCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { AnalyticsUtils } from "../../utils/analytics";
@@ -140,18 +139,28 @@ export class DoctorUtils {
     if (result.isValid) return true;
 
     const error = new DendronError({
-      message: `"${filename}" is not a valid hierarchy. Please rename it so that it follows the `,
+      message:
+        "This note has an invalid filename. Please click the button below to fix it.",
     });
     VSCodeUtils.showMessage(
       MessageSeverity.WARN,
       error.message,
       {},
-      { title: "Rename note" }
+      { title: "Fix Invalid Filenames" }
     ).then(async (resp) => {
-      if (resp && resp.title === "Rename note") {
-        await wsUtils.openNote(note);
-        const cmd = new RenameNoteCommand(extension);
-        await cmd.run();
+      if (resp && resp.title === "Fix Invalid Filenames") {
+        const cmd: vscode.Command = {
+          command: new DoctorCommand(ExtensionProvider.getExtension()).key,
+          title: "Fix Invalid Filenames",
+          arguments: [
+            {
+              scope: "file",
+              action: DoctorActionsEnum.FIX_INVALID_FILENAMES,
+              data: { note },
+            },
+          ],
+        };
+        vscode.commands.executeCommand(cmd.command, ...cmd.arguments!);
       }
     });
 

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -2,6 +2,7 @@ import { DendronQuickPickerV2 } from "./types";
 import { CancellationToken, CancellationTokenSource } from "vscode";
 import {
   DNodePropsQuickInputV2,
+  InvalidFilenameReason,
   NoteQuickInput,
   RespV2,
   SchemaQuickInput,
@@ -16,7 +17,15 @@ export type ILookupProviderV3 = {
     quickpick: DendronQuickPickerV2;
     cancellationToken: CancellationTokenSource;
   }): any;
-  shouldRejectItem?: (opts: { item: NoteQuickInput }) => boolean;
+  shouldRejectItem?: (opts: { item: NoteQuickInput }) =>
+    | {
+        shouldReject: true;
+        reason: InvalidFilenameReason;
+      }
+    | {
+        shouldReject: false;
+        reason?: never;
+      };
 };
 
 export interface INoteLookupProviderFactory {

--- a/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
@@ -121,13 +121,6 @@ export class NoteLookupProvider implements ILookupProviderV3 {
         shouldReject,
       };
     }
-
-    // if (result.isValid) {
-    //   return { shouldReject: false };
-    // } else if (PickerUtilsV2.isCreateNewNotePick(item)) {
-    //   return { shouldReject: true, reason: result.reason };
-    // }
-    // return { shouldReject: false };
   }
 
   /**

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -1,13 +1,8 @@
-import {
-  asyncLoopOneAtATime,
-  NoteProps,
-  NoteUtils,
-} from "@dendronhq/common-all";
+import { NoteProps } from "@dendronhq/common-all";
 import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestEngineUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import { beforeEach, describe, it, suite } from "mocha";
-import sinon from "sinon";
 import { ExtensionContext, Selection } from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import {
@@ -293,51 +288,6 @@ suite("selection2Items", () => {
 });
 
 suite("onAccept", () => {
-  describeMultiWS(
-    "GIVEN invalid fname",
-    {
-      preSetupHook: ENGINE_HOOKS.setupBasic,
-    },
-    () => {
-      test("THEN rejected", async () => {
-        const validateFnameSpy = sinon.spy(NoteUtils, "validateFname");
-        const cmd = new NoteLookupCommand();
-        const { controller, provider, quickpick } = await cmd.gatherInputs();
-        const invalidFnames = [
-          "foo.", // trailing dot
-          "foo..", // multiple trailing dots
-          ".foo", // leading dot
-          "..foo", // multiple leading dots
-          " foo", // leading whitespace
-          "  foo", // multiple leading whitespace
-          "foo ", // trailing whitespace
-          "foo  ", // multiple trailing whitespace
-          " foo ", // leading and trailing whitespace
-          "  foo  ", // multiple leading and trailing whitespace
-          "foo..bar", // empty hierarchy
-          "foo...bar", // multiple empty hierarchy
-          "foo. .bar", // whitespace hierarchy
-          "foo.bar .baz", // hierarchy with trailing whitespace
-          "foo. bar.baz", // hierarchy with leading whitespace
-          "foo. bar .baz", // hierarchy with leading and trailing whitespace
-          " foo . . bar . . baz ", // everything
-        ];
-
-        await asyncLoopOneAtATime(invalidFnames, async (fname) => {
-          quickpick.value = fname;
-          await provider.onDidAccept({
-            quickpick,
-            cancellationToken: controller.cancelToken,
-          })();
-          const lastCall = validateFnameSpy.lastCall;
-          expect(lastCall.args[0]).toEqual(fname);
-          expect(lastCall.returnValue).toBeFalsy();
-        });
-        cmd.cleanUp();
-        validateFnameSpy.restore();
-      });
-    }
-  );
   describeMultiWS(
     "GIVEN a note with invalid name that already exists",
     {

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -319,7 +319,7 @@ suite("onAccept", () => {
           alwaysShow: true,
         };
         const out = provider.shouldRejectItem!({ item });
-        expect(out).toBeFalsy();
+        expect(out.shouldReject).toBeFalsy();
         cmd.cleanUp();
       });
     }
@@ -349,7 +349,8 @@ suite("onAccept", () => {
           alwaysShow: true,
         };
         const out = provider.shouldRejectItem!({ item });
-        expect(out).toBeTruthy();
+        expect(out.shouldReject).toBeTruthy();
+        expect(out.reason).toBeTruthy();
         cmd.cleanUp();
       });
     }


### PR DESCRIPTION
# chore(workspace): validate filename that are illegal in SQLite

This PR:
- Extends the file name validation logic to capture illegal SQLite characters.
- Enhance warning / error messages to be more specific about what is invalid.
- Add doctor action `fixInvalidFileNames` on cli and extension
- 

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)