### PR TITLE
fix(workspace): Update backlinks after engine updates

### DIFF
--- a/packages/common-all/src/BacklinkUtils.ts
+++ b/packages/common-all/src/BacklinkUtils.ts
@@ -1,0 +1,59 @@
+import _ from "lodash";
+import { DLink, NotePropsMeta } from "./types";
+
+export class BacklinkUtils {
+  /**
+   * Create backlink out of link if it references another note (denoted by presence of link.to field)
+   *
+   * @param link Original link to create backlink out of
+   * @returns backlink or none if not applicable
+   */
+  static createFromDLink(
+    link: DLink
+  ): (Omit<DLink, "type"> & { type: "backlink" }) | undefined {
+    const maybeToNoteFname = link.to?.fname;
+    if (maybeToNoteFname) {
+      return {
+        from: link.from,
+        type: "backlink",
+        position: link.position,
+        value: link.value,
+      };
+    }
+    return;
+  }
+
+  /** Adds a backlink by mutating the 'note' argument in place.
+   *
+   *  @param note note that the link is pointing to. (mutated)
+   *  @param link backlink to add. */
+  static addBacklink({
+    note,
+    backlink,
+  }: {
+    note: NotePropsMeta;
+    backlink: Omit<DLink, "type"> & { type: "backlink" };
+  }): void {
+    note.links.push(backlink);
+  }
+
+  /**
+   * Remove backlink from note. If note does not contain that backlink, do nothing.
+   * Mutates note in place
+   *
+   * @param note Note to update backlinks for.
+   * @param backlink Backlink to remove
+   */
+  static removeBacklink({
+    note,
+    backlink,
+  }: {
+    note: NotePropsMeta;
+    backlink: Omit<DLink, "type"> & { type: "backlink" };
+  }): void {
+    const filteredBacklinks = note.links.filter((link) => {
+      return !_.isEqual(backlink, link);
+    });
+    note.links = filteredBacklinks;
+  }
+}

