### PR TITLE
feat(workspace): copy as command

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -245,6 +245,10 @@
         "title": "Dendron: Copy Codespace URL"
       },
       {
+        "command": "dendron.copyAs",
+        "title": "Dendron: Copy As"
+      },
+      {
         "command": "dendron.delete",
         "title": "Dendron: Delete"
       },
@@ -658,6 +662,10 @@
         },
         {
           "command": "dendron.copyCodespaceURL",
+          "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.copyAs",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1333,6 +1333,12 @@
         "when": "editorFocus && dendron:pluginActive"
       },
       {
+        "command": "dendron.copyAs",
+        "key": "ctrl+k ctrl+c",
+        "mac": "cmd+k cmd+c",
+        "when": "dendron:pluginActive"
+      },
+      {
         "command": "dendron.delete",
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -1,4 +1,6 @@
 import { DendronError } from "@dendronhq/common-all";
+import { PodUtils } from "@dendronhq/pods-core";
+import { ensureDirSync } from "fs-extra";
 import _ from "lodash";
 import { IDendronExtension } from "./dendronExtensionInterface";
 import { IWSUtilsV2 } from "./WSUtilsV2Interface";
@@ -50,5 +52,12 @@ export class ExtensionProvider {
 
   static register(extension: IDendronExtension) {
     ExtensionProvider.extension = extension;
+  }
+
+  static getPodsDir() {
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const podsDir = PodUtils.getPodDir({ wsRoot });
+    ensureDirSync(podsDir);
+    return podsDir;
   }
 }

--- a/packages/plugin-core/src/KeybindingUtils.ts
+++ b/packages/plugin-core/src/KeybindingUtils.ts
@@ -344,12 +344,44 @@ export class KeybindingUtils {
       return result[0].key;
     } else if (result.length > 1) {
       throw new DendronError({
-        message: KeybindingUtils.MULTIPLE_KEYBINDINGS_MSG_FMT,
+        message: this.getMultipleKeybindingsMsgFormat("pod"),
       });
     }
     return undefined;
   }
 
-  static MULTIPLE_KEYBINDINGS_MSG_FMT =
-    "Multiple keybindings found for pod command shortcut.";
+  static getKeybindingsForCopyAsIfExists(format: string): string | undefined {
+    const { keybindingConfigPath } = this.getKeybindingConfigPath();
+
+    if (!fs.existsSync(keybindingConfigPath)) {
+      return undefined;
+    }
+
+    const keybindings = readJSONWithCommentsSync(keybindingConfigPath);
+
+    if (!KeybindingUtils.checkKeybindingsExist(keybindings)) {
+      return undefined;
+    }
+
+    const result = keybindings.filter((item) => {
+      return (
+        item.command &&
+        item.command === DENDRON_COMMANDS.COPY_AS.key &&
+        item.args === format
+      );
+    });
+
+    if (result.length === 1 && result[0].key) {
+      return result[0].key;
+    } else if (result.length > 1) {
+      throw new DendronError({
+        message: this.getMultipleKeybindingsMsgFormat("copy as"),
+      });
+    }
+    return undefined;
+  }
+
+  static getMultipleKeybindingsMsgFormat(cmd: string) {
+    return `Multiple keybindings found for ${cmd} command shortcut.`;
+  }
 }

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -1,4 +1,4 @@
-import { assertUnreachable } from "@dendronhq/common-all";
+import { DendronError } from "@dendronhq/common-all";
 import {
   CopyAsFormat,
   getAllCopyAsFormat,
@@ -68,7 +68,9 @@ export class CopyAsCommand extends BasicCommand<
         return PodCommandFactory.createPodCommandForStoredConfig({ config });
       }
       default:
-        assertUnreachable(format);
+        throw new DendronError({
+          message: `${format} is not a valid copy as format. If you are using a keybinding, make sure the argument is one of the following values: ${getAllCopyAsFormat()}`,
+        });
     }
   }
 

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -6,9 +6,11 @@ import {
   PodExportScope,
   PodV2Types,
 } from "@dendronhq/pods-core";
+import _ from "lodash";
 import { PodCommandFactory } from "../components/pods/PodCommandFactory";
 import { PodUIControls } from "../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../constants";
