### PR TITLE
fix(workspace): tree view still displays if a note has no title

### DIFF
--- a/packages/common-all/src/util/treeUtil.ts
+++ b/packages/common-all/src/util/treeUtil.ts
@@ -172,9 +172,9 @@ export class TreeUtils {
         if (labelType) {
           return labelType === TreeViewItemLabelTypeEnum.filename
             ? _.last(noteDict[noteId]?.fname.split("."))?.toLowerCase()
-            : noteDict[noteId]?.title.toLowerCase();
+            : noteDict[noteId]?.title?.toLowerCase();
         } else {
-          return noteDict[noteId]?.title.toLowerCase();
+          return noteDict[noteId]?.title?.toLowerCase();
         }
       },
       // If titles are identical, sort by last updated date

--- a/packages/plugin-core/src/web/views/treeView/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/web/views/treeView/EngineNoteProvider.ts
@@ -290,9 +290,9 @@ export class EngineNoteProvider
         if (labelType) {
           return labelType === TreeViewItemLabelTypeEnum.filename
             ? _.last(noteProps.fname.split("."))?.toLowerCase()
-            : noteProps.title.toLowerCase();
+            : noteProps.title?.toLowerCase();
         } else {
-          return noteProps.title.toLowerCase();
+          return noteProps.title?.toLowerCase();
         }
       },
       // If titles are identical, sort by last updated date


### PR DESCRIPTION
## fix(workspace): tree view still displays if a note has no title

In case a title is missing from NoteProps metadata, the sort order logic won't crash.