--- a/packages/common-all/src/BacklinkUtils.ts
+++ b/packages/common-all/src/BacklinkUtils.ts
@@ -28,7 +28,7 @@ export class BacklinkUtils {
    *
    *  @param note note that the link is pointing to. (mutated)
    *  @param link backlink to add. */
-  static addBacklink({
+  static addBacklinkInPlace({
     note,
     backlink,
   }: {
@@ -51,7 +51,7 @@ export class BacklinkUtils {
    * @param note Note to update backlinks for.
    * @param backlink Backlink to remove
    */
-  static removeBacklink({
+  static removeBacklinkInPlace({
     note,
     backlink,
   }: {

--- a/packages/common-all/src/BacklinkUtils.ts
+++ b/packages/common-all/src/BacklinkUtils.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { DLinkUtils } from "./DLinkUtils";
 import { DLink, NotePropsMeta } from "./types";
 
 type BackLink = Omit<DLink, "type"> & { type: "backlink" };
@@ -23,6 +24,7 @@ export class BacklinkUtils {
   }
 
   /** Adds a backlink by mutating the 'note' argument in place.
+   * Check if backlink already exists before pushing
    *
    *  @param note note that the link is pointing to. (mutated)
    *  @param link backlink to add. */
@@ -33,7 +35,13 @@ export class BacklinkUtils {
     note: NotePropsMeta;
     backlink: BackLink;
   }): void {
-    note.links.push(backlink);
+    if (
+      !note.links.some((linkToCompare) =>
+        DLinkUtils.isEquivalent(backlink, linkToCompare)
+      )
+    ) {
+      note.links.push(backlink);
+    }
   }
 
   /**

--- a/packages/common-all/src/BacklinkUtils.ts
+++ b/packages/common-all/src/BacklinkUtils.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { DLink, NotePropsMeta } from "./types";
 
+type BackLink = Omit<DLink, "type"> & { type: "backlink" };
 export class BacklinkUtils {
   /**
    * Create backlink out of link if it references another note (denoted by presence of link.to field)
@@ -8,9 +9,7 @@ export class BacklinkUtils {
    * @param link Original link to create backlink out of
    * @returns backlink or none if not applicable
    */
-  static createFromDLink(
-    link: DLink
-  ): (Omit<DLink, "type"> & { type: "backlink" }) | undefined {
+  static createFromDLink(link: DLink): BackLink | undefined {
     const maybeToNoteFname = link.to?.fname;
     if (maybeToNoteFname) {
       return {
@@ -32,7 +31,7 @@ export class BacklinkUtils {
     backlink,
   }: {
     note: NotePropsMeta;
-    backlink: Omit<DLink, "type"> & { type: "backlink" };
+    backlink: BackLink;
   }): void {
     note.links.push(backlink);
   }
@@ -49,7 +48,7 @@ export class BacklinkUtils {
     backlink,
   }: {
     note: NotePropsMeta;
-    backlink: Omit<DLink, "type"> & { type: "backlink" };
+    backlink: BackLink;
   }): void {
     const filteredBacklinks = note.links.filter((link) => {
       return !_.isEqual(backlink, link);

--- a/packages/common-all/src/DLinkUtils.ts
+++ b/packages/common-all/src/DLinkUtils.ts
@@ -1,0 +1,44 @@
+import _ from "lodash";
+import { DLink, DLoc, Position } from "./types";
+
+export class DLinkUtils {
+  static isEquivalent(linkA: DLink, linkB: DLink): boolean {
+    return (
+      linkA.type === linkB.type &&
+      this.isDLocEquivalent(linkA.from, linkB.from) &&
+      this.isDLocEquivalent(linkA.to, linkB.to) &&
+      linkA.value === linkB.value &&
+      this.isPositionEquivalent(linkA.position, linkB.position)
+    );
+  }
+  static isDLocEquivalent(
+    locA: DLoc | undefined,
+    locB: DLoc | undefined
+  ): boolean {
+    if (!locA && !locB) return true;
+    if (locA && locB) {
+      return (
+        locA.fname === locB.fname &&
+        locA.id === locB.id &&
+        locA.vaultName === locB.vaultName
+      );
+    }
+    return false;
+  }
+  static isPositionEquivalent(
+    posA: Position | undefined,
+    posB: Position | undefined
+  ): boolean {
+    if (!posA && !posB) return true;
+    if (posA && posB) {
+      return (
+        posA.start.line === posB.start.line &&
+        posA.start.column === posB.start.column &&
+        posA.end.line === posB.end.line &&
+        posA.end.column === posB.end.column &&
+        _.isEqual(posA.indent, posB.indent)
+      );
+    }
+    return false;
+  }
+}

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -17,7 +17,6 @@ import { DendronError } from "./error";
 import { Time } from "./time";
 import {
   DEngineClient,
-  DLink,
   DNodeExplicitPropsEnum,
   DNodeImplicitPropsEnum,
   DNodeOpts,

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -334,33 +334,6 @@ export class NoteUtils {
     return _.get(note, "traitIds", []);
   }
 
-  /** Adds a backlink by mutating the 'to' argument in place.
-   *
-   *  @param from note that the link is pointing from.
-   *  @param to note that the link is pointing to. (mutated)
-   *  @param link backlink to add. */
-  static addBacklink({
-    from,
-    to,
-    link,
-  }: {
-    from: NoteProps;
-    to: NoteProps;
-    link: DLink;
-  }): void {
-    to.links.push({
-      from: {
-        id: from.id,
-        fname: from.fname,
-        vaultName: VaultUtils.getName(from.vault),
-      },
-      type: "backlink",
-      position: link.position,
-      value: link.value,
-      alias: link.alias,
-    });
-  }
-
   /**
    * Add node to parents up the note tree, or create stubs if no direct parents exists
    *
@@ -828,12 +801,10 @@ export class NoteUtils {
     engine: DEngineClient;
     vault?: DVault;
   }): NoteProps[] {
-    return _.cloneDeep(
-      NoteDictsUtils.findByFname(
-        fname,
-        { notesById: engine.notes, notesByFname: engine.noteFnames },
-        vault
-      )
+    return NoteDictsUtils.findByFname(
+      fname,
+      { notesById: engine.notes, notesByFname: engine.noteFnames },
+      vault
     );
   }
 

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -421,7 +421,7 @@ export abstract class EngineV3Base implements ReducedDEngine {
             const prevNote = _.merge(_.cloneDeep(note), {
               body: "",
             });
-            BacklinkUtils.addBacklink({ note, backlink: maybeBacklink });
+            BacklinkUtils.addBacklinkInPlace({ note, backlink: maybeBacklink });
             // Temp solution to get around current restrictions where NoteChangeEntry needs a NoteProp
             const updatedNote = _.merge(note, {
               body: "",
@@ -466,7 +466,10 @@ export abstract class EngineV3Base implements ReducedDEngine {
             const prevNote = _.merge(_.cloneDeep(note), {
               body: "",
             });
-            BacklinkUtils.removeBacklink({ note, backlink: maybeBacklink });
+            BacklinkUtils.removeBacklinkInPlace({
+              note,
+              backlink: maybeBacklink,
+            });
             // Temp solution to get around current restrictions where NoteChangeEntry needs a NoteProp
             const updatedNote = _.merge(note, {
               body: "",

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -400,6 +400,9 @@ export abstract class EngineV3Base implements ReducedDEngine {
    * @param link Link potentionally referencing another note
    */
   protected async addBacklink(link: DLink): Promise<NoteChangeEntry[]> {
+    if (!link.to?.fname) {
+      return [];
+    }
     const maybeBacklink = BacklinkUtils.createFromDLink(link);
     if (maybeBacklink) {
       const maybeVault = link.to?.vaultName
@@ -409,7 +412,7 @@ export abstract class EngineV3Base implements ReducedDEngine {
           })
         : undefined;
       const notes = await this.noteStore.findMetaData({
-        fname: link.to!.fname!,
+        fname: link.to.fname,
         vault: maybeVault,
       });
       if (notes.data) {
@@ -439,9 +442,12 @@ export abstract class EngineV3Base implements ReducedDEngine {
    * Remove backlink associated with given link that references another note (denoted by presence of link.to field)
    * from that referenced note
    *
-   * @param link Link potentionally referencing another note
+   * @param link Link potentially referencing another note
    */
   protected async removeBacklink(link: DLink): Promise<NoteChangeEntry[]> {
+    if (!link.to?.fname) {
+      return [];
+    }
     const maybeBacklink = BacklinkUtils.createFromDLink(link);
     if (maybeBacklink) {
       const maybeVault = link.to?.vaultName
@@ -451,7 +457,7 @@ export abstract class EngineV3Base implements ReducedDEngine {
           })
         : undefined;
       const notes = await this.noteStore.findMetaData({
-        fname: link.to!.fname!,
+        fname: link.to.fname,
         vault: maybeVault,
       });
       if (notes.data) {

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -36,6 +36,7 @@ export * from "./DLogger";
 export * from "./sidebar";
 export * from "./parse";
 export * from "./BacklinkUtils";
+export * from "./DLinkUtils";
 
 export { axios, AxiosError };
 export { DateTime };

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -35,6 +35,7 @@ export * from "./drivers";
 export * from "./DLogger";
 export * from "./sidebar";
 export * from "./parse";
+export * from "./BacklinkUtils";
 
 export { axios, AxiosError };
 export { DateTime };

--- a/packages/common-all/src/noteDictsUtils.ts
+++ b/packages/common-all/src/noteDictsUtils.ts
@@ -66,7 +66,7 @@ export class NoteDictsUtils {
     if (vault) {
       notes = notes.filter((note) => VaultUtils.isEqualV2(note.vault, vault));
     }
-    return notes;
+    return _.cloneDeep(notes);
   }
 
   /**

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -1034,7 +1034,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
             );
 
             notes.forEach((noteTo: NoteProps) => {
-              BacklinkUtils.addBacklink({
+              BacklinkUtils.addBacklinkInPlace({
                 note: noteTo,
                 backlink: maybeBacklink,
               });

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -65,6 +65,7 @@ import {
   GetSchemaResp,
   WriteSchemaResp,
   BacklinkUtils,
+  DLinkUtils,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -509,14 +510,14 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
         (link) =>
           link.to?.fname &&
           !note.links.some((linkToCompare) =>
-            LinkUtils.isEquivalent(link, linkToCompare)
+            DLinkUtils.isEquivalent(link, linkToCompare)
           )
       );
       const addedLinks = note.links.filter(
         (link) =>
           link.to?.fname &&
           !existingNote.links.some((linkToCompare) =>
-            LinkUtils.isEquivalent(link, linkToCompare)
+            DLinkUtils.isEquivalent(link, linkToCompare)
           )
       );
 

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -609,6 +609,56 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
 
     let notesChangedEntries: NoteChangeEntry[] = [];
 
+    // Get list of notes referencing old note. We need to rename those references
+    const notesReferencingOld = _.uniq(
+      oldNote.links
+        .filter((link) => link.type === "backlink")
+        .map((link) => link.from.id)
+        .filter(isNotUndefined)
+    );
+
+    const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
+
+    // update note body of all notes that have changed
+    const config = DConfig.readConfigSync(this.wsRoot);
+    const notesToUpdate = linkNotesResp
+      .map((resp) => {
+        if (resp.error) {
+          this.logger.error({
+            ctx,
+            message: `Unable to find note linking to ${oldNote.fname}`,
+            error: stringifyError(resp.error),
+          });
+          return undefined;
+        } else {
+          const note = this.processNoteChangedByRename({
+            note: resp.data,
+            oldLoc,
+            newLoc,
+            config,
+          });
+          if (note && note.id === oldNote.id) {
+            // If note being renamed has references to itself, make sure to update those as well
+            oldNote.body = note.body;
+            oldNote.tags = note.tags;
+          }
+          return note;
+        }
+      })
+      .filter(isNotUndefined);
+
+    this.logger.info({ ctx, msg: "updateAllNotes:pre" });
+    const writeResp = await this.bulkWriteNotes({ notes: notesToUpdate });
+    if (writeResp.error) {
+      return {
+        error: new DendronError({
+          message: `Unable to update note link references`,
+          innerError: writeResp.error,
+        }),
+      };
+    }
+    notesChangedEntries = notesChangedEntries.concat(writeResp.data);
+
     /**
      * If the event source is not engine(ie: vscode rename context menu), we do not want to
      * delete the original files. We just update the references on onWillRenameFiles and return.
@@ -666,56 +716,6 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
         notesChangedEntries = notesChangedEntries.concat(out.data);
       }
     }
-
-    // Get list of notes referencing old note. We need to rename those references
-    const notesReferencingOld = _.uniq(
-      oldNote.links
-        .filter((link) => link.type === "backlink")
-        .map((link) => link.from.id)
-        .filter(isNotUndefined)
-    );
-
-    const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
-
-    // update note body of all notes that have changed
-    const config = DConfig.readConfigSync(this.wsRoot);
-    const notesToUpdate = linkNotesResp
-      .map((resp) => {
-        if (resp.error) {
-          this.logger.error({
-            ctx,
-            message: `Unable to find note linking to ${oldNote.fname}`,
-            error: stringifyError(resp.error),
-          });
-          return undefined;
-        } else {
-          const note = this.processNoteChangedByRename({
-            note: resp.data,
-            oldLoc,
-            newLoc,
-            config,
-          });
-          if (note && note.id === oldNote.id) {
-            // If note being renamed has references to itself, make sure to update those as well
-            oldNote.body = note.body;
-            oldNote.tags = note.tags;
-          }
-          return note;
-        }
-      })
-      .filter(isNotUndefined);
-
-    this.logger.info({ ctx, msg: "updateAllNotes:pre" });
-    const writeResp = await this.bulkWriteNotes({ notes: notesToUpdate });
-    if (writeResp.error) {
-      return {
-        error: new DendronError({
-          message: `Unable to update note link references`,
-          innerError: writeResp.error,
-        }),
-      };
-    }
-    notesChangedEntries = notesChangedEntries.concat(writeResp.data);
 
     this.logger.info({
       ctx,

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -11,6 +11,7 @@ import {
   DEngineInitResp,
   DHookEntry,
   DLink,
+  DLinkUtils,
   DNodeUtils,
   DNoteAnchorPositioned,
   DNoteLoc,
@@ -1412,14 +1413,14 @@ export class FileStorage implements DStore {
         (link) =>
           link.to?.fname &&
           !note.links.some((linkToCompare) =>
-            LinkUtils.isEquivalent(link, linkToCompare)
+            DLinkUtils.isEquivalent(link, linkToCompare)
           )
       );
       const addedLinks = note.links.filter(
         (link) =>
           link.to?.fname &&
           !maybeNote.links.some((linkToCompare) =>
-            LinkUtils.isEquivalent(link, linkToCompare)
+            DLinkUtils.isEquivalent(link, linkToCompare)
           )
       );
 

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -614,7 +614,7 @@ export class FileStorage implements DStore {
 
             notes.forEach((noteTo: NoteProps) => {
               _noteToForErrorLog = noteTo;
-              BacklinkUtils.addBacklink({
+              BacklinkUtils.addBacklinkInPlace({
                 note: noteTo,
                 backlink: maybeBacklink,
               });
@@ -1495,7 +1495,7 @@ export class FileStorage implements DStore {
       return Promise.all(
         notes.map(async (note) => {
           const prevNote = _.cloneDeep(note);
-          BacklinkUtils.addBacklink({ note, backlink: maybeBacklink });
+          BacklinkUtils.addBacklinkInPlace({ note, backlink: maybeBacklink });
           NoteDictsUtils.add(note, {
             notesById: this.notes,
             notesByFname: this.noteFnames,
@@ -1537,7 +1537,10 @@ export class FileStorage implements DStore {
       return Promise.all(
         notes.map(async (note) => {
           const prevNote = _.cloneDeep(note);
-          BacklinkUtils.removeBacklink({ note, backlink: maybeBacklink });
+          BacklinkUtils.removeBacklinkInPlace({
+            note,
+            backlink: maybeBacklink,
+          });
           NoteDictsUtils.add(note, {
             notesById: this.notes,
             notesByFname: this.noteFnames,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -688,11 +688,6 @@ export class DendronEngineV2 implements DEngine {
     note: NoteProps,
     opts?: EngineWriteOptsV2
   ): Promise<WriteNoteResp> {
-    await EngineUtils.refreshNoteLinksAndAnchors({
-      note,
-      engine: this,
-      config: DConfig.readConfigSync(this.wsRoot),
-    });
     const out = await this.store.writeNote(note, opts);
     this.fuseEngine.replaceNotesIndex(this.notes);
     return out;

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -72,7 +72,7 @@ const runRename = async ({
   return out.concat([
     {
       actual: changed.data!.length,
-      expected: numChanges || 5,
+      expected: numChanges || 6,
     },
     {
       actual: checkVault,
@@ -270,6 +270,7 @@ const NOTES = {
         wsRoot,
         vaults,
         engine,
+        numChanges: 7, // extra update due to extra link
         cb: ({ barChange }) => {
           return [
             {
@@ -529,10 +530,10 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 7,
+          expected: 8,
         },
         {
-          actual: _.trim(changed.data![3].note.body),
+          actual: _.trim(changed.data![1].note.body),
           expected: "[[gamma]]",
         },
         {
@@ -597,10 +598,10 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 7,
+          expected: 8,
         },
         {
-          actual: _.trim(changed.data![3].note.body),
+          actual: _.trim(changed.data![1].note.body),
           expected: "[[gamma]]",
         },
         {
@@ -761,7 +762,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 7,
+          expected: 8,
         },
         {
           actual: createdChange?.note.title,
@@ -812,7 +813,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 5,
+          expected: 6,
         },
         {
           actual: await AssertUtils.assertInString({
@@ -931,15 +932,16 @@ const NOTES = {
         {
           actual: updated,
           expected: [
+            { status: "update", fname: "foo" },
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
-            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![2].note.body),
+          actual: _.trim(changed![1].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[1])}/baz]]`,
         },
         {
@@ -993,16 +995,17 @@ const NOTES = {
         {
           actual: updated,
           expected: [
+            { status: "update", fname: "foo" },
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
-            { status: "update", fname: "bar" },
             // this is a diff vault
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![2].note.body),
+          actual: _.trim(changed![1].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[2])}/baz]]`,
         },
         {
@@ -1060,10 +1063,11 @@ const NOTES = {
         {
           actual: updated,
           expected: [
+            { status: "update", fname: "alpha" },
+            { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
             { status: "update", fname: "beta" },
             { status: "delete", fname: "alpha" },
-            { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
             { status: "update", fname: "beta" },
             { status: "create", fname: "gamma" },

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -31,17 +31,6 @@ const findCreated = (changed: NoteChangeEntry[]) => {
   return created;
 };
 
-const findByName = (
-  fname: string,
-  changed: NoteChangeEntry[]
-): NoteChangeEntry => {
-  const created = _.find(changed, (ent) => ent.note.fname === fname);
-  if (!created) {
-    throw Error("not found");
-  }
-  return created;
-};
-
 const runRename = async ({
   engine,
   vaults,
@@ -543,7 +532,7 @@ const NOTES = {
           expected: 7,
         },
         {
-          actual: _.trim(findByName("alpha", changed.data!).note.body),
+          actual: _.trim(changed.data![3].note.body),
           expected: "[[gamma]]",
         },
         {
@@ -611,7 +600,7 @@ const NOTES = {
           expected: 7,
         },
         {
-          actual: _.trim(findByName("alpha", changed.data!).note.body),
+          actual: _.trim(changed.data![3].note.body),
           expected: "[[gamma]]",
         },
         {
@@ -942,15 +931,15 @@ const NOTES = {
         {
           actual: updated,
           expected: [
-            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![0].note.body),
+          actual: _.trim(changed![2].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[1])}/baz]]`,
         },
         {
@@ -1004,16 +993,16 @@ const NOTES = {
         {
           actual: updated,
           expected: [
-            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
+            { status: "update", fname: "bar" },
             // this is a diff vault
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![0].note.body),
+          actual: _.trim(changed![2].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[2])}/baz]]`,
         },
         {
@@ -1071,10 +1060,10 @@ const NOTES = {
         {
           actual: updated,
           expected: [
-            { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
             { status: "update", fname: "beta" },
             { status: "delete", fname: "alpha" },
+            { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
             { status: "update", fname: "beta" },
             { status: "create", fname: "gamma" },

--- a/packages/engine-test-utils/src/presets/engine-server/rename.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/rename.ts
@@ -540,7 +540,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 5,
+          expected: 7,
         },
         {
           actual: _.trim(findByName("alpha", changed.data!).note.body),
@@ -582,10 +582,22 @@ const NOTES = {
     async ({ wsRoot, vaults, engine }) => {
       const vault = vaults[0];
       const beta = NOTE_PRESETS_V4.NOTE_WITH_LINK.fname;
+      const alphaBefore = await engine.getNote(
+        NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname
+      );
+      const alphaBackLinksBefore = alphaBefore.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
       const changed = await engine.renameNote({
         oldLoc: { fname: beta, vaultName: VaultUtils.getName(vault) },
         newLoc: { fname: "gamma", vaultName: VaultUtils.getName(vault) },
       });
+      const alphaAfter = await engine.getNote(
+        NOTE_PRESETS_V4.NOTE_WITH_TARGET.fname
+      );
+      const alphaBackLinksAfter = alphaAfter.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
 
       const checkVault = await FileTestUtils.assertInVault({
         wsRoot,
@@ -596,7 +608,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 5,
+          expected: 7,
         },
         {
           actual: _.trim(findByName("alpha", changed.data!).note.body),
@@ -605,6 +617,22 @@ const NOTES = {
         {
           actual: checkVault,
           expected: true,
+        },
+        {
+          actual: alphaBackLinksBefore.length,
+          expected: 1,
+        },
+        {
+          actual: alphaBackLinksBefore[0].from.fname,
+          expected: beta,
+        },
+        {
+          actual: alphaBackLinksAfter.length,
+          expected: 1,
+        },
+        {
+          actual: alphaBackLinksAfter[0].from.fname,
+          expected: "gamma",
         },
       ];
     },
@@ -744,7 +772,7 @@ const NOTES = {
       return [
         {
           actual: changed.data?.length,
-          expected: 5,
+          expected: 7,
         },
         {
           actual: createdChange?.note.title,
@@ -857,8 +885,10 @@ const NOTES = {
           actual: updated,
           expected: [
             { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
             { status: "delete", fname: fnameTarget },
             { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
             { status: "create", fname: fnameNew },
           ],
         },
@@ -912,15 +942,15 @@ const NOTES = {
         {
           actual: updated,
           expected: [
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
-            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![2].note.body),
+          actual: _.trim(changed![0].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[1])}/baz]]`,
         },
         {
@@ -974,16 +1004,16 @@ const NOTES = {
         {
           actual: updated,
           expected: [
+            { status: "update", fname: "bar" },
             { status: "update", fname: "root" },
             { status: "delete", fname: "foo" },
-            { status: "update", fname: "bar" },
             // this is a diff vault
             { status: "update", fname: "root" },
             { status: "create", fname: "baz" },
           ],
         },
         {
-          actual: _.trim(changed![2].note.body),
+          actual: _.trim(changed![0].note.body),
           expected: `![[dendron://${VaultUtils.getName(vaults[2])}/baz]]`,
         },
         {
@@ -1041,10 +1071,12 @@ const NOTES = {
         {
           actual: updated,
           expected: [
-            { status: "update", fname: "root" },
-            { status: "delete", fname: "alpha" },
             { status: "update", fname: "beta" },
             { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
+            { status: "delete", fname: "alpha" },
+            { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
             { status: "create", fname: "gamma" },
           ],
         },
@@ -1099,13 +1131,16 @@ const NOTES = {
         match: [fnameNew],
         nomatch: [fnameTarget],
       });
+
       return [
         {
           actual: updated,
           expected: [
             { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
             { status: "delete", fname: "alpha" },
             { status: "update", fname: "root" },
+            { status: "update", fname: "beta" },
             { status: "create", fname: "gamma" },
           ],
         },

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -226,7 +226,7 @@ const NOTES = {
       });
       await engine.writeNote(note);
 
-      // Alpha be deleted, leaving behind beta and 3 root notes
+      // Alpha is written, updating backlinks for beta
       const notesInVaultAfter = await engine.findNotesMeta({ vault });
       const betaNoteAfter = await engine.getNoteMeta("beta");
       const betaBackLinksAfter = betaNoteAfter.data!.links.filter(
@@ -246,6 +246,153 @@ const NOTES = {
         await NOTE_PRESETS_V4.NOTE_WITH_LINK.create({
           wsRoot,
           vault: vaults[0],
+        });
+      },
+    }
+  ),
+  UPDATE_NOTE_ADD_BACKLINK: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const vault = vaults[0];
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
+      const betaNoteBefore = await engine.getNoteMeta("beta");
+      const betaBackLinksBefore = betaNoteBefore.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      const fooNote = (await engine.getNote("foo")).data!;
+      fooNote.body = "[[beta]]";
+      await engine.writeNote(fooNote);
+
+      // Foo is updated, updating backlinks for beta
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const betaNoteAfter = await engine.getNoteMeta("beta");
+      const betaBackLinksAfter = betaNoteAfter.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      return [
+        { actual: betaNoteBefore.data?.links.length, expected: 2 },
+        { actual: betaBackLinksBefore.length, expected: 1 },
+        { actual: _.size(notesInVaultBefore), expected: 4 },
+        { actual: _.size(notesInVaultAfter), expected: 4 },
+        { actual: betaNoteAfter.data?.links.length, expected: 3 },
+        { actual: betaBackLinksAfter.length, expected: 2 },
+      ];
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_LINK.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          vault: vaults[0],
+          wsRoot,
+        });
+      },
+    }
+  ),
+  UPDATE_NOTE_REMOVE_BACKLINK: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const vault = vaults[0];
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
+      const betaNoteBefore = await engine.getNoteMeta("beta");
+      const betaBackLinksBefore = betaNoteBefore.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      const alphaNote = (await engine.getNote("alpha")).data!;
+      alphaNote.body = "test";
+      await engine.writeNote(alphaNote);
+
+      // Alpha is updated, updating backlinks for beta
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const betaNoteAfter = await engine.getNoteMeta("beta");
+      const betaBackLinksAfter = betaNoteAfter.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      return [
+        { actual: betaNoteBefore.data?.links.length, expected: 2 },
+        { actual: betaBackLinksBefore.length, expected: 1 },
+        { actual: _.size(notesInVaultBefore), expected: 4 },
+        { actual: _.size(notesInVaultAfter), expected: 4 },
+        { actual: betaNoteAfter.data?.links.length, expected: 1 },
+        { actual: betaBackLinksAfter.length, expected: 0 },
+      ];
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_LINK.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          vault: vaults[0],
+          wsRoot,
+        });
+      },
+    }
+  ),
+  UPDATE_NOTE_UPDATE_BACKLINK: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const vault = vaults[0];
+      const notesInVaultBefore = await engine.findNotesMeta({ vault });
+      const betaNoteBefore = await engine.getNoteMeta("beta");
+      const betaBackLinksBefore = betaNoteBefore.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      const fooNoteBefore = await engine.getNoteMeta("foo");
+      const fooBackLinksBefore = fooNoteBefore.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      const alphaNote = (await engine.getNote("alpha")).data!;
+      alphaNote.body = "[[foo]]";
+      await engine.writeNote(alphaNote);
+
+      // Alpha is updated, updating backlinks for beta and foo
+      const notesInVaultAfter = await engine.findNotesMeta({ vault });
+      const betaNoteAfter = await engine.getNoteMeta("beta");
+      const betaBackLinksAfter = betaNoteAfter.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      const fooNoteAfter = await engine.getNoteMeta("foo");
+      const fooBackLinksAfter = fooNoteAfter.data!.links.filter(
+        (link) => link.type === "backlink"
+      );
+      return [
+        { actual: betaNoteBefore.data?.links.length, expected: 2 },
+        { actual: betaBackLinksBefore.length, expected: 1 },
+        { actual: fooNoteBefore.data?.links.length, expected: 0 },
+        { actual: fooBackLinksBefore.length, expected: 0 },
+        { actual: _.size(notesInVaultBefore), expected: 4 },
+        { actual: _.size(notesInVaultAfter), expected: 4 },
+        { actual: betaNoteAfter.data?.links.length, expected: 1 },
+        { actual: betaBackLinksAfter.length, expected: 0 },
+        { actual: fooNoteAfter.data?.links.length, expected: 1 },
+        { actual: fooBackLinksAfter.length, expected: 1 },
+      ];
+    },
+    {
+      preSetupHook: async ({ wsRoot, vaults }) => {
+        await NOTE_PRESETS_V4.NOTE_WITH_LINK.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NOTE_PRESETS_V4.NOTE_WITH_TARGET.create({
+          wsRoot,
+          vault: vaults[0],
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "foo",
+          vault: vaults[0],
+          wsRoot,
         });
       },
     }

--- a/packages/plugin-core/src/commands/RenameHeader.ts
+++ b/packages/plugin-core/src/commands/RenameHeader.ts
@@ -163,6 +163,7 @@ export class RenameHeaderCommand extends BasicCommand<
         anchorHeader: slugger.slug(newAnchorHeader),
         alias: newAnchorHeader,
       },
+      metaOnly: true,
     });
     return out;
   }

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteLink.test.ts
@@ -366,7 +366,7 @@ suite("CopyNoteLink", function () {
             engine,
           });
 
-        const editor = await openNote(noteWithTarget);
+        let editor = await openNote(noteWithTarget);
         const pos = LocationTestUtils.getPresetWikiLinkPosition();
         const pos2 = LocationTestUtils.getPresetWikiLinkPosition({
           char: 12,
@@ -376,6 +376,8 @@ suite("CopyNoteLink", function () {
         expect(link).toEqual(
           `[[H1|dendron://vault1/${noteWithTarget.fname}#h1]]`
         );
+
+        editor = await openNote(noteWithTarget);
         editor.selection = new vscode.Selection(
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8 }),
           LocationTestUtils.getPresetWikiLinkPosition({ line: 8, char: 12 })

--- a/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MergeNoteCommand.test.ts
@@ -119,9 +119,17 @@ suite("MergeNote", function () {
             "[[dest]]\n[[dendron://vault1/dest]]\n![[dest]]\n![[dendron://vault1/dest]]"
           );
 
-          expect(runOut?.changed.length).toEqual(4);
+          expect(runOut?.changed.length).toEqual(12);
           expect(runOut?.changed.map((change) => change.status)).toEqual([
             "update", // dest updated
+            "update", // dest updated
+            "update", // dest updated
+            "update", // dest updated
+            "update", // dest updated
+            "update", // source updated
+            "update", // source updated
+            "update", // source updated
+            "update", // source updated
             "update", // ref updated
             "update", // root updated
             "delete", // source deleted

--- a/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
@@ -48,7 +48,7 @@ suite("RenameNoteCommand", function () {
       });
 
       // note `.foo` is renamed to `foo`, `some-note`'s reference to `.foo` is updated to `foo`
-      expect(out.changed.length).toEqual(5);
+      expect(out.changed.length).toEqual(6);
       const foo = (
         await engine.findNotes({
           vault: vaults[0],

--- a/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
@@ -121,7 +121,7 @@ suite("RenameProvider", function () {
           expect(newTarget).toBeTruthy();
         });
         test("THEN references to target note is correctly updated", async () => {
-          expect(executeOut?.changed.length).toEqual(7);
+          expect(executeOut?.changed.length).toEqual(13);
           const { vaults, engine } = getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
@@ -250,7 +250,7 @@ suite("RenameProvider", function () {
           expect(newTarget).toBeTruthy();
         });
         test("THEN references to target note is correctly updated", async () => {
-          expect(executeOut?.changed.length).toEqual(7);
+          expect(executeOut?.changed.length).toEqual(12);
           const { vaults, engine } = getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
@@ -348,7 +348,7 @@ suite("RenameProvider", function () {
           expect(newTarget).toBeTruthy();
         });
         test("THEN references to target note is correctly updated", async () => {
-          expect(executeOut?.changed.length).toEqual(8);
+          expect(executeOut?.changed.length).toEqual(10);
           const { vaults, engine } = getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
@@ -434,7 +434,7 @@ suite("RenameProvider", function () {
           expect(newTarget).toBeTruthy();
         });
         test("THEN references to target note is correctly updated", async () => {
-          expect(executeOut?.changed.length).toEqual(8);
+          expect(executeOut?.changed.length).toEqual(10);
           const { vaults, engine } = getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
@@ -524,7 +524,7 @@ suite("RenameProvider", function () {
           expect(newTarget).toBeTruthy();
         });
         test("THEN references to target note is correctly updated", async () => {
-          expect(executeOut?.changed.length).toEqual(8);
+          expect(executeOut?.changed.length).toEqual(10);
           const { vaults, engine } = getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({

--- a/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
+++ b/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
@@ -472,7 +472,7 @@ export class DendronEngineV3Web
             );
 
             notes.forEach((noteTo: NoteProps) => {
-              BacklinkUtils.addBacklink({
+              BacklinkUtils.addBacklinkInPlace({
                 note: noteTo,
                 backlink: maybeBacklink,
               });

--- a/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
+++ b/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
@@ -1,4 +1,5 @@
 import {
+  BacklinkUtils,
   ConsoleLogger,
   DeleteNoteResp,
   DendronCompositeError,
@@ -50,11 +51,11 @@ export class DendronEngineV3Web
 
   constructor(
     @inject("wsRoot") private wsRoot: URI,
-    @inject("vaults") private vaults: DVault[],
+    @inject("vaults") vaults: DVault[],
     @inject("IFileStore") private fileStore: IFileStore, // TODO: Engine shouldn't be aware of FileStore. Currently still needed because of Init Logic
     @inject("INoteStore") noteStore: INoteStore<string>
   ) {
-    super(noteStore, new ConsoleLogger());
+    super(noteStore, new ConsoleLogger(), vaults);
 
     this.fuseEngine = new FuseEngine({
       fuzzThreshold: 0.2, // TODO: Pull from config: ConfigUtils.getLookup(props.config).note.fuzzThreshold,
@@ -463,17 +464,19 @@ export class DendronEngineV3Web
     notesWithLinks.forEach((noteFrom) => {
       try {
         noteFrom.links.forEach((link) => {
-          const fname = link.to?.fname;
-          // Note referencing itself does not count as backlink
-          if (fname && fname !== noteFrom.fname) {
-            const notes = NoteDictsUtils.findByFname(fname, noteDicts);
+          const maybeBacklink = BacklinkUtils.createFromDLink(link);
+          if (maybeBacklink) {
+            const notes = NoteDictsUtils.findByFname(
+              link.to!.fname!,
+              noteDicts
+            );
 
             notes.forEach((noteTo: NoteProps) => {
-              NoteUtils.addBacklink({
-                from: noteFrom,
-                to: noteTo,
-                link,
+              BacklinkUtils.addBacklink({
+                note: noteTo,
+                backlink: maybeBacklink,
               });
+              NoteDictsUtils.add(noteTo, noteDicts);
             });
           }
         });

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -366,45 +366,6 @@ const getLinkCandidates = async ({
 };
 
 export class LinkUtils {
-  static isEquivalent(linkA: DLink, linkB: DLink): boolean {
-    return (
-      linkA.type === linkB.type &&
-      this.isDLocEquivalent(linkA.from, linkB.from) &&
-      this.isDLocEquivalent(linkA.to, linkB.to) &&
-      linkA.value === linkB.value &&
-      this.isPositionEquivalent(linkA.position, linkB.position)
-    );
-  }
-  static isDLocEquivalent(
-    locA: DLoc | undefined,
-    locB: DLoc | undefined
-  ): boolean {
-    if (!locA && !locB) return true;
-    if (locA && locB) {
-      return (
-        locA.fname === locB.fname &&
-        locA.id === locB.id &&
-        locA.vaultName === locB.vaultName
-      );
-    }
-    return false;
-  }
-  static isPositionEquivalent(
-    posA: Position | undefined,
-    posB: Position | undefined
-  ): boolean {
-    if (!posA && !posB) return true;
-    if (posA && posB) {
-      return (
-        posA.start.line === posB.start.line &&
-        posA.start.column === posB.start.column &&
-        posA.end.line === posB.end.line &&
-        posA.end.column === posB.end.column &&
-        _.isEqual(posA.indent, posB.indent)
-      );
-    }
-    return false;
-  }
   static astType2DLinkType(type: DendronASTTypes): DLink["type"] {
     switch (type) {
       case DendronASTTypes.WIKI_LINK:

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -7,6 +7,7 @@ import {
   DendronError,
   DEngineClient,
   DLink,
+  DLoc,
   DNodeProps,
   DNoteAnchor,
   DNoteAnchorBasic,
@@ -365,6 +366,45 @@ const getLinkCandidates = async ({
 };
 
 export class LinkUtils {
+  static isEquivalent(linkA: DLink, linkB: DLink): boolean {
+    return (
+      linkA.type === linkB.type &&
+      this.isDLocEquivalent(linkA.from, linkB.from) &&
+      this.isDLocEquivalent(linkA.to, linkB.to) &&
+      linkA.value === linkB.value &&
+      this.isPositionEquivalent(linkA.position, linkB.position)
+    );
+  }
+  static isDLocEquivalent(
+    locA: DLoc | undefined,
+    locB: DLoc | undefined
+  ): boolean {
+    if (!locA && !locB) return true;
+    if (locA && locB) {
+      return (
+        locA.fname === locB.fname &&
+        locA.id === locB.id &&
+        locA.vaultName === locB.vaultName
+      );
+    }
+    return false;
+  }
+  static isPositionEquivalent(
+    posA: Position | undefined,
+    posB: Position | undefined
+  ): boolean {
+    if (!posA && !posB) return true;
+    if (posA && posB) {
+      return (
+        posA.start.line === posB.start.line &&
+        posA.start.column === posB.start.column &&
+        posA.end.line === posB.end.line &&
+        posA.end.column === posB.end.column &&
+        _.isEqual(posA.indent, posB.indent)
+      );
+    }
+    return false;
+  }
   static astType2DLinkType(type: DendronASTTypes): DLink["type"] {
     switch (type) {
       case DendronASTTypes.WIKI_LINK:

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -7,7 +7,6 @@ import {
   DendronError,
   DEngineClient,
   DLink,
-  DLoc,
   DNodeProps,
   DNoteAnchor,
   DNoteAnchorBasic,


### PR DESCRIPTION
**Background**
Currently we do not update backlinks when a note is created/updated/deleted. This pr fills in that gap by computing the diff of links between the old and new note. This will be implemented for both the engine v3 and v2.

**Changes**
1. For a newly created note, scan through its links and create backlink if applicable
2. For a deleted note,  scan through its links and delete backlink if applicable
3. For updated note, calculate diff and add/remove backlinks
4. Created new `BacklinkUtils` to handle basic backlink methods. `LinkUtils` is intertwined with many other services so I wanted to keep it separate
