### PR TITLE
chore(workspace): Change default keybinding for Create Scratch Note

### DIFF
--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -51,6 +51,10 @@ type Metadata = Partial<{
    */
   firstInstall: number;
   /**
+   * What was the version of the first install?
+   */
+  firstInstallVersion: string;
+  /**
    * When the first workspace was initialized
    */
   firstWsInitialize: number;
@@ -289,6 +293,10 @@ export class MetadataService {
     return this.getMeta().v100ReleaseMessageShown;
   }
 
+  get firstInstallVersion(): string | undefined {
+    return this.getMeta().firstInstallVersion;
+  }
+
   /**
    * Set first install logic
    *  ^o4y7ijuvi5nv
@@ -296,6 +304,10 @@ export class MetadataService {
   setInitialInstall(time?: number) {
     time ||= Time.now().toSeconds();
     this.setMeta("firstInstall", time);
+  }
+
+  setInitialInstallVersion(version: string) {
+    this.setMeta("firstInstallVersion", version);
   }
 
   setFirstWsInitialize() {

--- a/packages/engine-server/src/metadata/service.ts
+++ b/packages/engine-server/src/metadata/service.ts
@@ -25,6 +25,7 @@ export enum ShowcaseEntry {
   BacklinksPanelHover = "BacklinksPanelHover",
   ObsidianImport = "ObsidianImport",
   SettingsUI = "SettingsUI",
+  CreateScratchNoteKeybindingTip = "CreateScratchNoteKeybindingTip",
 }
 
 /**

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1342,8 +1342,8 @@
       },
       {
         "command": "dendron.createScratchNote",
-        "key": "ctrl+shift+s",
-        "mac": "cmd+shift+s",
+        "key": "ctrl+k s",
+        "mac": "cmd+k s",
         "when": "dendron:pluginActive && shellExecutionSupported"
       },
       {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -71,6 +71,7 @@ import { DendronExtension, getDWorkspace, getExtension } from "./workspace";
 import { TutorialInitializer } from "./workspace/tutorialInitializer";
 import { WorkspaceActivator } from "./workspace/workspaceActivator";
 import { WSUtils } from "./WSUtils";
+import { CreateScratchNoteKeybindingTip } from "./showcase/CreateScratchNoteKeybindingTip";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -353,7 +354,14 @@ export async function _activate(
         const ONE_MINUTE_IN_MS = 60_000;
         setTimeout(() => {
           const showcase = new FeatureShowcaseToaster();
-          showcase.showToast();
+          // Temporarily show the new toast instead of the rest.
+          // for subsequent sessions this will not be shown as it already has been shown.
+          const hasShown = showcase.showSpecificToast(
+            new CreateScratchNoteKeybindingTip()
+          );
+          if (!hasShown) {
+            showcase.showToast();
+          }
         }, ONE_MINUTE_IN_MS);
       }
     } else {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -72,6 +72,7 @@ import { TutorialInitializer } from "./workspace/tutorialInitializer";
 import { WorkspaceActivator } from "./workspace/workspaceActivator";
 import { WSUtils } from "./WSUtils";
 import { CreateScratchNoteKeybindingTip } from "./showcase/CreateScratchNoteKeybindingTip";
+import semver from "semver";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
 // === Main
@@ -356,9 +357,19 @@ export async function _activate(
           const showcase = new FeatureShowcaseToaster();
           // Temporarily show the new toast instead of the rest.
           // for subsequent sessions this will not be shown as it already has been shown.
-          const hasShown = showcase.showSpecificToast(
-            new CreateScratchNoteKeybindingTip()
-          );
+          // TODO: remove this special treatment after 1~2 weeks.
+          let hasShown = false;
+          // only show for users installed prior to v113
+          const firstInstallVersion =
+            MetadataService.instance().firstInstallVersion;
+          if (
+            firstInstallVersion === undefined ||
+            semver.lt(firstInstallVersion, "0.113.0")
+          ) {
+            hasShown = showcase.showSpecificToast(
+              new CreateScratchNoteKeybindingTip()
+            );
+          }
           if (!hasShown) {
             showcase.showToast();
           }

--- a/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
@@ -14,6 +14,8 @@ import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegi
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { ConfigUtils } from "@dendronhq/common-all";
 import { VaultSelectionModeConfigUtils } from "../components/lookup/vaultSelectionModeConfigUtils";
+import { FeatureShowcaseToaster } from "../showcase/FeatureShowcaseToaster";
+import { CreateScratchNoteKeybindingTip } from "../showcase/CreateScratchNoteKeybindingTip";
 
 type CommandOpts = NoteLookupRunOpts;
 type CommandOutput = void;
@@ -61,5 +63,9 @@ export class CreateScratchNoteCommand extends BasicCommand<
     const lookupCmd = AutoCompletableRegistrar.getNoteLookupCmd();
     lookupCmd.controller = this.createLookupController();
     await lookupCmd.run(opts);
+
+    // TODO: remove after we sufficiently warned users.
+    const showcase = new FeatureShowcaseToaster();
+    showcase.showSpecificToast(new CreateScratchNoteKeybindingTip());
   }
 }

--- a/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateScratchNoteCommand.ts
@@ -16,6 +16,8 @@ import { ConfigUtils } from "@dendronhq/common-all";
 import { VaultSelectionModeConfigUtils } from "../components/lookup/vaultSelectionModeConfigUtils";
 import { FeatureShowcaseToaster } from "../showcase/FeatureShowcaseToaster";
 import { CreateScratchNoteKeybindingTip } from "../showcase/CreateScratchNoteKeybindingTip";
+import { MetadataService } from "@dendronhq/engine-server";
+import semver from "semver";
 
 type CommandOpts = NoteLookupRunOpts;
 type CommandOutput = void;
@@ -64,8 +66,14 @@ export class CreateScratchNoteCommand extends BasicCommand<
     lookupCmd.controller = this.createLookupController();
     await lookupCmd.run(opts);
 
-    // TODO: remove after we sufficiently warned users.
-    const showcase = new FeatureShowcaseToaster();
-    showcase.showSpecificToast(new CreateScratchNoteKeybindingTip());
+    // TODO: remove after 1-2 weeks.
+    const firstInstallVersion = MetadataService.instance().firstInstallVersion;
+    if (
+      firstInstallVersion === undefined ||
+      semver.lt(firstInstallVersion, "0.113.0")
+    ) {
+      const showcase = new FeatureShowcaseToaster();
+      showcase.showSpecificToast(new CreateScratchNoteKeybindingTip());
+    }
   }
 }

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -627,8 +627,8 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.createScratchNote",
     title: `${CMD_PREFIX} Create Scratch Note`,
     keybindings: {
-      key: "ctrl+shift+s",
-      mac: "cmd+shift+s",
+      key: "ctrl+k s",
+      mac: "cmd+k s",
       when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
     },
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,

--- a/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
+++ b/packages/plugin-core/src/showcase/AllFeatureShowcases.ts
@@ -1,5 +1,6 @@
 import { ShowcaseEntry } from "@dendronhq/engine-server";
 import { BacklinksPanelHoverTip } from "./BacklinksPanelHoverTip";
+import { CreateScratchNoteKeybindingTip } from "./CreateScratchNoteKeybindingTip";
 import { GraphPanelTip } from "./GraphPanelTip";
 import { GraphThemeTip } from "./GraphThemeTip";
 import { IFeatureShowcaseMessage } from "./IFeatureShowcaseMessage";
@@ -90,4 +91,5 @@ export const ALL_FEATURE_SHOWCASES: IFeatureShowcaseMessage[] = [
   new BacklinksPanelHoverTip(),
   new ObsidianImportTip(),
   new SettingsUITip(),
+  new CreateScratchNoteKeybindingTip(),
 ];

--- a/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
+++ b/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
@@ -1,0 +1,43 @@
+import { ShowcaseEntry } from "@dendronhq/engine-server";
+import _ from "lodash";
+import { VSCodeUtils } from "../vsCodeUtils";
+import {
+  DisplayLocation,
+  IFeatureShowcaseMessage,
+} from "./IFeatureShowcaseMessage";
+
+export class CreateScratchNoteKeybindingTip implements IFeatureShowcaseMessage {
+  /**
+   * Only shows a toast, this tip does not appear in tip of day.
+   * @param displayLocation
+   * @returns
+   */
+  shouldShow(displayLocation: DisplayLocation): boolean {
+    if (displayLocation === DisplayLocation.TipOfTheDayView) {
+      return false;
+    }
+
+    return true;
+  }
+
+  get showcaseEntry(): ShowcaseEntry {
+    return ShowcaseEntry.CreateScratchNoteKeybindingTip;
+  }
+
+  getDisplayMessage(_displayLocation: DisplayLocation): string {
+    return `Keyboard shortcut for "Dendron: Create Scratch Note" has changed. If you wish to keep the original, please follow the instructions.`;
+  }
+
+  onConfirm() {
+    // TODO: get actual link
+    VSCodeUtils.openLink("https://wiki.dendron.so");
+  }
+
+  get confirmText(): string {
+    return "Show me how";
+  }
+
+  get deferText(): string {
+    return "Later";
+  }
+}

