### PR TITLE
fix(views): fix mermaid diagrams

### DIFF
--- a/packages/common-frontend/src/components/DendronNote.tsx
+++ b/packages/common-frontend/src/components/DendronNote.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable react/no-danger */
-import { IntermediateDendronConfig } from "@dendronhq/common-all";
 import React from "react";
 import { createLogger } from "../utils/logger";
 
 type Props = {
   noteContent: string;
-  config: IntermediateDendronConfig;
 };
 
 export const useMermaid = ({

--- a/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronNotePreview.tsx
@@ -71,13 +71,11 @@ const DendronNotePreview: DendronComponent = (props) => {
   const ctx = "DendronNotePreview";
   const logger = createLogger("DendronNotePreview");
   const noteProps = props.ide.noteActive;
-  const config = props.engine.config!;
 
   logger.info({
     ctx,
     msg: "enter",
     noteProps: noteProps ? noteProps.id : "no notes found",
-    config,
   });
 
   const [noteRenderedBody] = useRenderedNoteBody({
@@ -93,7 +91,7 @@ const DendronNotePreview: DendronComponent = (props) => {
 
   useClickHandler(noteProps?.id);
   const { currentTheme: themeType } = useCurrentTheme();
-  useMermaid({ config, themeType, mermaid, noteRenderedBody });
+  useMermaid({ themeType, mermaid, noteRenderedBody });
 
   if (props.engine.error) {
     return (
@@ -126,7 +124,7 @@ const DendronNotePreview: DendronComponent = (props) => {
 
   return (
     <>
-      <DendronNote noteContent={noteRenderedBody} config={config} />
+      <DendronNote noteContent={noteRenderedBody} />
       <Button
         shape="circle"
         icon={isLocked ? <LockFilled /> : <UnlockOutlined />}

--- a/packages/dendron-plugin-views/src/hooks/index.tsx
+++ b/packages/dendron-plugin-views/src/hooks/index.tsx
@@ -1,8 +1,4 @@
-import {
-  ConfigUtils,
-  IntermediateDendronConfig,
-  NoteProps,
-} from "@dendronhq/common-all";
+import { IntermediateDendronConfig, NoteProps } from "@dendronhq/common-all";
 import {
   createLogger,
   engineHooks,
@@ -95,7 +91,6 @@ export const useRenderedNoteBody = ({
  * https://mermaid-js.github.io/mermaid/#/
  */
 export const useMermaid = ({
-  config,
   themeType,
   mermaid,
   noteRenderedBody,
@@ -107,25 +102,23 @@ export const useMermaid = ({
 }) => {
   React.useEffect(() => {
     const logger = createLogger("useMermaid");
-    if (config && ConfigUtils.getPreview(config)?.enableMermaid) {
-      mermaid.initialize({
-        startOnLoad: true,
-        // Cast here because the type definitions seem to be incorrect. I can't
-        // get a value for the mermaid Theme enum, it's always undefined at
-        // runtime.
-        theme: (themeType === "light" ? "forest" : "dark") as any,
-      });
-      // use for debugging
-      // @ts-ignore
-      window._mermaid = mermaid;
-      // @ts-ignore
-      mermaid.init();
-      logger.info({ msg: "init mermaid library", themeType });
-    } else {
-      logger.info("skip mermaid library");
-    }
+
+    mermaid.initialize({
+      startOnLoad: true,
+      // Cast here because the type definitions seem to be incorrect. I can't
+      // get a value for the mermaid Theme enum, it's always undefined at
+      // runtime.
+      theme: (themeType === "light" ? "forest" : "dark") as any,
+    });
+    // use for debugging
+    // @ts-ignore
+    window._mermaid = mermaid;
+    // @ts-ignore
+    mermaid.init();
+    logger.info({ msg: "init mermaid library", themeType });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [config, noteRenderedBody, themeType]);
+  }, [noteRenderedBody, themeType]);
 };
 
 /**


### PR DESCRIPTION
## fix(views): fix mermaid diagrams

Fixes mermaid diagrams in preview.  Note: this change causes mermaid to always be enabled, and no longer observes the `enableMermaid` setting. I don't think this should be a problem though, given the recent change to lazy load mermaid only when it's necessary.  Let me know if you think otherwise. 

TODO: Remove the `enableMermaid` setting. 