### PR TITLE
chore(internal): fix typo in dendron-main.code-workspace

### DIFF
--- a/dendron-main.code-workspace
+++ b/dendron-main.code-workspace
@@ -64,7 +64,7 @@
   ],
   "settings": {
     "files.exclude": {
-      ".next/**": true
+      ".next/**": true,
       "**/profile": true,
       "**/*.tff": true,
       "**/*.woff": true,


### PR DESCRIPTION
# chore(internal): fix typo in dendron-main.code-workspace

This PR:
- Adds an omitted comma in `dendron-main.code-workspace`