### PR TITLE
Chore/separate out ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,27 +102,6 @@ jobs:
         run: |
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           echo 'DISPLAY=:99.0' >>$GITHUB_ENV
-
-      - name: Export test-workspace
-        if: runner.os == 'Linux' && matrix.suite == 'cli' && matrix.node-version == '14.x'
-        working-directory: ./test-workspace
-        run:  ../node_modules/.bin/dendron exportPod --podId dendron.nextjs --config "dest=../packages/nextjs-template/"
-
-      - name: Install Playwright dependencies
-        if: runner.os == 'Linux' && matrix.suite == 'cli' && matrix.node-version == '14.x'
-        run: npx playwright install --with-deps
-
-      - name: Run Playwright tests
-        if: runner.os == 'Linux' && matrix.suite == 'cli' && matrix.node-version == '14.x'
-        run: yarn ci:test:template
-
-      - name: Upload Playwright test results
-        uses: actions/upload-artifact@v3
-        if: runner.os == 'Linux' && matrix.suite == 'cli' && matrix.node-version == '14.x' && (success() || failure())
-        with:
-          name: test-artifact
-          path: ./packages/nextjs-template/test-results/
-
       - name: Run tests
         run: yarn ci:test:${{ matrix.suite }}
         timeout-minutes: 30
@@ -172,3 +151,62 @@ jobs:
 
       - name: Run Plugin-Web tests
         run: yarn ci:test:plugin-web
+
+  test-playwright:
+    strategy:
+      # Allow other matrix jobs to continue after one fails, allowing us to
+      # isolate platform-specific issues.
+      fail-fast: false
+
+    timeout-minutes: 15
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          cache: "yarn"
+          cache-dependency-path: yarn.lock
+
+      - name: Restore typescript lib cache
+        uses: actions/cache@v2
+        id: ts-cache
+        with:
+          path: |
+            packages/*/lib/*
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-21
+          restore-keys: |
+            ${{ runner.os }}-yarn-9
+
+      - name: Bootstrap
+        run: yarn bootstrap:bootstrap
+        shell: bash
+
+      - name: Build
+        run: yarn bootstrap:buildCI
+        shell: bash
+
+      # - name: Start Xvfb
+      #   run: |
+      #     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+      #     echo 'DISPLAY=:99.0' >>$GITHUB_ENV
+
+      - name: Export test-workspace
+        working-directory: ./test-workspace
+        run: ../node_modules/.bin/dendron exportPod --podId dendron.nextjs --config "dest=../packages/nextjs-template/"
+
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: yarn ci:test:template
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-artifact
+          path: ./packages/nextjs-template/test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - "*"
       - "*/*"
 
+env:
+  binary-cache-index: 23 # Rev this if we need a new node cache
+
 jobs:
   test:
     strategy:
@@ -79,23 +82,17 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-22
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
           restore-keys: |
-            ${{ runner.os }}-yarn-9
-
-      - name: Sets env vars for publish test
-        run: |
-          echo "TEST_NEXT_TEMPLATE=1" >> $GITHUB_ENV
-          echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
-        if: runner.os == 'Linux'
+            ${{ runner.os }}-yarn-${{ binary-cache-index }}
 
       - name: Bootstrap
         run: yarn bootstrap:bootstrap
         shell: bash
 
-      - name: Build
-        run: yarn bootstrap:buildCI
-        shell: bash
+      # - name: Build
+      #   run: yarn bootstrap:buildCI
+      #   shell: bash
 
       - name: Start Xvfb
         if: runner.os == 'Linux' && (matrix.suite == 'plugin' || matrix.suite == 'plugin-web')
@@ -132,17 +129,17 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-21
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
           restore-keys: |
-            ${{ runner.os }}-yarn-9
+            ${{ runner.os }}-yarn-${{ binary-cache-index }}
 
       - name: Bootstrap
         run: yarn bootstrap:bootstrap
         shell: bash
 
-      - name: Build
-        run: yarn bootstrap:buildCI
-        shell: bash
+      # - name: Build
+      #   run: yarn bootstrap:buildCI
+      #   shell: bash
 
       - name: Start Xvfb
         run: |
@@ -178,22 +175,23 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-21
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
           restore-keys: |
-            ${{ runner.os }}-yarn-9
+            ${{ runner.os }}-yarn-${{ binary-cache-index }}
 
-      - name: Bootstrap
-        run: yarn bootstrap:bootstrap
-        shell: bash
+      - name: Sets env vars for publish test
+        run: |
+          echo "TEST_NEXT_TEMPLATE=1" >> $GITHUB_ENV
+          echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
+        if: runner.os == 'Linux'
+
+      # - name: Bootstrap
+      #   run: yarn bootstrap:bootstrap
+      #   shell: bash
 
       - name: Build
         run: yarn bootstrap:buildCI
         shell: bash
-
-      # - name: Start Xvfb
-      #   run: |
-      #     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-      #     echo 'DISPLAY=:99.0' >>$GITHUB_ENV
 
       - name: Export test-workspace
         working-directory: ./test-workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
         run: yarn bootstrap:bootstrap
         shell: bash
 
-      # - name: Build
-      #   run: yarn bootstrap:buildCI
-      #   shell: bash
+      - name: Build
+        run: yarn bootstrap:buildCI
+        shell: bash
 
       - name: Start Xvfb
-        if: runner.os == 'Linux' && (matrix.suite == 'plugin' || matrix.suite == 'plugin-web')
+        if: runner.os == 'Linux'
         run: |
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           echo 'DISPLAY=:99.0' >>$GITHUB_ENV
@@ -137,9 +137,9 @@ jobs:
         run: yarn bootstrap:bootstrap
         shell: bash
 
-      # - name: Build
-      #   run: yarn bootstrap:buildCI
-      #   shell: bash
+      - name: Build
+        run: yarn bootstrap:buildCI
+        shell: bash
 
       - name: Start Xvfb
         run: |
@@ -183,11 +183,11 @@ jobs:
         run: |
           echo "TEST_NEXT_TEMPLATE=1" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
-        if: runner.os == 'Linux'
+        # if: runner.os == 'Linux'
 
-      # - name: Bootstrap
-      #   run: yarn bootstrap:bootstrap
-      #   shell: bash
+      - name: Bootstrap
+        run: yarn bootstrap:bootstrap
+        shell: bash
 
       - name: Build
         run: yarn bootstrap:buildCI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,6 @@ jobs:
         timeout-minutes: 30
 
   test-plugin-web:
-    strategy:
-      # Allow other matrix jobs to continue after one fails, allowing us to
-      # isolate platform-specific issues.
-      fail-fast: false
-
     timeout-minutes: 15
 
     runs-on: ubuntu-latest
@@ -150,11 +145,6 @@ jobs:
         run: yarn ci:test:plugin-web
 
   test-playwright:
-    strategy:
-      # Allow other matrix jobs to continue after one fails, allowing us to
-      # isolate platform-specific issues.
-      fail-fast: false
-
     timeout-minutes: 15
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - "*/*"
 
 env:
-  binary-cache-index: 23 # Rev this if we need a new node cache
+  BINARY_CACHE_INDEX: 23 # Rev this if we need a new node cache
 
 jobs:
   test:
@@ -82,9 +82,9 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ env.BINARY_CACHE_INDEX }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ binary-cache-index }}
+            ${{ runner.os }}-yarn-${{ env.BINARY_CACHE_INDEX }}
 
       - name: Bootstrap
         run: yarn bootstrap:bootstrap
@@ -129,9 +129,9 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ env.BINARY_CACHE_INDEX }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ binary-cache-index }}
+            ${{ runner.os }}-yarn-${{ env.BINARY_CACHE_INDEX }}
 
       - name: Bootstrap
         run: yarn bootstrap:bootstrap
@@ -175,9 +175,9 @@ jobs:
         with:
           path: |
             packages/*/lib/*
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ binary-cache-index }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ env.BINARY_CACHE_INDEX }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ binary-cache-index }}
+            ${{ runner.os }}-yarn-${{ env.BINARY_CACHE_INDEX }}
 
       - name: Sets env vars for publish test
         run: |

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -36,6 +36,9 @@ import { HierarchyUtils, stripLocalOnlyTags } from "../utils";
 
 const LOGGER_NAME = "SiteUtils";
 
+/**
+ * @deprecated - prefer to use methods in unified/SiteUtils if they exist.
+ */
 export class SiteUtils {
   static canPublish(opts: {
     note: NoteProps;

--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -119,7 +119,7 @@ export default function Note({
           <Row gutter={20}>
             <Col xs={24} md={18}>
               {BannerAlert && <BannerAlert />}
-              <DendronNote noteContent={noteBody} config={config} />
+              <DendronNote noteContent={noteBody} />
               {maybeCollection}
               <DendronNoteGiscusWidget note={note} config={config} />
             </Col>

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -303,6 +303,7 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
         vault: note.vault,
         config: engineConfig,
         vaults: engine.vaults,
+        wsRoot: engine.wsRoot,
       },
       { flavor: ProcFlavor.PUBLISHING }
     );

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -456,27 +456,26 @@ export function convertNoteRefASTV2(
 
       // apply publish rules and do duplicate
       if (shouldApplyPublishRules && !_.isUndefined(duplicateNoteConfig)) {
-        // JYTODO: Add back Handle Dup Logic
-        // const maybeNote = SiteUtils.handleDup({
-        //   allowStubs: false,
-        //   dupBehavior: duplicateNoteConfig,
-        //   engine,
-        //   config,
-        //   fname: link.from.fname,
-        //   noteCandidates: resp.data,
-        //   noteDict: engine.notes,
-        // });
-        // if (!maybeNote) {
-        //   return {
-        //     error: undefined,
-        //     data: [
-        //       MdastUtils.genMDErrorMsg(
-        //         `Error rendering note reference for ${link.from.fname}`
-        //       ),
-        //     ],
-        //   };
-        // }
-        // note = maybeNote;
+        const maybeNote = SiteUtils.handleDup({
+          dupBehavior: duplicateNoteConfig,
+          config,
+          vaults,
+          wsRoot,
+          fname: link.from.fname,
+          noteCandidates: data,
+          noteDict: noteCacheForRenderDict!,
+        });
+        if (!maybeNote) {
+          return {
+            error: undefined,
+            data: [
+              MdastUtils.genMDErrorMsg(
+                `Error rendering note reference for ${link.from.fname}`
+              ),
+            ],
+          };
+        }
+        note = maybeNote;
       } else {
         // no need to apply publish rules, try to pick the one that is in same vault
 


### PR DESCRIPTION
## Chore: separate out CI playwright workflows

This change pulls the playwright test pass into a separate job to make it easier for us to spot failures in it. It was previously running as part of the CLI-14 pass.

NOTE TO REVIEWERS: the only relevant changes are in `ci.yml`.  The other changes are artifacts of a separate PR here https://github.com/dendronhq/dendron/pull/3539, but I wanted to include some test fixes in my branch here to make sure the playwright tests were working correctly.

There are some duplicate GH action jobs here, but I tried using [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow), but it seems a bit immature at the moment so I decided not to continue. (See https://stackoverflow.com/questions/71046096/reusable-workflows-with-local-actions)

