### PR TITLE
chore: add setVault to note trait template

### DIFF
--- a/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
+++ b/packages/plugin-core/src/commands/RegisterNoteTraitCommand.ts
@@ -85,6 +85,15 @@ module.exports = {
     // setTemplate: () => {
     //   return "root";
     // },
+    /**
+     * Specify the vault in which a new note is created.
+     * This method is optional, uncomment out
+     * the lines below if you want to specify the vault.
+     * @returns the name of the desired vault.
+     */
+    // setVault: () => {
+    //   return "vault";
+    // },
   },
 };
 `;


### PR DESCRIPTION
# chore: add setVault to note trait template
This PR:
- adds the new `setVault` onCreate method as an example to the note trait template
