### PR TITLE
enhance(publish): make search mode as default for search bar in published site

### DIFF
--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -1192,7 +1192,7 @@
             }
           ]
         },
-        "searchDefaultBehavior": {
+        "searchMode": {
           "$ref": "#/definitions/SearchMode"
         }
       },

--- a/packages/common-all/data/dendron-yml.validator.json
+++ b/packages/common-all/data/dendron-yml.validator.json
@@ -1191,6 +1191,9 @@
               "const": false
             }
           ]
+        },
+        "searchDefaultBehavior": {
+          "$ref": "#/definitions/SearchMode"
         }
       },
       "required": [
@@ -1493,6 +1496,13 @@
         "mapping"
       ],
       "additionalProperties": false
+    },
+    "SearchMode": {
+      "type": "string",
+      "enum": [
+        "search",
+        "lookup"
+      ]
     }
   }
 }

--- a/packages/common-all/src/constants/configs/publishing.ts
+++ b/packages/common-all/src/constants/configs/publishing.ts
@@ -279,7 +279,7 @@ export const PUBLISHING: DendronConfigEntryCollection<DendronPublishingConfig> =
       desc: "Define custom sidebar",
       value: undefined,
     },
-    searchDefaultBehavior: {
+    searchMode: {
       label: "Default search mode for publishing",
       desc: "Default behavior of search bar in published site",
     },

--- a/packages/common-all/src/constants/configs/publishing.ts
+++ b/packages/common-all/src/constants/configs/publishing.ts
@@ -279,4 +279,8 @@ export const PUBLISHING: DendronConfigEntryCollection<DendronPublishingConfig> =
       desc: "Define custom sidebar",
       value: undefined,
     },
+    searchDefaultBehavior: {
+      label: "Default search mode for publishing",
+      desc: "Default behavior of search bar in published site",
+    },
   };

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -871,6 +871,9 @@ export class NoteUtils {
     return URI.file(this.getFullPath({ note, wsRoot }));
   }
 
+  static getRoots(notes: NotePropsByIdDict): NoteProps[] {
+    return _.filter(_.values(notes), DNodeUtils.isRoot);
+  }
   /**
    * Get a list that has all the parents of the current note with the current note
    */

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -870,10 +870,6 @@ export class NoteUtils {
   }): URI {
     return URI.file(this.getFullPath({ note, wsRoot }));
   }
-
-  static getRoots(notes: NotePropsByIdDict): NoteProps[] {
-    return _.filter(_.values(notes), DNodeUtils.isRoot);
-  }
   /**
    * Get a list that has all the parents of the current note with the current note
    */

--- a/packages/common-all/src/types/configs/publishing/publishing.ts
+++ b/packages/common-all/src/types/configs/publishing/publishing.ts
@@ -56,7 +56,7 @@ export type DendronPublishingConfig = {
   siteBanner?: string;
   giscus?: GiscusConfig;
   sidebarPath?: string | false;
-  searchDefaultBehavior?: SearchMode;
+  searchMode?: SearchMode;
 };
 
 export type CleanDendronPublishingConfig = DendronPublishingConfig &
@@ -115,6 +115,6 @@ export function genDefaultPublishingConfig(): DendronPublishingConfig {
     enableRandomlyColoredTags: true,
     enableTaskNotes: true,
     enablePrettyLinks: true,
-    searchDefaultBehavior: SearchMode.SEARCH,
+    searchMode: SearchMode.SEARCH,
   };
 }

--- a/packages/common-all/src/types/configs/publishing/publishing.ts
+++ b/packages/common-all/src/types/configs/publishing/publishing.ts
@@ -9,6 +9,11 @@ export enum Theme {
   CUSTOM = "custom",
 }
 
+export enum SearchMode {
+  SEARCH = "search",
+  LOOKUP = "lookup",
+}
+
 /**
  * Namespace for all publishing related configurations
  */
@@ -51,6 +56,7 @@ export type DendronPublishingConfig = {
   siteBanner?: string;
   giscus?: GiscusConfig;
   sidebarPath?: string | false;
+  searchDefaultBehavior?: SearchMode;
 };
 
 export type CleanDendronPublishingConfig = DendronPublishingConfig &
