### PR TITLE
chore: fixing useGraphElements.tsx build error

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -910,6 +910,10 @@ export class NoteUtils {
     return hpath.split(".").slice(0, numCompoenents).join(".");
   }
 
+  static getRoots(notes: NotePropsByIdDict): NoteProps[] {
+    return _.filter(_.values(notes), DNodeUtils.isRoot);
+  }
+
   /**
    * Add derived metadata from `noteHydrated` to `noteRaw`
    * By default, include the following properties:

--- a/packages/common-all/src/utils/lookup.ts
+++ b/packages/common-all/src/utils/lookup.ts
@@ -3,6 +3,8 @@ import {
   DEngineClient,
   FuseExtendedSearchConstants,
   NoteProps,
+  NotePropsByIdDict,
+  NoteUtils,
   ReducedDEngine,
 } from "..";
 
@@ -71,6 +73,14 @@ export class NoteLookupUtils {
     const childrenOfRoot = roots.flatMap((ent) => ent.children);
     const childrenOfRootNotes = await engine.bulkGetNotes(childrenOfRoot);
     return roots.concat(childrenOfRootNotes.data);
+  };
+
+  static fetchRootResults = (notes: NotePropsByIdDict) => {
+    const roots: NoteProps[] = NoteUtils.getRoots(notes);
+
+    const childrenOfRoot = roots.flatMap((ent) => ent.children);
+    const childrenOfRootNotes = _.map(childrenOfRoot, (ent) => notes[ent]);
+    return roots.concat(childrenOfRootNotes);
   };
 
   /**

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -12,6 +12,7 @@ import {
   VaultUtils,
   milliseconds,
   FIFOQueue,
+  NotePropsMeta,
 } from "@dendronhq/common-all";
 import { createLogger, engineSlice } from "@dendronhq/common-frontend";
 import { message } from "antd";
@@ -37,7 +38,7 @@ const DEFAULT_NODE_CLASSES = `${DEFAULT_CLASSES}`; //color-fill
 const DEFAULT_EDGE_CLASSES = `${DEFAULT_CLASSES}`;
 
 type QueueData = {
-  note: NoteProps;
+  note: NotePropsMeta;
   /**
    * How far (in the graph) away is this note from the original note?
    */
@@ -243,9 +244,10 @@ function computeLinkedElements({
       const noteVaultClass = getVaultClass(note.vault);
       if (showBacklinks) {
         // setup inward links for note
+
         const connectedNotes = NoteUtils.getNotesWithLinkTo({
           note,
-          notes,
+          notes: Object.values(notes),
         });
         connectedNotes.forEach((connectedNote) => {
           // return if it is a self-referential link or there's already an outward link for this set of nodes
@@ -373,7 +375,7 @@ function getOutwardLinkedConnections({
   noteVaultClass,
   linkedEdgesMap,
 }: {
-  note: NoteProps;
+  note: NotePropsMeta;
   vaults: DVault[] | undefined;
   notes: NotePropsByIdDict;
   fNameDict: NotePropsByFnameDict;

--- a/packages/nextjs-template/.gitignore
+++ b/packages/nextjs-template/.gitignore
@@ -50,4 +50,3 @@ custom/*
 !custom/NoOp.tsx
 builds
 test-results/
-tests/

--- a/packages/nextjs-template/.gitignore
+++ b/packages/nextjs-template/.gitignore
@@ -49,3 +49,5 @@ dist
 custom/*
 !custom/NoOp.tsx
 builds
+test-results/
+tests/

--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -124,7 +124,7 @@ export default function Note({
               <DendronNoteGiscusWidget note={note} config={config} />
             </Col>
             <Col xs={0} md={6}>
-              <DendronTOC note={note} offsetTop={HEADER.HEIGHT} />
+              <DendronTOC note={note} />
             </Col>
           </Row>
         </Col>

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -48,16 +48,16 @@ function DebouncedDendronSearchComponent(props: DendronCommonProps) {
   // gets fresh results.
   const debouncedSearch: SearchFunction | undefined = fuse
     ? _.debounce<SearchFunction>((query, setResults) => {
-      if (_.isUndefined(query)) {
-        return;
-      }
+        if (_.isUndefined(query)) {
+          return;
+        }
 
-      const fuseResults = fuse
-        .search(query.substring(1))
-        .slice(0, MAX_SEARCH_RESULTS);
+        const fuseResults = fuse
+          .search(query.substring(1))
+          .slice(0, MAX_SEARCH_RESULTS);
 
-      setResults(fuseResults);
-    }, SEARCH_DELAY)
+        setResults(fuseResults);
+      }, SEARCH_DELAY)
     : undefined;
   return (
     <DendronSearchComponent {...props} {...results} search={debouncedSearch} />
@@ -363,20 +363,20 @@ const highlight: (
   indices?: Fuse.FuseResultMatch["indices"],
   value?: string
 ) => {
-    const pair = indices?.[indices.length - i];
+  const pair = indices?.[indices.length - i];
 
-    return !pair ? (
-      <>{value}</>
-    ) : (
-      <>
-        {highlight(i + 1, indices, value?.substring(0, pair[0]))}
-        <span style={{ fontWeight: "bolder" }}>
-          {value?.substring(pair[0], pair[1] + 1)}
-        </span>
-        {value?.substring(pair[1] + 1)}
-      </>
-    );
-  };
+  return !pair ? (
+    <>{value}</>
+  ) : (
+    <>
+      {highlight(i + 1, indices, value?.substring(0, pair[0]))}
+      <span style={{ fontWeight: "bolder" }}>
+        {value?.substring(pair[0], pair[1] + 1)}
+      </span>
+      {value?.substring(pair[1] + 1)}
+    </>
+  );
+};
 
 const TitleHighlight = ({
   hit,


### PR DESCRIPTION
## chore: fixing build errors

Fixing a few build errors related to refactoring changes:
- useGraphElements.tsx build error 
- type error in `DendronNotePage.tsx`
- Adding back `fetchRootResults` and its dependencies (@tma66 it's still needed in published site)

If you also include @namjul 's change here https://github.com/dendronhq/dendron/pull/3561, then the playwright tests will pass now.