### PR TITLE
feat(views): create note button in tree view

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -166,6 +166,11 @@
         "icon": "$(expand-all)"
       },
       {
+        "command": "dendron.treeView.createNote",
+        "title": "Create Note",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "dendron.graph-panel.increaseDepth",
         "title": "Increase Depth",
         "icon": "$(arrow-up)"
@@ -1045,6 +1050,11 @@
         {
           "command": "dendron.treeView.expandAll",
           "when": "view == dendron.treeView && dendron:devMode",
+          "group": "navigation@2"
+        },
+        {
+          "command": "dendron.treeView.createNote",
+          "when": "view == dendron.treeView && shellExecutionSupported",
           "group": "navigation@2"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1054,7 +1054,7 @@
         },
         {
           "command": "dendron.treeView.createNote",
-          "when": "view == dendron.treeView && shellExecutionSupported",
+          "when": "view == dendron.treeView",
           "group": "navigation@2"
         },
         {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -256,7 +256,7 @@ export const DENDRON_MENUS = {
     },
     {
       command: "dendron.treeView.createNote",
-      when: `view == dendron.treeView && shellExecutionSupported`,
+      when: `view == dendron.treeView`,
       group: "navigation@2",
     },
     {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -255,6 +255,11 @@ export const DENDRON_MENUS = {
       group: "navigation@2",
     },
     {
+      command: "dendron.treeView.createNote",
+      when: `view == dendron.treeView && shellExecutionSupported`,
+      group: "navigation@2",
+    },
+    {
       command: "dendron.graph-panel.increaseDepth",
       when: "view == dendron.graph-panel",
       group: "navigation@2",
@@ -391,6 +396,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: "Expand All",
     icon: "$(expand-all)",
     when: DendronContext.DEV_MODE,
+  },
+  TREEVIEW_CREATE_NOTE: {
+    key: "dendron.treeView.createNote",
+    title: "Create Note",
+    icon: "$(new-file)",
   },
   // graph panel buttons
   GRAPH_PANEL_INCREASE_DEPTH: {

--- a/packages/plugin-core/src/web/extension.ts
+++ b/packages/plugin-core/src/web/extension.ts
@@ -70,6 +70,16 @@ async function setupCommands(context: vscode.ExtensionContext) {
       )
     );
   }
+  if (!existingCommands.includes(DENDRON_COMMANDS.TREEVIEW_CREATE_NOTE.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.TREEVIEW_CREATE_NOTE.key,
+        async (_args: any) => {
+          await container.resolve(NoteLookupCmd).run();
+        }
+      )
+    );
+  }
 }
 
 async function setupViews(context: vscode.ExtensionContext) {

--- a/packages/plugin-core/src/workspace/workspaceActivator.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivator.ts
@@ -43,6 +43,7 @@ import { DendronCodeWorkspace } from "./codeWorkspace";
 import { DendronNativeWorkspace } from "./nativeWorkspace";
 import { WorkspaceInitFactory } from "./WorkspaceInitFactory";
 import { WorkspaceInitializer } from "./workspaceInitializer";
+import { CreateNoteCommand } from "../commands/CreateNoteCommand";
 
 function _setupTreeViewCommands(
   treeView: NativeTreeView,
@@ -70,6 +71,15 @@ function _setupTreeViewCommands(
         treeView.updateLabelType({
           labelType: TreeViewItemLabelTypeEnum.filename,
         });
+      })
+    );
+  }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.TREEVIEW_CREATE_NOTE.key)) {
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.TREEVIEW_CREATE_NOTE.key,
+      sentryReportingCallback(async (opts) => {
+        await new CreateNoteCommand().run(opts);
       })
     );
   }


### PR DESCRIPTION
This PR aims to add a Create Note button in tree view. 
- Docs PR: https://github.com/dendronhq/dendron-site/pull/649
- Loom video: https://www.loom.com/share/5975b56f2dfb4e0d9615e9a507f2f56e

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)