### PR TITLE
chore: make Nextjs build more customizable

### DIFF
--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -73,14 +73,16 @@
   "settings": {
     "files.exclude": {
       "*.d.ts": true,
-      "profile": true
+      "profile": true,
+      ".next/**": true
     },
     "editor.codeActionsOnSave": {},
     "search.exclude": {
       "**/node_modules": true,
       "**/bower_components": true,
       "CHANGELOG.md": true,
-      "*.d.ts": true
+      "*.d.ts": true,
+      ".next/**": true
     },
     "files.watcherExclude": {
       "**/.git/objects/**": true,

--- a/packages/nextjs-template/.dockerignore
+++ b/packages/nextjs-template/.dockerignore
@@ -1,0 +1,51 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+data
+*.zip
+public/assets
+public/CNAME
+public/logo.*
+public/themes
+local
+
+# generated
+robots.txt
+sitemap.xml
+public/*.html
+dist
+.env.production
+custom/*
+!custom/NoOp.tsx
+

--- a/packages/nextjs-template/.gitignore
+++ b/packages/nextjs-template/.gitignore
@@ -48,3 +48,4 @@ dist
 .env.production
 custom/*
 !custom/NoOp.tsx
+builds

--- a/packages/nextjs-template/next.config.js
+++ b/packages/nextjs-template/next.config.js
@@ -1,7 +1,8 @@
 const path = require("path");
+const process = require("process");
 const { FRONTEND_CONSTANTS } = require("@dendronhq/common-frontend");
 
-const { NEXT_PUBLIC_ASSET_PREFIX } = process.env;
+const { NEXT_PUBLIC_ASSET_PREFIX, BUILD_DIR, DATA_DIR, PUBLIC_DIR } = process.env;
 const isProd = process.env.NODE_ENV === "production";
 
 // NOTE: __dirname is the dirname where this configuration file is located
@@ -13,8 +14,10 @@ const payload = {
   assetPrefix:
     isProd && NEXT_PUBLIC_ASSET_PREFIX ? NEXT_PUBLIC_ASSET_PREFIX : undefined,
   env: {
-    DATA_DIR: path.join(__dirname, FRONTEND_CONSTANTS.DEFAULT_DATA_DIR),
+    DATA_DIR: DATA_DIR || path.join(__dirname, FRONTEND_CONSTANTS.DEFAULT_DATA_DIR),
+    PUBLIC_DIR: PUBLIC_DIR || path.join(__dirname, "public"),
   },
+  distDir: BUILD_DIR || '.next',
 };
 
 if (!isProd && process.env.ANALYZE) {

--- a/packages/nextjs-template/utils/build.ts
+++ b/packages/nextjs-template/utils/build.ts
@@ -40,7 +40,7 @@ export function getNotes(): NoteData {
   if (_.isUndefined(_NOTES_CACHE)) {
     const dataDir = getDataDir();
     _NOTES_CACHE = fs.readJSONSync(
-      path.join(dataDir, "notes.json"),
+      path.join(dataDir, "notes.json")
     ) as NoteData;
   }
   return _NOTES_CACHE;
@@ -60,11 +60,9 @@ export function getNotePaths(): GetStaticPathsResult<DendronNotePageParams> {
   // filter out the index node
   const paths = Object.keys(notes)
     .filter((id) => id !== noteIndex.id)
-    .map(
-      (id) => {
-        return { params: { id } };
-      },
-    );
+    .map((id) => {
+      return { params: { id } };
+    });
   return {
     paths,
     fallback: false,
@@ -76,9 +74,7 @@ export function getNotePaths(): GetStaticPathsResult<DendronNotePageParams> {
  */
 export function getNoteMeta(id: string): Promise<NoteProps> {
   const dataDir = getDataDir();
-  return fs.readJSON(
-    path.join(dataDir, NOTE_META_DIR, `${id}.json`),
-  );
+  return fs.readJSON(path.join(dataDir, NOTE_META_DIR, `${id}.json`));
 }
 
 let _CONFIG_CACHE: IntermediateDendronConfig | undefined;
@@ -91,7 +87,11 @@ export function getConfig(): Promise<IntermediateDendronConfig> {
 }
 
 export function getPublicDir(): string {
-  return path.join(process.cwd(), "public");
+  const publicDir = process.env.PUBLIC_DIR;
+  if (!publicDir) {
+    throw new Error("PUBLIC_DIR not set");
+  }
+  return publicDir;
 }
 
 export async function getCustomHead(): Promise<string | null> {


### PR DESCRIPTION
chore: make Nextjs build more customizable

Some changes to make it possible to use a single instance of the `nextjs-template` to build any number of sites. Before this change, nextjs will build everything in the directory as `nextjs-template`. 

- BUILD_DIR: where nextjs compiles the output
- DATA_DIR: where notes data can be found
- PUBLIC_DIR: where the public dir can be found

Details of how these will be used for managed publishing in [[dendron://private/pkg.worker-buildv2.lifecycle.build]]