### PR TITLE
fix(publish): allow spaces between links in headers

### DIFF
--- a/packages/nextjs-template/styles/scss/content.scss
+++ b/packages/nextjs-template/styles/scss/content.scss
@@ -173,6 +173,7 @@
     // Align the anchor to the middle of the heading
     display: flex;
     align-items: center;
+    white-space: pre-wrap;
 
     .anchor-heading {
       // headings can fit a slightly bigger icon


### PR DESCRIPTION
This PR adds missing parts that where not [salient](https://discord.com/channels/717965437182410783/802578902429597726/1012770550290055268) during the original attempt at https://github.com/dendronhq/dendron/pull/3403
The issue: https://github.com/dendronhq/dendron/issues/3396#issuecomment-1229861053
Docs: [[dendron://private/task.2022.08.29.revisit-headings-whitespace]]



# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
