### PR TITLE
chore(internal): add `workspace.enableSmartRefs` to `DEPRECATED_PATHS`

### DIFF
--- a/packages/engine-server/src/migrations/utils.ts
+++ b/packages/engine-server/src/migrations/utils.ts
@@ -249,6 +249,7 @@ export const DEPRECATED_PATHS = [
   "site.generateChangelog",
   "dev.enableWebUI",
   "workspace.enableHandlebarTemplates",
+  "workspace.enableSmartRefs",
 ];
 
 export class MigrationUtils {


### PR DESCRIPTION
# chore(internal): add `workspace.enableSmartRefs` to `DEPRECATED_PATHS`

This PR:
- adds `workspace.enableSmartRefs` to `DEPRECATED_PATHS` so they could be properly cleaned up at upgrade.
