### PR TITLE
chore(workspace): First Pass. Clean up usages of engine.notes in plugin-core

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -10,6 +10,10 @@ import {
   RenderNoteOpts,
   WriteNoteResp,
   BulkWriteNotesResp,
+  FindNotesResp,
+  RespV3,
+  FindNoteOpts,
+  APIRequest,
 } from "@dendronhq/common-all";
 import { ExpressUtils } from "@dendronhq/common-server";
 import { Request, Response, Router } from "express";
@@ -63,6 +67,16 @@ router.get(
       req.query as unknown as NoteQueryRequest
     );
     ExpressUtils.setResponse(res, resp);
+  })
+);
+
+router.post(
+  "/find",
+  asyncHandler(async (req: Request, res: Response<RespV3<FindNotesResp>>) => {
+    const { ws, ...opts } = req.body as APIRequest<FindNoteOpts>;
+    const engine = await getWSEngine({ ws: ws || "" });
+    const out = await engine.findNotes(opts);
+    ExpressUtils.setResponse(res, { data: out });
   })
 );
 

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -20,6 +20,8 @@ import {
   DeleteSchemaResp,
   DEngineInitResp,
   EngineSchemaWriteOpts,
+  FindNoteOpts,
+  FindNotesResp,
   GetDecorationsResp,
   GetNoteBlocksResp,
   GetSchemaResp,
@@ -367,6 +369,14 @@ export class DendronAPI extends API {
   engineWrite(req: EngineWriteRequest): Promise<WriteNoteResp> {
     return this._makeRequest({
       path: "note/write",
+      method: "post",
+      body: req,
+    });
+  }
+
+  noteFind(req: APIRequest<FindNoteOpts>): Promise<RespV3<FindNotesResp>> {
+    return this._makeRequest({
+      path: "note/find",
       method: "post",
       body: req,
     });

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -29,6 +29,7 @@ import {
   RenameNoteResp,
   RespV3,
   WriteNoteResp,
+  GetNoteMetaResp,
 } from "../types";
 import { isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
@@ -50,6 +51,13 @@ export abstract class EngineV3Base implements ReducedDEngine {
    */
   async getNote(id: string): Promise<GetNoteResp> {
     return this.noteStore.get(id);
+  }
+
+  /**
+   * See {@link DEngine.getNoteMeta}
+   */
+  async getNoteMeta(id: string): Promise<GetNoteMetaResp> {
+    return this.noteStore.getMetadata(id);
   }
 
   /**

--- a/packages/common-all/src/store/NoteMetadataStore.ts
+++ b/packages/common-all/src/store/NoteMetadataStore.ts
@@ -50,8 +50,8 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
    * See {@link IDataStore.find}
    */
   async find(opts: FindNoteOpts): Promise<RespV3<NotePropsMeta[]>> {
-    const { fname, vault } = opts;
-    if (!fname && !vault) {
+    const { fname, vault, excludeStub } = opts;
+    if (!fname && !vault && _.isUndefined(excludeStub)) {
       return { data: [] };
     }
     let noteMetadata: NotePropsMeta[];
@@ -75,6 +75,9 @@ export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
       );
     }
 
+    if (excludeStub) {
+      noteMetadata = noteMetadata.filter((note) => note.stub !== true);
+    }
     return { data: _.cloneDeep(noteMetadata) };
   }
 

--- a/packages/common-all/src/types/ReducedDEngine.ts
+++ b/packages/common-all/src/types/ReducedDEngine.ts
@@ -6,6 +6,7 @@ import { DEngine } from "./typesv2";
 export type ReducedDEngine = Pick<
   DEngine,
   | "getNote"
+  | "getNoteMeta"
   | "bulkGetNotes"
   | "bulkGetNotesMeta"
   | "findNotes"

--- a/packages/common-all/src/types/store.ts
+++ b/packages/common-all/src/types/store.ts
@@ -15,6 +15,8 @@ export type FindNoteOpts = {
   fname?: string;
   // If vault is provided, filter results so that only notes with matching vault is returned
   vault?: DVault;
+  // If true, exclude stubs from results. Otherwise, include stub notes
+  excludeStub?: boolean;
 };
 
 export type WriteNoteOpts<K> = {

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -541,6 +541,10 @@ export type DEngine = DCommonProps &
      */
     getNote: (id: string) => Promise<GetNoteResp>;
     /**
+     * Get NoteProps metadata by id. If note doesn't exist, return error
+     */
+    getNoteMeta: (id: string) => Promise<GetNoteMetaResp>;
+    /**
      * Bulk get NoteProps by list of ids
      */
     bulkGetNotes: (ids: string[]) => Promise<BulkGetNoteResp>;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -216,24 +216,32 @@ export class FileStorage implements DStore {
    * See {@link DStore.findNotes}
    */
   async findNotes(opts: FindNoteOpts): Promise<NoteProps[]> {
-    const { fname, vault } = opts;
-    if (fname) {
-      return _.cloneDeep(
-        NoteDictsUtils.findByFname(
-          fname,
-          { notesById: this.notes, notesByFname: this.noteFnames },
-          vault
-        )
-      );
-    } else if (vault) {
-      return _.cloneDeep(
-        _.values(this.notes).filter((note) =>
-          VaultUtils.isEqualV2(note.vault, vault)
-        )
-      );
-    } else {
+    const { fname, vault, excludeStub } = opts;
+    if (!fname && !vault && _.isUndefined(excludeStub)) {
       return [];
     }
+
+    let notes: NoteProps[];
+
+    if (fname) {
+      notes = NoteDictsUtils.findByFname(
+        fname,
+        { notesById: this.notes, notesByFname: this.noteFnames },
+        vault
+      );
+    } else if (vault) {
+      notes = _.values(this.notes).filter((note) =>
+        VaultUtils.isEqualV2(note.vault, vault)
+      );
+    } else {
+      notes = _.values(this.notes);
+    }
+
+    if (excludeStub) {
+      notes = notes.filter((note) => note.stub !== true);
+    }
+
+    return _.cloneDeep(notes);
   }
 
   /**

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -39,7 +39,6 @@ import {
   WriteNoteResp,
   FindNoteOpts,
   NotePropsMeta,
-  RespV3,
   ERROR_STATUS,
   EngineEventEmitter,
   NoteIndexProps,
@@ -49,6 +48,8 @@ import {
   GetSchemaResp,
   WriteSchemaResp,
   EngineSchemaWriteOpts,
+  GetNoteMetaResp,
+  GetNoteResp,
 } from "@dendronhq/common-all";
 import { createLogger, DConfig, DLogger } from "@dendronhq/common-server";
 import fs from "fs-extra";
@@ -198,7 +199,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
   /**
    * See {@link DStore.getNote}
    */
-  async getNote(id: string): Promise<RespV3<NoteProps>> {
+  async getNote(id: string): Promise<GetNoteResp> {
     const maybeNote = this.notes[id];
 
     if (maybeNote) {
@@ -212,6 +213,10 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
         }),
       };
     }
+  }
+
+  async getNoteMeta(id: string): Promise<GetNoteMetaResp> {
+    return this.getNote(id);
   }
 
   /**

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -238,24 +238,8 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
    * See {@link DStore.findNotes}
    */
   async findNotes(opts: FindNoteOpts): Promise<NoteProps[]> {
-    const { fname, vault } = opts;
-    if (fname) {
-      return _.cloneDeep(
-        NoteDictsUtils.findByFname(
-          fname,
-          { notesById: this.notes, notesByFname: this.noteFnames },
-          vault
-        )
-      );
-    } else if (vault) {
-      return _.cloneDeep(
-        _.values(this.notes).filter((note) =>
-          VaultUtils.isEqualV2(note.vault, vault)
-        )
-      );
-    } else {
-      return [];
-    }
+    const resp = await this.api.noteFind({ ...opts, ws: this.ws });
+    return resp.data!;
   }
 
   /**

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -43,7 +43,6 @@ import {
   QueryNotesOpts,
   RenameNoteOpts,
   RenderNoteOpts,
-  RespV3,
   SchemaModuleDict,
   SchemaModuleProps,
   QuerySchemaResp,
@@ -57,6 +56,8 @@ import {
   RenameNoteResp,
   RenderNoteResp,
   GetSchemaResp,
+  GetNoteMetaResp,
+  GetNoteResp,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -301,8 +302,12 @@ export class DendronEngineV2 implements DEngine {
   /**
    * See {@link DEngine.getNote}
    */
-  async getNote(id: string): Promise<RespV3<NoteProps>> {
+  async getNote(id: string): Promise<GetNoteResp> {
     return this.store.getNote(id);
+  }
+
+  async getNoteMeta(id: string): Promise<GetNoteMetaResp> {
+    return this.getNote(id);
   }
 
   async bulkGetNotes(ids: string[]): Promise<BulkGetNoteResp> {

--- a/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
@@ -156,6 +156,23 @@ describe("GIVEN NoteStore", () => {
         // Test NoteStore.getMetadata
         const noteMetadata = await noteStore.getMetadata(newNote.id);
         expect(noteMetadata.data!.fname).toEqual(newNote.fname);
+
+        // Test NoteStore.findMetadata
+        let findResp = await noteStore.findMetaData({ fname: "foobar" });
+        expect(findResp.data![0].fname).toEqual(newNote.fname);
+
+        // Test NoteStore.findMetadata excludeStub = true
+        findResp = await noteStore.findMetaData({
+          fname: "foobar",
+          excludeStub: true,
+        });
+        expect(findResp.data!.length).toEqual(0);
+
+        // Test NoteStore.findMetadata excludeStub = false
+        findResp = await noteStore.findMetaData({
+          excludeStub: false,
+        });
+        expect(findResp.data![0].fname).toEqual(newNote.fname);
       },
       {
         expect,

--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -1,6 +1,7 @@
 import {
   DVault,
   NoteProps,
+  NotePropsMeta,
   NoteUtils,
   SchemaModuleProps,
   VaultUtils,
@@ -177,7 +178,7 @@ export class WSUtils {
   /**
     @deprecated. Use same method in {@link WSUtilsV2}
   **/
-  static async openNote(note: NoteProps) {
+  static async openNote(note: NotePropsMeta) {
     const { vault, fname } = note;
     const fnameWithExtension = `${fname}.md`;
     return this.openFileInEditorUsingFullFname(vault, fnameWithExtension);

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -6,6 +6,7 @@ import {
   DNoteAnchorBasic,
   DVault,
   NoteProps,
+  NotePropsMeta,
   NoteUtils,
   RespV3,
   SchemaModuleProps,
@@ -260,7 +261,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
     return editor as vscode.TextEditor;
   }
 
-  async openNote(note: NoteProps) {
+  async openNote(note: NotePropsMeta) {
     const { vault, fname } = note;
     const fnameWithExtension = `${fname}.md`;
     return this.openFileInEditorUsingFullFname(vault, fnameWithExtension);

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -3,6 +3,7 @@ import {
   DNoteAnchorBasic,
   DVault,
   NoteProps,
+  NotePropsMeta,
   RespV3,
   SchemaModuleProps,
 } from "@dendronhq/common-all";
@@ -35,7 +36,7 @@ export interface IWSUtilsV2 {
     fnameWithExtension: string
   ): Promise<vscode.TextEditor>;
 
-  openNote(note: NoteProps): Promise<vscode.TextEditor>;
+  openNote(note: NotePropsMeta): Promise<vscode.TextEditor>;
   openSchema(schema: SchemaModuleProps): Promise<vscode.TextEditor>;
 
   /**

--- a/packages/plugin-core/src/commands/CopyNoteLink.ts
+++ b/packages/plugin-core/src/commands/CopyNoteLink.ts
@@ -6,6 +6,7 @@ import {
   isLineAnchor,
   NoteChangeEntry,
   NoteProps,
+  NotePropsMeta,
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -146,7 +147,7 @@ export class CopyNoteLinkCommand
     return { link: `[[${fsPath}${anchor}]]`, anchor };
   }
 
-  private async createNoteLink(editor: TextEditor, note: NoteProps) {
+  private async createNoteLink(editor: TextEditor, note: NotePropsMeta) {
     const engine = this.extension.getEngine();
     const { selection } = VSCodeUtils.getSelection();
     const { startAnchor: anchor } = await EditorUtils.getSelectionAnchors({
@@ -218,8 +219,8 @@ export class CopyNoteLinkCommand
       // Do nothing as engine may still not be up-to-date
       return;
     } else {
-      const note: NoteProps | undefined = (
-        await engine.findNotes({ fname, vault })
+      const note: NotePropsMeta | undefined = (
+        await engine.findNotesMeta({ fname, vault })
       )[0];
       return this.executeCopyNoteLink(note, editor);
     }
@@ -233,7 +234,7 @@ export class CopyNoteLinkCommand
   }
 
   private async executeCopyNoteLink(
-    note: NoteProps | undefined,
+    note: NotePropsMeta | undefined,
     editor: TextEditor
   ) {
     let link: string;

--- a/packages/plugin-core/src/commands/CopyNoteLink.ts
+++ b/packages/plugin-core/src/commands/CopyNoteLink.ts
@@ -5,7 +5,6 @@ import {
   isBlockAnchor,
   isLineAnchor,
   NoteChangeEntry,
-  NoteProps,
   NotePropsMeta,
   NoteUtils,
   VaultUtils,

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -519,10 +519,9 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         break;
       }
       case DoctorActionsEnum.CREATE_MISSING_LINKED_NOTES: {
-        let notes;
+        let notes: NoteProps[];
         if (_.isUndefined(note)) {
-          notes = _.values(engine.notes);
-          notes = notes.filter((note) => !note.stub);
+          notes = await engine.findNotes({ excludeStub: true });
         } else {
           notes = [note];
         }
@@ -562,8 +561,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       case DoctorActionsEnum.FIND_BROKEN_LINKS: {
         let notes;
         if (_.isUndefined(note)) {
-          notes = _.values(engine.notes);
-          notes = notes.filter((note) => !note.stub);
+          notes = await engine.findNotes({ excludeStub: true });
         } else {
           notes = [note];
         }

--- a/packages/plugin-core/src/commands/GoToSiblingCommand.ts
+++ b/packages/plugin-core/src/commands/GoToSiblingCommand.ts
@@ -155,12 +155,21 @@ export class GoToSiblingCommand extends BasicCommand<
     engine: ReducedDEngine,
     currNote: NoteProps
   ): Promise<NotePropsMeta[]> => {
-    const monthNote = await engine.getNoteMeta(currNote.parent!);
+    if (!currNote.parent) {
+      return [];
+    }
+    const monthNote = await engine.getNoteMeta(currNote.parent);
     if (!monthNote.data) {
       return [];
     }
-    const yearNote = await engine.getNoteMeta(monthNote.data.parent!);
+    if (!monthNote.data.parent) {
+      return [];
+    }
+    const yearNote = await engine.getNoteMeta(monthNote.data.parent);
     if (!yearNote.data) {
+      return [];
+    }
+    if (!yearNote.data.parent) {
       return [];
     }
     const parentNote = await engine.getNoteMeta(yearNote.data.parent!);

--- a/packages/plugin-core/src/commands/GoUpCommand.ts
+++ b/packages/plugin-core/src/commands/GoUpCommand.ts
@@ -1,4 +1,4 @@
-import { DNodeUtils, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { DNodeUtils, NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import path from "path";
 import { Uri, window } from "vscode";
@@ -24,14 +24,14 @@ export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
       return;
     }
     const engine = getDWorkspace().engine;
-    const nparent = DNodeUtils.findClosestParent(
+    const nparent = await DNodeUtils.findClosestParentWithEngine(
       path.basename(maybeTextEditor.document.uri.fsPath, ".md"),
-      { notesById: engine.notes, notesByFname: engine.noteFnames },
+      engine,
       {
-        noStubs: true,
+        excludeStub: true,
         vault: PickerUtilsV2.getVaultForOpenEditor(),
       }
-    ) as NoteProps;
+    );
     const nppath = NoteUtils.getFullPath({
       note: nparent,
       wsRoot: getDWorkspace().wsRoot,

--- a/packages/plugin-core/src/commands/RandomNote.ts
+++ b/packages/plugin-core/src/commands/RandomNote.ts
@@ -1,4 +1,4 @@
-import { ConfigUtils, NoteProps, NoteUtils } from "@dendronhq/common-all";
+import { ConfigUtils, NotePropsMeta, NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { Uri, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
@@ -10,7 +10,7 @@ type CommandOpts = {};
 
 type CommandInput = {};
 
-type CommandOutput = NoteProps | undefined;
+type CommandOutput = NotePropsMeta | undefined;
 
 export class RandomNoteCommand extends BasicCommand<
   CommandOpts,
@@ -29,7 +29,7 @@ export class RandomNoteCommand extends BasicCommand<
     const randomNoteConfig = ConfigUtils.getCommands(config).randomNote;
     const includeSet: string[] = randomNoteConfig.include ?? [""];
 
-    const searchPredicate = function (note: NoteProps) {
+    const searchPredicate = function (note: NotePropsMeta) {
       if (note.stub === true) {
         return false;
       }
@@ -57,10 +57,10 @@ export class RandomNoteCommand extends BasicCommand<
 
       return isMatch;
     };
+    const notesToPick = await engine.findNotesMeta({ excludeStub: true });
+    const noteSet = _.filter(notesToPick, (ent) => searchPredicate(ent));
 
-    const noteSet = _.filter(engine.notes, (ent) => searchPredicate(ent));
-
-    const noteCount = Object.keys(noteSet).length;
+    const noteCount = noteSet.length;
     if (noteCount === 0) {
       window.showInformationMessage(
         "No notes match the search pattern. Adjust the patterns with the Dendron:Configure (yaml) command"
@@ -69,7 +69,7 @@ export class RandomNoteCommand extends BasicCommand<
     }
 
     const index = Math.floor(Math.random() * noteCount);
-    const note = Object.values(noteSet)[index];
+    const note = noteSet[index];
 
     const npath = NoteUtils.getFullPath({
       note,

--- a/packages/plugin-core/src/commands/RandomNote.ts
+++ b/packages/plugin-core/src/commands/RandomNote.ts
@@ -57,6 +57,7 @@ export class RandomNoteCommand extends BasicCommand<
 
       return isMatch;
     };
+    // TODO: Potentially expensive call. Consider deferring to engine
     const notesToPick = await engine.findNotesMeta({ excludeStub: true });
     const noteSet = _.filter(notesToPick, (ent) => searchPredicate(ent));
 

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -243,26 +243,17 @@ export abstract class BaseExportPodCommand<
    * Gets notes matching the selected hierarchy(for a specefic vault)
    * @returns
    */
-  private async getPropsForHierarchyScope(): Promise<
-    DNodeProps<any, any>[] | undefined
-  > {
-    return new Promise<DNodeProps<any, any>[] | undefined>((resolve) => {
-      this.hierarchySelector.getHierarchy().then((selection) => {
-        if (!selection) {
-          return resolve(undefined);
-        }
-        const { hierarchy, vault } = selection;
-        const notes = this.extension.getEngine().notes;
+  private async getPropsForHierarchyScope(): Promise<NoteProps[] | undefined> {
+    return this.hierarchySelector.getHierarchy().then(async (selection) => {
+      if (!selection) {
+        return undefined;
+      }
+      const { hierarchy, vault } = selection;
+      const notes = await this.extension
+        .getEngine()
+        .findNotes({ excludeStub: true, vault });
 
-        resolve(
-          Object.values(notes).filter(
-            (value) =>
-              value.fname.startsWith(hierarchy) &&
-              value.stub !== true &&
-              VaultUtils.isEqualV2(value.vault, vault)
-          )
-        );
-      });
+      return notes.filter((value) => value.fname.startsWith(hierarchy));
     });
   }
 

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -160,7 +160,7 @@ export abstract class BaseExportPodCommand<
           vscode.window.showErrorMessage("Unable to get vault payload.");
           return;
         }
-        payload = this.getPropsForVaultScope(vault);
+        payload = await this.getPropsForVaultScope(vault);
 
         if (!payload) {
           vscode.window.showErrorMessage("Unable to get vault payload.");
@@ -379,11 +379,9 @@ export abstract class BaseExportPodCommand<
    *
    * @returns all notes in the vault
    */
-  private getPropsForVaultScope(vault: DVault): DNodeProps[] | undefined {
+  private async getPropsForVaultScope(vault: DVault): Promise<DNodeProps[]> {
     const engine = this.extension.getEngine();
-    return Object.values(engine.notes).filter(
-      (note) => note.stub !== true && VaultUtils.isEqualV2(note.vault, vault)
-    );
+    return engine.findNotes({ excludeStub: true, vault });
   }
 
   addAnalyticsPayload(opts: { config: Config; payload: NoteProps[] }) {

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -169,7 +169,7 @@ export abstract class BaseExportPodCommand<
         break;
       }
       case PodExportScope.Workspace: {
-        payload = this.getPropsForWorkspaceScope();
+        payload = await this.getPropsForWorkspaceScope();
 
         if (!payload) {
           vscode.window.showErrorMessage("Unable to get workspace payload.");
@@ -370,9 +370,9 @@ export abstract class BaseExportPodCommand<
    *
    * @returns all notes in the workspace
    */
-  private getPropsForWorkspaceScope(): DNodeProps[] | undefined {
+  private async getPropsForWorkspaceScope(): Promise<DNodeProps[]> {
     const engine = this.extension.getEngine();
-    return Object.values(engine.notes).filter((notes) => notes.stub !== true);
+    return engine.findNotes({ excludeStub: true });
   }
 
   /**

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -91,7 +91,14 @@ export class NoteGraphPanelFactory {
         ).graph.createStub;
         switch (msg.type) {
           case GraphViewMessageEnum.onSelect: {
-            const note: NoteProps = this._ext.getEngine().notes[msg.data.id];
+            const resp = await this._ext.getEngine().getNote(msg.data.id);
+            if (resp.error) {
+              throw new DendronError({
+                message: `Note not found for ${msg.data.id}`,
+                innerError: resp.error,
+              });
+            }
+            const note = resp.data;
             if (note.stub && !createStub) {
               this.refresh(note, createStub);
             } else {

--- a/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
+++ b/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
@@ -5,7 +5,6 @@ import {
   isVSCodeCommandUri,
   isWebUri,
   NoteProps,
-  NoteUtils,
   NoteViewMessage,
   TutorialEvents,
 } from "@dendronhq/common-all";
@@ -211,10 +210,7 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
       // of the note was in place of the id in the HREF (as in case of navigating to a note
       // in a different vault without explicit vault specification). Hence we will attempt
       // to find the note by file name.
-      const candidates = NoteUtils.getNotesByFnameFromEngine({
-        fname: noteId,
-        engine,
-      });
+      const candidates = await engine.findNotes({ fname: noteId });
 
       if (candidates.length === 1) {
         note = candidates[0];

--- a/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
+++ b/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
@@ -166,7 +166,7 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
     data: NoteViewMessage["data"];
     engine: DEngineClient;
   }): Promise<{
-    note: NoteProps | undefined | null;
+    note: NoteProps | undefined;
     anchor: DNoteAnchorBasic | undefined;
   }> {
     // wiki links will have the following format
@@ -203,7 +203,7 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
     const anchor = AnchorUtils.string2anchor(
       vscode.Uri.parse(data.href).fragment
     );
-    let note: NoteProps | undefined | null = engine.notes[noteId];
+    let note = (await engine.getNote(noteId)).data;
 
     if (note === undefined) {
       // If we could not find the note by the extracted id (when the note is within the same
@@ -222,7 +222,6 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
         // We have more than one candidate hence lets as the user which candidate they would like
         // to navigate to
         note = await QuickPickUtil.showChooseNote(candidates);
-        if (note === undefined) note = null;
       }
     }
 

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -41,6 +41,7 @@ import {
   QuerySchemaResp,
   WriteSchemaResp,
   EngineSchemaWriteOpts,
+  GetNoteMetaResp,
 } from "@dendronhq/common-all";
 import { DendronEngineClient, HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
@@ -177,6 +178,13 @@ export class EngineAPIService
    */
   async getNote(id: string): Promise<GetNoteResp> {
     return this._internalEngine.getNote(id);
+  }
+
+  /**
+   * See {@link IEngineAPIService.getNote}
+   */
+  async getNoteMeta(id: string): Promise<GetNoteMetaResp> {
+    return this._internalEngine.getNoteMeta(id);
   }
 
   /**

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -34,6 +34,7 @@ import {
   GetSchemaResp,
   QuerySchemaResp,
   WriteSchemaResp,
+  GetNoteMetaResp,
 } from "@dendronhq/common-all";
 
 export interface IEngineAPIService {
@@ -58,6 +59,10 @@ export interface IEngineAPIService {
    * Get NoteProps by id. If note doesn't exist, return undefined
    */
   getNote: (id: string) => Promise<GetNoteResp>;
+  /**
+   * Get NoteProps metadata by id. If note doesn't exist, return error
+   */
+  getNoteMeta: (id: string) => Promise<GetNoteMetaResp>;
   /**
    * Bulk get NoteProps by list of ids
    */

--- a/packages/plugin-core/src/test/presets/GotoNotePreset.ts
+++ b/packages/plugin-core/src/test/presets/GotoNotePreset.ts
@@ -85,7 +85,7 @@ const LINK_TO_NOTE_IN_SAME_VAULT = new TestPresetEntry<{
 
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["alpha"];
+    const note = (await engine.getNote("alpha")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
       line: 7,
@@ -131,7 +131,7 @@ const LINK_IN_CODE_BLOCK = new TestPresetEntry<{
 
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["test.note"];
+    const note = (await engine.getNote("test.note")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
       line: 9,
@@ -173,7 +173,7 @@ const LINK_TO_NOTE_WITH_URI_HTTP = new TestPresetEntry<{
 
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["beta"];
+    const note = (await engine.getNote("beta")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
       line: 7,
@@ -203,7 +203,7 @@ const VALID_URL = new TestPresetEntry<{
   },
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["test.note"];
+    const note = (await engine.getNote("test.note")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = new Selection(8, 3, 8, 3);
   },
@@ -229,7 +229,7 @@ const PARTIAL_URL = new TestPresetEntry<{
   },
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["test.note"];
+    const note = (await engine.getNote("test.note")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = new Selection(8, 15, 8, 25);
   },
@@ -242,10 +242,10 @@ const NO_LINK = new TestPresetEntry<{
   ext: IDendronExtension;
 }>({
   label: "WHEN there is no valid link under the cursor",
-  preSetupHook: async (opts) => await ENGINE_HOOKS.setupBasic(opts),
+  preSetupHook: async (opts) => ENGINE_HOOKS.setupBasic(opts),
   beforeTestResults: async ({ ext }) => {
     const { engine } = ext.getDWorkspace();
-    const note = engine.notes["foo"];
+    const note = (await engine.getNote("foo")).data!;
     const editor = await new WSUtilsV2(ext).openNote(note);
     editor.selection = LocationTestUtils.getPresetWikiLinkSelection({
       line: 8,

--- a/packages/plugin-core/src/test/suite-integ/ApplyTemplateCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ApplyTemplateCommand.test.ts
@@ -57,7 +57,7 @@ async function runTemplateTest({
 }) {
   const ext = ExtensionProvider.getExtension();
   const engine = ext.getEngine();
-  const targetNote = _targetNote || engine.notes["foo"];
+  const targetNote = _targetNote || (await engine.getNote("foo")).data!;
   // note needs to be open, otherwise, command will throw an error
   await WSUtilsV2.instance().openNote(targetNote);
   const { updatedTargetNote } = await executeTemplateApply({

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -651,12 +651,12 @@ suite("BacklinksTreeDataProvider", function () {
     () => {
       test("THEN BacklinksTreeDataProvider calculates correct number of links", async () => {
         const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
-        const alpha = engine.notes["tags.my.test-0.tag"];
+        const alpha = (await engine.getNote("tags.my.test-0.tag")).data!;
         await ExtensionProvider.getWSUtils().openNote(alpha);
         const { out } = await getRootChildrenBacklinksAsPlainObject();
         const expectedPath = vscode.Uri.file(
           NoteUtils.getFullPath({
-            note: engine.notes["test"],
+            note: (await engine.getNote("test")).data!,
             wsRoot,
           })
         ).path;

--- a/packages/plugin-core/src/test/suite-integ/CopyCodespaceURL.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyCodespaceURL.test.ts
@@ -32,9 +32,7 @@ describeSingleWS(
       );
       await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
       const resp = await cmd.execute({});
-      expect(resp).toContain(
-        "https://github.dev/dendronhq/dendron/blob/master"
-      );
+      expect(resp).toContain("https://github.dev/dendronhq/dendron/blob/");
     });
   }
 );

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -1,4 +1,9 @@
-import { ConfigUtils, NoteProps, VaultUtils } from "@dendronhq/common-all";
+import {
+  ConfigUtils,
+  NoteProps,
+  NoteUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import {
   AssertUtils,
@@ -50,8 +55,11 @@ suite("CopyNoteLink", function () {
       });
 
       test("WHEN the editor is on a dirty file, THEN CopyNoteLink should return undefined and cause an onDidSaveTextDocument to be fired", (done) => {
-        const engine = ExtensionProvider.getEngine();
-        const testNote = engine.notes["foo"];
+        const { vaults } = ExtensionProvider.getDWorkspace();
+        const testNote = NoteUtils.create({
+          fname: "foo",
+          vault: vaults[0],
+        });
         // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
         const disposable = vscode.workspace.onDidSaveTextDocument(
           (textDocument) => {
@@ -304,8 +312,11 @@ suite("CopyNoteLink", function () {
       });
 
       test("WHEN the editor is on a dirty file, THEN CopyNoteLink should return undefined and cause an onDidSaveTextDocument to be fired", (done) => {
-        const engine = ExtensionProvider.getEngine();
-        const testNote = engine.notes["foo"];
+        const { vaults } = ExtensionProvider.getDWorkspace();
+        const testNote = NoteUtils.create({
+          fname: "foo",
+          vault: vaults[0],
+        });
         // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
         const disposable = vscode.workspace.onDidSaveTextDocument(
           (textDocument) => {

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -146,7 +146,7 @@ suite("CopyNoteLink", function () {
           engine,
         });
 
-        const editor = await openNote(noteWithTarget);
+        let editor = await openNote(noteWithTarget);
         const pos = LocationTestUtils.getPresetWikiLinkPosition();
         const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
           char: 12,
@@ -154,6 +154,8 @@ suite("CopyNoteLink", function () {
         editor.selection = new vscode.Selection(pos, pos2);
         const link = (await copyNoteLinkCommand.run())?.link;
         expect(link).toEqual(`[[H1|${noteWithTarget.fname}#h1]]`);
+
+        editor = await openNote(noteWithTarget);
         editor.selection = new vscode.Selection(
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -42,7 +42,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
             const link = await new CopyNoteRefCommand().run();
@@ -60,7 +60,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 4);
             const link = await new CopyNoteRefCommand().run();
@@ -90,7 +90,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
             const link = await new CopyNoteRefCommand().run();
@@ -128,7 +128,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(8, 0, 8, 0);
             const link = await new CopyNoteRefCommand().run();
@@ -166,7 +166,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(8, 0, 11, 0);
             const link = await new CopyNoteRefCommand().run();
@@ -250,7 +250,7 @@ suite("CopyNoteRef", function () {
       () => {
         test("THEN generate note to note", async () => {
           const engine = ExtensionProvider.getEngine();
-          const note = engine.notes["foo"];
+          const note = (await engine.getNoteMeta("foo")).data!;
           await WSUtils.openNote(note);
           const link = await new CopyNoteRefCommand().run();
           expect(link).toEqual("![[foo]]");
@@ -279,7 +279,7 @@ suite("CopyNoteRef", function () {
         () => {
           test("THEN generate note ref", async () => {
             const engine = ExtensionProvider.getEngine();
-            const note = engine.notes["bar"];
+            const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
             const link = await new CopyNoteRefCommand().run();

--- a/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateDailyJournalNote.test.ts
@@ -440,10 +440,14 @@ suite("Create Daily Journal Suite", function () {
         const dailySchema = engine.schemas["daily"];
         expect(dailySchema.fname === "dendron.daily").toBeTruthy();
         expect(_.size(dailySchema.schemas) === 5).toBeTruthy();
-        const numNotesBefore = _.size(engine.notes);
+        const numNotesBefore = (
+          await engine.findNotesMeta({ excludeStub: true })
+        ).length;
         const numSchemasBefore = _.size(engine.schemas);
         await cmd.run();
-        expect(numNotesBefore).toEqual(_.size(engine.notes));
+        expect(numNotesBefore).toEqual(
+          (await engine.findNotesMeta({ excludeStub: true })).length
+        );
         expect(numSchemasBefore).toEqual(_.size(engine.schemas));
       });
     }

--- a/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DefinitionProvider.test.ts
@@ -87,8 +87,8 @@ suite("DefinitionProvider", function () {
       () => {
         test("THEN provide correct definitions", async () => {
           const { wsRoot, engine } = ExtensionProvider.getDWorkspace();
-          const note = engine.notes["alpha"];
-          const beta = engine.notes["beta"];
+          const note = (await engine.getNoteMeta("alpha")).data!;
+          const beta = (await engine.getNoteMeta("beta")).data!;
           const editor = await WSUtils.openNote(note);
           const location = (await provide(editor)) as vscode.Location;
           expect(location.uri.fsPath.toLowerCase()).toEqual(
@@ -115,7 +115,7 @@ suite("DefinitionProvider", function () {
       () => {
         test("THEN provide correct definitions", async () => {
           const { engine } = ExtensionProvider.getDWorkspace();
-          const note = engine.notes["beta"];
+          const note = (await engine.getNoteMeta("beta")).data!;
           const editor = await WSUtils.openNote(note);
           const doc = editor?.document as vscode.TextDocument;
           const provider = new DefinitionProvider();
@@ -183,7 +183,7 @@ suite("DefinitionProvider", function () {
       () => {
         test("THEN provide correct definitions", async () => {
           const { engine } = ExtensionProvider.getDWorkspace();
-          const note = engine.notes["beta"];
+          const note = (await engine.getNoteMeta("beta")).data!;
           const editor = await WSUtils.openNote(note);
           const doc = editor?.document as vscode.TextDocument;
           const provider = new DefinitionProvider();
@@ -211,7 +211,7 @@ suite("DefinitionProvider", function () {
     () => {
       test("THEN provide correct definitions", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const note = engine.notes["alpha"];
+        const note = (await engine.getNoteMeta("alpha")).data!;
         const editor = await WSUtils.openNote(note);
 
         const doc = editor?.document as vscode.TextDocument;
@@ -242,7 +242,7 @@ suite("DefinitionProvider", function () {
     () => {
       test("THEN provide correct definitions", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
-        const note = engine.notes["alpha"];
+        const note = (await engine.getNoteMeta("alpha")).data!;
         const editor = await WSUtils.openNote(note);
 
         const doc = editor?.document as vscode.TextDocument;

--- a/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/FileWatcher.test.ts
@@ -42,9 +42,9 @@ suite("GIVEN FileWatcher", function () {
             const notePath = path.join(wsRoot, vaults[0].fsPath, "newbar.md");
             const uri = vscode.Uri.file(notePath);
             await watcher.onDidCreate(uri.fsPath);
-            const note = engine.notes["newbar"];
+            const note = (await engine.getNoteMeta("newbar")).data!;
             const root = (
-              await engine.findNotes({
+              await engine.findNotesMeta({
                 fname: "root",
                 vault: vaults[0],
               })
@@ -88,9 +88,9 @@ suite("GIVEN FileWatcher", function () {
             const notePath = path.join(wsRoot, vaults[0].fsPath, "newbar.md");
             const uri = vscode.Uri.file(notePath);
             await watcher.onDidCreate(uri.fsPath);
-            const note = engine.notes["newbar"];
+            const note = (await engine.getNoteMeta("newbar")).data!;
             const root = (
-              await engine.findNotes({
+              await engine.findNotesMeta({
                 fname: "root",
                 vault: vaults[0],
               })

--- a/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
@@ -15,7 +15,7 @@ suite("notes", function () {
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
       onInit: async ({ engine }) => {
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         await new GoDownCommand().run({ noConfirm: true });
         const editor = VSCodeUtils.getActiveTextEditor();

--- a/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
@@ -16,7 +16,7 @@ suite("GoUpCommand", function () {
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
       onInit: async ({ engine }) => {
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         await new GoUpCommand().run();
         expect(
@@ -34,7 +34,7 @@ suite("GoUpCommand", function () {
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
       onInit: async ({ engine }) => {
-        const note = engine.notes["foo.ch1"];
+        const note = (await engine.getNoteMeta("foo.ch1")).data!;
         await WSUtils.openNote(note);
         await new GoUpCommand().run();
         expect(

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -48,7 +48,7 @@ suite("GotoNote", function () {
         test("THEN goto note", async () => {
           const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const vault = vaults[0];
-          const note = engine.notes["foo"];
+          const note = (await engine.getNoteMeta("foo")).data!;
           const { note: out } = (await createGoToNoteCmd().run({
             qs: "foo",
             vault,
@@ -561,7 +561,9 @@ suite("GotoNote", function () {
           await ENGINE_HOOKS_MULTI.setupLinksMulti(opts);
         },
         onInit: async ({ engine, vaults }) => {
-          const note = engine.notes[NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname];
+          const note = (
+            await engine.getNoteMeta(NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname)
+          ).data!;
           const editor = await WSUtils.openNote(note);
           const linkPos = LocationTestUtils.getPresetWikiLinkPosition();
           editor.selection = new vscode.Selection(linkPos, linkPos);
@@ -731,7 +733,9 @@ suite("GotoNote", function () {
           sinon
             .stub(PickerUtilsV2, "promptVault")
             .returns(Promise.resolve(vaults[1]));
-          const note = engine.notes[NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname];
+          const note = (
+            await engine.getNoteMeta(NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname)
+          ).data!;
           const editor = await WSUtils.openNote(note);
           const linkPos = LocationTestUtils.getPresetWikiLinkPosition();
           editor.selection = new vscode.Selection(linkPos, linkPos);
@@ -765,7 +769,7 @@ suite("GotoNote", function () {
           );
         },
         onInit: async ({ engine, vaults }) => {
-          const note = engine.notes["foo"];
+          const note = (await engine.getNoteMeta("foo")).data!;
           const editor = await WSUtils.openNote(note);
           // put cursor in location on 48
           editor.selection = new vscode.Selection(

--- a/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
@@ -25,10 +25,10 @@ suite("InsertNoteIndex", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
+          const foo = (await engine.getNoteMeta("foo")).data!;
           const cmd = new InsertNoteIndexCommand();
 
-          await WSUtils.openNote(notes["foo"]);
+          await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           editor.selection = new vscode.Selection(9, 0, 9, 0);
           await cmd.execute({});
@@ -51,10 +51,10 @@ suite("InsertNoteIndex", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
+          const foo = (await engine.getNoteMeta("foo")).data!;
           const cmd = new InsertNoteIndexCommand();
 
-          await WSUtils.openNote(notes["foo"]);
+          await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           editor.selection = new vscode.Selection(9, 0, 9, 0);
           await cmd.execute({ marker: true });
@@ -98,10 +98,10 @@ suite("InsertNoteIndex", function () {
             { wsRoot }
           );
 
-          const notes = engine.notes;
+          const foo = (await engine.getNoteMeta("foo")).data!;
           const cmd = new InsertNoteIndexCommand();
 
-          await WSUtils.openNote(notes["foo"]);
+          await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           editor.selection = new vscode.Selection(9, 0, 9, 0);
           await cmd.execute({});
@@ -136,10 +136,10 @@ suite("InsertNoteIndex", function () {
             { wsRoot }
           );
 
-          const notes = engine.notes;
+          const foo = (await engine.getNoteMeta("foo")).data!;
           const cmd = new InsertNoteIndexCommand();
 
-          await WSUtils.openNote(notes["foo"]);
+          await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
           editor.selection = new vscode.Selection(9, 0, 9, 0);
           await cmd.execute({});
@@ -184,7 +184,7 @@ suite("InsertNoteIndex", function () {
     () => {
       test("THEN insert note index add tags as index", async () => {
         const engine = ExtensionProvider.getEngine();
-        const rootNote = engine.notes["root"];
+        const rootNote = (await engine.getNoteMeta("root")).data!;
         await ExtensionProvider.getWSUtils().openNote(rootNote);
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         const cmd = new InsertNoteIndexCommand();
@@ -228,7 +228,7 @@ suite("InsertNoteIndex", function () {
     () => {
       test("THEN insert note index add tags as index", async () => {
         const engine = ExtensionProvider.getEngine();
-        const rootNote = engine.notes["root"];
+        const rootNote = (await engine.getNoteMeta("root")).data!;
         await ExtensionProvider.getWSUtils().openNote(rootNote);
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
         const cmd = new InsertNoteIndexCommand();

--- a/packages/plugin-core/src/test/suite-integ/InsertNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/InsertNoteLink.test.ts
@@ -21,12 +21,12 @@ suite("InsertNoteLink", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo"]);
+          const note = (await engine.getNote("foo")).data!;
+          await WSUtils.openNote(note);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [note],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -48,12 +48,13 @@ suite("InsertNoteLink", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -78,11 +79,11 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
+          const note = (await engine.getNote("foo")).data!;
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [note],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -104,11 +105,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -133,12 +136,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [foo],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -161,12 +165,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -189,12 +194,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [foo],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -214,12 +220,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -242,12 +249,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [foo],
             })
           );
           sinon.stub(cmd, "promptForAlias").resolves("user input");
@@ -271,12 +279,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           sinon
@@ -305,12 +314,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"]],
+              notes: [foo],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -330,12 +340,13 @@ suite("InsertNoteLink", function () {
         ctx,
         preSetupHook: ENGINE_HOOKS.setupBasic,
         onInit: async ({ engine }) => {
-          const notes = engine.notes;
-          await WSUtils.openNote(notes["foo.ch1"]);
+          const foo = (await engine.getNote("foo")).data!;
+          const fooCh1 = (await engine.getNote("foo.ch1")).data!;
+          await WSUtils.openNote(fooCh1);
           const cmd = new InsertNoteLinkCommand();
           sinon.stub(cmd, "gatherInputs").returns(
             Promise.resolve({
-              notes: [notes["foo"], notes["foo.ch1"]],
+              notes: [foo, fooCh1],
             })
           );
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -380,9 +380,7 @@ suite("MoveNoteCommand", function () {
           })
         ).toBeTruthy();
         // note foo is now a stub
-        const fooNoteAfter = _.toArray(engine.notes).find((note) => {
-          return note.fname === "foo";
-        });
+        const fooNoteAfter = (await engine.findNotes({ fname: "foo" }))[0];
         expect(!_.isUndefined(fooNoteAfter) && fooNoteAfter.stub).toBeTruthy();
         // bar isn't in the first vault
         expect(
@@ -409,7 +407,6 @@ suite("MoveNoteCommand", function () {
       test("THEN do right thing", async () => {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
         const ext = ExtensionProvider.getExtension();
-        const notes = engine.notes;
         const vault1 = vaults[0];
         const vault2 = vaults[0];
         const fname = "scratch.2020.02.03.0123";
@@ -442,12 +439,8 @@ suite("MoveNoteCommand", function () {
             path.join("vault1", "bar.md")
           )
         ).toBeTruthy();
-        expect(
-          await AssertUtils.assertInString({
-            body: _.keys(notes).join("\n"),
-            match: [fname],
-          })
-        ).toBeTruthy();
+        const note = await engine.getNote(fname);
+        expect(note.data).toBeTruthy();
       });
     }
   );
@@ -505,9 +498,7 @@ suite("MoveNoteCommand", function () {
             match: ["foo.md"],
           })
         ).toBeTruthy();
-        const fooNotes = _.toArray(engine.notes).filter((note) => {
-          return note.fname === "foo";
-        });
+        const fooNotes = await engine.findNotesMeta({ fname: "foo" });
         const vault1Foo = fooNotes.find(
           (note) => note.vault.fsPath === "vault1"
         );
@@ -589,9 +580,13 @@ suite("MoveNoteCommand", function () {
           })
         ).toBeTruthy();
 
-        const vault1Foo = _.toArray(engine.notes)
-          .filter((note) => note.fname === "foo")
-          .find((note) => note.vault.fsPath === "vault1");
+        const vault1Foo = (
+          await engine.findNotesMeta({
+            fname: "foo",
+            vault: vault1,
+          })
+        )[0];
+
         expect(!_.isUndefined(vault1Foo) && vault1Foo.stub).toBeTruthy();
         expect(
           _.isUndefined(

--- a/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NativeTreeView.test.ts
@@ -1,4 +1,9 @@
-import { DendronError, NoteProps, TreeUtils } from "@dendronhq/common-all";
+import {
+  DendronError,
+  NoteProps,
+  NotePropsMeta,
+  TreeUtils,
+} from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
@@ -15,7 +20,7 @@ import { expect } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
 import { MockEngineEvents } from "./MockEngineEvents";
 
-function getNoteUri(opts: { note: NoteProps; wsRoot: string }) {
+function getNoteUri(opts: { note: NotePropsMeta; wsRoot: string }) {
   const { note, wsRoot } = opts;
   const { fname, vault } = note;
   const notePath = fname + ".md";
@@ -28,7 +33,7 @@ async function runRenameNote(opts: { noteId: string; newName: string }) {
   const { wsRoot } = engine;
 
   const { noteId, newName } = opts;
-  const noteToRename = engine.notes[noteId];
+  const noteToRename = (await engine.getNoteMeta(noteId)).data!;
   const noteToRenameVaultPath = vault2Path({
     wsRoot,
     vault: noteToRename.vault,
@@ -57,7 +62,7 @@ async function runDeleteNote(opts: { noteId: string }) {
 
   const { wsRoot } = engine;
   const { noteId } = opts;
-  const noteToDelete = engine.notes[noteId];
+  const noteToDelete = (await engine.getNoteMeta(noteId)).data!;
   const fsPath = getNoteUri({ note: noteToDelete, wsRoot }).fsPath;
   const deleteCmd = new DeleteCommand();
   const deleteOpts = {
@@ -190,7 +195,8 @@ suite("NativeTreeView tests", function () {
           });
 
           const engine = ExtensionProvider.getEngine();
-          const vault1RootPropsAfter = engine.notes[vaultOneRootId];
+          const vault1RootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const childrenAfter = await (provider.getChildren(
             vault1RootPropsAfter
           ) as Promise<NoteProps[]>);
@@ -457,7 +463,8 @@ suite("NativeTreeView tests", function () {
           });
 
           const engine = ExtensionProvider.getEngine();
-          const vault1RootPropsAfter = engine.notes[vaultOneRootId];
+          const vault1RootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const childrenAfter = await (provider.getChildren(
             vault1RootPropsAfter
           ) as Promise<NoteProps[]>);
@@ -529,7 +536,8 @@ suite("NativeTreeView tests", function () {
             newName: "fooz",
           });
 
-          const vault1RootPropsAfter = engine.notes[vaultOneRootId];
+          const vault1RootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const childrenAfter = await (provider.getChildren(
             vault1RootPropsAfter
           ) as Promise<NoteProps[]>);
@@ -615,7 +623,8 @@ suite("NativeTreeView tests", function () {
             newName: "fooz",
           });
 
-          const vault1RootPropsAfter = engine.notes[vaultOneRootId];
+          const vault1RootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const childrenAfter = await (provider.getChildren(
             vault1RootPropsAfter
           ) as Promise<NoteProps[]>);
@@ -698,7 +707,8 @@ suite("NativeTreeView tests", function () {
             newName: "zero",
           });
 
-          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const vaultOneRootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const fullTreeAfter = await getFullTree({
             root: vaultOneRootPropsAfter,
             provider,
@@ -760,7 +770,8 @@ suite("NativeTreeView tests", function () {
             newName: "one.two.three.foo",
           });
 
-          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const vaultOneRootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const fullTreeAfter = await getFullTree({
             root: vaultOneRootPropsAfter,
             provider,
@@ -856,7 +867,8 @@ suite("NativeTreeView tests", function () {
             newName: "one",
           });
 
-          const vaultOneRootPropsAfter = engine.notes[vaultOneRootId];
+          const vaultOneRootPropsAfter = (await engine.getNote(vaultOneRootId))
+            .data!;
           const fullTreeAfter = await getFullTree({
             root: vaultOneRootPropsAfter,
             provider,
@@ -880,8 +892,8 @@ suite("NativeTreeView tests", function () {
               },
             ],
           });
-
-          expect(engine.notes["foo"].stub).toBeFalsy();
+          const foo = (await engine.getNoteMeta("foo")).data!;
+          expect(foo.stub).toBeFalsy();
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1060,7 +1060,7 @@ suite("NoteLookupCommand", function () {
             }) as Thenable<vscode.QuickPickItem>
           );
           const cmd = new NoteLookupCommand();
-          cmd
+          await cmd
             .run({
               initialValue: "food.ch2",
               noConfirm: true,
@@ -1132,7 +1132,7 @@ suite("NoteLookupCommand", function () {
           // Escape out, leading to undefined note
           showQuickPick.onFirstCall().returns(Promise.resolve(undefined));
           const cmd = new NoteLookupCommand();
-          cmd
+          await cmd
             .run({
               initialValue: "food.ch2",
               noConfirm: true,

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -7,6 +7,7 @@ import {
   LookupNoteTypeEnum,
   LookupSelectionModeEnum,
   LookupSelectionTypeEnum,
+  NoteProps,
   NoteQuickInput,
   NoteUtils,
   SchemaTemplate,
@@ -330,7 +331,7 @@ suite("NoteLookupCommand", function () {
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
           const actualNote = WSUtils.getNoteFromDocument(editor!.document);
-          const expectedNote = engine.notes["foo"];
+          const expectedNote = (await engine.getNote("foo")).data!;
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
             moduleId: "foo",
@@ -357,7 +358,7 @@ suite("NoteLookupCommand", function () {
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
           const actualNote = WSUtils.getNoteFromDocument(editor!.document);
-          const expectedNote = engine.notes["foo.ch1"];
+          const expectedNote = (await engine.getNote("foo.ch1")).data!;
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
             moduleId: "foo",
@@ -416,7 +417,7 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           const opts = (await cmd.run({ noConfirm: true }))!;
           expect(opts.quickpick.value).toEqual("foo");
           expect(_.first(opts.quickpick.selectedItems)?.fname).toEqual("foo");
@@ -698,13 +699,12 @@ suite("NoteLookupCommand", function () {
             noConfirm: true,
             initialValue: "bar",
           })!;
-          const barFromEngine = engine.notes["bar"];
+          const barFromEngine = (await engine.getNote("bar")).data!;
           const editor = VSCodeUtils.getActiveTextEditor()!;
           const activeNote = WSUtils.getNoteFromDocument(editor.document);
           expect(activeNote).toEqual(barFromEngine);
-          expect(
-            DNodeUtils.isRoot(engine.notes[barFromEngine.parent as string])
-          );
+          const parent = (await engine.getNote(barFromEngine.parent!)).data!;
+          expect(DNodeUtils.isRoot(parent));
           done();
         },
       });
@@ -1456,7 +1456,7 @@ suite("NoteLookupCommand", function () {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           // with journal note modifier enabled,
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           const out = (await cmd.run({
             noteType: LookupNoteTypeEnum.journal,
             noConfirm: true,
@@ -1498,7 +1498,7 @@ suite("NoteLookupCommand", function () {
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           const out = (await cmd.run({
             noteType: LookupNoteTypeEnum.scratch,
             noConfirm: true,
@@ -1531,7 +1531,7 @@ suite("NoteLookupCommand", function () {
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
 
           const createScratch = async () => {
             const out = (await cmd.run({
@@ -1565,7 +1565,7 @@ suite("NoteLookupCommand", function () {
           stubVaultPick(vaults);
 
           // with scratch note modifier enabled,
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           const out = (await cmd.run({
             noteType: LookupNoteTypeEnum.task,
             noConfirm: true,
@@ -1590,7 +1590,7 @@ suite("NoteLookupCommand", function () {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           // with journal note modifier enabled,
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           const out = (await cmd.run({
             noteType: LookupNoteTypeEnum.journal,
             initialValue: "gamma",
@@ -1626,7 +1626,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
 
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
@@ -1656,7 +1656,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
 
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
@@ -1686,7 +1686,7 @@ suite("NoteLookupCommand", function () {
           await ENGINE_HOOKS.setupBasic({ wsRoot, vaults });
         },
         onInit: async ({ vaults, engine }) => {
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
 
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
@@ -1789,7 +1789,11 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
+          const fooNoteEditor = await WSUtils.openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           // selects "foo body"
           fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
@@ -1820,7 +1824,7 @@ suite("NoteLookupCommand", function () {
           // event firing. However, NoteSyncService is currently not exposed in
           // the test infrastructure.
 
-          // const oldNote = engine.notes["foo"];
+          // const oldNote = (await engine.getNoteMeta("foo")).data!;
           // expect(oldNote.links.length).toEqual(1);
           // expect(oldNote.links[0].value).toEqual("foo.foo-body");
           cmd.cleanUp();
@@ -1848,7 +1852,9 @@ suite("NoteLookupCommand", function () {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
           const fooNoteEditor = await ExtensionProvider.getWSUtils().openNote(
-            engine.notes["multi-line"]
+            (
+              await engine.getNoteMeta("multi-line")
+            ).data!
           );
 
           // selects "test \n ing \n"
@@ -1887,7 +1893,11 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
+          const fooNoteEditor = await WSUtils.openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
           const { text } = VSCodeUtils.getSelection();
@@ -1919,8 +1929,11 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+          const fooNoteEditor = await WSUtils.openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
           // selects "foo body"
           fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
           const { text } = VSCodeUtils.getSelection();
@@ -1962,8 +1975,11 @@ suite("NoteLookupCommand", function () {
           );
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+          const fooNoteEditor = await WSUtils.openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
           // selects "foo body"
           fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
           const { text } = VSCodeUtils.getSelection();
@@ -2041,7 +2057,11 @@ suite("NoteLookupCommand", function () {
         onInit: async ({ vaults, engine }) => {
           const cmd = new NoteLookupCommand();
           stubVaultPick(vaults);
-          const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
+          const fooNoteEditor = await WSUtils.openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
           const { text } = VSCodeUtils.getSelection();
@@ -2076,7 +2096,7 @@ suite("NoteLookupCommand", function () {
           // close all editors before running.
           VSCodeUtils.closeAllEditors();
 
-          await WSUtils.openNote(engine.notes["foo"]);
+          await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
           await cmd.run({
             initialValue: "bar",
             splitType: "horizontal",
@@ -2155,8 +2175,11 @@ suite("NoteLookupCommand", function () {
       const cmd = new NoteLookupCommand();
       stubVaultPick(vaults);
 
-      const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+      const fooNoteEditor = await WSUtils.openNote(
+        (
+          await engine.getNoteMeta("foo")
+        ).data!
+      );
       // selects "foo body"
       fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
       const { text } = VSCodeUtils.getSelection();
@@ -2211,8 +2234,11 @@ suite("NoteLookupCommand", function () {
         const cmd = new NoteLookupCommand();
         stubVaultPick(vaults);
 
-        const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+        const fooNoteEditor = await WSUtils.openNote(
+          (
+            await engine.getNoteMeta("foo")
+          ).data!
+        );
         // selects "foo body"
         fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
         const { text } = VSCodeUtils.getSelection();
@@ -2267,8 +2293,11 @@ suite("NoteLookupCommand", function () {
         const cmd = new NoteLookupCommand();
         stubVaultPick(vaults);
 
-        const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+        const fooNoteEditor = await WSUtils.openNote(
+          (
+            await engine.getNoteMeta("foo")
+          ).data!
+        );
         // selects "foo body"
         fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
         const { text } = VSCodeUtils.getSelection();
@@ -2320,8 +2349,11 @@ suite("NoteLookupCommand", function () {
         const cmd = new NoteLookupCommand();
         stubVaultPick(vaults);
 
-        const fooNoteEditor = await WSUtils.openNote(engine.notes["foo"]);
-
+        const fooNoteEditor = await WSUtils.openNote(
+          (
+            await engine.getNoteMeta("foo")
+          ).data!
+        );
         // selects "foo body"
         fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
         const { text } = VSCodeUtils.getSelection();
@@ -2404,9 +2436,9 @@ suite("NoteLookupCommand", function () {
         opts,
       }: any) => {
         const cmd = new NoteLookupCommand();
-        const notesToSelect = ["foo.ch1", "bar", "lorem", "ipsum"].map(
-          (fname) => engine.notes[fname]
-        );
+        const notesToSelect: NoteProps[] = (
+          await engine.bulkGetNotes(["foo.ch1", "bar", "lorem", "ipsum"])
+        ).data;
         const selectedItems = notesToSelect.map((note) => {
           return DNodeUtils.enhancePropForQuickInputV3({
             props: note,
@@ -2467,7 +2499,7 @@ suite("NoteLookupCommand", function () {
             // make clean slate.
             VSCodeUtils.closeAllEditors();
 
-            await WSUtils.openNote(engine.notes["foo"]);
+            await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
             const { cmd } = await prepareCommandFunc({
               wsRoot,
               vaults,
@@ -2511,8 +2543,7 @@ suite("NoteLookupCommand", function () {
             // make clean slate.
             VSCodeUtils.closeAllEditors();
 
-            await WSUtils.openNote(engine.notes["foo"]);
-
+            await WSUtils.openNote((await engine.getNoteMeta("foo")).data!);
             const { cmd } = await prepareCommandFunc({
               wsRoot,
               vaults,

--- a/packages/plugin-core/src/test/suite-integ/PasteFile.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PasteFile.test.ts
@@ -42,7 +42,7 @@ suite("PasteFile", function () {
         const fakeAsset = path.join(tmpRoot, "apples.pdf");
         fs.writeFileSync(fakeAsset, "data");
         clipboard.writeText(fakeAsset);
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         const editor = await WSUtils.openNote(note);
         editor.selection = new vscode.Selection(8, 0, 8, 12);
 
@@ -77,7 +77,7 @@ suite("PasteFile", function () {
         const fakeAsset = path.join(tmpRoot, `${fname}.pdf`);
         fs.writeFileSync(fakeAsset, "data");
         clipboard.writeText(fakeAsset);
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         const editor = await WSUtils.openNote(note);
         editor.selection = new vscode.Selection(8, 0, 8, 12);
 

--- a/packages/plugin-core/src/test/suite-integ/PasteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PasteLink.test.ts
@@ -46,7 +46,7 @@ suite("pasteLink", function () {
       test("THEN gets link with metadata", async () => {
         // You can access the workspace inside the test like this:
         const { engine } = getDWorkspace();
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");
         sinon
@@ -69,7 +69,7 @@ suite("pasteLink", function () {
       test("THEN trims link title", async () => {
         // You can access the workspace inside the test like this:
         const { engine } = getDWorkspace();
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");
         sinon
@@ -92,7 +92,7 @@ suite("pasteLink", function () {
       test("THEN gets raw link", async () => {
         // You can access the workspace inside the test like this:
         const { engine } = getDWorkspace();
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");
         sinon

--- a/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SchemaLookupCommand.test.ts
@@ -112,7 +112,7 @@ suite("SchemaLookupCommand", function () {
         },
         onInit: async ({ engine }) => {
           const cmd = new SchemaLookupCommand();
-          const fooNote = engine.notes["foo"];
+          const fooNote = (await engine.getNoteMeta("foo")).data!;
           await WSUtils.openNote(fooNote);
           await cmd.run({ noConfirm: true, initialValue: "baz" });
           const editor = VSCodeUtils.getActiveTextEditor();

--- a/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SetupWorkspace.test.ts
@@ -215,7 +215,8 @@ suite("GIVEN SetupWorkspace Command", function () {
           const meta = openWSMetaFile({ fpath });
           expect(meta.version).toEqual("0.0.1");
           expect(meta.activationTime < Time.now().toMillis()).toBeTruthy();
-          expect(_.values(engine.notes).length).toEqual(1);
+          const notes = await engine.findNotesMeta({ excludeStub: true });
+          expect(notes.length).toEqual(1);
           const vault = path.join(wsRoot, VaultUtils.getRelPath(vaults[0]));
 
           const settings = fs.readJSONSync(

--- a/packages/plugin-core/src/test/suite-integ/ShowLegacyPreview.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ShowLegacyPreview.test.ts
@@ -17,7 +17,7 @@ suite("ShowLegacyPreview", function () {
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
       onInit: async ({ engine }) => {
-        const note = engine.notes["foo"];
+        const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         sinon.stub(MarkdownUtils, "hasLegacyPreview").returns(true);
         const showLegacyPreview = sinon.stub(

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
@@ -21,11 +21,10 @@ runSuiteButSkipForWindows()(
         workspaceType: WorkspaceType.NATIVE,
       },
       () => {
-        test("THEN initializes correctly", (done) => {
+        test("THEN initializes correctly", async () => {
           const { engine } = getDWorkspace();
-          const testNote = engine.notes["foo"];
+          const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
-          done();
         });
 
         test("THEN is of NATIVE type", (done) => {
@@ -44,11 +43,10 @@ runSuiteButSkipForWindows()(
         workspaceType: WorkspaceType.CODE,
       },
       () => {
-        test("THEN initializes correctly", (done) => {
+        test("THEN initializes correctly", async () => {
           const { engine } = getDWorkspace();
-          const testNote = engine.notes["foo"];
+          const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
-          done();
         });
 
         test("THEN is of CODE type", (done) => {
@@ -66,11 +64,10 @@ runSuiteButSkipForWindows()(
         ctx,
       },
       () => {
-        test("THEN initializes correctly", (done) => {
+        test("THEN initializes correctly", async () => {
           const { engine } = getDWorkspace();
-          const testNote = engine.notes["foo"];
+          const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
-          done();
         });
 
         test("THEN is of CODE type", (done) => {

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/LookupControllerV3.test.ts
@@ -81,7 +81,11 @@ describe(`GIVEN a LookupControllerV3`, () => {
         test(`THEN the contents of the quick pick update with 'journal'`, async () => {
           const engine = ExtensionProvider.getEngine();
 
-          await WSUtilsV2.instance().openNote(engine.notes["foo"]);
+          await WSUtilsV2.instance().openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           const provider = new NoteLookupProviderFactory(
             ExtensionProvider.getExtension()
@@ -112,7 +116,11 @@ describe(`GIVEN a LookupControllerV3`, () => {
         test(`THEN the contents of the quick pick update with 'scratch'`, async () => {
           const engine = ExtensionProvider.getEngine();
 
-          await WSUtilsV2.instance().openNote(engine.notes["foo"]);
+          await WSUtilsV2.instance().openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           const provider = new NoteLookupProviderFactory(
             ExtensionProvider.getExtension()
@@ -143,7 +151,11 @@ describe(`GIVEN a LookupControllerV3`, () => {
         test(`THEN the contents of the quick pick update with 'task.'`, async () => {
           const engine = ExtensionProvider.getEngine();
 
-          await WSUtilsV2.instance().openNote(engine.notes["foo"]);
+          await WSUtilsV2.instance().openNote(
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
+          );
 
           const provider = new NoteLookupProviderFactory(
             ExtensionProvider.getExtension()
@@ -210,7 +222,9 @@ describe(`GIVEN a LookupControllerV3`, () => {
           const engine = ExtensionProvider.getEngine();
 
           const fooNoteEditor = await WSUtilsV2.instance().openNote(
-            engine.notes["foo"]
+            (
+              await engine.getNoteMeta("foo")
+            ).data!
           );
 
           // selects "foo body"

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -1,4 +1,4 @@
-import { assert, DVault, NoteProps } from "@dendronhq/common-all";
+import { assert, DVault, NoteProps, NoteUtils } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import {
   NoteTestUtilsV4,
@@ -59,9 +59,12 @@ suite("BaseExportPodCommand", function () {
           const cmd = new TestExportPodCommand(
             ExtensionProvider.getExtension()
           );
-          const engine = ExtensionProvider.getEngine();
 
-          const testNote = engine.notes["foo"];
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          const testNote = NoteUtils.create({
+            fname: "foo",
+            vault: vaults[0],
+          });
           const textToAppend = "BaseExportPodCommand testing";
           // onEngineNoteStateChanged is not being triggered by save so test to make sure that save is being triggered instead
           const disposable = vscode.workspace.onDidSaveTextDocument(
@@ -98,9 +101,12 @@ suite("BaseExportPodCommand", function () {
           const cmd = new TestExportPodCommand(
             ExtensionProvider.getExtension()
           );
-          const engine = ExtensionProvider.getEngine();
 
-          const testNote = engine.notes["foo"];
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          const testNote = NoteUtils.create({
+            fname: "foo",
+            vault: vaults[0],
+          });
           const disposable = vscode.workspace.onDidSaveTextDocument(() => {
             assert(false, "Callback not expected");
           });

--- a/packages/plugin-core/src/test/suite-integ/md.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/md.test.ts
@@ -27,7 +27,7 @@ suite("WHEN getReferenceAtPosition", function () {
       test("THEN initializes correctly", async () => {
         // You can access the workspace inside the test like this:
         const { engine, wsRoot, vaults } = ExtensionProvider.getDWorkspace();
-        const activeNote = engine.notes[activeNoteName];
+        const activeNote = (await engine.getNoteMeta(activeNoteName)).data!;
         const editor = await WSUtils.openNote(activeNote);
         const position = new vscode.Position(7, 0);
         const reference = await getReferenceAtPosition({

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -426,9 +426,6 @@ export function stubSetupWorkspace({ wsRoot }: { wsRoot: string }) {
 }
 
 class FakeEngine {
-  get notes() {
-    return getDWorkspace().engine.notes;
-  }
   get schemas() {
     return getDWorkspace().engine.schemas;
   }
@@ -512,7 +509,7 @@ export function runSuiteButSkipForWindows() {
  *   () => {
  *     test("THEN initializes correctly", (done) => {
  *       const { engine, _wsRoot, _vaults } = getDWorkspace();
- *       const testNote = engine.notes["foo"];
+ *       const testNote = await engine.getNote("foo").data!;
  *       expect(testNote).toBeTruthy();
  *       done();
  *     });

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -488,7 +488,7 @@ export async function findReferencesById(id: string) {
 
   const engine = ExtensionProvider.getEngine();
 
-  const note = engine.notes[id];
+  const note = (await engine.getNote(id)).data;
 
   if (!note) {
     return;

--- a/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
+++ b/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
@@ -75,6 +75,10 @@ export class MockEngineAPIService implements ReducedDEngine {
     return this.store.get(id) as Promise<RespV3<NoteProps>>;
   }
 
+  async getNoteMeta(id: string): Promise<RespV3<NotePropsMeta>> {
+    return this.store.get(id);
+  }
+
   bulkGetNotes(_ids: string[]): Promise<BulkGetNoteResp> {
     throw new Error("Not Implemented");
   }


### PR DESCRIPTION
This is my first pass at migrating `engine.notes` to use the proper engine methods in plugin-core. I've left some of the more complicated ones for future commits.

**Other Changes**
1. Add support in api for `findNotes`
2. Add support in `findNotes` to exclude stubs
3. Replace `NoteProps` with `NotePropsMeta` where applicable