### PR TITLE
fix(workspace): Disallow note creation through go to note if filename is invalid

### DIFF
--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -3,6 +3,7 @@ import {
   Awaited,
   DNoteAnchorBasic,
   getSlugger,
+  InvalidFilenameReason,
   NoteProps,
   NoteUtils,
   VaultUtils,
@@ -317,8 +318,7 @@ export class GotoNoteCommand extends BasicCommand<
           } else {
             // should not create note if fname is invalid.
             // let the user know and exit early.
-            const message = `Cannot create note ${fname}: ${validationResp.reason}`;
-            window.showErrorMessage(message);
+            this.displayInvalidFilenameError({ fname, validationResp });
             return;
           }
         } else {
@@ -362,5 +362,17 @@ export class GotoNoteCommand extends BasicCommand<
     };
     const payload = { ...getAnalyticsPayload(source), fileType: type };
     return payload;
+  }
+
+  private displayInvalidFilenameError(opts: {
+    fname: string;
+    validationResp: {
+      isValid: boolean;
+      reason: InvalidFilenameReason;
+    };
+  }) {
+    const { fname, validationResp } = opts;
+    const message = `Cannot create note ${fname}: ${validationResp.reason}`;
+    window.showErrorMessage(message);
   }
 }

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -18,7 +18,6 @@ import { PickerUtilsV2 } from "../../components/lookup/utils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { PluginFileUtils } from "../../utils/files";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { GOTO_NOTE_PRESETS } from "../presets/GotoNotePreset";
 import { getActiveEditorBasename } from "../testUtils";
@@ -32,7 +31,7 @@ import {
 const { ANCHOR_WITH_SPECIAL_CHARS, ANCHOR } = GOTO_NOTE_PRESETS;
 
 function createGoToNoteCmd() {
-  return new GotoNoteCommand(getExtension());
+  return new GotoNoteCommand(ExtensionProvider.getExtension());
 }
 
 suite("GotoNote", function () {
@@ -109,6 +108,31 @@ suite("GotoNote", function () {
             fname: "foo.ch2",
           });
           expect(getActiveEditorBasename()).toEqual("foo.ch2.md");
+        });
+      }
+    );
+
+    describeMultiWS(
+      "WHEN goto new note with invalid filename",
+      {
+        preSetupHook,
+      },
+      () => {
+        test("THEN note is not created, and error toast is displayed", async () => {
+          const { vaults } = ExtensionProvider.getDWorkspace();
+          const vault = vaults[0];
+          const cmd = createGoToNoteCmd();
+          const errorSpy = sinon.spy(
+            cmd,
+            "displayInvalidFilenameError" as keyof GotoNoteCommand
+          );
+          const out = await cmd.run({
+            qs: "foo..bar",
+            vault,
+          });
+          expect(out).toEqual(undefined);
+          expect(errorSpy.called).toBeTruthy();
+          errorSpy.restore();
         });
       }
     );