+import { VSCodeUtils } from "../vsCodeUtils";
 import { BaseCommand, CodeCommandInstance } from "./base";
 
 type CommandOutput = void;
@@ -30,6 +32,13 @@ export class CopyAsCommand extends BaseCommand<
   constructor(_name?: string) {
     super(_name);
     this.format = getAllCopyAsFormat();
+  }
+
+  async sanityCheck(_opts?: Partial<CodeCommandInstance> | undefined) {
+    if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
+      return "you must have a note open to execute this command";
+    }
+    return;
   }
 
   async gatherInputs() {

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -1,0 +1,66 @@
+import { assertUnreachable } from "@dendronhq/common-all";
+import {
+  CopyAsFormat,
+  getAllCopyAsFormat,
+  JSONV2PodConfig,
+  PodExportScope,
+  PodV2Types,
+} from "@dendronhq/pods-core";
+import { PodCommandFactory } from "../components/pods/PodCommandFactory";
+import { PodUIControls } from "../components/pods/PodControls";
+import { DENDRON_COMMANDS } from "../constants";
+import { BaseCommand, CodeCommandInstance } from "./base";
+
+type CommandOutput = void;
+type CommandInput = CodeCommandInstance;
+type CommandOpts = CodeCommandInstance;
+
+/**
+ * Command that will find the appropriate export command to run, and then run
+ * it. This is the UI entry point for all export pod functionality.
+ */
+export class CopyAsCommand extends BaseCommand<
+  CommandOpts,
+  CommandOutput,
+  CommandInput
+> {
+  public format: CopyAsFormat[];
+  key = DENDRON_COMMANDS.COPY_AS.key;
+
+  constructor(_name?: string) {
+    super(_name);
+    this.format = getAllCopyAsFormat();
+  }
+
+  async gatherInputs() {
+    const format = await PodUIControls.promtToSelectCopyAsFormat();
+
+    if (!format) {
+      return;
+    }
+    switch (format) {
+      case CopyAsFormat.JSON: {
+        const config: JSONV2PodConfig = {
+          destination: "clipboard",
+          exportScope: PodExportScope.Note,
+          podType: PodV2Types.JSONExportV2,
+          podId: "copyAs.json", // dummy value, required property
+        };
+        return PodCommandFactory.createPodCommandForStoredConfig({ config });
+      }
+      default:
+        assertUnreachable(format);
+    }
+  }
+
+  /**
+   * no-op
+   */
+  async enrichInputs(inputs: CommandInput): Promise<CommandOpts | undefined> {
+    return inputs;
+  }
+
+  async execute(opts: CommandOpts) {
+    opts.run();
+  }
+}

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -12,7 +12,7 @@ import { PodCommandFactory } from "../components/pods/PodCommandFactory";
 import { PodUIControls } from "../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { BaseCommand, CodeCommandInstance } from "./base";
+import { BasicCommand, CodeCommandInstance } from "./base";
 
 type CommandOutput = void;
 type CommandInput = CodeCommandInstance;
@@ -22,7 +22,7 @@ type CommandOpts = CodeCommandInstance;
  * Command that will find the appropriate export command to run, and then run
  * it. This is the UI entry point for all export pod functionality.
  */
-export class CopyAsCommand extends BaseCommand<
+export class CopyAsCommand extends BasicCommand<
   CommandOpts,
   CommandOutput,
   CommandInput
@@ -70,13 +70,6 @@ export class CopyAsCommand extends BaseCommand<
       default:
         assertUnreachable(format);
     }
-  }
-
-  /**
-   * no-op
-   */
-  async enrichInputs(inputs: CommandInput): Promise<CommandOpts | undefined> {
-    return inputs;
   }
 
   async execute(opts: CommandOpts) {

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -15,7 +15,6 @@ import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand, CodeCommandInstance } from "./base";
 
 type CommandOutput = void;
