### PR TITLE
chore(internal): track config diff during startup

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -146,6 +146,7 @@ export enum ConfigEvents {
   MissingSelfContainedVaultsMessageAccept = "MissingSelfContainedVaultsMessageAccept",
   OutdatedSeedVaultMessageShow = "OutdatedSeedVaultMessageShow",
   OutdatedSeedVaultMessageAccept = "OutdatedSeedVaultMessageAccept",
+  ConfigChangeDetected = "ConfigChangeDetected",
 }
 
 export enum MigrationEvents {

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -1300,9 +1300,10 @@ export class ConfigUtils {
    */
   static flattenConfigObject(opts: { obj: Object; omitPaths?: string[] }) {
     const { obj, omitPaths } = opts;
+    const objDeepCopy = _.cloneDeep(obj);
     if (omitPaths && omitPaths.length > 0) {
       omitPaths.forEach((path) => {
-        _.unset(obj, path);
+        _.unset(objDeepCopy, path);
       });
     }
 
@@ -1334,7 +1335,7 @@ export class ConfigUtils {
         }
       });
     };
-    flattenToPathValuePairs({ obj });
+    flattenToPathValuePairs({ obj: objDeepCopy });
     return accumulator;
   }
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
@@ -9,6 +9,64 @@ function getConfig(
 }
 
 describe("ConfigUtils", () => {
+  describe("GIVEN findDifference", () => {
+    describe("WHEN config has no difference", () => {
+      test("THEN correctly outputs no change", () => {
+        const config = getConfig();
+        const output = ConfigUtils.findDifference({ config });
+        expect(output.length).toEqual(0);
+      });
+    });
+    describe("WHEN v4 config is given", () => {
+      test("THEN return empty list", () => {
+        const config = ConfigUtils.genDefaultV4Config();
+        const output = ConfigUtils.findDifference({ config });
+        expect(output.length).toEqual(0);
+      });
+    });
+    describe("WHEN changed config is given", () => {
+      test("THEN correctly output list of changes", () => {
+        const config = getConfig({
+          commands: {
+            lookup: {
+              note: {
+                selectionMode: "link",
+                leaveTrace: true,
+              },
+            },
+          },
+          workspace: {
+            journal: {
+              dailyDomain: "dailys",
+            },
+            task: {
+              taskCompleteStatus: ["x", "finished"],
+            },
+          },
+        });
+        const output = ConfigUtils.findDifference({ config });
+        expect(output.length).toEqual(4);
+        expect(output).toEqual([
+          {
+            path: "commands.lookup.note.selectionMode",
+            value: "link",
+          },
+          {
+            path: "commands.lookup.note.leaveTrace",
+            value: true,
+          },
+          {
+            path: "workspace.journal.dailyDomain",
+            value: "dailys",
+          },
+          {
+            path: "workspace.task.taskCompleteStatus",
+            value: JSON.stringify(["x", "finished"]),
+          },
+        ]);
+      });
+    });
+  });
   describe("GIVEN getSiteLogoUrl", () => {
     describe("WHEN logo is not defined", () => {
       test("THEN logo is undefined", () => {

--- a/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/configUtils.spec.ts
@@ -66,6 +66,47 @@ describe("ConfigUtils", () => {
         ]);
       });
     });
+    describe("WHEN config with changes only in omitted paths is given", () => {
+      test("THEN return empty list", () => {
+        const config = ConfigUtils.genDefaultConfig();
+        config.workspace.vaults = [
+          {
+            fsPath: "some.vault",
+            name: "some vault",
+          },
+          {
+            fsPath: "some.vault2",
+            name: "some vault2",
+          },
+          {
+            fsPath: "some.vault3",
+            name: "some vault3",
+          },
+        ];
+        config.workspace.workspaces = {
+          foo: {
+            remote: {
+              type: "git",
+              url: "foo",
+            },
+          },
+        };
+        config.workspace.seeds = {
+          "dendron.dendron-site": {
+            branch: "dev",
+            site: {
+              url: "https://wiki.dendron.son",
+              index: "dendron",
+            },
+          },
+        };
+        config.dev = {
+          enableSelfContainedVaults: false,
+        };
+        const output = ConfigUtils.findDifference({ config });
+        expect(output.length).toEqual(0);
+      });
+    });
   });
   describe("GIVEN getSiteLogoUrl", () => {
     describe("WHEN logo is not defined", () => {

--- a/packages/plugin-core/src/utils/ExtensionUtils.ts
+++ b/packages/plugin-core/src/utils/ExtensionUtils.ts
@@ -441,11 +441,15 @@ export class ExtensionUtils {
     };
 
     if (dendronConfigChanged) {
-      _.set(
-        trackProps,
-        "changedDendronConfigs",
-        configDiff.map((item) => item.path)
-      );
+      _.set(trackProps, "numConfigChanged", configDiff.length);
+      /**
+       * This is a separate event because {@link VSCodeEvents.InitializeWorkspace} is getting a little crowded.
+       * The payload will be stored in a _single column_ with a `text` type, and there is no to the length.
+       * There is a hard limit of 1GB per field, but not a concern here.
+       */
+      AnalyticsUtils.track(ConfigEvents.ConfigChangeDetected, {
+        changed: JSON.stringify(configDiff),
+      });
     }
 
     if (siteUrl !== undefined) {

--- a/packages/plugin-core/src/utils/ExtensionUtils.ts
+++ b/packages/plugin-core/src/utils/ExtensionUtils.ts
@@ -401,6 +401,9 @@ export class ExtensionUtils {
     const { workspaceFile, workspaceFolders } = vscode.workspace;
     const configVersion = ConfigUtils.getVersion(dendronConfig);
 
+    const configDiff = ConfigUtils.findDifference({ config: dendronConfig });
+    const dendronConfigChanged = configDiff.length > 0;
+
     const trackProps = {
       duration: durationReloadWorkspace,
       noCaching: dendronConfig.noCaching || false,
@@ -434,7 +437,17 @@ export class ExtensionUtils {
         : workspaceFolders.length,
       hasLocalConfig: false,
       numLocalConfigVaults: 0,
+      dendronConfigChanged,
     };
+
+    if (dendronConfigChanged) {
+      _.set(
+        trackProps,
+        "changedDendronConfigs",
+        configDiff.map((item) => item.path)
+      );
+    }
+
     if (siteUrl !== undefined) {
       _.set(trackProps, "siteUrl", siteUrl);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25485,11 +25485,6 @@ typescript@^4.1.2, typescript@^4.4.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-typescript@^4.1.5:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 typescript@~4.3.4:
   version "4.3.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"


### PR DESCRIPTION
# chore(internal): track config diff during startup
This PR:
- Adds new properties `dendronConfigChanged` and and `changedDendronConfigs`, which tracks configs that deviated from the default configuration defined

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)