### PR TITLE
fix(views): make preview theme background color render correctly

### DIFF
--- a/packages/common-server/src/etc.ts
+++ b/packages/common-server/src/etc.ts
@@ -80,7 +80,7 @@ export class WebViewCommonUtils {
           list-style-type: disc;
         }
 
-        body {
+        body, .ant-layout {
           background-color: var(--vscode-editor-background);
         }
 

--- a/packages/dendron-plugin-views/src/components/DendronApp.tsx
+++ b/packages/dendron-plugin-views/src/components/DendronApp.tsx
@@ -208,7 +208,6 @@ function DendronApp(props: DendronAppProps) {
       <Layout
         style={{
           padding: props.opts.padding,
-          backgroundColor: "var(--vscode-editor-background)",
         }}
       >
         <Content>


### PR DESCRIPTION
The aim of this PR is to fix [inconsistent background colors](https://github.com/dendronhq/dendron/issues/3453) when using the `preview.theme` setting.
The issue was introduced in 6fad4f05fc (my change) and basically reverts it.
The commit message expands on the reasons.


# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