-type CommandInput = CodeCommandInstance;
 type CommandOpts = CodeCommandInstance;
 
 /**
@@ -25,7 +24,7 @@ type CommandOpts = CodeCommandInstance;
 export class CopyAsCommand extends BasicCommand<
   CommandOpts,
   CommandOutput,
-  CommandInput
+  CopyAsFormat
 > {
   public format: CopyAsFormat[];
   key = DENDRON_COMMANDS.COPY_AS.key;
@@ -35,15 +34,16 @@ export class CopyAsCommand extends BasicCommand<
     this.format = getAllCopyAsFormat();
   }
 
-  async sanityCheck(_opts?: Partial<CodeCommandInstance> | undefined) {
+  async sanityCheck() {
     if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
       return "you must have a note open to execute this command";
     }
     return;
   }
 
-  async gatherInputs() {
-    const format = await PodUIControls.promtToSelectCopyAsFormat();
+  async gatherInputs(copyAsFormat?: CopyAsFormat) {
+    const format =
+      copyAsFormat || (await PodUIControls.promptToSelectCopyAsFormat());
 
     if (!format) {
       return;

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -3,6 +3,7 @@ import {
   CopyAsFormat,
   getAllCopyAsFormat,
   JSONV2PodConfig,
+  MarkdownV2PodConfig,
   PodExportScope,
   PodV2Types,
 } from "@dendronhq/pods-core";
@@ -54,6 +55,15 @@ export class CopyAsCommand extends BaseCommand<
           exportScope: PodExportScope.Note,
           podType: PodV2Types.JSONExportV2,
           podId: "copyAs.json", // dummy value, required property
+        };
+        return PodCommandFactory.createPodCommandForStoredConfig({ config });
+      }
+      case CopyAsFormat.MARKDOWN: {
+        const config: MarkdownV2PodConfig = {
+          destination: "clipboard",
+          exportScope: PodExportScope.Note,
+          podType: PodV2Types.MarkdownExportV2,
+          podId: "copyAs.markdown", // dummy value, required property
         };
         return PodCommandFactory.createPodCommandForStoredConfig({ config });
       }

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -87,6 +87,7 @@ import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
 import { CopyCodespaceURL } from "./CopyCodespaceURL";
 import { MoveSelectionToCommand } from "./MoveSelectionToCommand";
+import { CopyAsCommand } from "./CopyAsCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -181,6 +182,7 @@ const ALL_COMMANDS = [
   MergeNoteCommand,
   CreateNoteCommand,
   CopyCodespaceURL,
+  CopyAsCommand,
 ] as CodeCommandConstructor[];
 
 export { ALL_COMMANDS };

--- a/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
+++ b/packages/plugin-core/src/commands/pods/ExportPodV2Command.ts
@@ -48,10 +48,10 @@ export class ExportPodV2Command extends BaseCommand<
 
     // If a podId is passed in, use this instead of prompting the user
     if (args?.podId) {
-      return PodCommandFactory.createPodCommandForStoredConfig(
-        { podId: args.podId },
-        args.exportScope
-      );
+      return PodCommandFactory.createPodCommandForStoredConfig({
+        configId: { podId: args.podId },
+        exportScope: args.exportScope,
+      });
     }
 
     const exportChoice = await PodUIControls.promptForExportConfigOrNewExport();
@@ -66,7 +66,9 @@ export class ExportPodV2Command extends BaseCommand<
       }
       return PodCommandFactory.createPodCommandForPodType(podType);
     } else {
-      return PodCommandFactory.createPodCommandForStoredConfig(exportChoice);
+      return PodCommandFactory.createPodCommandForStoredConfig({
+        configId: exportChoice,
+      });
     }
   }
 

--- a/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/JSONExportPodCommand.ts
@@ -110,9 +110,11 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
     exportReturnValue: JSONExportReturnType;
     config: RunnableJSONV2PodConfig;
   }) {
+    let successMessage = "Finished running JSON export pod.";
     const data = exportReturnValue.data?.exportedNotes;
     if (_.isString(data) && config.destination === "clipboard") {
       vscode.env.clipboard.writeText(data);
+      successMessage += " Content is copied to the clipboard";
     }
     if (ResponseUtil.hasError(exportReturnValue)) {
       const errorMsg = `Finished JSON Export. Error encountered: ${ErrorFactory.safeStringify(
@@ -120,7 +122,7 @@ export class JSONExportPodCommand extends BaseExportPodCommand<
       )}`;
       this.L.error(errorMsg);
     } else {
-      vscode.window.showInformationMessage("Finished running JSON export pod.");
+      vscode.window.showInformationMessage(successMessage);
     }
   }
 

--- a/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/MarkdownExportPodCommand.ts
@@ -123,8 +123,10 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
     config: RunnableMarkdownV2PodConfig;
   }) {
     const data = exportReturnValue.data?.exportedNotes;
+    let successMessage = "Finished running Markdown export pod.";
     if (_.isString(data) && config.destination === "clipboard") {
       vscode.env.clipboard.writeText(data);
+      successMessage += " Content is copied to the clipboard";
     }
     const count = data?.length ?? 0;
     if (ResponseUtil.hasError(exportReturnValue)) {
@@ -133,9 +135,7 @@ export class MarkdownExportPodCommand extends BaseExportPodCommand<
       )}`;
       this.L.error(errorMsg);
     } else {
-      vscode.window.showInformationMessage(
-        "Finished running Markdown export pod."
-      );
+      vscode.window.showInformationMessage(successMessage);
     }
   }
 

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -43,14 +43,19 @@ export class PodCommandFactory {
       podType = config.podType;
       storedConfig = config;
     } else {
+      if (!configId) {
+        throw new DendronError({
+          message: `Please provide a config id`,
+        });
+      }
       storedConfig = PodV2ConfigManager.getPodConfigById({
         podsDir: path.join(getExtension().podsDir, "custom"),
-        opts: configId!,
+        opts: configId,
       });
 
       if (!storedConfig) {
         throw new DendronError({
-          message: `No pod config with id ${configId!.podId} found.`,
+          message: `No pod config with id ${configId.podId} found.`,
         });
       }
       // overrides the exportScope of stored config with the exportScope passed in args

--- a/packages/plugin-core/src/components/pods/PodCommandFactory.ts
+++ b/packages/plugin-core/src/components/pods/PodCommandFactory.ts
@@ -13,7 +13,6 @@ import { JSONExportPodCommand } from "../../commands/pods/JSONExportPodCommand";
 import { MarkdownExportPodCommand } from "../../commands/pods/MarkdownExportPodCommand";
 import { NotionExportPodCommand } from "../../commands/pods/NotionExportPodCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
-import { getExtension } from "../../workspace";
 
 export class PodCommandFactory {
   /**
@@ -48,8 +47,9 @@ export class PodCommandFactory {
           message: `Please provide a config id`,
         });
       }
+
       storedConfig = PodV2ConfigManager.getPodConfigById({
-        podsDir: path.join(getExtension().podsDir, "custom"),
+        podsDir: path.join(ExtensionProvider.getPodsDir(), "custom"),
         opts: configId,
       });
 

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -2,10 +2,12 @@ import { assertUnreachable, DVault, VaultUtils } from "@dendronhq/common-all";
 import { DLogger } from "@dendronhq/common-server";
 import { HistoryEvent } from "@dendronhq/engine-server";
 import {
+  CopyAsFormat,
   ExportPodConfigurationV2,
   ExternalConnectionManager,
   ExternalService,
   ExternalTarget,
+  getAllCopyAsFormat,
   PodExportScope,
   PodUtils,
   PodV2ConfigManager,
@@ -28,7 +30,7 @@ import { NoteLookupProviderUtils } from "../lookup/NoteLookupProviderUtils";
  */
 export class PodUIControls {
   /**
-   * Prompts the user with a quick-pick to select a {@link PodConfigurationV2}
+   * Prompts the user with a quick-pick to select a {@link ExportPodConfigurationV2}
    * by its podId. Furthermore, there is an option to create a new export
    * configuration intead.
    * @returns
@@ -551,5 +553,24 @@ export class PodUIControls {
       ignoreFocusOut: true,
     });
     return podIdQuickPick?.label;
+  }
+
+  /**
+   * Prompt user to select the copy as format
+   */
+  public static async promtToSelectCopyAsFormat(): Promise<
+    CopyAsFormat | undefined
+  > {
+    const items = getAllCopyAsFormat().map<QuickPickItem>((value) => {
+      return {
+        label: value,
+        detail: `Format Dendron note to ${value} and copy it to the clipboard`,
+      };
+    });
+    const formatQuickPick = await VSCodeUtils.showQuickPick(items, {
+      title: "Pick the format to convert",
+      ignoreFocusOut: true,
+    });
+    return formatQuickPick?.label as CopyAsFormat;
   }
 }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -410,7 +410,9 @@ export class PodUIControls {
       } catch (e: any) {
         if (
           e.message &&
-          e.message.includes(KeybindingUtils.MULTIPLE_KEYBINDINGS_MSG_FMT)
+          e.message.includes(
+            KeybindingUtils.getMultipleKeybindingsMsgFormat("pod")
+          )
         ) {
           keybinding = "Multiple Keybindings";
         }
@@ -558,12 +560,28 @@ export class PodUIControls {
   /**
    * Prompt user to select the copy as format
    */
-  public static async promtToSelectCopyAsFormat(): Promise<
+  public static async promptToSelectCopyAsFormat(): Promise<
     CopyAsFormat | undefined
   > {
     const items = getAllCopyAsFormat().map<QuickPickItem>((value) => {
+      let keybinding;
+
+      try {
+        keybinding =
+          KeybindingUtils.getKeybindingsForCopyAsIfExists(value) || "";
+      } catch (e: any) {
+        if (
+          e.message &&
+          e.message.includes(
+            KeybindingUtils.getMultipleKeybindingsMsgFormat("copy as")
+          )
+        ) {
+          keybinding = "Multiple Keybindings";
+        }
+      }
       return {
         label: value,
+        description: keybinding,
         detail: `Format Dendron note to ${value} and copy it to the clipboard`,
       };
     });

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -516,6 +516,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
   COPY_AS: {
     key: "dendron.copyAs",
     title: `${CMD_PREFIX} Copy As`,
+    keybindings: {
+      key: "ctrl+k ctrl+c",
+      mac: "cmd+k cmd+c",
+      when: "dendron:pluginActive",
+    },
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   DELETE: {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -513,6 +513,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Copy Codespace URL`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
+  COPY_AS: {
+    key: "dendron.copyAs",
+    title: `${CMD_PREFIX} Copy As`,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+  },
   DELETE: {
     key: "dendron.delete",
     title: `${CMD_PREFIX} Delete`,

--- a/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
@@ -1,0 +1,50 @@
+import { CopyAsFormat } from "@dendronhq/pods-core";
+import { describe } from "mocha";
+import sinon from "sinon";
+import { CopyAsCommand } from "../../commands/CopyAsCommand";
+import { PodUIControls } from "../../components/pods/PodControls";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { WSUtilsV2 } from "../../WSUtilsV2";
+import { describeSingleWS } from "../testUtilsV3";
+import { expect } from "../testUtilsv2";
+import { PodCommandFactory } from "../../components/pods/PodCommandFactory";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { window } from "vscode";
+
+suite("CopyAsCommand", function () {
+  describe("GIVEN CopyAs command is run", () => {
+    describeSingleWS(
+      "WHEN the format selected is JSON",
+      { timeout: 5e3 },
+      () => {
+        test("THEN json formatted note must be copied to clipboard", async () => {
+          const { engine } = ExtensionProvider.getDWorkspace();
+          const targetNote = (await engine.findNotes({ fname: "root" }))[0];
+          await WSUtilsV2.instance().openNote(targetNote);
+          const factorySpy = sinon.spy(
+            PodCommandFactory,
+            "createPodCommandForStoredConfig"
+          );
+          const cmd = new CopyAsCommand();
+          sinon
+            .stub(PodUIControls, "promtToSelectCopyAsFormat")
+            .resolves(CopyAsFormat.JSON);
+          await cmd.run();
+          const out = factorySpy.returnValues[0];
+          expect(out.key).toEqual("dendron.jsonexportv2");
+        });
+        test("AND NO note is open THEN throw error", async () => {
+          await VSCodeUtils.closeAllEditors();
+
+          const windowSpy = sinon.spy(window, "showErrorMessage");
+          const cmd = new CopyAsCommand();
+          await cmd.run();
+          const errorMsg = windowSpy.getCall(0).args[0];
+          expect(errorMsg).toEqual(
+            "you must have a note open to execute this command"
+          );
+        });
+      }
+    );
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
@@ -27,7 +27,7 @@ suite("CopyAsCommand", function () {
           );
           const cmd = new CopyAsCommand();
           sinon
-            .stub(PodUIControls, "promtToSelectCopyAsFormat")
+            .stub(PodUIControls, "promptToSelectCopyAsFormat")
             .resolves(CopyAsFormat.JSON);
           await cmd.run();
           const out = factorySpy.returnValues[0];
@@ -60,9 +60,28 @@ suite("CopyAsCommand", function () {
           );
           const cmd = new CopyAsCommand();
           sinon
-            .stub(PodUIControls, "promtToSelectCopyAsFormat")
+            .stub(PodUIControls, "promptToSelectCopyAsFormat")
             .resolves(CopyAsFormat.MARKDOWN);
           await cmd.run();
+          const out = factorySpy.returnValues[0];
+          expect(out.key).toEqual("dendron.markdownexportv2");
+        });
+      }
+    );
+    describeSingleWS(
+      "WHEN the Markdown format is provided in keybinding args",
+      { timeout: 5e3 },
+      () => {
+        test("THEN markdown formatted note must be copied to clipboard", async () => {
+          const { engine } = ExtensionProvider.getDWorkspace();
+          const targetNote = (await engine.findNotes({ fname: "root" }))[0];
+          await WSUtilsV2.instance().openNote(targetNote);
+          const factorySpy = sinon.spy(
+            PodCommandFactory,
+            "createPodCommandForStoredConfig"
+          );
+          const cmd = new CopyAsCommand();
+          await cmd.gatherInputs(CopyAsFormat.MARKDOWN);
           const out = factorySpy.returnValues[0];
           expect(out.key).toEqual("dendron.markdownexportv2");
         });

--- a/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyAsCommand.test.ts
@@ -46,5 +46,27 @@ suite("CopyAsCommand", function () {
         });
       }
     );
+    describeSingleWS(
+      "WHEN the format selected is Markdown",
+      { timeout: 5e3 },
+      () => {
+        test("THEN markdown formatted note must be copied to clipboard", async () => {
+          const { engine } = ExtensionProvider.getDWorkspace();
+          const targetNote = (await engine.findNotes({ fname: "root" }))[0];
+          await WSUtilsV2.instance().openNote(targetNote);
+          const factorySpy = sinon.spy(
+            PodCommandFactory,
+            "createPodCommandForStoredConfig"
+          );
+          const cmd = new CopyAsCommand();
+          sinon
+            .stub(PodUIControls, "promtToSelectCopyAsFormat")
+            .resolves(CopyAsFormat.MARKDOWN);
+          await cmd.run();
+          const out = factorySpy.returnValues[0];
+          expect(out.key).toEqual("dendron.markdownexportv2");
+        });
+      }
+    );
   });
 });

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -79,7 +79,7 @@ export enum CopyAsFormat {
 }
 
 export function getAllCopyAsFormat(): CopyAsFormat[] {
-  return [CopyAsFormat.JSON, CopyAsFormat.MARKDOWN];
+  return Object.values(CopyAsFormat);
 }
 
 export { JSONSchemaType, Client, Page, TitlePropertyValue };

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -75,10 +75,11 @@ export function getAllImportPods(): PodClassEntryV4[] {
 
 export enum CopyAsFormat {
   "JSON" = "JSON",
+  "MARKDOWN" = "Markdown",
 }
 
 export function getAllCopyAsFormat(): CopyAsFormat[] {
-  return [CopyAsFormat.JSON];
+  return [CopyAsFormat.JSON, CopyAsFormat.MARKDOWN];
 }
 
 export { JSONSchemaType, Client, Page, TitlePropertyValue };

--- a/packages/pods-core/src/index.ts
+++ b/packages/pods-core/src/index.ts
@@ -73,4 +73,12 @@ export function getAllImportPods(): PodClassEntryV4[] {
   ];
 }
 
+export enum CopyAsFormat {
+  "JSON" = "JSON",
+}
+
+export function getAllCopyAsFormat(): CopyAsFormat[] {
+  return [CopyAsFormat.JSON];
+}
+
 export { JSONSchemaType, Client, Page, TitlePropertyValue };


### PR DESCRIPTION
This PR aims to add a Copy As command. It is similar to Export pod command, with a predefined config. 
Presently it supports two formats: JSON and markdown. The formatted note is copied to the clipboard.

- Task: [[Copy as Command|dendron://private/task.2022.07.31.copy-as-command]]
- Docs: https://github.com/dendronhq/dendron-site/pull/655

TODO: copy as for a selection in note body


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop
