### PR TITLE
chore: deprecate open links command

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -893,7 +893,7 @@
         },
         {
           "command": "dendron.openLink",
-          "when": "dendron:pluginActive && shellExecutionSupported"
+          "when": "false"
         },
         {
           "command": "dendron.pasteLink",

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -1,8 +1,4 @@
-import {
-  DendronError,
-  ERROR_STATUS,
-  ExtensionEvents,
-} from "@dendronhq/common-all";
+import { DendronError, ERROR_STATUS } from "@dendronhq/common-all";
 import { resolvePath, vault2Path } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
@@ -11,9 +7,8 @@ import path from "path";
 import { env, Uri, window } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
-import { AnalyticsUtils } from "../utils/analytics";
 import { getURLAt } from "../utils/md";
-import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
+import { VSCodeUtils } from "../vsCodeUtils";
 import { getDWorkspace, getExtension } from "../workspace";
 import { BasicCommand } from "./base";
 
@@ -29,8 +24,6 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return {};
   }
   async execute(opts?: { uri?: string }) {
-    showDepreciationWarnign();
-
     const ctx = DENDRON_COMMANDS.OPEN_LINK;
     this.L.info({ ctx });
 
@@ -86,14 +79,3 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
     return { filepath: assetPath };
   }
 }
-
-const showDepreciationWarnign = () => {
-  AnalyticsUtils.track(ExtensionEvents.DeprecationNoticeShow, {
-    source: DENDRON_COMMANDS.OPEN_LINK.key,
-  });
-  VSCodeUtils.showMessage(
-    MessageSeverity.WARN,
-    "Open link will be deprecated. Please use Dendron: Go to command instead",
-    {}
-  );
-};

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -896,7 +896,7 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   OPEN_LINK: {
     key: "dendron.openLink",
     title: `${CMD_PREFIX} Open Link`,
-    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+    when: `false`,
   },
   PASTE_LINK: {
     key: "dendron.pasteLink",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25485,11 +25485,6 @@ typescript@^4.1.2, typescript@^4.4.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-typescript@^4.1.5:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 typescript@~4.3.4:
   version "4.3.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"


### PR DESCRIPTION
# chore: deprecate open links command
This PR:
- Removes the open link deprecation notice (that also shows up during `Dendron: Go To`)
- Flips the when clause to `false` so that it could be registered but only be used as an internal command

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)