@@ -789,7 +813,7 @@ suite("GotoNote", function () {
     describe("GIVEN non-note files", () => {
       describeMultiWS("WHEN used on a link to a non-note file", { ctx }, () => {
         before(async () => {
-          const { wsRoot, vaults } = getDWorkspace();
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
           await fs.writeFile(
             path.join(wsRoot, "test.txt"),
             "Et voluptatem autem sunt."
@@ -809,7 +833,7 @@ suite("GotoNote", function () {
         });
 
         test("THEN opens the non-note file", async () => {
-          const { vaults, wsRoot, engine } = getDWorkspace();
+          const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
           const note = await NoteTestUtilsV4.createNoteWithEngine({
             wsRoot,
             vault: vaults[0],
@@ -831,7 +855,8 @@ suite("GotoNote", function () {
 
         describe("AND the link doesn't include a slash", () => {
           before(async () => {
-            const { vaults, wsRoot, engine } = getDWorkspace();
+            const { vaults, wsRoot, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],
@@ -856,7 +881,8 @@ suite("GotoNote", function () {
 
         describe("AND the link starts with assets", () => {
           before(async () => {
-            const { vaults, wsRoot, engine } = getDWorkspace();
+            const { vaults, wsRoot, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],
@@ -885,7 +911,8 @@ suite("GotoNote", function () {
         { ctx },
         () => {
           before(async () => {
-            const { wsRoot, vaults, engine } = getDWorkspace();
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],
@@ -929,7 +956,8 @@ suite("GotoNote", function () {
         { ctx },
         () => {
           before(async () => {
-            const { wsRoot, vaults, engine } = getDWorkspace();
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],
@@ -974,7 +1002,8 @@ suite("GotoNote", function () {
         { ctx },
         () => {
           before(async () => {
-            const { wsRoot, vaults, engine } = getDWorkspace();
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],
@@ -1047,7 +1076,8 @@ suite("GotoNote", function () {
         { ctx },
         () => {
           before(async () => {
-            const { wsRoot, vaults, engine } = getDWorkspace();
+            const { wsRoot, vaults, engine } =
+              ExtensionProvider.getDWorkspace();
             const note = await NoteTestUtilsV4.createNoteWithEngine({
               wsRoot,
               vault: vaults[0],

--- a/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
@@ -1195,6 +1195,60 @@ suite("GIVEN ReferenceHoverProvider", function () {
         });
       });
 
+      describeMultiWS("GIVEN link to non-existent note", {}, () => {
+        before(async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const note = await NoteTestUtilsV4.createNote({
+            vault: vaults[0],
+            wsRoot,
+            fname: "source",
+            body: ["[[foo.bar.baz]]", "[[foo.bar..baz]]"].join("\n"),
+          });
+          await ExtensionProvider.getWSUtils().openNote(note);
+        });
+        describe("WHEN filename is valid", () => {
+          const position = new vscode.Position(7, 4);
+          test("THEN display message to create it with go to note", async () => {
+            const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              position
+            );
+            expect(hover).toBeTruthy();
+            expect(
+              await AssertUtils.assertInString({
+                body: hover!.contents.join(""),
+                match: [
+                  'Note foo.bar.baz is missing, use "Dendron: Go to Note" command to create it.',
+                ],
+              })
+            ).toBeTruthy();
+          });
+        });
+
+        describe("WHEN filename is invalid", () => {
+          const position = new vscode.Position(8, 4);
+          test("THEN display invalid filename warning and suggestion", async () => {
+            const editor = VSCodeUtils.getActiveTextEditorOrThrow();
+            const provider = new ReferenceHoverProvider();
+            const hover = await provider.provideHover(
+              editor.document,
+              position
+            );
+            expect(hover).toBeTruthy();
+            expect(
+              await AssertUtils.assertInString({
+                body: (hover!.contents[0] as MarkdownString).value,
+                match: [
+                  "Note `foo.bar..baz` is missing, and the filename is invalid for the following reason:\n\n `Hierarchies cannot be empty strings`.\n\n Maybe you meant `foo.bar.baz`?",
+                ],
+              })
+            ).toBeTruthy();
+          });
+        });
+      });
+
       describeSingleWS(
         "WHEN used on a link to a non-note file",
         { ctx },

--- a/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceHoverProvider.test.ts
@@ -13,7 +13,6 @@ import { MarkdownString } from "vscode";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import ReferenceHoverProvider from "../../features/ReferenceHoverProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
 import {
@@ -1254,7 +1253,7 @@ suite("GIVEN ReferenceHoverProvider", function () {
         { ctx },
         () => {
           before(async () => {
-            const { wsRoot, vaults } = getDWorkspace();
+            const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
             await fs.writeFile(
               path.join(wsRoot, "test.txt"),
               "Et nam velit laboriosam."


### PR DESCRIPTION
# fix(workspace): Disallow note creation through go to note if filename is invalid
This PR:
- disallows note creation through go to note if the filename at reference position is invalid
- an error toast will be displayed
- show warning on hover when filename at reference position is invalid

## Demonstration

hover:
![image](https://user-images.githubusercontent.com/1219789/191173447-19a43aa4-2f77-4ccc-88ba-5063bffb58be.png)

toast:
![image](https://user-images.githubusercontent.com/1219789/191173479-779bc818-54f0-4408-aa1a-3e7bbf36c668.png)

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)