### PR TITLE
fix(publish): correctly handle asset prefix in markdown link

### DIFF
--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/hierarchies.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/__snapshots__/hierarchies.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`hierarchies "HTML: BASIC" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>
 <hr>
 <strong>Children</strong>
 <ol>
@@ -19,7 +19,7 @@ VFile {
 exports[`hierarchies "HTML: DIFF_HIERARCHY_TITLE" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>
 <hr>
 <strong>Better Children</strong>
 <ol>
@@ -35,7 +35,7 @@ VFile {
 exports[`hierarchies "HTML: NO_HIERARCHY" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>",
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -46,7 +46,7 @@ VFile {
 exports[`hierarchies "HTML: NO_HIERARCHY_VIA_FM" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\">Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>",
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -57,7 +57,7 @@ VFile {
 exports[`hierarchies "HTML: SKIP_LEVELS" 1`] = `
 VFile {
   "contents": "<h1 id=\\"daily\\">Daily</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>
 <hr>
 <strong>Children</strong>
 <ol>

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/hierarchies.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/v5/__snapshots__/hierarchies.spec.ts.snap
@@ -19,7 +19,7 @@ VFile {
 exports[`WHEN enableHierarchyDisplay is set to false "HTML: enableHierarchyDisplay: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading icon-link\\" href=\\"#foo\\"></a>Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>",
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>",
   "cwd": "<PROJECT_ROOT>",
   "data": Object {},
   "history": Array [],
@@ -30,7 +30,7 @@ VFile {
 exports[`WHEN enableHierarchyDisplay is set to true "HTML: enableHierarchyDisplay: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading icon-link\\" href=\\"#foo\\"></a>Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>
 <hr>
 <strong>Children</strong>
 <ol>
@@ -46,7 +46,7 @@ VFile {
 exports[`WHEN hierarchyDisplayTitle is set to 'Better Children'  "HTML: hierarchyDisplayTitle: PUBLISHING" 1`] = `
 VFile {
   "contents": "<h1 id=\\"foo\\"><a aria-hidden=\\"true\\" class=\\"anchor-heading icon-link\\" href=\\"#foo\\"></a>Foo</h1>
-<p><a href=\\"foo.ch1.html\\">Ch1</a></p>
+<p><a href=\\"/foo.ch1.html\\">Ch1</a></p>
 <hr>
 <strong>Better Children</strong>
 <ol>

--- a/packages/unified/src/remark/dendronPub.ts
+++ b/packages/unified/src/remark/dendronPub.ts
@@ -164,8 +164,6 @@ class NodeUrlHandler extends DendronNodeHander {
       : cOpts?.assetsPrefix;
     const NodeToHandle = node;
 
-    console.log({ node });
-
     if (!isWebUri(NodeToHandle.url)) {
       const url = _.trim(NodeToHandle.url, "/");
       NodeToHandle.url = (assetsPrefix ? assetsPrefix + "/" : "/") + url;
@@ -173,14 +171,6 @@ class NodeUrlHandler extends DendronNodeHander {
     return { node: NodeToHandle };
   }
 }
-
-/**
- * Handler for published markdown links.
- * This matches all vanilla markdown links [](),
- * check if the href is referencing a path (i.e. not a web address),
- * and if so correctly resolve the path so they point to the right location
- * when published.
- */
 
 function shouldInsertTitle({ proc }: { proc: Processor }) {
   const data = MDUtilsV5.getProcData(proc);


### PR DESCRIPTION
# fix(publish): correctly handle asset prefix in markdown link

This PR:
- fixes issue with markdown links (e.g. `[some pdf](assets/dummy-pdf.pdf)`) to be corrected properly if asset prefix is given during publishing. (+ add forward slash if missing)

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)