### PR TITLE
fix(sync): next js export pod error

### DIFF
--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -36,6 +36,9 @@ import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
 
 const LOGGER_NAME = "SiteUtils";
 
+/**
+ * @deprecated - prefer to use methods in unified/SiteUtils if they exist.
+ */
 export class SiteUtils {
   static canPublish(opts: {
     note: NoteProps;

--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -119,7 +119,7 @@ export default function Note({
           <Row gutter={20}>
             <Col xs={24} md={18}>
               {BannerAlert && <BannerAlert />}
-              <DendronNote noteContent={noteBody} config={config} />
+              <DendronNote noteContent={noteBody} />
               {maybeCollection}
               <DendronNoteGiscusWidget note={note} config={config} />
             </Col>

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -303,6 +303,7 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
         vault: note.vault,
         config: engineConfig,
         vaults: engine.vaults,
+        wsRoot: engine.wsRoot,
       },
       { flavor: ProcFlavor.PUBLISHING }
     );

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -456,27 +456,26 @@ export function convertNoteRefASTV2(
 
       // apply publish rules and do duplicate
       if (shouldApplyPublishRules && !_.isUndefined(duplicateNoteConfig)) {
-        // JYTODO: Add back Handle Dup Logic
-        // const maybeNote = SiteUtils.handleDup({
-        //   allowStubs: false,
-        //   dupBehavior: duplicateNoteConfig,
-        //   engine,
-        //   config,
-        //   fname: link.from.fname,
-        //   noteCandidates: resp.data,
-        //   noteDict: engine.notes,
-        // });
-        // if (!maybeNote) {
-        //   return {
-        //     error: undefined,
-        //     data: [
-        //       MdastUtils.genMDErrorMsg(
-        //         `Error rendering note reference for ${link.from.fname}`
-        //       ),
-        //     ],
-        //   };
-        // }
-        // note = maybeNote;
+        const maybeNote = SiteUtils.handleDup({
+          dupBehavior: duplicateNoteConfig,
+          config,
+          vaults,
+          wsRoot,
+          fname: link.from.fname,
+          noteCandidates: data,
+          noteDict: noteCacheForRenderDict!,
+        });
+        if (!maybeNote) {
+          return {
+            error: undefined,
+            data: [
+              MdastUtils.genMDErrorMsg(
+                `Error rendering note reference for ${link.from.fname}`
+              ),
+            ],
+          };
+        }
+        note = maybeNote;
       } else {
         // no need to apply publish rules, try to pick the one that is in same vault
 


### PR DESCRIPTION
## fix(sync): next js export pod error

Fixing a few issues in Next JS Export and the playwright test pass:
- adding back 'handleDup' logic in publishing
- adding a missing `wsRoot` parameter in NextJS Export Pod
- Fixing a compile warning/error in `DendronNotePage.tsx`