### PR TITLE
fix: render favicon when assetsPrefix is set

### DIFF
--- a/packages/nextjs-template/pages/_app.tsx
+++ b/packages/nextjs-template/pages/_app.tsx
@@ -37,9 +37,9 @@ const themes: { [key in Theme]: string } = {
 };
 
 type PageProps = {
-  noteIndex: NoteProps
+  noteIndex: NoteProps;
   config: IntermediateDendronConfig;
-}
+};
 
 function AppContainer(appProps: AppProps & { pageProps: PageProps }) {
   const { config } = appProps.pageProps;
@@ -59,7 +59,10 @@ function AppContainer(appProps: AppProps & { pageProps: PageProps }) {
   );
 }
 
-function DendronApp({ Component, pageProps }: AppProps & { pageProps: PageProps }) {
+function DendronApp({
+  Component,
+  pageProps,
+}: AppProps & { pageProps: PageProps }) {
   const [noteData, setNoteData] = useState<NoteData>();
   const logger = createLogger("App");
   const dendronRouter = useDendronRouter();
@@ -101,7 +104,7 @@ function DendronApp({ Component, pageProps }: AppProps & { pageProps: PageProps 
         dendronRouter={dendronRouter}
       >
         <Head>
-          <link rel="icon" href="/favicon.ico" />
+          <link rel="icon" href={getAssetUrl("/favicon.ico")} />
         </Head>
         <Component
           {...pageProps}


### PR DESCRIPTION
This Pr aims to fix the issue with rendering favicon when assetsPrefix is set

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended


## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)