### PR TITLE
chore: remove circular deps in common all

### DIFF
--- a/hooks/pre-push.js
+++ b/hooks/pre-push.js
@@ -8,25 +8,22 @@ const path = require("path");
  * Uses madge to check for circular dependencies. Issues soft warning if
  * circular dependencies detected
  */
-function checkCircularDependencies() {
-  const CIRCULAR_DEP_THRESHOLD = 1; // Lower this each time we fix a circular dependency
-  const rootPath = exec("git rev-parse --show-toplevel").stdout;
-  const filePath = path.resolve(rootPath, "packages/plugin-core");
-  madge(filePath, {
+function checkCircularDependencies(path, threshold) {
+  madge(path, {
     fileExtensions: ["ts"],
   }).then((res) => {
     const circDepCount = res.circular().length;
     if (circDepCount === 0) {
-      console.log("No circular dependencies detected");
-    } else if (circDepCount <= CIRCULAR_DEP_THRESHOLD) {
+      console.log(`No circular dependencies detected for ${path}`);
+    } else if (circDepCount <= threshold) {
       console.log(
-        `Circular dependency count of ${circDepCount} is lower than or equal threshold of ${CIRCULAR_DEP_THRESHOLD}`
+        `Circular dependency count of ${circDepCount} is lower than or equal threshold of ${threshold} for ${path}.`
       );
     } else {
       console.error(
         `ERROR: ${
           res.circular().length
-        } circular dependencies detected in plugin-core, which exceeds the threshold of ${CIRCULAR_DEP_THRESHOLD}. Please ensure you are not introducing new circular dependencies by running the following on the commit prior to your change: \nnpm -g install madge && cd $DENDRON_REPO_ROOT/packages/plugin-core && madge --circular --extensions ts .\n\nFor more details, see https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e/#avoiding-circular-dependencies`
+        } circular dependencies detected in ${path}, which exceeds the threshold of ${threshold}. Please ensure you are not introducing new circular dependencies by running the following on the commit prior to your change: \nnpm -g install madge && cd ${path} && madge --circular --extensions ts .\n\nFor more details, see https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e/#avoiding-circular-dependencies`
       );
       process.exit(1);
     }
@@ -34,7 +31,21 @@ function checkCircularDependencies() {
 }
 
 function main() {
-  checkCircularDependencies();
+  // Lower these each time we fix a circular dependency:
+  const PLUGIN_CORE_CIRCULAR_DEP_THRESHOLD = 1;
+  const COMMON_ALL_CIRCULAR_DEP_THRESHOLD = 0;
+
+  const rootPath = exec("git rev-parse --show-toplevel").stdout;
+
+  checkCircularDependencies(
+    path.resolve(rootPath, "packages/plugin-core"),
+    PLUGIN_CORE_CIRCULAR_DEP_THRESHOLD
+  );
+
+  checkCircularDependencies(
+    path.resolve(rootPath, "packages/common-all/src"),
+    COMMON_ALL_CIRCULAR_DEP_THRESHOLD
+  );
 
   // Where we would push if we ran `git push`
   let upstream;

--- a/packages/common-all/src/FuseEngine.ts
+++ b/packages/common-all/src/FuseEngine.ts
@@ -11,7 +11,8 @@ import {
   SchemaProps,
   SchemaUtils,
 } from ".";
-import { DVault, NoteChangeEntry } from "./types";
+import { NoteChangeEntry } from "./types";
+import { DVault } from "./types/DVault";
 import { levenshteinDistance } from "./util/stringUtil";
 
 export type NoteIndexProps = {

--- a/packages/common-all/src/VaultUtilsV2.ts
+++ b/packages/common-all/src/VaultUtilsV2.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { URI, Utils } from "vscode-uri";
 import { FOLDERS } from "./constants";
-import { DVault } from "./types";
+import { DVault } from "./types/DVault";
 import { VaultUtils } from "./vault";
 
 /**

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -4,7 +4,6 @@ import * as querystring from "qs";
 import {
   BulkWriteNotesOpts,
   DNodeProps,
-  DVault,
   EngineDeleteOpts,
   EngineInfoResp,
   EngineWriteOptsV2,
@@ -20,7 +19,6 @@ import {
   DeleteSchemaResp,
   DEngineInitResp,
   EngineSchemaWriteOpts,
-  FindNoteOpts,
   FindNotesResp,
   GetDecorationsResp,
   GetNoteBlocksResp,
@@ -35,6 +33,8 @@ import {
   VSRange,
   WriteSchemaResp,
 } from "./types";
+import { DVault } from "./types/DVault";
+import { FindNoteOpts } from "./types/FindNoteOpts";
 
 // === Types
 

--- a/packages/common-all/src/constants/configs/dev.ts
+++ b/packages/common-all/src/constants/configs/dev.ts
@@ -1,5 +1,5 @@
 import { DendronConfigEntryCollection } from "../../types/configs/base";
-import { DendronDevConfig } from "../../types/configs/dev/dev";
+import { DendronDevConfig } from "../../types/configs/dev/DendronDevConfig";
 
 export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
   nextServerUrl: {
@@ -29,5 +29,9 @@ export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
   enableSelfContainedVaults: {
     label: "Enable self contained vaults",
     desc: "If enabled, Dendron will create self contained vaults. Dendron can still read self contained vaults even if this is disabled.",
+  },
+  forceWatcherType: {
+    label: "Specify the file watcher type",
+    desc: "plugin: Uses VSCode's builtin watcher, engine: Uses the engine watcher, watching the files directly without VSCode",
   },
 };

--- a/packages/common-all/src/constants/configs/workspace.ts
+++ b/packages/common-all/src/constants/configs/workspace.ts
@@ -8,7 +8,7 @@ import {
   JournalConfig,
 } from "../../types/configs/workspace/journal";
 import { TaskConfig } from "../../types/configs/workspace/task";
-import { DendronWorkspaceConfig } from "../../types/configs/workspace/workspace";
+import { DendronWorkspaceConfig } from "../../types/configs/workspace/DendronWorkspaceConfig";
 import { DendronGraphConfig } from "../../types/configs/workspace/graph";
 import { ScratchConfig } from "../../types/configs/workspace/scratch";
 import { VAULT_SYNC_MODES } from "./base";

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -23,7 +23,6 @@ import {
   DNodeProps,
   DNodePropsQuickInputV2,
   DNoteLoc,
-  DVault,
   NoteChangeEntry,
   NoteLocalConfig,
   NoteOpts,
@@ -53,6 +52,7 @@ import {
 import { genUUID } from "./uuid";
 import { VaultUtils } from "./vault";
 import { NoteDictsUtils } from "./noteDictsUtils";
+import { DVault } from "./types/DVault";
 
 export type ValidateFnameResp =
   | {

--- a/packages/common-all/src/drivers/string2Note.ts
+++ b/packages/common-all/src/drivers/string2Note.ts
@@ -2,7 +2,8 @@ import matter from "gray-matter";
 import YAML from "js-yaml";
 import _ from "lodash";
 import { DNodeUtils } from "../dnode";
-import { DNodeImplicitPropsEnum, DVault } from "../types";
+import { DNodeImplicitPropsEnum } from "../types";
+import { DVault } from "../types/DVault";
 import { genHash } from "../utils";
 
 /**

--- a/packages/common-all/src/drivers/vault2Path.ts
+++ b/packages/common-all/src/drivers/vault2Path.ts
@@ -1,5 +1,5 @@
 import { URI, Utils } from "vscode-uri";
-import { DVault } from "../types";
+import { DVault } from "../types/DVault";
 import { VaultUtils } from "../vault";
 
 /** Returns the path to where the notes are stored inside the vault.

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -6,7 +6,7 @@ import { ERROR_SEVERITY, ERROR_STATUS } from "../constants";
 import { DLogger } from "../DLogger";
 import { DNodeUtils, NoteUtils } from "../dnode";
 import { DendronCompositeError, DendronError } from "../error";
-import { FuseEngine } from "../fuse";
+import { FuseEngine } from "../FuseEngine";
 import { INoteStore } from "../store";
 import {
   BulkGetNoteMetaResp,
@@ -16,7 +16,6 @@ import {
   DeleteNoteResp,
   EngineDeleteOpts,
   EngineWriteOptsV2,
-  FindNoteOpts,
   FindNotesMetaResp,
   FindNotesResp,
   GetNoteResp,
@@ -32,8 +31,9 @@ import {
   WriteNoteResp,
   GetNoteMetaResp,
   DLink,
-  DVault,
 } from "../types";
+import { DVault } from "../types/DVault";
+import { FindNoteOpts } from "../types/FindNoteOpts";
 import { isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
 

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -20,7 +20,7 @@ export * from "./user";
 export * from "./analytics";
 export * from "./types";
 export * from "./themes";
-export * from "./fuse";
+export * from "./FuseEngine";
 export * from "./util";
 export * from "./timing";
 export * from "./config";

--- a/packages/common-all/src/noteDictsUtils.ts
+++ b/packages/common-all/src/noteDictsUtils.ts
@@ -2,11 +2,11 @@ import _ from "lodash";
 import {
   NotePropsByIdDict,
   NotePropsByFnameDict,
-  DVault,
   NoteProps,
   NoteDicts,
   NotePropsMeta,
 } from "./types";
+import { DVault } from "./types/DVault";
 import { cleanName, isNotUndefined } from "./utils";
 import { VaultUtils } from "./vault";
 

--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -1,12 +1,12 @@
 import {
   DNoteLoc,
-  FindNoteOpts,
   NoteProps,
   NotePropsMeta,
   RespV3,
   WriteNoteMetaOpts,
   WriteNoteOpts,
 } from "../types";
+import { FindNoteOpts } from "../types/FindNoteOpts";
 
 /**
  * Interface responsible for interacting with NoteProps storage layer

--- a/packages/common-all/src/store/NoteMetadataStore.ts
+++ b/packages/common-all/src/store/NoteMetadataStore.ts
@@ -2,12 +2,8 @@ import _ from "lodash";
 import { ERROR_STATUS, ERROR_SEVERITY } from "../constants";
 import { DendronError } from "../error";
 import { NoteFnameDictUtils } from "../noteDictsUtils";
-import {
-  NotePropsMeta,
-  NotePropsByFnameDict,
-  RespV3,
-  FindNoteOpts,
-} from "../types";
+import { NotePropsMeta, NotePropsByFnameDict, RespV3 } from "../types";
+import { FindNoteOpts } from "../types/FindNoteOpts";
 import { cleanName, isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
 import { IDataStore } from "./IDataStore";

--- a/packages/common-all/src/store/NoteStore.ts
+++ b/packages/common-all/src/store/NoteStore.ts
@@ -6,13 +6,13 @@ import { DendronError } from "../error";
 import {
   Disposable,
   DNoteLoc,
-  FindNoteOpts,
   NoteProps,
   NotePropsMeta,
   RespV3,
   WriteNoteMetaOpts,
   WriteNoteOpts,
 } from "../types";
+import { FindNoteOpts } from "../types/FindNoteOpts";
 import { genHash, isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
 import { IDataStore } from "./IDataStore";

--- a/packages/common-all/src/types/DVault.ts
+++ b/packages/common-all/src/types/DVault.ts
@@ -1,0 +1,65 @@
+import { RemoteEndpoint } from "./RemoteEndpoint";
+
+export type DPermission = {
+  read: string[];
+  write: string[];
+};
+
+export enum DVaultVisibility {
+  PRIVATE = "private",
+}
+
+export enum DVaultSync {
+  SKIP = "skip",
+  NO_PUSH = "noPush",
+  NO_COMMIT = "noCommit",
+  SYNC = "sync",
+}
+
+export type DVault = {
+  /** Name of vault */
+  name?: string;
+  visibility?: DVaultVisibility;
+  /** Filesystem path to vault */
+  fsPath: string;
+  /**
+   * Indicate the workspace that this vault is part of
+   */
+  workspace?: string;
+  remote?: RemoteEndpoint;
+  // TODO
+  userPermission?: DPermission;
+  /**
+   * If this is enabled, don't apply workspace push commands
+   */
+  noAutoPush?: boolean;
+  /**
+   * How the vault should be handled when using "add and commit" and "sync" commands.
+   *
+   * Options are:
+   * * skip: Skip them entirely. You must manage the repository manually.
+   * * noPush: Commit any changes and pull updates, but don't push. You can watch the repository and make local changes without sharing them back.
+   * * noCommit: Pull and push updates if the workspace is clean, but don't commit. You manually commit your local changes, but automatically share them once you committed.
+   * * sync: Commit changes, and pull and push updates. Treats workspace vaults like regular vaults.
+   *
+   * This setting overrides the `workspaceVaultSync` setting for the vault, even if the vault is a workspace vault.
+   *
+   * Defaults to `sync`.
+   */
+  sync?: DVaultSync;
+  /**
+   * Id of a seed this vault belongs to
+   */
+  seed?: string;
+  /** Marks the vault as a self-contained vault. This is (hopefully) temporary until we eventually drop support for non-self contained vaults. */
+  selfContained?: boolean;
+  /**
+   * Published URL endpoint for the vault.
+   * When wikilinks are exported from this vault, they will be converted with url defined here
+   */
+  siteUrl?: string;
+  /**
+   * Index page for the vault
+   */
+  siteIndex?: string;
+};

--- a/packages/common-all/src/types/DWorkspace.ts
+++ b/packages/common-all/src/types/DWorkspace.ts
@@ -1,0 +1,10 @@
+import { DVault } from "./DVault";
+import { RemoteEndpoint } from "./RemoteEndpoint";
+
+export type DWorkspace = {
+  name: string;
+  vaults: DVault[];
+  remote: RemoteEndpoint;
+};
+
+export type DWorkspaceEntry = Omit<DWorkspace, "name" | "vaults">;

--- a/packages/common-all/src/types/DWorkspaceV2.ts
+++ b/packages/common-all/src/types/DWorkspaceV2.ts
@@ -1,0 +1,38 @@
+import { URI } from "vscode-uri";
+import { DEngineClient } from "./typesv2";
+import { IntermediateDendronConfig } from "./intermediateConfigs";
+import { DVault } from "./DVault";
+
+export enum WorkspaceType {
+  NATIVE = "NATIVE",
+  CODE = "CODE",
+  NONE = "NONE",
+}
+
+export type DWorkspaceV2 = {
+  /**
+   * Absolute path to the workspace directory
+   */
+  wsRoot: string;
+  type: WorkspaceType;
+  config: IntermediateDendronConfig;
+  vaults: DVault[];
+  engine: DEngineClient;
+  /**
+   * Where are assets stored (eg. tutorial workspace)
+   */
+  assetUri: URI;
+  /**
+   * Log storage
+   */
+  logUri: URI;
+};
+
+/**
+ * Extension Install Status
+ */
+export enum InstallStatus {
+  NO_CHANGE = "NO_CHANGE",
+  INITIAL_INSTALL = "INITIAL_INSTALL",
+  UPGRADED = "UPGRADED",
+}

--- a/packages/common-all/src/types/DendronWorkspace.ts
+++ b/packages/common-all/src/types/DendronWorkspace.ts
@@ -1,0 +1,8 @@
+import { DVault } from "./DVault";
+import { RemoteEndpoint } from "./RemoteEndpoint";
+
+export type DendronWorkspace = {
+  name: string;
+  vaults: DVault[];
+  remote: RemoteEndpoint;
+};

--- a/packages/common-all/src/types/DendronWorkspaceEntry.ts
+++ b/packages/common-all/src/types/DendronWorkspaceEntry.ts
@@ -1,0 +1,3 @@
+import { DendronWorkspace } from "./DendronWorkspace";
+
+export type DendronWorkspaceEntry = Omit<DendronWorkspace, "name" | "vaults">;

--- a/packages/common-all/src/types/FindNoteOpts.ts
+++ b/packages/common-all/src/types/FindNoteOpts.ts
@@ -1,0 +1,17 @@
+import { DVault } from "./DVault";
+
+/**
+ * Properties used to find notes by. If multiple properties are provided, then returned notes
+ * must satisfy all constraints.
+ *
+ * For example, if fname = "foo" and vault = "vaultOne", then only notes with fname "foo" in vault "vaultOne" are returned
+ */
+export type FindNoteOpts = {
+  // Find notes by fname
+  fname?: string;
+  // If vault is provided, filter results so that only notes with matching vault is returned
+  vault?: DVault;
+  // If true, exclude stubs from results. Otherwise, include stub notes
+  // WARNING: If false and no other parameters are set, this will return all notes in the engine
+  excludeStub?: boolean;
+};

--- a/packages/common-all/src/types/RemoteEndpoint.ts
+++ b/packages/common-all/src/types/RemoteEndpoint.ts
@@ -1,0 +1,4 @@
+export type RemoteEndpoint = {
+  type: "git";
+  url: string;
+};

--- a/packages/common-all/src/types/SeedEntry.ts
+++ b/packages/common-all/src/types/SeedEntry.ts
@@ -1,0 +1,12 @@
+import { SeedSite } from "./seed";
+
+export type SeedEntry = {
+  /**
+   * Specific branch to pull from
+   */
+  branch?: string;
+  /**
+   * When in this seed, what url to use
+   */
+  site?: SeedSite;
+};

--- a/packages/common-all/src/types/configs/dendronConfig.ts
+++ b/packages/common-all/src/types/configs/dendronConfig.ts
@@ -5,7 +5,7 @@ import {
 import {
   DendronWorkspaceConfig,
   genDefaultWorkspaceConfig,
-} from "./workspace/workspace";
+} from "./workspace/DendronWorkspaceConfig";
 import {
   DendronPreviewConfig,
   genDefaultPreviewConfig,
@@ -15,7 +15,7 @@ import {
   genDefaultPublishingConfig,
 } from "./publishing/publishing";
 import { DendronGlobalConfig, genDefaultGlobalConfig } from "./global/global";
-import { DendronDevConfig, genDefaultDevConfig } from "./dev/dev";
+import { DendronDevConfig, genDefaultDevConfig } from "./dev/DendronDevConfig";
 
 /**
  * DendronConfig

--- a/packages/common-all/src/types/configs/dendronConfigLegacy.ts
+++ b/packages/common-all/src/types/configs/dendronConfigLegacy.ts
@@ -1,184 +1,8 @@
-import { URI } from "vscode-uri";
-import { DHookDict } from "./hooks";
-import { SeedSite } from "./seed";
-import { DEngineClient } from "./typesv2";
-import { IntermediateDendronConfig } from "./intermediateConfigs";
-
-// === Primitives
-export type DPermission = {
-  read: string[];
-  write: string[];
-};
-
-// === Vaults
-export type RemoteEndpoint = {
-  type: "git";
-  url: string;
-};
-export enum DVaultVisibility {
-  PRIVATE = "private",
-}
-
-export enum DVaultSync {
-  SKIP = "skip",
-  NO_PUSH = "noPush",
-  NO_COMMIT = "noCommit",
-  SYNC = "sync",
-}
-
-export type DVault = {
-  /** Name of vault */
-  name?: string;
-  visibility?: DVaultVisibility;
-  /** Filesystem path to vault */
-  fsPath: string;
-  /**
-   * Indicate the workspace that this vault is part of
-   */
-  workspace?: string;
-  remote?: RemoteEndpoint;
-  // TODO
-  userPermission?: DPermission;
-  /**
-   * If this is enabled, don't apply workspace push commands
-   */
-  noAutoPush?: boolean;
-  /**
-   * How the vault should be handled when using "add and commit" and "sync" commands.
-   *
-   * Options are:
-   * * skip: Skip them entirely. You must manage the repository manually.
-   * * noPush: Commit any changes and pull updates, but don't push. You can watch the repository and make local changes without sharing them back.
-   * * noCommit: Pull and push updates if the workspace is clean, but don't commit. You manually commit your local changes, but automatically share them once you committed.
-   * * sync: Commit changes, and pull and push updates. Treats workspace vaults like regular vaults.
-   *
-   * This setting overrides the `workspaceVaultSync` setting for the vault, even if the vault is a workspace vault.
-   *
-   * Defaults to `sync`.
-   */
-  sync?: DVaultSync;
-  /**
-   * Id of a seed this vault belongs to
-   */
-  seed?: string;
-  /** Marks the vault as a self-contained vault. This is (hopefully) temporary until we eventually drop support for non-self contained vaults. */
-  selfContained?: boolean;
-  /**
-   * Published URL endpoint for the vault.
-   * When wikilinks are exported from this vault, they will be converted with url defined here
-   */
-  siteUrl?: string;
-  /**
-   * Index page for the vault
-   */
-  siteIndex?: string;
-};
-
-export type DWorkspace = {
-  name: string;
-  vaults: DVault[];
-  remote: RemoteEndpoint;
-};
-
-export type DWorkspaceEntry = Omit<DWorkspace, "name" | "vaults">;
-
-export enum WorkspaceType {
-  NATIVE = "NATIVE",
-  CODE = "CODE",
-  NONE = "NONE",
-}
-
-export type DWorkspaceV2 = {
-  /**
-   * Absolute path to the workspace directory
-   */
-  wsRoot: string;
-  type: WorkspaceType;
-  config: IntermediateDendronConfig;
-  vaults: DVault[];
-  engine: DEngineClient;
-  /**
-   * Where are assets stored (eg. tutorial workspace)
-   */
-  assetUri: URI;
-  /**
-   * Log storage
-   */
-  logUri: URI;
-};
-
-export type SeedEntry = {
-  /**
-   * Specific branch to pull from
-   */
-  branch?: string;
-  /**
-   * When in this seed, what url to use
-   */
-  site?: SeedSite;
-};
-
-/**
- * Extension Install Status
- */
-export enum InstallStatus {
-  NO_CHANGE = "NO_CHANGE",
-  INITIAL_INSTALL = "INITIAL_INSTALL",
-  UPGRADED = "UPGRADED",
-}
-
-export enum LegacyNoteAddBehavior {
-  "childOfDomain" = "childOfDomain",
-  "childOfDomainNamespace" = "childOfDomainNamespace",
-  "childOfCurrent" = "childOfCurrent",
-  "asOwnDomain" = "asOwnDomain",
-}
-
-export enum LegacyLookupSelectionType {
-  "selection2link" = "selection2link",
-  "selectionExtract" = "selectionExtract",
-  "none" = "none",
-}
-
-export type LegacyNoteLookupConfig = {
-  selectionType: LegacyLookupSelectionType;
-  leaveTrace: boolean;
-};
-
-export type LegacyLookupConfig = {
-  note: LegacyNoteLookupConfig;
-};
-
-export enum LegacyInsertNoteLinkAliasMode {
-  "snippet" = "snippet",
-  "selection" = "selection",
-  "title" = "title",
-  "prompt" = "prompt",
-  "none" = "none",
-}
-
-export type LegacyInsertNoteLinkConfig = {
-  aliasMode: LegacyInsertNoteLinkAliasMode;
-  multiSelect: boolean;
-};
-
-export type LegacyJournalConfig = {
-  dailyDomain: string;
-  /**
-   * If set, add all daily journals to specified vault
-   */
-  dailyVault?: string;
-  name: string;
-  dateFormat: string;
-  addBehavior: LegacyNoteAddBehavior;
-  /** 0 is Sunday, 1 is Monday, ... */
-  firstDayOfWeek: number;
-};
-
-export type LegacyScratchConfig = Pick<
-  LegacyJournalConfig,
-  "name" | "dateFormat" | "addBehavior"
->;
+import { DVault, DVaultSync } from "../DVault";
+import { DHookDict } from "../hooks";
+import { SeedEntry } from "../SeedEntry";
+import { DendronWorkspaceEntry } from "../DendronWorkspaceEntry";
+import { DendronDevConfig } from "./dev/DendronDevConfig";
 
 export type DendronConfig = {
   /**
@@ -223,7 +47,7 @@ export type DendronConfig = {
   /**
    * Workspaces
    */
-  workspaces?: { [key: string]: DWorkspaceEntry | undefined };
+  workspaces?: { [key: string]: DendronWorkspaceEntry | undefined };
   seeds?: { [key: string]: SeedEntry | undefined };
   /**
    * Dendron vaults in workspace.
@@ -375,6 +199,59 @@ export type DendronConfig = {
   noRandomlyColoredTags?: boolean;
 };
 
+export enum LegacyNoteAddBehavior {
+  "childOfDomain" = "childOfDomain",
+  "childOfDomainNamespace" = "childOfDomainNamespace",
+  "childOfCurrent" = "childOfCurrent",
+  "asOwnDomain" = "asOwnDomain",
+}
+
+export enum LegacyLookupSelectionType {
+  "selection2link" = "selection2link",
+  "selectionExtract" = "selectionExtract",
+  "none" = "none",
+}
+
+export type LegacyNoteLookupConfig = {
+  selectionType: LegacyLookupSelectionType;
+  leaveTrace: boolean;
+};
+
+export type LegacyLookupConfig = {
+  note: LegacyNoteLookupConfig;
+};
+
+export enum LegacyInsertNoteLinkAliasMode {
+  "snippet" = "snippet",
+  "selection" = "selection",
+  "title" = "title",
+  "prompt" = "prompt",
+  "none" = "none",
+}
+
+export type LegacyInsertNoteLinkConfig = {
+  aliasMode: LegacyInsertNoteLinkAliasMode;
+  multiSelect: boolean;
+};
+
+export type LegacyJournalConfig = {
+  dailyDomain: string;
+  /**
+   * If set, add all daily journals to specified vault
+   */
+  dailyVault?: string;
+  name: string;
+  dateFormat: string;
+  addBehavior: LegacyNoteAddBehavior;
+  /** 0 is Sunday, 1 is Monday, ... */
+  firstDayOfWeek: number;
+};
+
+export type LegacyScratchConfig = Pick<
+  LegacyJournalConfig,
+  "name" | "dateFormat" | "addBehavior"
+>;
+
 export type LegacyRandomNoteConfig = {
   /**
    * Hiearchies to include
@@ -392,45 +269,6 @@ export type LegacyInsertNoteIndexConfig = {
    * Include marker when inserting note index.
    */
   marker?: boolean;
-};
-
-export type DendronDevConfig = {
-  /**
-   * Custom next server
-   */
-  nextServerUrl?: string;
-  /**
-   * Static assets for next
-   */
-  nextStaticRoot?: string;
-  /**
-   * What port to use for engine server. Default behavior is to create at startup
-   */
-  engineServerPort?: number;
-  /**
-   * Enable displaying and indexing link candidates. Default is false
-   */
-  enableLinkCandidates?: boolean;
-  /**
-   * Enable new preview as default
-   */
-  enablePreviewV2?: boolean;
-  /** Force the use of a specific type of watcher.
-   *
-   * - plugin: Uses VSCode's builtin watcher
-   * - engine: Uses the engine watcher, watching the files directly without VSCode
-   */
-  forceWatcherType?: "plugin" | "engine";
-  /**
-   * Enable export pod v2
-   */
-  enableExportPodV2?: boolean;
-  /**
-   * Sets self contained vaults as the default vault type. Dendron can read
-   * self-contained vaults even if this option is not enabled, but it will only
-   * create self contained vaults if this option is enabled.
-   */
-  enableSelfContainedVaults?: boolean;
 };
 
 export type DendronSiteConfig = {

--- a/packages/common-all/src/types/configs/dev/DendronDevConfig.ts
+++ b/packages/common-all/src/types/configs/dev/DendronDevConfig.ts
@@ -26,6 +26,12 @@ export type DendronDevConfig = {
    * Enable new preview as default
    */
   enablePreviewV2?: boolean;
+  /** Force the use of a specific type of watcher.
+   *
+   * - plugin: Uses VSCode's builtin watcher
+   * - engine: Uses the engine watcher, watching the files directly without VSCode
+   */
+  forceWatcherType?: "plugin" | "engine";
   /**
    * Enable export pod v2
    */

--- a/packages/common-all/src/types/configs/index.ts
+++ b/packages/common-all/src/types/configs/index.ts
@@ -3,4 +3,5 @@ export * from "./workspace";
 export * from "./preview";
 export * from "./global/global";
 export * from "./publishing";
-// export * from "./dev";
+export * from "./dev/DendronDevConfig";
+export * from "./dendronConfigLegacy";

--- a/packages/common-all/src/types/configs/publishing/publishing.ts
+++ b/packages/common-all/src/types/configs/publishing/publishing.ts
@@ -1,4 +1,4 @@
-import { DVault } from "../../workspace";
+import { DVault } from "../../DVault";
 import { GiscusConfig } from "./giscus";
 import { GithubConfig, genDefaultGithubConfig } from "./github";
 import { SEOConfig, genDefaultSEOConfig } from "./seo";

--- a/packages/common-all/src/types/configs/workspace/DendronWorkspaceConfig.ts
+++ b/packages/common-all/src/types/configs/workspace/DendronWorkspaceConfig.ts
@@ -1,11 +1,12 @@
-import { DVault, RemoteEndpoint } from "../../workspace";
 import { genDefaultJournalConfig, JournalConfig } from "./journal";
 import { genDefaultScratchConfig, ScratchConfig } from "./scratch";
-import { genDefaultGraphConfig, DendronGraphConfig } from "../workspace/graph";
+import { genDefaultGraphConfig, DendronGraphConfig } from "./graph";
 import { SeedSite } from "../../seed";
 import { DHookDict } from "../../hooks";
 import { VaultSyncMode, VaultSyncModeEnum } from "../base";
 import { genDefaultTaskConfig, TaskConfig } from "./task";
+import { DVault } from "../../DVault";
+import { DendronWorkspaceEntry } from "../../DendronWorkspaceEntry";
 
 /**
  * Namespace for configurations that affect the workspace
@@ -40,14 +41,6 @@ export type DendronWorkspaceConfig = {
   apiEndpoint?: string;
   metadataStore?: "sqlite" | "json";
 };
-
-export type DendronWorkspace = {
-  name: string;
-  vaults: DVault[];
-  remote: RemoteEndpoint;
-};
-
-export type DendronWorkspaceEntry = Omit<DendronWorkspace, "name" | "vaults">;
 
 export type DendronSeedEntry = {
   branch?: string;

--- a/packages/common-all/src/types/configs/workspace/index.ts
+++ b/packages/common-all/src/types/configs/workspace/index.ts
@@ -2,5 +2,5 @@ export * from "./graph";
 export * from "./journal";
 export * from "./scratch";
 export * from "./types";
-export * from "./workspace";
+export * from "./DendronWorkspaceConfig";
 export * from "./task";

--- a/packages/common-all/src/types/configs/workspace/task.ts
+++ b/packages/common-all/src/types/configs/workspace/task.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { LegacyLookupSelectionType, NoteProps, NotePropsMeta } from "../..";
+import { NoteProps, NotePropsMeta } from "../..";
+import { LegacyLookupSelectionType } from "../dendronConfigLegacy";
 import { JournalConfig } from "./journal";
 import { NoteAddBehaviorEnum } from "./types";
 

--- a/packages/common-all/src/types/errorTypes.ts
+++ b/packages/common-all/src/types/errorTypes.ts
@@ -1,8 +1,8 @@
 import { ERROR_SEVERITY } from "../constants";
 import { DendronError, DendronErrorProps, IDendronError } from "../error";
 import { VaultUtils } from "../vault";
+import { DVault } from "./DVault";
 import { NoteProps } from "./foundation";
-import { DVault } from "./workspace";
 
 /** The error codes of errors that can occur during engine init. */
 export enum EngineInitErrorType {

--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -1,7 +1,6 @@
-import { DNoteAnchorPositioned } from "./typesv2";
 import { URI } from "vscode-uri";
-import { DVault } from "./workspace";
 import { DendronGlobalConfig } from ".";
+import { DVault } from "./DVault";
 
 export interface Point {
   /**
@@ -258,4 +257,61 @@ export type SEOProps = {
   canonicalUrl?: string;
   noindex?: boolean;
   twitter?: string;
+};
+
+export type DNoteLoc = {
+  fname: string;
+  alias?: string;
+  id?: string;
+  vaultName?: string;
+  anchorHeader?: string;
+};
+
+export type DNoteAnchor =
+  | DNoteBlockAnchor
+  | DNoteHeaderAnchor
+  | DNoteLineAnchor;
+
+/**
+ * Anchor without {@link DNoteHeaderAnchor.depth} info
+ * @todo see migration [[DNoteAnchorBasic|dendron://dendron.docs/dev.changelog#dnoteanchorbasic]]
+ */
+export type DNoteAnchorBasic =
+  | DNoteBlockAnchor
+  | Omit<DNoteHeaderAnchor, "depth">
+  | DNoteLineAnchor;
+
+export type DNoteBlockAnchor = {
+  type: "block";
+  text?: string; //original text for the anchor
+  value: string;
+};
+
+/**
+ * This represents a markdown header
+ * ```md
+ * # H1
+ * ```
+ */
+export type DNoteHeaderAnchor = {
+  type: "header";
+  text?: string; //original text for the anchor
+  value: string;
+  depth: number;
+};
+
+/** An anchor referring to a specific line in a file. These don't exist inside of files, they are implied by the link containing the anchor.
+ *
+ * Lines are indexed starting at 1, which is similar to how you refer to specific lines on Github.
+ */
+export type DNoteLineAnchor = {
+  type: "line";
+  /** 1-indexed line number. */
+  line: number;
+  value: string;
+};
+
+export type DNoteAnchorPositioned = (DNoteBlockAnchor | DNoteHeaderAnchor) & {
+  line: number;
+  column: number;
 };

--- a/packages/common-all/src/types/index.ts
+++ b/packages/common-all/src/types/index.ts
@@ -7,7 +7,7 @@ export * from "./intermediateConfigs";
 export * from "./noteTrait";
 export * from "./seed";
 export * from "./typesv2";
-export * from "./workspace";
+export * from "./DWorkspaceV2";
 export * from "./foundation";
 export * from "./seed";
 export * from "./intermediateConfigs";
@@ -20,6 +20,10 @@ export * from "./cacheData";
 export * from "./errorTypes";
 export * from "./store";
 export * from "./ReducedDEngine";
+export * from "./DVault";
+export * from "./DWorkspace";
+export * from "./FindNoteOpts";
+export * from "./SeedEntry";
 
 export type Stage = "dev" | "prod" | "test";
 

--- a/packages/common-all/src/types/intermediateConfigs.ts
+++ b/packages/common-all/src/types/intermediateConfigs.ts
@@ -3,7 +3,7 @@
  * Holds part of both old and new configs
  * During the migration period.
  */
-import { DendronConfig as DendronConfigV1 } from "./workspace";
+import { DendronConfig as DendronConfigV1 } from "./configs/dendronConfigLegacy";
 import { DendronConfig as DendronConfigV2 } from "./configs/dendronConfig";
 import _ from "lodash";
 

--- a/packages/common-all/src/types/store.ts
+++ b/packages/common-all/src/types/store.ts
@@ -1,24 +1,7 @@
 import { NoteProps, NotePropsMeta } from "./foundation";
 import { SchemaModuleProps } from "./typesv2";
-import { DVault } from "./workspace";
 
 // Types used on the store layer
-
-/**
- * Properties used to find notes by. If multiple properties are provided, then returned notes
- * must satisfy all constraints.
- *
- * For example, if fname = "foo" and vault = "vaultOne", then only notes with fname "foo" in vault "vaultOne" are returned
- */
-export type FindNoteOpts = {
-  // Find notes by fname
-  fname?: string;
-  // If vault is provided, filter results so that only notes with matching vault is returned
-  vault?: DVault;
-  // If true, exclude stubs from results. Otherwise, include stub notes
-  // WARNING: If false and no other parameters are set, this will return all notes in the engine
-  excludeStub?: boolean;
-};
 
 export type WriteNoteOpts<K> = {
   key: K;

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -3,6 +3,8 @@ import { IDendronError } from "../error";
 import {
   DNodeProps,
   DNodeType,
+  DNoteAnchorPositioned,
+  DNoteLoc,
   NoteProps,
   NotePropsMeta,
   Position,
@@ -10,12 +12,12 @@ import {
   SchemaProps,
 } from "./foundation";
 import { DHookDict } from "./hooks";
-import { DVault } from "./workspace";
 import { IntermediateDendronConfig } from "./intermediateConfigs";
 import { VSRange } from "./compat";
 import { Decoration, Diagnostic } from ".";
-import { FindNoteOpts } from "./store";
 import { DendronASTDest, ProcFlavor } from "./unified";
+import { FindNoteOpts } from "./FindNoteOpts";
+import { DVault } from "./DVault";
 
 export type OptionalExceptFor<T, TRequired extends keyof T> = Partial<T> &
   Pick<T, TRequired>;
@@ -32,63 +34,6 @@ export type EngineDeleteOpts = {
 };
 
 // === New
-
-export type DNoteLoc = {
-  fname: string;
-  alias?: string;
-  id?: string;
-  vaultName?: string;
-  anchorHeader?: string;
-};
-
-export type DNoteAnchor =
-  | DNoteBlockAnchor
-  | DNoteHeaderAnchor
-  | DNoteLineAnchor;
-
-/**
- * Anchor without {@link DNoteHeaderAnchor.depth} info
- * @todo see migration [[DNoteAnchorBasic|dendron://dendron.docs/dev.changelog#dnoteanchorbasic]]
- */
-export type DNoteAnchorBasic =
-  | DNoteBlockAnchor
-  | Omit<DNoteHeaderAnchor, "depth">
-  | DNoteLineAnchor;
-
-export type DNoteBlockAnchor = {
-  type: "block";
-  text?: string; //original text for the anchor
-  value: string;
-};
-
-/**
- * This represents a markdown header
- * ```md
- * # H1
- * ```
- */
-export type DNoteHeaderAnchor = {
-  type: "header";
-  text?: string; //original text for the anchor
-  value: string;
-  depth: number;
-};
-
-/** An anchor referring to a specific line in a file. These don't exist inside of files, they are implied by the link containing the anchor.
- *
- * Lines are indexed starting at 1, which is similar to how you refer to specific lines on Github.
- */
-export type DNoteLineAnchor = {
-  type: "line";
-  /** 1-indexed line number. */
-  line: number;
-  value: string;
-};
-
-export type DNoteAnchorPositioned = (DNoteBlockAnchor | DNoteHeaderAnchor) & {
-  line: number;
-  column: number;
-};
 
 export type DLinkType = "wiki" | "refv2" | "hashtag" | "usertag" | "fmtag";
 

--- a/packages/common-all/src/user.ts
+++ b/packages/common-all/src/user.ts
@@ -1,4 +1,5 @@
-import { DendronUserSpecial, DVault } from "./types";
+import { DendronUserSpecial } from "./types";
+import { DVault } from "./types/DVault";
 
 export class DUser {
   public username: string;

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -16,15 +16,7 @@ import {
 } from "../constants";
 import { DENDRON_CONFIG } from "../constants/configs/dendronConfig";
 import { DendronError, ErrorMessages } from "../error";
-import {
-  DendronSiteConfig,
-  DHookDict,
-  DVault,
-  LegacyDuplicateNoteBehavior,
-  LegacyHierarchyConfig,
-  NoteChangeEntry,
-  NoteProps,
-} from "../types";
+import { DHookDict, NoteChangeEntry, NoteProps } from "../types";
 import { GithubConfig } from "../types/configs/publishing/github";
 import {
   DendronPublishingConfig,
@@ -52,6 +44,12 @@ import {
   StrictConfigV5,
 } from "../types/intermediateConfigs";
 import { isWebUri } from "../util/regex";
+import {
+  DendronSiteConfig,
+  LegacyDuplicateNoteBehavior,
+  LegacyHierarchyConfig,
+} from "../types/configs/dendronConfigLegacy";
+import { DVault } from "../types/DVault";
 
 export * from "./lookup";
 export * from "./publishUtils";

--- a/packages/common-all/src/utils/publishUtils.ts
+++ b/packages/common-all/src/utils/publishUtils.ts
@@ -1,15 +1,11 @@
 import path from "path";
-import {
-  DendronSiteConfig,
-  DendronSiteFM,
-  NoteProps,
-  SEOProps,
-} from "../types";
+import { ConfigUtils } from ".";
+import { DendronSiteFM, NoteProps, SEOProps } from "../types";
+import { DendronSiteConfig } from "../types/configs/dendronConfigLegacy";
 import {
   configIsV4,
   IntermediateDendronConfig,
 } from "../types/intermediateConfigs";
-import { ConfigUtils } from "./index";
 
 export class PublishUtils {
   static getPublishFM(note: NoteProps): DendronSiteFM {

--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -3,7 +3,8 @@ import path from "path";
 import { FOLDERS, normalizeUnixPath } from ".";
 import { CONSTANTS } from "./constants";
 import { DendronError } from "./error";
-import { DVault, WorkspaceFolderRaw } from "./types";
+import { WorkspaceFolderRaw } from "./types";
+import { DVault } from "./types/DVault";
 import { NonOptional } from "./utils";
 
 export type SelfContainedVault = Omit<DVault, "selfContained"> & {


### PR DESCRIPTION
## chore: remove circular deps in common all

This change removes all circular dependencies in common-all. 

When working on this change https://github.com/dendronhq/dendron/pull/3572, all the CLI tests started failing because some changes in common-all caused import resolution to fail b/c of circular dependencies in common-all. 

Functionally, the code should be exactly the same as before - all I did was move stuff around as-is.  The one exception is that I found two definitions for `DendronDevConfig` - I wasn't 100% sure which one we actually want.  @hikchoi - I left a comment in the PR itself. 

This change also introduces a new madge check for common-all in addition to the one we have in plugin-core.  I'll soon add checks for all of our packages to limit our circ deps to the current counts.

On a side note... common-all is due for a clean up.  There are duplicated types, nearly identical v1 and v2 types, and files are a bit all over the place.