### PR TITLE
fix(workspace): wikilinks appear broken + pod fixes

### DIFF
--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -133,7 +133,6 @@ export class MoveHeaderCommand extends BasicCommand<
     }
 
     // parse selection and get the target header node
-    // JYTODO: Add header target information into the render cache
     const proc = this.getProc(engine, maybeNote);
 
     // TODO: shoudl account for line number

--- a/packages/pods-core/src/builtin/HTMLPod.ts
+++ b/packages/pods-core/src/builtin/HTMLPod.ts
@@ -92,6 +92,8 @@ export class HTMLPublishPod extends PublishPod<HTMLPublishPodConfig> {
       noteToRender: note,
       noteCacheForRenderDict,
       vault: note.vault,
+      vaults: engine.vaults,
+      wsRoot: engine.wsRoot,
       fname,
       config: overrideConfig,
       wikiLinksOpts: { convertLinks },

--- a/packages/pods-core/src/builtin/MarkdownPod.ts
+++ b/packages/pods-core/src/builtin/MarkdownPod.ts
@@ -479,11 +479,13 @@ export class MarkdownImportPod extends ImportPod<MarkdownImportPodConfig> {
           const noteDirlevel = note.fname.split(".").length;
           const siblingNotes = hDict[noteDirlevel];
           const proc = MDUtilsV5.procRemarkFull({
-            noteToRender: (await engine.getNote(note.fname)).data!, // JYTODO: check !
+            noteToRender: note,
             fname: note.fname,
             vault: note.vault,
+            vaults: engine.vaults,
             dest: DendronASTDest.MD_DENDRON,
             config: DConfig.readConfigSync(engine.wsRoot),
+            wsRoot: engine.wsRoot,
           });
 
           const tree = proc.parse(note.body) as DendronASTNode;
@@ -558,7 +560,6 @@ export class MarkdownPublishPod extends PublishPod<MarkdownPublishPodConfig> {
     let remark = MDUtilsV5.procRemarkFull({
       noteToRender: note,
       noteCacheForRenderDict,
-      vaults: engine.vaults,
       dest: DendronASTDest.MD_REGULAR,
       config: {
         ...DConfig.readConfigSync(engine.wsRoot),
@@ -566,6 +567,8 @@ export class MarkdownPublishPod extends PublishPod<MarkdownPublishPodConfig> {
       },
       fname: note.fname,
       vault: note.vault,
+      vaults: engine.vaults,
+      wsRoot: engine.wsRoot,
     });
     if (wikiLinkToURL && !_.isUndefined(dendronConfig)) {
       remark = remark.use(

--- a/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/MarkdownExportPodV2.ts
@@ -249,6 +249,8 @@ export class MarkdownExportPodV2
       },
       fname: note.fname,
       vault: note.vault,
+      vaults: engine.vaults,
+      wsRoot: engine.wsRoot,
     });
     if (this._config.wikiLinkToURL && !_.isUndefined(this._dendronConfig)) {
       remark = remark.use(

--- a/packages/unified/src/decorations/hashTags.ts
+++ b/packages/unified/src/decorations/hashTags.ts
@@ -57,7 +57,7 @@ export async function decorateTag({
   const { type, errors } = await linkedNoteType({
     fname,
     engine,
-    vaults: config.vaults ?? [],
+    vaults: config.workspace?.vaults ?? config.vaults ?? [],
   });
   const decoration: DecorationHashTag = {
     type,

--- a/packages/unified/src/decorations/references.ts
+++ b/packages/unified/src/decorations/references.ts
@@ -17,7 +17,7 @@ export const decorateReference: Decorator<
     vaultName: reference.data.link.data.vaultName,
     engine,
     note,
-    vaults: config.vaults ?? [],
+    vaults: config.workspace?.vaults ?? config.vaults ?? [],
   });
   const decoration: DecorationWikilink = {
     type,

--- a/packages/unified/src/decorations/userTags.ts
+++ b/packages/unified/src/decorations/userTags.ts
@@ -12,7 +12,7 @@ export const decorateUserTag: Decorator<UserTag, DecorationWikilink> = async (
   const { type, errors } = await linkedNoteType({
     fname: userTag.fname,
     engine,
-    vaults: config.vaults ?? [],
+    vaults: config.workspace?.vaults ?? config.vaults ?? [],
   });
 
   const decoration: DecorationWikilink = {

--- a/packages/unified/src/decorations/wikilinks.ts
+++ b/packages/unified/src/decorations/wikilinks.ts
@@ -47,7 +47,7 @@ export const decorateWikilink: Decorator<
     vaultName,
     note,
     engine,
-    vaults: config.vaults ?? [],
+    vaults: config.workspace?.vaults ?? config.vaults ?? [],
   });
   const wikilinkRange = position2VSCodeRange(position);
   const decorations: DecorationsForDecorateWikilink[] = [];

--- a/packages/unified/src/utilities/getParsingDependencyDicts.ts
+++ b/packages/unified/src/utilities/getParsingDependencyDicts.ts
@@ -112,7 +112,7 @@ function getNoteDependencies(ast: Node<Data>): DNodeCompositeKey[] {
     [DendronASTTypes.WIKI_LINK],
     (wikilink: WikiLinkNoteV4, _index) => {
       renderDependencies.push({
-        fname: wikilink.value, //JYTODO: I think this is wrong for cross vault links.
+        fname: wikilink.value,
         vaultName: wikilink.data.vaultName,
       });
     }
@@ -269,8 +269,6 @@ async function getForwardLinkDependencies(
     curDependencies = newRecursiveDependencies;
     curDepth += 1;
   }
-
-  // TODO: Account for wildcard wikilink syntax. See gatherNoteRefs.
 
   let allData: NoteProps[] = [];
 


### PR DESCRIPTION
## fix(workspace): wikilinks appear broken + pod fixes

Fixing a few regressions from the unified refactoring:
- wikilinks (and hashtags / user tags) were showing up as broken links (yellow in color). 
- a few fixes in export pod logic.
- some small additional cleanup