@@ -109,5 +115,6 @@ export function genDefaultPublishingConfig(): DendronPublishingConfig {
     enableRandomlyColoredTags: true,
     enableTaskNotes: true,
     enablePrettyLinks: true,
+    searchDefaultBehavior: SearchMode.SEARCH,
   };
 }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -961,11 +961,9 @@ export class ConfigUtils {
     return config.version;
   }
 
-  static getSearchDefaultBehavior(
-    config: IntermediateDendronConfig
-  ): SearchMode {
+  static getSearchMode(config: IntermediateDendronConfig): SearchMode {
     const isConfigV4 = configIsV4(config);
-    const defaultMode = ConfigUtils.getPublishing(config).searchDefaultBehavior;
+    const defaultMode = ConfigUtils.getPublishing(config).searchModes;
     if (!isConfigV4 && defaultMode) {
       return defaultMode;
     }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -23,6 +23,7 @@ import {
   DuplicateNoteBehavior,
   genDefaultPublishingConfig,
   HierarchyConfig,
+  SearchMode,
 } from "../types/configs/publishing/publishing";
 import { TaskConfig } from "../types/configs/workspace/task";
 import {
@@ -960,6 +961,16 @@ export class ConfigUtils {
     return config.version;
   }
 
+  static getSearchDefaultBehavior(
+    config: IntermediateDendronConfig
+  ): SearchMode {
+    const isConfigV4 = configIsV4(config);
+    const defaultMode = ConfigUtils.getPublishing(config).searchDefaultBehavior;
+    if (!isConfigV4 && defaultMode) {
+      return defaultMode;
+    }
+    return SearchMode.SEARCH;
+  }
   // set
   static setProp<K extends keyof StrictConfigV4>(
     config: IntermediateDendronConfig,

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -963,7 +963,7 @@ export class ConfigUtils {
 
   static getSearchMode(config: IntermediateDendronConfig): SearchMode {
     const isConfigV4 = configIsV4(config);
-    const defaultMode = ConfigUtils.getPublishing(config).searchModes;
+    const defaultMode = ConfigUtils.getPublishing(config).searchMode;
     if (!isConfigV4 && defaultMode) {
       return defaultMode;
     }

--- a/packages/common-all/src/utils/lookup.ts
+++ b/packages/common-all/src/utils/lookup.ts
@@ -82,7 +82,6 @@ export class NoteLookupUtils {
     const childrenOfRootNotes = _.map(childrenOfRoot, (ent) => notes[ent]);
     return roots.concat(childrenOfRootNotes);
   };
-
   /**
    * The core of Dendron lookup logic
    */

--- a/packages/dendron-plugin-views/src/utils/dendronConfig.ts
+++ b/packages/dendron-plugin-views/src/utils/dendronConfig.ts
@@ -374,7 +374,7 @@ export const dendronConfig: { [key: string]: Config } = {
     type: "object",
     group: "publishing",
   },
-  "publishing.searchDefaultBehavior": {
+  "publishing.searchMode": {
     type: "select",
     enum: [SearchMode.LOOKUP, SearchMode.SEARCH],
     group: "publishing",

--- a/packages/dendron-plugin-views/src/utils/dendronConfig.ts
+++ b/packages/dendron-plugin-views/src/utils/dendronConfig.ts
@@ -1,3 +1,5 @@
+import { SearchMode } from "@dendronhq/common-all";
+
 export type Config = {
   type: string;
   group: string;
@@ -370,6 +372,11 @@ export const dendronConfig: { [key: string]: Config } = {
   },
   "publishing.hierarchy": {
     type: "object",
+    group: "publishing",
+  },
+  "publishing.searchDefaultBehavior": {
+    type: "select",
+    enum: [SearchMode.LOOKUP, SearchMode.SEARCH],
     group: "publishing",
   },
   "publishing.sidebarPath": {

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -125,7 +125,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -281,7 +281,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -419,7 +419,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
 "
 `;
 
@@ -529,7 +529,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -656,7 +656,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -419,6 +419,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
 "
 `;
 

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -125,6 +125,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -280,6 +281,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -526,6 +528,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -652,6 +655,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -119,6 +119,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -274,6 +275,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -520,6 +522,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -646,6 +649,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -780,6 +784,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -899,6 +904,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
     duplicateNoteBehavior:
         action: useVault
         payload:

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -413,6 +413,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
+    searchDefaultBehavior: search
 "
 `;
 

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -119,7 +119,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -275,7 +275,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -413,7 +413,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
 "
 `;
 
@@ -523,7 +523,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -650,7 +650,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -785,7 +785,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -905,7 +905,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchDefaultBehavior: search
+    searchMode: search
     duplicateNoteBehavior:
         action: useVault
         payload:

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -78,7 +78,7 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
 
   const engine = useEngineAppSelector((state) => state.engine);
   const defaultSearchMode = engine.config
-    ? ConfigUtils.getSearchDefaultBehavior(engine.config)
+    ? ConfigUtils.getSearchMode(engine.config)
     : SearchMode.SEARCH;
   const [searchResults, setSearchResults] =
     React.useState<SearchResults>(undefined);
@@ -253,7 +253,10 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
       );
     });
   }
-
+  const placeholder =
+    searchMode === SearchMode.SEARCH
+      ? "For lookup please use the '/' prefix. e.g. /root"
+      : "For full text search please use the '?' prefix. e.g. ? Onboarding";
   return (
     <AutoComplete
       size="large"
@@ -268,7 +271,7 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
       }
       // @ts-ignore
       onSelect={onSelect}
-      placeholder="For full text search please use the '?' prefix. e.g. ? Onboarding"
+      placeholder={placeholder}
     >
       {autocompleteChildren}
     </AutoComplete>

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -1,7 +1,9 @@
 import {
+  ConfigUtils,
   NoteIndexProps,
   NoteLookupUtils,
   NoteProps,
+  SearchMode,
 } from "@dendronhq/common-all";
 import { LoadingStatus } from "@dendronhq/common-frontend";
 import { AutoComplete, Alert, Row, Col, Typography } from "antd";
@@ -15,6 +17,7 @@ import DendronSpinner from "./DendronSpinner";
 import { useDendronLookup, useNoteActive, useNoteBodies } from "../utils/hooks";
 import FileTextOutlined from "@ant-design/icons/lib/icons/FileTextOutlined";
 import _ from "lodash";
+import { useEngineAppSelector } from "../features/engine/hooks";
 
 /** For notes where nothing in the note body matches, only show this many characters for the note body snippet. */
 const MAX_NOTE_SNIPPET_LENGTH = 30;
@@ -51,9 +54,9 @@ function DebouncedDendronSearchComponent(props: DendronCommonProps) {
         if (_.isUndefined(query)) {
           return;
         }
-
+        const searchQuery = query.startsWith("?") ? query.substring(1) : query;
         const fuseResults = fuse
-          .search(query.substring(1))
+          .search(searchQuery)
           .slice(0, MAX_SEARCH_RESULTS);
 
         setResults(fuseResults);
@@ -70,20 +73,21 @@ type SearchProps = Omit<ReturnType<typeof useFetchFuse>, "fuse"> & {
   search: SearchFunction | undefined;
 };
 
-enum SearchMode {
-  LOOKUP_MODE = "lookupMode",
-  SEARCH_MODE = "searchMode",
-}
-
 function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
   const { noteIndex, dendronRouter, search, error, loading, notes } = props;
 
+  const engine = useEngineAppSelector((state) => state.engine);
+  const defaultSearchMode = engine.config
+    ? ConfigUtils.getSearchDefaultBehavior(engine.config)
+    : SearchMode.SEARCH;
   const [searchResults, setSearchResults] =
     React.useState<SearchResults>(undefined);
   const [lookupResults, setLookupResults] = React.useState<NoteIndexProps[]>(
     []
   );
-  const [results, setResults] = React.useState<SearchMode>();
+  const [searchMode, setSearchMode] =
+    React.useState<SearchMode>(defaultSearchMode);
+
   const dispatch = useCombinedDispatch();
   const { noteBodies, requestNotes } = useNoteBodies();
   const lookup = useDendronLookup(props.notes);
@@ -103,21 +107,24 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
 
   useEffect(() => {
     if (searchQueryValue?.startsWith("?")) {
-      setResults(SearchMode.SEARCH_MODE);
+      setSearchMode(SearchMode.SEARCH);
+    } else if (searchQueryValue?.startsWith("/")) {
+      setSearchMode(SearchMode.LOOKUP);
     } else {
-      setResults(SearchMode.LOOKUP_MODE);
+      setSearchMode(defaultSearchMode);
     }
   }, [searchQueryValue]);
 
   const onLookup = useCallback(
-    (qs: string) => {
+    async (qs: string) => {
       if (_.isUndefined(qs) || !notes || !verifyNoteData({ notes })) {
         return;
       }
+      const lookupQuery = qs.startsWith("/") ? qs.substring(1) : qs;
       const out =
         qs === ""
-          ? NoteLookupUtils.fetchRootResults(notes)
-          : lookup?.queryNote({ qs, originalQS: qs });
+          ? await NoteLookupUtils.fetchRootResults(notes)
+          : lookup?.queryNote({ qs: lookupQuery, originalQS: lookupQuery });
 
       setLookupResults(_.isUndefined(out) ? [] : out);
     },
@@ -126,7 +133,7 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
 
   // This is needed to make sure the lookup results are updated when notes are fetched
   useEffect(() => {
-    if (results === SearchMode.LOOKUP_MODE) {
+    if (searchMode === SearchMode.LOOKUP) {
       onLookup(searchQueryValue);
     }
   }, [notes]); // intentionally not including searchQueryValue, so that it triggers only when notes are fetched
@@ -185,7 +192,7 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
         <DendronSpinner />
       </AutoComplete.Option>
     );
-  } else if (results === SearchMode.SEARCH_MODE) {
+  } else if (searchMode === SearchMode.SEARCH) {
     autocompleteChildren = searchResults?.map(({ item: note, matches }) => {
       return (
         <AutoComplete.Option key={note.id} value={note.fname}>
@@ -255,9 +262,9 @@ function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
       value={searchQueryValue}
       getPopupContainer={(trigger) => trigger.parentElement}
       // @ts-ignore
-      onClick={results === SearchMode.SEARCH_MODE ? () => null : onClickLookup}
+      onClick={searchMode === SearchMode.SEARCH ? () => null : onClickLookup}
       onChange={
-        results === SearchMode.SEARCH_MODE ? onChangeSearch : onChangeLookup
+        searchMode === SearchMode.SEARCH ? onChangeSearch : onChangeLookup
       }
       // @ts-ignore
       onSelect={onSelect}

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -3,6 +3,7 @@ import {
   InsertNoteLinkAliasModeEnum,
   LegacyLookupSelectionType,
   NoteAddBehaviorEnum,
+  SearchMode,
   StrictConfigV5,
 } from "@dendronhq/common-all";
 
@@ -117,6 +118,7 @@ export class WorkspaceTestUtils {
         siteHierarchies: ["root"],
         writeStubs: false,
         siteRootDir: "docs",
+        searchDefaultBehavior: SearchMode.SEARCH,
         seo: {
           title: "Dendron",
           description: "Personal Knowledge Space",

--- a/packages/plugin-core/src/test/utils/workspace.ts
+++ b/packages/plugin-core/src/test/utils/workspace.ts
@@ -118,7 +118,7 @@ export class WorkspaceTestUtils {
         siteHierarchies: ["root"],
         writeStubs: false,
         siteRootDir: "docs",
-        searchDefaultBehavior: SearchMode.SEARCH,
+        searchMode: SearchMode.SEARCH,
         seo: {
           title: "Dendron",
           description: "Personal Knowledge Space",


### PR DESCRIPTION
This PR aims to make search as default mode in a published site. It also adds a config option `searchDefaultBehavior` which can take two values: either `search` or `lookup`.  Added back the `fetchRootResults` in `NoteLookupUtils`. This is still needed in nextjs-template
```yml
publishing:
  searchDefaultBehavior: "search|lookup"
```
- if set to `lookup`, default lookup, add a `?` to toggle search
- if set to `search`, default search, add a `/` to toggle lookup
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)