### PR TITLE
fix(workspace): initial value incorrect in lookup for webext(win)

### DIFF
--- a/packages/plugin-core/src/web/commands/lookup/LookupQuickpickFactory.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupQuickpickFactory.ts
@@ -7,10 +7,10 @@ import {
   NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import _ from "lodash";
-import path from "path";
 import { inject, injectable } from "tsyringe";
 import * as vscode from "vscode";
 import { QuickPick, QuickPickOptions } from "vscode";
+import { Utils } from "vscode-uri";
 import { WSUtilsWeb } from "../../utils/WSUtils";
 import { type ILookupProvider } from "./ILookupProvider";
 import { VaultQuickPick } from "./VaultQuickPick";
@@ -159,10 +159,9 @@ export class LookupQuickpickFactory {
   }
 
   private getInitialValueBasedOnActiveNote() {
-    const initialValue = path.basename(
-      vscode.window.activeTextEditor?.document.uri.fsPath || "",
-      ".md"
-    );
+    const uri = vscode.window.activeTextEditor?.document.uri;
+    if (!uri) return "";
+    const initialValue = _.trimEnd(Utils.basename(uri), ".md");
     return initialValue;
   }
 


### PR DESCRIPTION
This PR aims to fix the lookbar bar initial value for codespaces(windows)
Bug:
![image](https://user-images.githubusercontent.com/84971366/189656996-c63cb74e-1664-45c5-9ae0-af9deefb028a.png)
