### PR TITLE
fix: click into "empty area" on sidebar submenuitem

### DIFF
--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -177,7 +177,7 @@ function MenuView({
           title={
             <MenuItemTitle
               menu={menu}
-              noteIndex={noteIndex!}
+              noteIndex={noteIndex}
               onSubMenuSelect={onSubMenuSelect}
             />
           }
@@ -200,7 +200,7 @@ function MenuView({
       <MenuItem key={menu.key} icon={menu.icon}>
         <MenuItemTitle
           menu={menu}
-          noteIndex={noteIndex!}
+          noteIndex={noteIndex}
           onSubMenuSelect={onSubMenuSelect}
         />
       </MenuItem>
@@ -244,7 +244,7 @@ function MenuItemTitle(
     <Typography.Text ellipsis={{ tooltip: props.menu.title }}>
       <Link
         href={getNoteUrl(props.menu.key as string, {
-          noteIndex: props.noteIndex!,
+          noteIndex: props.noteIndex,
         })}
         passHref
       >

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -184,6 +184,7 @@ function MenuView({
           onTitleClick={(event) => {
             const target = event.domEvent.target as HTMLElement;
             const isAnchor = target.nodeName === "A";
+            // only expand SubMenu when not an anchor, which means that a page transition will occur.
             if (!isAnchor) {
               onExpand(event.key);
             }
@@ -248,7 +249,9 @@ function MenuItemTitle(
         passHref
       >
         <a
-          href="dummy"
+          href={
+            "dummy" /* a way to dodge eslint warning that conflicts with `next/link`. see https://github.com/vercel/next.js/discussions/32233#discussioncomment-1766768*/
+          }
           onClick={() => {
             props.onSubMenuSelect(props.menu.key as string);
           }}

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -174,13 +174,17 @@ function MenuView({
             menu.key === activeNote ? "dendron-ant-menu-submenu-selected" : ""
           }
           key={menu.key}
-          title={<MenuItemTitle menu={menu} noteIndex={noteIndex!} />}
+          title={
+            <MenuItemTitle
+              menu={menu}
+              noteIndex={noteIndex!}
+              onSubMenuSelect={onSubMenuSelect}
+            />
+          }
           onTitleClick={(event) => {
             const target = event.domEvent.target as HTMLElement;
-            const isArrow = target.dataset.expandedicon;
-            if (!isArrow) {
-              onSubMenuSelect(event.key);
-            } else {
+            const isAnchor = target.nodeName === "A";
+            if (!isAnchor) {
               onExpand(event.key);
             }
           }}
@@ -193,7 +197,11 @@ function MenuView({
     }
     return (
       <MenuItem key={menu.key} icon={menu.icon}>
-        <MenuItemTitle menu={menu} noteIndex={noteIndex!} />
+        <MenuItemTitle
+          menu={menu}
+          noteIndex={noteIndex!}
+          onSubMenuSelect={onSubMenuSelect}
+        />
       </MenuItem>
     );
   };
@@ -223,7 +231,12 @@ function MenuView({
   );
 }
 
-function MenuItemTitle(props: Partial<NoteData> & { menu: DataNode }) {
+function MenuItemTitle(
+  props: Partial<NoteData> & {
+    menu: DataNode;
+    onSubMenuSelect: (noteId: string) => void;
+  }
+) {
   const { getNoteUrl } = useDendronRouter();
 
   return (
@@ -232,8 +245,16 @@ function MenuItemTitle(props: Partial<NoteData> & { menu: DataNode }) {
         href={getNoteUrl(props.menu.key as string, {
           noteIndex: props.noteIndex!,
         })}
+        passHref
       >
-        {props.menu.title}
+        <a
+          href="dummy"
+          onClick={() => {
+            props.onSubMenuSelect(props.menu.key as string);
+          }}
+        >
+          {props.menu.title}
+        </a>
       </Link>
     </Typography.Text>
   );

--- a/packages/nextjs-template/utils/hooks.ts
+++ b/packages/nextjs-template/utils/hooks.ts
@@ -19,8 +19,11 @@ export type DendronRouterProps = ReturnType<typeof useDendronRouter>;
 export function useDendronRouter() {
   const router = useRouter();
   const query = getNoteRouterQuery(router);
-  const getNoteUrl = (id: string, opts: { noteIndex: NoteProps }) => {
-    if (id === opts.noteIndex.id) {
+  const getNoteUrl = (
+    id: string,
+    opts: { noteIndex: NoteProps | undefined }
+  ) => {
+    if (id === opts?.noteIndex?.id) {
       return `/`;
     }
     return `/notes/${id}`;


### PR DESCRIPTION
This PR aim is to make clicks into the "empty area" of sidebar submenuitems not do nothing and rather to something.
The something could be expanding the submenuitem or opening the page. I decided for expanding since that is the default behavior of the antd Menu component. I think it makes sense to expect/intiut that the user wants to expand the submenu when he has not clicked directly on the link text.

Context: [[dendron://private/task.2022.08.21.nav-bar-should-navigate-when-menu-is-clicked]]

Demostration of the issue: https://www.loom.com/share/4998f4d983e94ee8b2ecb55a3550a6ec
Demostration of the fix: https://www.loom.com/share/266547466558423ba20b9b775cbcf405

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