--- a/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
+++ b/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
@@ -25,7 +25,7 @@ export class CreateScratchNoteKeybindingTip implements IFeatureShowcaseMessage {
   }
 
   getDisplayMessage(_displayLocation: DisplayLocation): string {
-    return `Keyboard shortcut for "Dendron: Create Scratch Note" has changed. If you wish to keep the original, please follow the instructions.`;
+    return `Keyboard shortcut for "Dendron: Create Scratch Note" has changed. If you wish to keep the original, please follow the instructions online.`;
   }
 
   onConfirm() {

--- a/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
+++ b/packages/plugin-core/src/showcase/CreateScratchNoteKeybindingTip.ts
@@ -29,8 +29,9 @@ export class CreateScratchNoteKeybindingTip implements IFeatureShowcaseMessage {
   }
 
   onConfirm() {
-    // TODO: get actual link
-    VSCodeUtils.openLink("https://wiki.dendron.so");
+    VSCodeUtils.openLink(
+      "https://wiki.dendron.so/notes/50kdbcwwda3gphjhccb0e5t"
+    );
   }
 
   get confirmText(): string {

--- a/packages/plugin-core/src/utils/ExtensionUtils.ts
+++ b/packages/plugin-core/src/utils/ExtensionUtils.ts
@@ -34,6 +34,7 @@ import * as Sentry from "@sentry/node";
 import { MarkdownUtils } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { URI, Utils } from "vscode-uri";
+import { VersionProvider } from "../versionProvider";
 
 /** Before sending saved telemetry events, wait this long (in ms) to make sure
  * the workspace will likely remain open long enough for us to send everything.
@@ -273,6 +274,8 @@ export class ExtensionUtils {
       const metadata = MetadataService.instance().getMeta();
       if (metadata.firstInstall === undefined && !UUIDPathExists) {
         MetadataService.instance().setInitialInstall();
+        const version = VersionProvider.version();
+        MetadataService.instance().setInitialInstallVersion(version);
       } else {
         // we still want to proceed with InstallStatus.INITIAL_INSTALL because we want everything
         // tied to initial install to happen in this instance of VSCode once for the first time


### PR DESCRIPTION
# chore(workspace): Change default keybinding for Create Scratch Note
This PR:
- Changes default keybinding for `Create Scratch Note` from `shift+cmd/ctrl+s` to `cmd/ctrl+k s`
- Add a temporary feature toast during startup to notify the change, and a fail-safe backup toast in the command itself
  - This is only shown once ever, and will be tracked with `FeatureShowcaseDisplayed`

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)