### PR TITLE
fix(schema): schemas being overwritten on save 

### DIFF
--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -1,14 +1,6 @@
 {
   "folders": [
     {
-      "path": "docs/dendron-docs",
-      "name": "dendron-docs"
-    },
-    {
-      "path": "docs/seeds/dendron.dendron-site",
-      "name": "dendron.dendron-site"
-    },
-    {
       "path": ".",
       "name": "root"
     },
@@ -72,15 +64,18 @@
   ],
   "settings": {
     "files.exclude": {
-      "*.d.ts": true,
-      "profile": true
+      "**/*.d.ts": true,
+      "**/profile": true,
+      "docs/*.md": true,
+      "**/*.tff": true,
+      "**/*.woff": true,
+      "**/*.woff2": true,
     },
     "editor.codeActionsOnSave": {},
     "search.exclude": {
       "**/node_modules": true,
       "**/bower_components": true,
       "CHANGELOG.md": true,
-      "*.d.ts": true
     },
     "files.watcherExclude": {
       "**/.git/objects/**": true,

--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -64,15 +64,15 @@
   ],
   "settings": {
     "files.exclude": {
-      "**/*.d.ts": true,
       "**/profile": true,
-      "docs/*.md": true,
       "**/*.tff": true,
       "**/*.woff": true,
       "**/*.woff2": true,
     },
     "editor.codeActionsOnSave": {},
     "search.exclude": {
+      "docs/*.md": true,
+      "**/*.d.ts": true,
       "**/node_modules": true,
       "**/bower_components": true,
       "CHANGELOG.md": true,

--- a/docs/dendron.yml
+++ b/docs/dendron.yml
@@ -18,7 +18,8 @@ commands:
         enableMultiSelect: false
     insertNoteIndex:
         enableMarker: false
-    copyNoteLink: {}
+    copyNoteLink:
+        aliasMode: title
     templateHierarchy: template
 workspace:
     dendronVersion: 0.83.0
@@ -89,7 +90,6 @@ workspace:
             - x
     enableEditorDecorations: true
     enableFullHierarchyNoteTitle: false
-    enableHandlebarTemplates: true
     enableSmartRefs: false
 preview:
     enableFMTitle: true

--- a/packages/api-server/src/modules/schemas/index.ts
+++ b/packages/api-server/src/modules/schemas/index.ts
@@ -19,9 +19,9 @@ export class SchemaController {
   }
 
   async create(req: SchemaWriteRequest): Promise<WriteSchemaResp> {
-    const { ws, schema } = req;
+    const { ws, schema, opts } = req;
     const engine = await getWSEngine({ ws });
-    return engine.writeSchema(schema);
+    return engine.writeSchema(schema, opts);
   }
 
   async delete({

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -19,6 +19,7 @@ import {
   DeleteNoteResp,
   DeleteSchemaResp,
   DEngineInitResp,
+  EngineSchemaWriteOpts,
   GetDecorationsResp,
   GetNoteBlocksResp,
   GetSchemaResp,
@@ -146,6 +147,7 @@ export type SchemaQueryRequest = {
 } & Partial<WorkspaceRequest>;
 export type SchemaWriteRequest = {
   schema: SchemaModuleProps;
+  opts?: EngineSchemaWriteOpts;
 } & WorkspaceRequest;
 
 export type AssetGetRequest = { fpath: string } & WorkspaceRequest;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -50,6 +50,7 @@ import {
   USER_MESSAGES,
   VaultUtils,
   WriteNoteResp,
+  WriteSchemaResp,
 } from "@dendronhq/common-all";
 import {
   DLogger,
@@ -1383,7 +1384,7 @@ export class FileStorage implements DStore {
   async writeSchema(
     schemaModule: SchemaModuleProps,
     opts?: EngineSchemaWriteOpts
-  ) {
+  ): Promise<WriteSchemaResp> {
     this.schemas[schemaModule.root.id] = schemaModule;
     if (opts?.metaOnly) {
       return { data: undefined };

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -17,6 +17,7 @@ import {
   DStore,
   DVault,
   EngineDeleteOpts,
+  EngineSchemaWriteOpts,
   EngineUpdateNodesOptsV2,
   EngineWriteOptsV2,
   error2PlainObject,
@@ -1379,8 +1380,14 @@ export class FileStorage implements DStore {
     };
   }
 
-  async writeSchema(schemaModule: SchemaModuleProps) {
+  async writeSchema(
+    schemaModule: SchemaModuleProps,
+    opts?: EngineSchemaWriteOpts
+  ) {
     this.schemas[schemaModule.root.id] = schemaModule;
+    if (opts?.metaOnly) {
+      return { data: undefined };
+    }
     const vault = schemaModule.vault;
     const vpath = vault2Path({ vault, wsRoot: this.wsRoot });
     await schemaModuleProps2File(schemaModule, vpath, schemaModule.fname);

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -48,6 +48,7 @@ import {
   RenameNoteResp,
   GetSchemaResp,
   WriteSchemaResp,
+  EngineSchemaWriteOpts,
 } from "@dendronhq/common-all";
 import { createLogger, DConfig, DLogger } from "@dendronhq/common-server";
 import fs from "fs-extra";
@@ -525,8 +526,16 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
     return _.defaults(out, { data: [] });
   }
 
-  async writeSchema(schema: SchemaModuleProps): Promise<WriteSchemaResp> {
-    const out = await this.api.schemaWrite({ schema, ws: this.ws });
+  async writeSchema(
+    schema: SchemaModuleProps,
+    opts?: EngineSchemaWriteOpts
+  ): Promise<WriteSchemaResp> {
+    this.logger.debug({
+      ctx: "engineClient.writeSchema",
+      schema: schema.fname,
+      metaOnly: opts?.metaOnly,
+    });
+    const out = await this.api.schemaWrite({ schema, ws: this.ws, opts });
     await this.refreshSchemas([schema]);
     return out;
   }

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -14,6 +14,7 @@ import {
   DNodeType,
   DStore,
   DVault,
+  EngineSchemaWriteOpts,
   EngineDeleteOpts,
   EngineInfoResp,
   EngineWriteOptsV2,
@@ -677,8 +678,8 @@ export class DendronEngineV2 implements DEngine {
     return out;
   }
 
-  async writeSchema(schema: SchemaModuleProps) {
-    const out = this.store.writeSchema(schema);
+  async writeSchema(schema: SchemaModuleProps, opts?: EngineSchemaWriteOpts) {
+    const out = this.store.writeSchema(schema, opts);
     await this.updateIndex("schema");
     return out;
   }

--- a/packages/plugin-core/.vscode/launch.json
+++ b/packages/plugin-core/.vscode/launch.json
@@ -6,7 +6,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run Extension:Local",
+      "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -25,43 +25,6 @@
       ],
       "env": {
         "STAGE": "dev",
-        "VSCODE_DEBUGGING_EXTENSION": "dendron",
-        "LOG_LEVEL": "debug"
-      }
-    },
-    {
-      "name": "Run Extension:Remote",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-      ],
-      "outFiles": [
-        "${workspaceFolder:plugin-core}/out/**/*.js"
-      ],
-      "skipFiles": [
-        "<node_internals>/**/*.js",
-        "${workspaceFolder}/**/node_modules/mocha/**/*.js"
-      ],
-      "env": {
-        "STAGE": "dev",
-        "VSCODE_DEBUGGING_EXTENSION": "dendron",
-        "LOG_LEVEL": "debug"
-      }
-    },
-    {
-      "name": "Run Extension:Prod",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
-      "outFiles": [
-        "${workspaceFolder:plugin-core}/out/**/*.js"
-      ],
-      "env": {
         "VSCODE_DEBUGGING_EXTENSION": "dendron",
         "LOG_LEVEL": "debug"
       }

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -8,6 +8,7 @@ import {
   NoteProps,
   NoteUtils,
   RespV3,
+  SchemaModuleProps,
   VaultUtils,
 } from "@dendronhq/common-all";
 import _ from "lodash";
@@ -262,6 +263,12 @@ export class WSUtilsV2 implements IWSUtilsV2 {
   async openNote(note: NoteProps) {
     const { vault, fname } = note;
     const fnameWithExtension = `${fname}.md`;
+    return this.openFileInEditorUsingFullFname(vault, fnameWithExtension);
+  }
+
+  async openSchema(schema: SchemaModuleProps) {
+    const { vault, fname } = schema;
+    const fnameWithExtension = `${fname}.schema.yml`;
     return this.openFileInEditorUsingFullFname(vault, fnameWithExtension);
   }
 }

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -4,6 +4,7 @@ import {
   DVault,
   NoteProps,
   RespV3,
+  SchemaModuleProps,
 } from "@dendronhq/common-all";
 
 export interface IWSUtilsV2 {
@@ -35,6 +36,7 @@ export interface IWSUtilsV2 {
   ): Promise<vscode.TextEditor>;
 
   openNote(note: NoteProps): Promise<vscode.TextEditor>;
+  openSchema(schema: SchemaModuleProps): Promise<vscode.TextEditor>;
 
   /**
    * Given list of notes, prompt user to pick note by selecting corresponding vault name

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -40,6 +40,7 @@ import {
   GetSchemaResp,
   QuerySchemaResp,
   WriteSchemaResp,
+  EngineSchemaWriteOpts,
 } from "@dendronhq/common-all";
 import { DendronEngineClient, HistoryService } from "@dendronhq/engine-server";
 import _ from "lodash";
@@ -225,8 +226,11 @@ export class EngineAPIService
     return this._internalEngine.writeNote(note, opts);
   }
 
-  writeSchema(schema: SchemaModuleProps): Promise<WriteSchemaResp> {
-    return this._internalEngine.writeSchema(schema);
+  writeSchema(
+    schema: SchemaModuleProps,
+    opts?: EngineSchemaWriteOpts
+  ): Promise<WriteSchemaResp> {
+    return this._internalEngine.writeSchema(schema, opts);
   }
   init(): Promise<DEngineInitResp> {
     // this.setupEngineAnalyticsTracking();

--- a/packages/plugin-core/src/services/SchemaSyncService.ts
+++ b/packages/plugin-core/src/services/SchemaSyncService.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { ISchemaSyncService } from "./SchemaSyncServiceInterface";
 import { IDendronExtension } from "../dendronExtensionInterface";
+import { WriteSchemaResp } from "@dendronhq/common-all";
 
 /** Currently responsible for keeping the engine in sync with schema
  *  changes on disk. */
@@ -33,7 +34,7 @@ export class SchemaSyncService implements ISchemaSyncService {
   }: {
     uri: Uri;
     isBrandNewFile?: boolean;
-  }) {
+  }): Promise<WriteSchemaResp[] | undefined> {
     const schemaParser = new SchemaParser({
       wsRoot: this.extension.getDWorkspace().wsRoot,
       logger: Logger,
@@ -46,9 +47,9 @@ export class SchemaSyncService implements ISchemaSyncService {
     );
 
     if (_.isEmpty(parsedSchema.errors)) {
-      await Promise.all(
+      const resp = await Promise.all(
         _.map(parsedSchema.schemas, async (schema) => {
-          await engineClient.writeSchema(schema, { metaOnly: true });
+          return engineClient.writeSchema(schema, { metaOnly: true });
         })
       );
 
@@ -61,6 +62,7 @@ export class SchemaSyncService implements ISchemaSyncService {
       // data when the error message closes (if they use 'Go to schema' button) so we
       // should overwrite the status bar with a 'happy' message as well.
       vscode.window.setStatusBarMessage(msg);
+      return resp;
     } else {
       const navigateButtonText = "Go to schema.";
       const msg = `Failed to update '${path.basename(
@@ -81,6 +83,7 @@ export class SchemaSyncService implements ISchemaSyncService {
       if (userAction === navigateButtonText) {
         await VSCodeUtils.openFileInEditor(uri);
       }
+      return;
     }
   }
 }

--- a/packages/plugin-core/src/services/SchemaSyncService.ts
+++ b/packages/plugin-core/src/services/SchemaSyncService.ts
@@ -21,7 +21,7 @@ export class SchemaSyncService implements ISchemaSyncService {
 
     Logger.info({
       ctx: "SchemaSyncService:onDidChange",
-      msg: "updating schema.",
+      msg: "updating schema",
     });
 
     await this.saveSchema({ uri });

--- a/packages/plugin-core/src/services/SchemaSyncServiceInterface.ts
+++ b/packages/plugin-core/src/services/SchemaSyncServiceInterface.ts
@@ -1,3 +1,4 @@
+import { WriteSchemaResp } from "@dendronhq/common-all";
 import vscode, { Uri } from "vscode";
 
 /**
@@ -13,5 +14,5 @@ export interface ISchemaSyncService {
   }: {
     uri: Uri;
     isBrandNewFile?: boolean;
-  }): Promise<void>;
+  }): Promise<WriteSchemaResp[] | undefined>;
 }

--- a/packages/plugin-core/src/test/suite-integ/SchemaSyncService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SchemaSyncService.test.ts
@@ -1,0 +1,64 @@
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { before, describe } from "mocha";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { SchemaSyncService } from "../../services/SchemaSyncService";
+import { expect } from "../testUtilsv2";
+
+import * as vscode from "vscode";
+import { describeMultiWS } from "../testUtilsV3";
+
+suite("WHEN syncing schema", function () {
+  let schemaSyncService: SchemaSyncService | undefined;
+
+  describe("AND file is not new", () => {
+    describeMultiWS(
+      "AND edit is made",
+      {
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      },
+      () => {
+        this.timeout(10e5);
+        before(() => {
+          schemaSyncService = new SchemaSyncService(
+            ExtensionProvider.getExtension()
+          );
+        });
+
+        test("THEN don't change file", async () => {
+          const ext = ExtensionProvider.getExtension();
+          const { data: schema } = await ext.getEngine().getSchema("foo");
+          await ExtensionProvider.getWSUtils()
+            .openSchema(schema!)
+            .then(async (editor) => {
+              await editor.edit((editBuilder) => {
+                /**
+								 * Results in the following text
+									- id: ch1
+										children: [{pattern: one}]
+										title: ch1
+								 */
+                return editBuilder.insert(
+                  new vscode.Position(9, 15),
+                  "{pattern: one}"
+                );
+              });
+              return editor.document.save().then(async () => {
+                await schemaSyncService?.saveSchema({
+                  uri: editor.document.uri,
+                  isBrandNewFile: false,
+                });
+
+                // schema file wasn't edited in the process
+                expect(editor.document.isDirty).toBeFalsy();
+                expect(
+                  editor.document
+                    .getText()
+                    .indexOf("children: [{pattern: one}]")
+                ).toBeTruthy();
+              });
+            });
+        });
+      }
+    );
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/SchemaSyncService.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SchemaSyncService.test.ts
@@ -32,11 +32,11 @@ suite("WHEN syncing schema", function () {
             .then(async (editor) => {
               await editor.edit((editBuilder) => {
                 /**
-								 * Results in the following text
-									- id: ch1
-										children: [{pattern: one}]
-										title: ch1
-								 */
+                 * Results in the following text
+                 * - id: ch1
+                 * 	children: [{pattern: one}]
+                 * 	title: ch1
+                 */
                 return editBuilder.insert(
                   new vscode.Position(9, 15),
                   "{pattern: one}"


### PR DESCRIPTION
fix(schema): schemas being overwritten on save 

Inline schemas ([[dendron://dendron.dendron-site/dendron.topic.schema#inline-schema-anatomy]]) are stored as a flat dictionary when saved in dendron - this representation is in memory and should not be persisted back to disk. The recent engine refactoring changed this behavior by writing these changes to disk

This change also cleans up olds tests in our workspace by removing un-used launch tests and excluding un-used assets from search.
