### PR TITLE
chore(workspace): Migrate getNoteByFnameFromEngine to engine methods

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -929,7 +929,7 @@ export class NoteUtils {
     opts,
   }: {
     noteRaw: NoteProps;
-    noteHydrated: NoteProps;
+    noteHydrated: NotePropsMeta;
     opts?: Partial<{
       keepBackLinks: boolean;
     }>;

--- a/packages/dendron-cli/src/commands/podsV2.ts
+++ b/packages/dendron-cli/src/commands/podsV2.ts
@@ -3,7 +3,6 @@ import {
   DEngineClient,
   ERROR_SEVERITY,
   NoteProps,
-  NoteUtils,
   RespV3,
   URI,
   VaultUtils,
@@ -163,7 +162,7 @@ export async function enrichPodArgs(
       payload = await getPropsForVaultScope({ engine, vaultName: args.vault });
       break;
     case PodExportScope.Note:
-      payload = getPropsForNoteScope({
+      payload = await getPropsForNoteScope({
         engine,
         vaultName: args.vault,
         fname: args.fname,
@@ -214,11 +213,11 @@ const getPropsForVaultScope = async (opts: {
   return engine.findNotes({ excludeStub: true, vault });
 };
 
-const getPropsForNoteScope = (opts: {
+const getPropsForNoteScope = async (opts: {
   engine: DEngineClient;
   vaultName?: string;
   fname?: string;
-}): NoteProps[] => {
+}): Promise<NoteProps[]> => {
   const { engine, fname, vaultName } = opts;
   const vault = checkVaultArgs({ engine, vaultName });
 
@@ -227,7 +226,7 @@ const getPropsForNoteScope = (opts: {
       message: "Please provide fname of note in --fname arg",
     });
   }
-  const note = NoteUtils.getNoteByFnameFromEngine({ fname, vault, engine });
+  const note = (await engine.findNotes({ fname, vault }))[0];
   if (!note)
     throw new DendronError({
       message: `Cannot find note with fname ${fname} in vault ${vault}`,

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -21,6 +21,7 @@ import {
   isBlockAnchor,
   getSlugger,
   IDendronError,
+  asyncLoopOneAtATime,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -541,7 +542,7 @@ export class SiteUtils {
 
     if (_.isArray(dupBehavior.payload)) {
       const vaultNames = dupBehavior.payload;
-      _.forEach(vaultNames, (vname) => {
+      await asyncLoopOneAtATime(vaultNames, async (vname) => {
         if (domainNote) {
           return;
         }
@@ -549,11 +550,7 @@ export class SiteUtils {
           vname,
           vaults: engine.vaults,
         });
-        const maybeNote = NoteUtils.getNoteByFnameFromEngine({
-          fname,
-          engine,
-          vault,
-        });
+        const maybeNote = (await engine.findNotes({ fname, vault }))[0];
         if (maybeNote && maybeNote.stub && !allowStubs) {
           return;
         }

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -22,6 +22,7 @@ import {
   getSlugger,
   IDendronError,
   asyncLoopOneAtATime,
+  NotePropsMeta,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -42,7 +43,7 @@ const LOGGER_NAME = "SiteUtils";
  */
 export class SiteUtils {
   static canPublish(opts: {
-    note: NoteProps;
+    note: NotePropsMeta;
     config: IntermediateDendronConfig;
     engine: DEngineClient;
   }) {
@@ -412,7 +413,7 @@ export class SiteUtils {
 
   static getConfigForHierarchy(opts: {
     config: IntermediateDendronConfig;
-    noteOrName: NoteProps | string;
+    noteOrName: NotePropsMeta | string;
   }) {
     const { config, noteOrName } = opts;
     const fname = _.isString(noteOrName) ? noteOrName : noteOrName.fname;

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/utils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/utils.spec.ts
@@ -2,7 +2,6 @@ import {
   ConfigUtils,
   NoteDictsUtils,
   NoteProps,
-  NoteUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
 import {
@@ -106,14 +105,9 @@ const WITH_TITLE = createProcTests({
 const WITH_VARIABLE = createProcTests({
   name: "WITH_VARIABLE",
   setupFunc: async (opts) => {
-    const { vaults, engine } = opts;
+    const { engine } = opts;
     const proc = await createProc(opts);
-    //const npath = path.join(opts.wsRoot, opts.vaults[0].fsPath, "foo.md");
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      vault: vaults[0],
-      fname: "foo",
-      engine,
-    });
+    const note = (await engine.getNote("foo")).data!;
     return readAndProcessNote({ note: note!, proc });
   },
   verifyFuncDict: {

--- a/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/podsv2.spec.ts
@@ -1,9 +1,4 @@
-import {
-  NoteProps,
-  NoteUtils,
-  ResponseUtil,
-  Time,
-} from "@dendronhq/common-all";
+import { ResponseUtil, Time } from "@dendronhq/common-all";
 import { tmpDir } from "@dendronhq/common-server";
 import { NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { EngineUtils, openPortFile } from "@dendronhq/engine-server";
@@ -349,11 +344,12 @@ describe("GIVEN a Google Docs Export Pod with a particular config", () => {
             errors: [],
           };
           pod.createGdoc = jest.fn().mockResolvedValue(response);
-          const props = NoteUtils.getNoteByFnameFromEngine({
-            fname: "simple-wikilink",
-            vault: opts.vaults[0],
-            engine: opts.engine,
-          }) as NoteProps;
+          const props = (
+            await opts.engine.findNotes({
+              fname: "simple-wikilink",
+              vault: opts.vaults[0],
+            })
+          )[0];
 
           const result = await pod.exportNotes([props]);
           const entCreate = result.data?.created!;
@@ -412,11 +408,12 @@ describe("GIVEN a Google Docs Export Pod with a particular config", () => {
             ],
           };
           pod.createGdoc = jest.fn().mockResolvedValue(response);
-          const props = NoteUtils.getNoteByFnameFromEngine({
-            fname: "simple-wikilink",
-            vault: opts.vaults[0],
-            engine: opts.engine,
-          }) as NoteProps;
+          const props = (
+            await opts.engine.findNotes({
+              fname: "simple-wikilink",
+              vault: opts.vaults[0],
+            })
+          )[0];
 
           const result = await pod.exportNotes([props]);
           const entCreate = result.data?.created!;
@@ -459,11 +456,12 @@ describe("GIVEN a Notion Export Pod with a particular config", () => {
           const pod = new NotionExportPodV2({
             podConfig,
           });
-          const props = NoteUtils.getNoteByFnameFromEngine({
-            fname: "bar",
-            vault: opts.vaults[0],
-            engine: opts.engine,
-          }) as NoteProps;
+          const props = (
+            await opts.engine.findNotes({
+              fname: "bar",
+              vault: opts.vaults[0],
+            })
+          )[0];
           const response = {
             data: [
               {
@@ -505,11 +503,12 @@ describe("GIVEN a JSON Export Pod with a particular config", () => {
           const pod = new JSONExportPodV2({
             podConfig,
           });
-          const props = NoteUtils.getNoteByFnameFromEngine({
-            fname: "bar",
-            vault: opts.vaults[0],
-            engine: opts.engine,
-          }) as NoteProps;
+          const props = (
+            await opts.engine.findNotes({
+              fname: "bar",
+              vault: opts.vaults[0],
+            })
+          )[0];
           const result = await pod.exportNotes([props]);
           const data = result.data?.exportedNotes!;
           expect(_.isString(data)).toBeTruthy();
@@ -544,11 +543,12 @@ describe("GIVEN a JSON Export Pod with a particular config", () => {
               podConfig,
             });
 
-            const props = NoteUtils.getNoteByFnameFromEngine({
-              fname: "bar",
-              vault: opts.vaults[0],
-              engine: opts.engine,
-            }) as NoteProps;
+            const props = (
+              await opts.engine.findNotes({
+                fname: "bar",
+                vault: opts.vaults[0],
+              })
+            )[0];
 
             await pod.exportNotes([props]);
             const content = fs.readFileSync(path.join(exportDest), {

--- a/packages/engine-test-utils/src/utils/git.ts
+++ b/packages/engine-test-utils/src/utils/git.ts
@@ -149,11 +149,9 @@ export class GitTestUtils {
   ) {
     const remoteDir = tmpDir().name;
     await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-    const rootNote = NoteUtils.getNoteByFnameFromEngine({
-      fname: "root",
-      vault: vaults[0],
-      engine,
-    })!;
+    const rootNote = (
+      await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+    )[0]!;
     // Add everything and push, so that there's no untracked changes
     const git = new Git({ localUrl: wsRoot, remoteUrl: remoteDir });
     await git.addAll();

--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -1,8 +1,6 @@
 import {
   DVault,
-  NoteProps,
   NotePropsMeta,
-  NoteUtils,
   SchemaModuleProps,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -14,8 +12,7 @@ import { DENDRON_COMMANDS } from "./constants";
 import { ExtensionProvider } from "./ExtensionProvider";
 import { Logger } from "./logger";
 import { VSCodeUtils } from "./vsCodeUtils";
-import { getDWorkspace, getExtension } from "./workspace";
-import { WSUtilsV2 } from "./WSUtilsV2";
+import { getDWorkspace } from "./workspace";
 
 /**
  * Prefer to use WSUtilsV2 instead of this class to prevent circular dependencies.
@@ -94,7 +91,7 @@ export class WSUtils {
   /**
     @deprecated. Use same method in {@link WSUtilsV2}
   **/
-  static getNoteFromPath(fsPath: string) {
+  static async getNoteFromPath(fsPath: string) {
     const { engine } = ExtensionProvider.getDWorkspace();
     const fname = path.basename(fsPath, ".md");
     let vault: DVault;
@@ -104,11 +101,7 @@ export class WSUtils {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    return (await engine.findNotes({ fname, vault }))[0];
   }
 
   /**
@@ -121,18 +114,9 @@ export class WSUtils {
   /**
     @deprecated. Use same method in {@link WSUtilsV2}
   **/
-  static getNoteFromDocument(document: vscode.TextDocument) {
+  static async getNoteFromDocument(document: vscode.TextDocument) {
     return this.getNoteFromPath(document.uri.fsPath);
   }
-
-  /**
-    @deprecated. Use same method in {@link WSUtilsV2}
-  **/
-  static tryGetNoteFromDocument = (
-    document: vscode.TextDocument
-  ): NoteProps | undefined => {
-    return new WSUtilsV2(getExtension()).tryGetNoteFromDocument(document);
-  };
 
   /**
     @deprecated. Use same method in {@link WSUtilsV2}

--- a/packages/plugin-core/src/WSUtilsV2.ts
+++ b/packages/plugin-core/src/WSUtilsV2.ts
@@ -7,7 +7,6 @@ import {
   DVault,
   NoteProps,
   NotePropsMeta,
-  NoteUtils,
   RespV3,
   SchemaModuleProps,
   VaultUtils,
@@ -43,7 +42,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
     });
   }
 
-  getNoteFromPath(fsPath: string): NoteProps | undefined {
+  async getNoteFromPath(fsPath: string): Promise<NoteProps | undefined> {
     const { engine } = this.extension.getDWorkspace();
     const fname = path.basename(fsPath, ".md");
     let vault: DVault;
@@ -53,11 +52,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    return (await engine.findNotes({ fname, vault }))[0];
   }
 
   /**
@@ -84,7 +79,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
     return vault;
   }
 
-  getNoteFromDocument(document: vscode.TextDocument) {
+  async getNoteFromDocument(document: vscode.TextDocument) {
     const { engine } = this.extension.getDWorkspace();
     const txtPath = document.uri.fsPath;
     const fname = path.basename(txtPath, ".md");
@@ -95,11 +90,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       // No vault
       return undefined;
     }
-    return NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    return (await engine.findNotes({ fname, vault }))[0];
   }
 
   /**
@@ -172,7 +163,9 @@ export class WSUtilsV2 implements IWSUtilsV2 {
     return vault;
   }
 
-  tryGetNoteFromDocument(document: vscode.TextDocument): NoteProps | undefined {
+  async tryGetNoteFromDocument(
+    document: vscode.TextDocument
+  ): Promise<NoteProps | undefined> {
     const { wsRoot, vaults } = this.extension.getDWorkspace();
     if (
       !WorkspaceUtils.isPathInWorkspace({
@@ -188,7 +181,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
       return;
     }
     try {
-      const note = this.getNoteFromDocument(document);
+      const note = await this.getNoteFromDocument(document);
       return note;
     } catch (err) {
       Logger.info({
@@ -226,7 +219,7 @@ export class WSUtilsV2 implements IWSUtilsV2 {
     }
   }
 
-  getActiveNote() {
+  async getActiveNote() {
     const editor = VSCodeUtils.getActiveTextEditor();
     if (editor) return this.getNoteFromDocument(editor.document);
     return;

--- a/packages/plugin-core/src/WSUtilsV2Interface.ts
+++ b/packages/plugin-core/src/WSUtilsV2Interface.ts
@@ -9,24 +9,28 @@ import {
 } from "@dendronhq/common-all";
 
 export interface IWSUtilsV2 {
-  getNoteFromDocument(document: vscode.TextDocument): undefined | NoteProps;
+  getNoteFromDocument(
+    document: vscode.TextDocument
+  ): Promise<undefined | NoteProps>;
 
   getVaultFromDocument(document: vscode.TextDocument): DVault;
 
-  tryGetNoteFromDocument(document: vscode.TextDocument): NoteProps | undefined;
+  tryGetNoteFromDocument(
+    document: vscode.TextDocument
+  ): Promise<NoteProps | undefined>;
 
   trySelectRevealNonNoteAnchor(
     editor: TextEditor,
     anchor: DNoteAnchorBasic
   ): Promise<void>;
 
-  getActiveNote(): NoteProps | undefined;
+  getActiveNote(): Promise<NoteProps | undefined>;
 
   getVaultFromUri(fileUri: Uri): DVault;
 
   getVaultFromPath(fsPath: string): DVault;
 
-  getNoteFromPath(fsPath: string): NoteProps | undefined;
+  getNoteFromPath(fsPath: string): Promise<NoteProps | undefined>;
 
   /** If the text document at `filePath` is open in any editor, return that document. */
   getMatchingTextDocument(filePath: string): vscode.TextDocument | undefined;

--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -254,7 +254,7 @@ export class WorkspaceWatcher {
    * @param event
    * @returns
    */
-  onWillSaveTextDocument(event: TextDocumentWillSaveEvent) {
+  async onWillSaveTextDocument(event: TextDocumentWillSaveEvent) {
     try {
       const ctx = "WorkspaceWatcher:onWillSaveTextDocument";
       const uri = event.document.uri;
@@ -299,18 +299,19 @@ export class WorkspaceWatcher {
    * @param event
    * @returns
    */
-  private onWillSaveNote(event: TextDocumentWillSaveEvent) {
+  private async onWillSaveNote(event: TextDocumentWillSaveEvent) {
     const ctx = "WorkspaceWatcher:onWillSaveNote";
     const uri = event.document.uri;
     const engine = this._extension.getEngine();
     const fname = path.basename(uri.fsPath, ".md");
     const now = Time.now().toMillis();
 
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault: this._extension.wsUtils.getVaultFromUri(uri),
-      engine,
-    });
+    const note = (
+      await engine.findNotes({
+        fname,
+        vault: this._extension.wsUtils.getVaultFromUri(uri),
+      })
+    )[0];
 
     // If we can't find the note, don't do anything
     if (!note) {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -444,7 +444,7 @@ export async function _activate(
         action: "activate",
       });
       // If automaticallyShowPreview = true, display preview panel on start up
-      const note = WSUtils.getActiveNote();
+      const note = await WSUtils.getActiveNote();
       if (
         note &&
         ws.workspaceService?.config.preview?.automaticallyShowPreview

--- a/packages/plugin-core/src/commands/ApplyTemplateCommand.ts
+++ b/packages/plugin-core/src/commands/ApplyTemplateCommand.ts
@@ -66,7 +66,7 @@ export class ApplyTemplateCommand extends BasicCommand<
       }
     );
     const config = extension.getDWorkspace().config;
-    const targetNote = WSUtilsV2.instance().getActiveNote();
+    const targetNote = await WSUtilsV2.instance().getActiveNote();
     if (!targetNote) {
       throw new DendronError({ message: "No Dendron note open" });
     }

--- a/packages/plugin-core/src/commands/ConvertLink.ts
+++ b/packages/plugin-core/src/commands/ConvertLink.ts
@@ -328,11 +328,9 @@ export class ConvertLinkCommand extends BasicCommand<
     if (targetVault === undefined) {
       throw ConvertLinkCommand.noVaultError();
     } else {
-      const targetNote = NoteUtils.getNoteByFnameFromEngine({
-        fname: ref,
-        engine: ExtensionProvider.getEngine(),
-        vault: targetVault,
-      });
+      const targetNote = (
+        await engine.findNotesMeta({ fname: ref, vault: targetVault })
+      )[0];
 
       if (targetNote === undefined) {
         const { option, parsedLink } =

--- a/packages/plugin-core/src/commands/CopyNoteRef.ts
+++ b/packages/plugin-core/src/commands/CopyNoteRef.ts
@@ -4,7 +4,7 @@ import {
   DNoteRefLink,
   getSlugger,
   isBlockAnchor,
-  NoteProps,
+  NotePropsMeta,
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -55,7 +55,7 @@ export class CopyNoteRefCommand extends BasicCommand<
   }
 
   async buildLink(opts: {
-    note: NoteProps;
+    note: NotePropsMeta;
     useVaultPrefix?: boolean;
     editor: TextEditor;
   }) {
@@ -103,11 +103,7 @@ export class CopyNoteRefCommand extends BasicCommand<
     const fname = NoteUtils.uri2Fname(editor.document.uri);
     const vault = PickerUtilsV2.getVaultForOpenEditor();
     const { engine } = ExtensionProvider.getDWorkspace();
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      engine,
-      vault,
-    });
+    const note = (await engine.findNotesMeta({ fname, vault }))[0];
     if (note) {
       const useVaultPrefix = DendronClientUtilsV2.shouldUseVaultPrefix(engine);
       const link = await this.buildLink({

--- a/packages/plugin-core/src/commands/CopyNoteURL.ts
+++ b/packages/plugin-core/src/commands/CopyNoteURL.ts
@@ -47,7 +47,7 @@ export class CopyNoteURLCommand extends BasicCommand<
     }
     const vault = WSUtils.getVaultFromDocument(maybeTextEditor.document);
 
-    const note = WSUtils.getNoteFromDocument(maybeTextEditor.document);
+    const note = await WSUtils.getNoteFromDocument(maybeTextEditor.document);
     if (_.isUndefined(note)) {
       window.showErrorMessage("You need to be in a note to use this command");
       return;

--- a/packages/plugin-core/src/commands/CreateTask.ts
+++ b/packages/plugin-core/src/commands/CreateTask.ts
@@ -39,7 +39,7 @@ export class CreateTaskCommand extends BasicCommand<
     const { createTaskSelectionType, addBehavior } =
       ConfigUtils.getTask(config);
 
-    await maybeSendMeetingNoteTelemetry("task");
+    maybeSendMeetingNoteTelemetry("task");
 
     return {
       lookup: AutoCompletableRegistrar.getNoteLookupCmd().run({

--- a/packages/plugin-core/src/commands/CreateTask.ts
+++ b/packages/plugin-core/src/commands/CreateTask.ts
@@ -39,7 +39,7 @@ export class CreateTaskCommand extends BasicCommand<
     const { createTaskSelectionType, addBehavior } =
       ConfigUtils.getTask(config);
 
-    maybeSendMeetingNoteTelemetry("task");
+    await maybeSendMeetingNoteTelemetry("task");
 
     return {
       lookup: AutoCompletableRegistrar.getNoteLookupCmd().run({

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -1,6 +1,7 @@
 import {
   DendronError,
   DEngineClient,
+  DNodeUtils,
   DVault,
   ExtensionEvents,
   extractNoteChangeEntryCounts,
@@ -11,7 +12,6 @@ import {
   NoteDictsUtils,
   NoteFnameDictUtils,
   NoteProps,
-  NoteUtils,
   Position,
   ValidateFnameResp,
   VaultUtils,
@@ -252,14 +252,10 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         vaults,
         vname: ent.vault,
       }) as DVault;
-      const note = NoteUtils.getNoteByFnameFromEngine({
-        fname: ent.file,
-        engine,
-        vault,
-      }) as NoteProps;
-      const fsPath = NoteUtils.getFullPath({
-        note,
+      const fsPath = DNodeUtils.getFullPath({
         wsRoot,
+        vault,
+        basename: ent.file + ".md",
       });
       const fileContent = fs.readFileSync(fsPath).toString();
       const nodePosition = RemarkUtils.getNodePositionPastFrontmatter(

--- a/packages/plugin-core/src/commands/Doctor.ts
+++ b/packages/plugin-core/src/commands/Doctor.ts
@@ -457,7 +457,9 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
       const document = VSCodeUtils.getActiveTextEditor()?.document;
       if (
         isNotUndefined(document) &&
-        isNotUndefined(this.extension.wsUtils.getNoteFromDocument(document))
+        isNotUndefined(
+          await this.extension.wsUtils.getNoteFromDocument(document)
+        )
       ) {
         await document.save();
       }
@@ -472,7 +474,7 @@ export class DoctorCommand extends BasicCommand<CommandOpts, CommandOutput> {
         if (_.isUndefined(document)) {
           throw new DendronError({ message: "No note open." });
         }
-        note = this.extension.wsUtils.getNoteFromDocument(document);
+        note = await this.extension.wsUtils.getNoteFromDocument(document);
       }
     }
 

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -82,16 +82,16 @@ export class GotoNoteCommand extends BasicCommand<
     this.wsUtils = extension.wsUtils;
   }
 
-  private getQs(
+  private async getQs(
     opts: GoToNoteCommandOpts,
     link: FoundLinkSelection
-  ): GoToNoteCommandOpts {
+  ): Promise<GoToNoteCommandOpts> {
     if (link.value) {
       // Reference to another file
       opts.qs = link.value;
     } else {
       // Same file block reference, implicitly current file
-      const note = this.wsUtils.getActiveNote();
+      const note = await this.wsUtils.getActiveNote();
       if (note) {
         // Same file link within note
         opts.qs = note.fname;
@@ -190,7 +190,7 @@ export class GotoNoteCommand extends BasicCommand<
     }
 
     // Get missing opts from the selected link, if possible
-    if (!opts.qs) opts = this.getQs(opts, link);
+    if (!opts.qs) opts = await this.getQs(opts, link);
     if (!opts.vault && link.vaultName)
       opts.vault = VaultUtils.getVaultByNameOrThrow({
         vaults: this.extension.getDWorkspace().vaults,
@@ -315,7 +315,7 @@ export class GotoNoteCommand extends BasicCommand<
 
             // check if we should send meeting note telemetry.
             const type = qs.startsWith("user.") ? "userTag" : "general";
-            maybeSendMeetingNoteTelemetry(type);
+            await maybeSendMeetingNoteTelemetry(type);
           } else {
             // should not create note if fname is invalid.
             // let the user know and exit early.

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -315,7 +315,7 @@ export class GotoNoteCommand extends BasicCommand<
 
             // check if we should send meeting note telemetry.
             const type = qs.startsWith("user.") ? "userTag" : "general";
-            await maybeSendMeetingNoteTelemetry(type);
+            maybeSendMeetingNoteTelemetry(type);
           } else {
             // should not create note if fname is invalid.
             // let the user know and exit early.

--- a/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
+++ b/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
@@ -60,7 +60,7 @@ export class InsertNoteIndexCommand extends BasicCommand<
       );
       return opts;
     }
-    const activeNote = WSUtils.getNoteFromDocument(maybeEditor.document)!;
+    const activeNote = await WSUtils.getNoteFromDocument(maybeEditor.document)!;
     if (_.isUndefined(activeNote)) {
       window.showErrorMessage("Active file is not a Dendron note.");
       return opts;

--- a/packages/plugin-core/src/commands/MergeNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MergeNoteCommand.ts
@@ -89,7 +89,7 @@ export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }
 
   async sanityCheck(): Promise<SanityCheckResults> {
-    const note = this.extension.wsUtils.getActiveNote();
+    const note = await this.extension.wsUtils.getActiveNote();
     if (!note) {
       return "You need to have a note open to merge.";
     }
@@ -98,7 +98,7 @@ export class MergeNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
 
   async gatherInputs(opts: CommandOpts): Promise<CommandOpts | undefined> {
     const controller = this.createLookupController();
-    const activeNote = this.extension.wsUtils.getActiveNote();
+    const activeNote = await this.extension.wsUtils.getActiveNote();
     const provider = this.createLookupProvider({
       activeNote,
     });

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -113,12 +113,12 @@ export class MoveHeaderCommand extends BasicCommand<
    * @param engine
    * @returns {}
    */
-  private validateAndProcessInput(engine: IEngineAPIService): {
+  private async validateAndProcessInput(engine: IEngineAPIService): Promise<{
     proc: Processor;
     origin: NoteProps;
     targetHeader: Heading;
     targetHeaderIndex: number;
-  } {
+  }> {
     const { editor, selection } = VSCodeUtils.getSelection();
 
     // basic input validation
@@ -126,7 +126,7 @@ export class MoveHeaderCommand extends BasicCommand<
     if (!selection) throw this.headerNotSelectedError;
 
     const line = editor.document.lineAt(selection.start.line).text;
-    const maybeNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+    const maybeNote = await ExtensionProvider.getWSUtils().getNoteFromDocument(
       editor.document
     );
     if (!maybeNote) {
@@ -240,7 +240,7 @@ export class MoveHeaderCommand extends BasicCommand<
     // validate and process input
     const engine = ExtensionProvider.getEngine();
     const { proc, origin, targetHeader, targetHeaderIndex } =
-      this.validateAndProcessInput(engine);
+      await this.validateAndProcessInput(engine);
 
     // extract nodes that need to be moved
     const originTree = proc.parse(origin.body);

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -12,6 +12,7 @@ import {
   extractNoteChangeEntryCounts,
   getSlugger,
   IntermediateDendronConfig,
+  isNotUndefined,
   NoteChangeEntry,
   NoteProps,
   NoteQuickInput,
@@ -203,7 +204,7 @@ export class MoveHeaderCommand extends BasicCommand<
    * @param opts
    * @returns
    */
-  prepareDestination(opts: {
+  async prepareDestination(opts: {
     engine: IEngineAPIService;
     quickpick: DendronQuickPickerV2;
     selectedItems: readonly NoteQuickInput[];
@@ -222,11 +223,7 @@ export class MoveHeaderCommand extends BasicCommand<
         // if a user selects a vault in the picker that
         // already has the note, we should not create a new one.
         const fname = selected.fname;
-        const maybeNote = NoteUtils.getNoteByFnameFromEngine({
-          fname,
-          engine,
-          vault, // this is the vault selected from the vault picker
-        });
+        const maybeNote = (await engine.findNotes({ fname, vault }))[0];
         if (_.isUndefined(maybeNote)) {
           dest = NoteUtils.create({ fname, vault });
         } else {
@@ -269,10 +266,10 @@ export class MoveHeaderCommand extends BasicCommand<
         id: this.key,
         controller: lc,
         logger: this.L,
-        onDone: (event: HistoryEvent) => {
+        onDone: async (event: HistoryEvent) => {
           const data = event.data as NoteLookupProviderSuccessResp;
           const quickpick: DendronQuickPickerV2 = lc.quickPick;
-          const dest = this.prepareDestination({
+          const dest = await this.prepareDestination({
             engine,
             quickpick,
             selectedItems: data.selectedItems,
@@ -349,20 +346,15 @@ export class MoveHeaderCommand extends BasicCommand<
    * @param engine
    * @returns note
    */
-  private getNoteByLocation(
+  private async getNoteByLocation(
     location: Location,
     engine: IEngineAPIService
-  ): NoteProps | undefined {
+  ): Promise<NoteProps | undefined> {
     const fsPath = location.uri.fsPath;
     const fname = NoteUtils.normalizeFname(path.basename(fsPath));
 
     const vault = ExtensionProvider.getWSUtils().getVaultFromUri(location.uri);
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      engine,
-      vault,
-    });
-    return note;
+    return (await engine.findNotes({ fname, vault }))[0];
   }
 
   /**
@@ -480,21 +472,24 @@ export class MoveHeaderCommand extends BasicCommand<
   ): Promise<NoteChangeEntry[]> {
     let noteChangeEntries: NoteChangeEntry[] = [];
     const ctx = `${this.key}:updateReferences`;
-    const refsToProcess = foundReferences
-      .filter((ref) => !ref.isCandidate)
-      .filter((ref) => hasAnchorsToUpdate(ref, anchorNamesToUpdate))
-      .map((ref) => this.getNoteByLocation(ref.location, engine))
-      .filter((note) => note !== undefined);
+    const refsToProcess = (
+      await Promise.all(
+        foundReferences
+          .filter((ref) => !ref.isCandidate)
+          .filter((ref) => hasAnchorsToUpdate(ref, anchorNamesToUpdate))
+          .map((ref) => this.getNoteByLocation(ref.location, engine))
+      )
+    ).filter(isNotUndefined);
     const config = DConfig.readConfigSync(engine.wsRoot);
 
     await asyncLoopOneAtATime(refsToProcess, async (note) => {
       try {
         const vaultPath = vault2Path({
-          vault: note!.vault,
+          vault: note.vault,
           wsRoot: engine.wsRoot,
         });
         const resp = file2Note(
-          path.join(vaultPath, note!.fname + ".md"),
+          path.join(vaultPath, note.fname + ".md"),
           note!.vault
         );
         if (ErrorUtils.isErrorResp(resp)) {
@@ -513,8 +508,8 @@ export class MoveHeaderCommand extends BasicCommand<
           linksToUpdate,
           dest,
         });
-        note!.body = modifiedNote.body;
-        const writeResp = await engine.writeNote(note!);
+        note.body = modifiedNote.body;
+        const writeResp = await engine.writeNote(note);
         if (writeResp.data) {
           noteChangeEntries = noteChangeEntries.concat(writeResp.data);
         }

--- a/packages/plugin-core/src/commands/MoveSelectionToCommand.ts
+++ b/packages/plugin-core/src/commands/MoveSelectionToCommand.ts
@@ -60,7 +60,7 @@ export class MoveSelectionToCommand extends BasicCommand<
 
     // needs active text editor
     if (activeTextEditor) {
-      const activeNote = this.extension.wsUtils.getNoteFromDocument(
+      const activeNote = await this.extension.wsUtils.getNoteFromDocument(
         activeTextEditor?.document
       );
 
@@ -174,7 +174,7 @@ export class MoveSelectionToCommand extends BasicCommand<
   async execute(opts: CommandOpts): Promise<CommandOutput> {
     const lookupCmd = AutoCompletableRegistrar.getNoteLookupCmd();
     const controller = this.createLookupController();
-    const activeNote = this.extension.wsUtils.getActiveNote();
+    const activeNote = await this.extension.wsUtils.getActiveNote();
     const { selection, text: selectionText } = VSCodeUtils.getSelection();
     await this.prepareProxyMetricPayload({
       sourceNote: activeNote,

--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -128,7 +128,7 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
   async promptMatchText() {
     const editor = VSCodeUtils.getActiveTextEditor();
     const value = editor?.document
-      ? WSUtils.getNoteFromDocument(editor.document)?.fname
+      ? (await WSUtils.getNoteFromDocument(editor.document))?.fname
       : "";
     const match = await VSCodeUtils.showInputBox({
       title: "Enter match text",

--- a/packages/plugin-core/src/commands/RenameHeader.ts
+++ b/packages/plugin-core/src/commands/RenameHeader.ts
@@ -59,7 +59,7 @@ export class RenameHeaderCommand extends BasicCommand<
     const { editor, selection } = VSCodeUtils.getSelection();
     const extension = ExtensionProvider.getExtension();
     const { wsUtils } = extension;
-    const note = wsUtils.getActiveNote();
+    const note = await wsUtils.getActiveNote();
     if (_.isUndefined(note)) {
       throw new DendronError({
         message: "You must first open a note to rename a header.",
@@ -123,7 +123,7 @@ export class RenameHeaderCommand extends BasicCommand<
     const editor = VSCodeUtils.getActiveTextEditor();
     if (_.isUndefined(newHeader) || _.isUndefined(oldHeader) || !editor) return;
     const document = editor.document;
-    const note = WSUtils.getNoteFromDocument(document);
+    const note = await WSUtils.getNoteFromDocument(document);
     if (!note) return;
 
     const noteLoc = {

--- a/packages/plugin-core/src/commands/TaskStatus.ts
+++ b/packages/plugin-core/src/commands/TaskStatus.ts
@@ -42,7 +42,7 @@ export class TaskStatusCommand extends BasicCommand<
 
     if (!selection) {
       // Then they are changing the status for the current note
-      selectedNote = this._ext.wsUtils.getActiveNote();
+      selectedNote = await this._ext.wsUtils.getActiveNote();
       if (!selectedNote || !TaskNoteUtils.isTaskNote(selectedNote)) {
         // No active note either
         VSCodeUtils.showMessage(

--- a/packages/plugin-core/src/commands/TogglePreview.ts
+++ b/packages/plugin-core/src/commands/TogglePreview.ts
@@ -64,10 +64,10 @@ export class TogglePreviewCommand extends InputArgCommand<
 
     if (opts !== undefined && !_.isEmpty(opts)) {
       // Used a context menu to open preview for a specific note
-      note = ExtensionProvider.getWSUtils().getNoteFromPath(opts.fsPath);
+      note = await ExtensionProvider.getWSUtils().getNoteFromPath(opts.fsPath);
     } else {
       // Used the command bar or keyboard shortcut to open preview for active note
-      note = ExtensionProvider.getWSUtils().getActiveNote();
+      note = await ExtensionProvider.getWSUtils().getActiveNote();
     }
     await this._panel.show();
 

--- a/packages/plugin-core/src/commands/TogglePreviewLock.ts
+++ b/packages/plugin-core/src/commands/TogglePreviewLock.ts
@@ -30,7 +30,7 @@ export class TogglePreviewLockCommand extends BasicCommand<
 
   async execute(_opts?: CommandOpts) {
     if (this._panel) {
-      const note = ExtensionProvider.getWSUtils().getActiveNote();
+      const note = await ExtensionProvider.getWSUtils().getActiveNote();
       if (this._panel.isLocked()) {
         this._panel.unlock();
         if (note) {

--- a/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
+++ b/packages/plugin-core/src/commands/pods/BaseExportPodCommand.ts
@@ -137,7 +137,7 @@ export abstract class BaseExportPodCommand<
         break;
       }
       case PodExportScope.Note: {
-        payload = this.getPropsForNoteScope();
+        payload = await this.getPropsForNoteScope();
 
         if (!payload) {
           vscode.window.showErrorMessage("Unable to get note payload.");
@@ -325,7 +325,7 @@ export abstract class BaseExportPodCommand<
     });
   }
 
-  private getPropsForNoteScope(): DNodeProps[] | undefined {
+  private async getPropsForNoteScope(): Promise<DNodeProps[] | undefined> {
     //TODO: Switch this to a lookup controller, allow multiselect
     const fsPath = VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath;
     if (!fsPath) {
@@ -345,11 +345,7 @@ export abstract class BaseExportPodCommand<
 
     const fname = path.basename(fsPath, ".md");
 
-    const maybeNote = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    }) as NoteProps;
+    const maybeNote = (await engine.findNotes({ fname, vault }))[0];
 
     if (!maybeNote) {
       vscode.window.showErrorMessage("couldn't find the note somehow");

--- a/packages/plugin-core/src/components/doctor/utils.ts
+++ b/packages/plugin-core/src/components/doctor/utils.ts
@@ -130,7 +130,7 @@ export class DoctorUtils {
     const extension = ExtensionProvider.getExtension();
     const wsUtils = extension.wsUtils;
     const filename = path.basename(document.fileName, ".md");
-    const note = wsUtils.getNoteFromDocument(document);
+    const note = await wsUtils.getNoteFromDocument(document);
 
     if (!note) return true;
 

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -284,7 +284,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
         this._viewModel.selectionState.bind(async (newValue, prevValue) => {
           switch (prevValue) {
             case LookupSelectionTypeEnum.selection2Items: {
-              this.onSelect2ItemsBtnToggled(false);
+              await this.onSelect2ItemsBtnToggled(false);
               break;
             }
             case LookupSelectionTypeEnum.selection2link: {
@@ -301,7 +301,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
 
           switch (newValue) {
             case LookupSelectionTypeEnum.selection2Items: {
-              this.onSelect2ItemsBtnToggled(true);
+              await this.onSelect2ItemsBtnToggled(true);
               break;
             }
             case LookupSelectionTypeEnum.selection2link: {
@@ -609,11 +609,11 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     }
   }
 
-  private onSelect2ItemsBtnToggled(enabled: boolean) {
+  private async onSelect2ItemsBtnToggled(enabled: boolean) {
     const quickPick = this._quickPick!;
     if (enabled) {
       const pickerItemsFromSelection =
-        NotePickerUtils.createItemsFromSelectedWikilinks();
+        await NotePickerUtils.createItemsFromSelectedWikilinks();
       quickPick.prevValue = quickPick.value;
       quickPick.value = "";
       quickPick.itemsFromSelection = pickerItemsFromSelection;

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -568,7 +568,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     }
   }
 
-  private onTaskButtonToggled(enabled: boolean) {
+  private async onTaskButtonToggled(enabled: boolean) {
     const quickPick = this._quickPick!;
     if (enabled) {
       quickPick.modifyPickerValueFunc = () => {
@@ -585,7 +585,8 @@ export class LookupControllerV3 implements ILookupControllerV3 {
       // If the lookup value ends up being identical to the current note, this will be confusing for the user because
       // they won't be able to create a new note. This can happen with the default settings of Task notes.
       // In that case, we add a trailing dot to suggest that they need to type something more.
-      const activeName = ExtensionProvider.getWSUtils().getActiveNote()?.fname;
+      const activeName = (await ExtensionProvider.getWSUtils().getActiveNote())
+        ?.fname;
       if (quickPick.value === activeName)
         quickPick.value = `${quickPick.value}.`;
       // Add default task note props to the created note
@@ -707,7 +708,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
     const engine = ExtensionProvider.getEngine();
     // parse text in range, update potential backlinks to it
     // so that it points to the destination instead of the source.
-    const sourceNote = wsUtils.getActiveNote();
+    const sourceNote = await wsUtils.getActiveNote();
     if (sourceNote) {
       const { anchors: sourceAnchors } = sourceNote;
       if (sourceAnchors) {
@@ -859,5 +860,12 @@ export class LookupControllerV3 implements ILookupControllerV3 {
         return note;
       }
     }
+  }
+
+  // eslint-disable-next-line camelcase
+  __DO_NOT_USE_IN_PROD_exposePropsForTesting() {
+    return {
+      onSelect2ItemsBtnToggled: this.onSelect2ItemsBtnToggled.bind(this),
+    };
   }
 }

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -38,8 +38,10 @@ export class NotePickerUtils {
     // dedupe wikilinks by value
     const uniqueWikiLinks = _.uniqBy(wikiLinks, "value");
 
-    const activeNote =
-      ExtensionProvider.getWSUtils().getActiveNote() as DNodeProps;
+    const activeNote = await ExtensionProvider.getWSUtils().getActiveNote();
+    if (!activeNote) {
+      return;
+    }
 
     // make a list of picker items from wikilinks
     const notesFromWikiLinks = await LinkUtils.getNotesFromWikiLinks({

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -22,9 +22,9 @@ import { filterPickerResults, PickerUtilsV2 } from "./utils";
 export const PAGINATE_LIMIT = 50;
 
 export class NotePickerUtils {
-  static createItemsFromSelectedWikilinks():
-    | DNodePropsQuickInputV2[]
-    | undefined {
+  static async createItemsFromSelectedWikilinks(): Promise<
+    DNodePropsQuickInputV2[] | undefined
+  > {
     const engine = ExtensionProvider.getEngine();
     const { vaults, schemas, wsRoot } = engine;
 
@@ -42,7 +42,7 @@ export class NotePickerUtils {
       ExtensionProvider.getWSUtils().getActiveNote() as DNodeProps;
 
     // make a list of picker items from wikilinks
-    const notesFromWikiLinks = LinkUtils.getNotesFromWikiLinks({
+    const notesFromWikiLinks = await LinkUtils.getNotesFromWikiLinks({
       activeNote,
       wikiLinks: uniqueWikiLinks,
       engine,

--- a/packages/plugin-core/src/components/lookup/utils.ts
+++ b/packages/plugin-core/src/components/lookup/utils.ts
@@ -10,7 +10,6 @@ import {
   FuseEngine,
   NoteProps,
   NoteQuickInput,
-  NoteUtils,
   OrderedMatcher,
   RenameNoteOpts,
   RespV2,
@@ -168,11 +167,7 @@ export class ProviderAcceptHooks {
       : selectedItem.fname;
 
     // get new note
-    const newNote = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      engine,
-      vault: newVault,
-    });
+    const newNote = (await engine.findNotesMeta({ fname, vault: newVault }))[0];
     const isStub = newNote?.stub;
     if (newNote && !isStub) {
       const vaultName = VaultUtils.getName(newVault);

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -77,9 +77,9 @@ export class NoteGraphPanelFactory {
           Logger.info({ ctx });
           if (this._panel && this._panel.visible) {
             await Promise.all(
-              noteChangeEntry.map((changeEntry) =>
-                this.refresh(changeEntry.note)
-              )
+              noteChangeEntry.map((changeEntry) => {
+                return this.refresh(changeEntry.note);
+              })
             );
           }
         });

--- a/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/NoteGraphViewFactory.ts
@@ -72,12 +72,14 @@ export class NoteGraphPanelFactory {
       );
 
       this._onEngineNoteStateChangedDisposable =
-        this._engineEvents.onEngineNoteStateChanged((noteChangeEntry) => {
+        this._engineEvents.onEngineNoteStateChanged(async (noteChangeEntry) => {
           const ctx = "NoteGraphViewFactoryEngineNoteStateChanged";
           Logger.info({ ctx });
           if (this._panel && this._panel.visible) {
-            noteChangeEntry.map((changeEntry) =>
-              this.refresh(changeEntry.note)
+            await Promise.all(
+              noteChangeEntry.map((changeEntry) =>
+                this.refresh(changeEntry.note)
+              )
             );
           }
         });
@@ -100,10 +102,12 @@ export class NoteGraphPanelFactory {
             }
             const note = resp.data;
             if (note.stub && !createStub) {
-              this.refresh(note, createStub);
+              await this.refresh(note, createStub);
             } else {
-              if (this._ext.wsUtils.getActiveNote()?.fname === note.fname) {
-                this.refresh(note);
+              if (
+                (await this._ext.wsUtils.getActiveNote())?.fname === note.fname
+              ) {
+                await this.refresh(note);
                 break;
               }
               await new GotoNoteCommand(this._ext).execute({
@@ -166,7 +170,7 @@ export class NoteGraphPanelFactory {
                 note: NoteUtils.toLogObj(note),
               });
             } else {
-              note = this._ext.wsUtils.getActiveNote();
+              note = await this._ext.wsUtils.getActiveNote();
               if (note) {
                 Logger.debug({
                   ctx,
@@ -176,7 +180,7 @@ export class NoteGraphPanelFactory {
               }
             }
             if (note) {
-              this.refresh(note);
+              await this.refresh(note);
             }
             break;
           }
@@ -241,7 +245,7 @@ export class NoteGraphPanelFactory {
    * Post message to the webview content.
    * @param note
    */
-  static refresh(note: NoteProps, createStub?: boolean): any {
+  static async refresh(note: NoteProps, createStub?: boolean): Promise<any> {
     if (this._panel) {
       this._panel.webview.postMessage({
         type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,
@@ -249,7 +253,9 @@ export class NoteGraphPanelFactory {
           note,
           syncChangedNote: true,
           activeNote:
-            note.stub && !createStub ? note : this._ext.wsUtils.getActiveNote(),
+            note.stub && !createStub
+              ? note
+              : await this._ext.wsUtils.getActiveNote(),
         },
         source: DMessageSource.vscode,
       } as OnDidChangeActiveTextEditorMsg);
@@ -275,9 +281,9 @@ export class NoteGraphPanelFactory {
       return;
     }
     if (basename.endsWith(".md")) {
-      const note = this._ext.wsUtils.getNoteFromDocument(editor.document);
+      const note = await this._ext.wsUtils.getNoteFromDocument(editor.document);
       if (note) {
-        this.refresh(note);
+        await this.refresh(note);
       }
     }
   }

--- a/packages/plugin-core/src/components/views/PreviewPanel.ts
+++ b/packages/plugin-core/src/components/views/PreviewPanel.ts
@@ -182,8 +182,8 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
   /**
    * If the Preview is locked and the active note does not match the locked note.
    */
-  isLockedAndDirty(): boolean {
-    const note = this._ext.wsUtils.getActiveNote();
+  async isLockedAndDirty(): Promise<boolean> {
+    const note = await this._ext.wsUtils.getActiveNote();
     return this.isLocked() && note?.id !== this._lockedEditorNoteId;
   }
   dispose() {
@@ -218,7 +218,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
               note: NoteUtils.toLogObj(note),
             });
           } else {
-            note = wsUtils.getActiveNote();
+            note = await wsUtils.getActiveNote();
             if (note) {
               Logger.debug({
                 ctx,
@@ -241,7 +241,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
           Logger.debug({ ctx, "msg.type": "onGetActiveEditor" });
           const activeTextEditor = VSCodeUtils.getActiveTextEditor();
           const maybeNote = !_.isUndefined(activeTextEditor)
-            ? this._ext.wsUtils.tryGetNoteFromDocument(
+            ? await this._ext.wsUtils.tryGetNoteFromDocument(
                 activeTextEditor?.document
               )
             : undefined;
@@ -279,7 +279,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
               !editor ||
               editor.document.uri.fsPath !==
                 vscode.window.activeTextEditor?.document.uri.fsPath ||
-              this.isLockedAndDirty()
+              (await this.isLockedAndDirty())
             ) {
               return;
             }
@@ -296,7 +296,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
               return;
             }
 
-            const maybeNote = this._ext.wsUtils.tryGetNoteFromDocument(
+            const maybeNote = await this._ext.wsUtils.tryGetNoteFromDocument(
               editor.document
             );
 
@@ -439,7 +439,7 @@ export class PreviewPanel implements PreviewProxy, vscode.Disposable {
     if (textDocument.document.isDirty === false) {
       return;
     }
-    if (this.isVisible() && !this.isLockedAndDirty()) {
+    if (this.isVisible() && !(await this.isLockedAndDirty())) {
       const note =
         await this._textDocumentService.processTextDocumentChangeEvent(
           textDocument

--- a/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
+++ b/packages/plugin-core/src/components/views/SchemaGraphViewFactory.ts
@@ -105,7 +105,7 @@ export class SchemaGraphViewFactory {
     });
 
     this._vsCodeCallback = vscode.window.onDidChangeActiveTextEditor(
-      sentryReportingCallback((editor: vscode.TextEditor | undefined) => {
+      sentryReportingCallback(async (editor: vscode.TextEditor | undefined) => {
         if (
           SchemaGraphViewFactory._panel &&
           SchemaGraphViewFactory._panel.visible
@@ -114,7 +114,7 @@ export class SchemaGraphViewFactory {
             return;
           }
 
-          const note = ext.wsUtils.getNoteFromDocument(editor.document);
+          const note = await ext.wsUtils.getNoteFromDocument(editor.document);
 
           SchemaGraphViewFactory._panel.webview.postMessage({
             type: DMessageEnum.ON_DID_CHANGE_ACTIVE_TEXT_EDITOR,

--- a/packages/plugin-core/src/features/BacklinksTreeDataProvider.ts
+++ b/packages/plugin-core/src/features/BacklinksTreeDataProvider.ts
@@ -138,7 +138,7 @@ export default class BacklinksTreeDataProvider
   public async getChildren(element?: Backlink): Promise<Backlink[]> {
     try {
       // TODO: Make the backlinks panel also work when preview is the active editor.
-      const activeNote = WSUtilsV2.instance().getActiveNote();
+      const activeNote = await WSUtilsV2.instance().getActiveNote();
 
       if (!activeNote) {
         return [];
@@ -325,7 +325,10 @@ export default class BacklinksTreeDataProvider
     isLinkCandidateEnabled: boolean | undefined,
     sortOrder: BacklinkPanelSortOrder
   ): Promise<Backlink[]> {
-    const references = await findReferencesById(noteId);
+    const references = await findReferencesById({
+      id: noteId,
+      isLinkCandidateEnabled,
+    });
     const referencesByPath = _.groupBy(
       // Exclude self-references:
       _.filter(references, (ref) => ref.note?.id !== noteId),

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -57,7 +57,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
     }
     const { note, pos } = out;
     return new Location(
-      Uri.file(NoteUtils.getFullPath({ note, wsRoot })),
+      NoteUtils.getURI({ note, wsRoot }),
       pos || new Position(0, 0)
     );
   }
@@ -101,9 +101,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
         engine,
         vault,
       });
-      const uris = notes.map((note) =>
-        Uri.file(NoteUtils.getFullPath({ note, wsRoot }))
-      );
+      const uris = notes.map((note) => NoteUtils.getURI({ note, wsRoot }));
       const out = uris.map((uri) => new Location(uri, new Position(0, 0)));
       if (out.length > 1) {
         return out;

--- a/packages/plugin-core/src/features/ReferenceProvider.ts
+++ b/packages/plugin-core/src/features/ReferenceProvider.ts
@@ -24,7 +24,7 @@ export default class ReferenceProvider implements vscode.ReferenceProvider {
       // provide reference to header if selection is header.
       const header = EditorUtils.getHeaderAt({ document, position });
       if (!_.isUndefined(header)) {
-        const note = new WSUtilsV2(
+        const note = await new WSUtilsV2(
           ExtensionProvider.getExtension()
         ).getNoteFromDocument(document);
         const references = await findReferences(note!.fname);

--- a/packages/plugin-core/src/features/RenameProvider.ts
+++ b/packages/plugin-core/src/features/RenameProvider.ts
@@ -57,7 +57,7 @@ export default class RenameProvider implements vscode.RenameProvider {
         });
       }
       this._targetNote = targetNote;
-      const currentNote = WSUtils.getNoteFromDocument(document);
+      const currentNote = await WSUtils.getNoteFromDocument(document);
       if (_.isEqual(currentNote, targetNote)) {
         throw new DendronError({
           message: `Cannot rename symbol that references current note.`,

--- a/packages/plugin-core/src/features/RenameProvider.ts
+++ b/packages/plugin-core/src/features/RenameProvider.ts
@@ -6,7 +6,6 @@ import {
   extractNoteChangeEntryCounts,
   NoteChangeEntry,
   NoteProps,
-  NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
 import { DLogger, vault2Path } from "@dendronhq/common-server";
@@ -32,7 +31,7 @@ export default class RenameProvider implements vscode.RenameProvider {
     this._targetNote = value;
   }
 
-  private getRangeForReference(opts: {
+  private async getRangeForReference(opts: {
     reference: getReferenceAtPositionResp;
     document: vscode.TextDocument;
   }) {
@@ -49,11 +48,9 @@ export default class RenameProvider implements vscode.RenameProvider {
       });
     } else {
       const fname = ref;
-      const targetNote = NoteUtils.getNoteByFnameFromEngine({
-        fname,
-        engine,
-        vault: targetVault,
-      });
+      const targetNote = (
+        await engine.findNotes({ fname, vault: targetVault })
+      )[0];
       if (targetNote === undefined) {
         throw new DendronError({
           message: `Cannot rename note ${ref} that doesn't exist.`,
@@ -235,8 +232,7 @@ export default class RenameProvider implements vscode.RenameProvider {
     });
     if (reference !== null) {
       this.refAtPos = reference;
-      const range = this.getRangeForReference({ reference, document });
-      return range;
+      return this.getRangeForReference({ reference, document });
     } else {
       throw new DendronError({
         message: "Rename is not supported for this symbol",

--- a/packages/plugin-core/src/features/codeActionProvider.ts
+++ b/packages/plugin-core/src/features/codeActionProvider.ts
@@ -177,7 +177,7 @@ export const refactorProvider: CodeActionProvider = {
 
       if (_range.isEmpty) {
         const { engine } = ext.getDWorkspace();
-        const note = new WSUtilsV2(ext).getActiveNote();
+        const note = await new WSUtilsV2(ext).getActiveNote();
         //return a code action for create note if user clicked next to a broken wikilink
         if (
           note &&

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -245,7 +245,7 @@ export const provideCompletionItems = sentryReportingCallback(
     const { wsRoot } = engine;
     let completionItems: CompletionItem[];
     const completionsIncomplete = true;
-    const currentVault = WSUtils.getNoteFromDocument(document)?.vault;
+    const currentVault = WSUtils.getVaultFromDocument(document);
 
     if (found?.groups?.hashTag) {
       completionItems = await provideCompletionsForTag({
@@ -497,7 +497,7 @@ export async function provideBlockCompletionItems(
     otherFile = true;
   } else {
     // This anchor is to the same file, e.g. [[#
-    note = WSUtils.getNoteFromDocument(document);
+    note = await WSUtils.getNoteFromDocument(document);
   }
 
   if (_.isUndefined(note) || token?.isCancellationRequested) return;

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -370,11 +370,7 @@ export const resolveCompletionItem = sentryReportingCallback(
       return;
     }
 
-    const note = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    const note = (await engine.findNotesMeta({ fname, vault }))[0];
 
     if (_.isUndefined(note)) {
       Logger.info({ ctx, msg: "note not found", fname, vault, wsRoot });

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -131,7 +131,7 @@ export async function updateDecorations(editor: TextEditor): Promise<{
     // Only show decorations & warnings for notes
     let note: NoteProps | undefined;
     try {
-      note = ExtensionProvider.getWSUtils().getNoteFromDocument(
+      note = await ExtensionProvider.getWSUtils().getNoteFromDocument(
         editor.document
       );
       if (_.isUndefined(note)) return {};

--- a/packages/plugin-core/src/fileWatcher.ts
+++ b/packages/plugin-core/src/fileWatcher.ts
@@ -123,11 +123,7 @@ export class FileWatcher {
       note = resp.data;
 
       // check if note exist as
-      const maybeNote = NoteUtils.getNoteByFnameFromEngine({
-        fname,
-        vault,
-        engine,
-      });
+      const maybeNote = (await engine.findNotesMeta({ fname, vault }))[0];
       if (maybeNote) {
         note = NoteUtils.hydrate({ noteRaw: note, noteHydrated: maybeNote });
         delete note["stub"];

--- a/packages/plugin-core/src/services/node/TextDocumentService.ts
+++ b/packages/plugin-core/src/services/node/TextDocumentService.ts
@@ -114,11 +114,7 @@ export class TextDocumentService implements ITextDocumentService {
       wsRoot,
       fsPath: uri.fsPath,
     });
-    const noteHydrated = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    const noteHydrated = (await engine.findNotes({ fname, vault }))[0];
     if (_.isUndefined(noteHydrated)) {
       return;
     }
@@ -198,11 +194,7 @@ export class TextDocumentService implements ITextDocumentService {
       wsRoot: this._extension.getEngine().wsRoot,
       fsPath: uri.fsPath,
     });
-    const noteHydrated = NoteUtils.getNoteByFnameFromEngine({
-      fname,
-      vault,
-      engine,
-    });
+    const noteHydrated = (await engine.findNotes({ fname, vault }))[0];
     if (_.isUndefined(noteHydrated)) {
       return;
     }

--- a/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/BacklinksTreeDataProvider.test.ts
@@ -1,10 +1,10 @@
 import {
   DVault,
   NoteChangeEntry,
-  NoteProps,
   NoteUtils,
   VaultUtils,
   BacklinkPanelSortOrder,
+  NotePropsMeta,
 } from "@dendronhq/common-all";
 import {
   NOTE_PRESETS_V4,
@@ -234,11 +234,9 @@ suite("BacklinksTreeDataProvider", function () {
           ?.enableLinkCandidates;
         expect(isLinkCandidateEnabled).toBeTruthy();
 
-        const noteWithTarget = NoteUtils.getNoteByFnameFromEngine({
-          fname: "alpha",
-          engine,
-          vault: vaults[0],
-        });
+        const noteWithTarget = (
+          await engine.findNotesMeta({ fname: "alpha", vault: vaults[0] })
+        )[0];
         await checkNoteBacklinks({ wsRoot, vaults, noteWithTarget });
       });
     }
@@ -282,20 +280,16 @@ suite("BacklinksTreeDataProvider", function () {
         await checkNoteBacklinks({
           wsRoot,
           vaults,
-          noteWithTarget: NoteUtils.getNoteByFnameFromEngine({
-            fname: "alpha",
-            engine,
-            vault: vaults[0],
-          }),
+          noteWithTarget: (
+            await engine.findNotesMeta({ fname: "alpha", vault: vaults[0] })
+          )[0],
         });
         await checkNoteBacklinks({
           wsRoot,
           vaults,
-          noteWithTarget: NoteUtils.getNoteByFnameFromEngine({
-            fname: "alpha",
-            engine,
-            vault: vaults[1],
-          }),
+          noteWithTarget: (
+            await engine.findNotesMeta({ fname: "alpha", vault: vaults[1] })
+          )[0],
         });
       });
     }
@@ -761,7 +755,7 @@ async function checkNoteBacklinks({
 }: {
   wsRoot: string;
   vaults: DVault[];
-  noteWithTarget?: NoteProps;
+  noteWithTarget?: NotePropsMeta;
 }): Promise<boolean> {
   expect(noteWithTarget).toBeTruthy();
   await ExtensionProvider.getWSUtils().openNote(noteWithTarget!);

--- a/packages/plugin-core/src/test/suite-integ/CreateJournalNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateJournalNoteCommand.test.ts
@@ -1,4 +1,3 @@
-import { NoteProps, NoteUtils } from "@dendronhq/common-all";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { CreateJournalNoteCommand } from "../../commands/CreateJournalNoteCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
@@ -16,12 +15,8 @@ suite("CreateJournalNoteCommand", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateJournalNoteCommand(ext);
-        const { vaults, engine } = ext.getDWorkspace();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const { engine } = ext.getDWorkspace();
+        const note = (await engine.getNoteMeta("foo")).data!;
         await wsUtils.openNote(note);
         await cmd.run({ noConfirm: true });
         const activeNote = getNoteFromTextEditor();

--- a/packages/plugin-core/src/test/suite-integ/CreateMeetingNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateMeetingNoteCommand.test.ts
@@ -1,4 +1,3 @@
-import { NoteProps, NoteUtils } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import { CreateMeetingNoteCommand } from "../../commands/CreateMeetingNoteCommand";
@@ -28,13 +27,9 @@ suite("GIVEN CreateMeetingNoteCommand in a basic workspace", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateMeetingNoteCommand(ext, true);
-        const { vaults, engine } = ext.getDWorkspace();
+        const { engine } = ext.getDWorkspace();
 
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const note = (await engine.getNoteMeta("foo")).data!;
 
         await wsUtils.openNote(note);
         await cmd.run();
@@ -46,13 +41,9 @@ suite("GIVEN CreateMeetingNoteCommand in a basic workspace", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateMeetingNoteCommand(ext, true);
-        const { vaults, engine } = ext.getDWorkspace();
+        const { engine } = ext.getDWorkspace();
 
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const note = (await engine.getNoteMeta("foo")).data!;
 
         await wsUtils.openNote(note);
         await cmd.run();
@@ -70,13 +61,9 @@ suite("GIVEN CreateMeetingNoteCommand in a basic workspace", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateMeetingNoteCommand(ext, true);
-        const { vaults, engine } = ext.getDWorkspace();
+        const { engine } = ext.getDWorkspace();
 
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const note = (await engine.getNoteMeta("foo")).data!;
 
         await wsUtils.openNote(note);
         await cmd.run();

--- a/packages/plugin-core/src/test/suite-integ/CreateScratchNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateScratchNoteCommand.test.ts
@@ -1,4 +1,3 @@
-import { NoteProps, NoteUtils } from "@dendronhq/common-all";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import * as vscode from "vscode";
 import { CreateScratchNoteCommand } from "../../commands/CreateScratchNoteCommand";
@@ -17,12 +16,8 @@ suite("CreateScratchNoteCommand", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateScratchNoteCommand(ext);
-        const { vaults, engine } = ext.getDWorkspace();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const { engine } = ext.getDWorkspace();
+        const note = (await engine.getNoteMeta("foo")).data!;
         await wsUtils.openNote(note);
         await cmd.run({ noConfirm: true });
         const activeNote = getNoteFromTextEditor();
@@ -33,12 +28,8 @@ suite("CreateScratchNoteCommand", function () {
         const ext = ExtensionProvider.getExtension();
         const wsUtils = ext.wsUtils;
         const cmd = new CreateScratchNoteCommand(ext);
-        const { vaults, engine } = ext.getDWorkspace();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaults[0],
-          engine,
-        }) as NoteProps;
+        const { engine } = ext.getDWorkspace();
+        const note = (await engine.getNoteMeta("foo")).data!;
         const fooNoteEditor = await wsUtils.openNote(note);
         fooNoteEditor.selection = new vscode.Selection(7, 0, 7, 12);
         await cmd.run({ noConfirm: true });

--- a/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/DoctorCommand.test.ts
@@ -714,7 +714,6 @@ suite("FIX_AIRTABLE_METADATA", function () {
       test("THEN remove airtableId from note FM and update it with pods namespace", async () => {
         const ext = ExtensionProvider.getExtension();
         const engine = ext.getEngine();
-        const { vaults } = engine;
         const cmd = new DoctorCommand(ext);
         const gatherInputsStub = sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
@@ -735,11 +734,7 @@ suite("FIX_AIRTABLE_METADATA", function () {
             );
           podIdQuickPickStub.onCall(0).returns(Promise.resolve("dendron.task"));
           await cmd.run();
-          const note = NoteUtils.getNoteByFnameFromEngine({
-            fname: "foo.bar",
-            engine,
-            vault: vaults[0],
-          });
+          const note = (await engine.getNoteMeta("foo.bar")).data!;
           expect(note?.custom.airtableId).toBeFalsy();
           expect(note?.custom.pods.airtable["dendron.task"]).toEqual(
             "airtableId-one"

--- a/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoDownCommand.test.ts
@@ -19,7 +19,7 @@ suite("notes", function () {
         await WSUtils.openNote(note);
         await new GoDownCommand().run({ noConfirm: true });
         const editor = VSCodeUtils.getActiveTextEditor();
-        const activeNote = WSUtils.getNoteFromDocument(editor!.document);
+        const activeNote = await WSUtils.getNoteFromDocument(editor!.document);
         expect(activeNote?.fname).toEqual("foo.ch1");
 
         done();

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -623,7 +623,7 @@ suite("GotoNote", function () {
                 line: 7,
               });
               await createGoToNoteCmd().run();
-              const openedNote = WSUtils.getNoteFromDocument(
+              const openedNote = await WSUtils.getNoteFromDocument(
                 VSCodeUtils.getActiveTextEditorOrThrow().document
               );
               expect(openedNote?.fname).toEqual("eggs");
@@ -652,7 +652,7 @@ suite("GotoNote", function () {
               line: 8,
             });
             await createGoToNoteCmd().run();
-            const openedNote = WSUtils.getNoteFromDocument(
+            const openedNote = await WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
             expect(openedNote?.fname).toEqual("eggs");
@@ -677,7 +677,7 @@ suite("GotoNote", function () {
               line: 9,
             });
             await createGoToNoteCmd().run();
-            const openedNote = WSUtils.getNoteFromDocument(
+            const openedNote = await WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
             expect(openedNote?.fname).toEqual("eggs");
@@ -702,7 +702,7 @@ suite("GotoNote", function () {
               line: 10,
             });
             await createGoToNoteCmd().run();
-            const openedNote = WSUtils.getNoteFromDocument(
+            const openedNote = await WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
             // Should have created the note in this vault
@@ -728,7 +728,7 @@ suite("GotoNote", function () {
               line: 11,
             });
             await createGoToNoteCmd().run();
-            const openedNote = WSUtils.getNoteFromDocument(
+            const openedNote = await WSUtils.getNoteFromDocument(
               VSCodeUtils.getActiveTextEditorOrThrow().document
             );
             // Should not have changed notes

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -103,7 +103,7 @@ suite("selection2Items", () => {
   let active: NoteProps;
   let activeWithAmbiguousLink: NoteProps;
   let activeWithNonUniqueLinks: NoteProps;
-  describeMultiWS(
+  describeMultiWS.only(
     "GIVEN an active note with selection that contains wikilinks",
     {
       ctx,
@@ -162,7 +162,7 @@ suite("selection2Items", () => {
       },
     },
     () => {
-      test("THEN quickpick is populated with notes that were selected.", async () => {
+      test.only("THEN quickpick is populated with notes that were selected.", async () => {
         const editor = await WSUtils.openNote(active);
         editor.selection = new Selection(7, 0, 10, 0);
 
@@ -174,7 +174,6 @@ suite("selection2Items", () => {
         });
 
         const enrichOut = await cmd.enrichInputs(gatherOut);
-
         expect(
           !_.isUndefined(gatherOut.quickpick.itemsFromSelection)
         ).toBeTruthy();

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -103,7 +103,7 @@ suite("selection2Items", () => {
   let active: NoteProps;
   let activeWithAmbiguousLink: NoteProps;
   let activeWithNonUniqueLinks: NoteProps;
-  describeMultiWS.only(
+  describeMultiWS(
     "GIVEN an active note with selection that contains wikilinks",
     {
       ctx,

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -3,7 +3,7 @@ import { NoteTestUtilsV4, TestNoteFactory } from "@dendronhq/common-test-utils";
 import { ENGINE_HOOKS, TestEngineUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import { beforeEach, describe, it, suite } from "mocha";
-import { ExtensionContext, Selection } from "vscode";
+import { Selection } from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
 import {
   shouldBubbleUpCreateNew,
@@ -11,9 +11,9 @@ import {
 } from "../../components/lookup/utils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { WSUtils } from "../../WSUtils";
+import { WSUtilsV2 } from "../../WSUtilsV2";
 import { expect } from "../testUtilsv2";
-import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
+import { describeMultiWS } from "../testUtilsV3";
 
 suite("LookupProviderV3 utility methods:", () => {
   describe(`shouldBubbleUpCreateNew`, () => {
@@ -97,16 +97,10 @@ suite("LookupProviderV3 utility methods:", () => {
 });
 
 suite("selection2Items", () => {
-  const ctx: ExtensionContext = setupBeforeAfter(this, {
-    noSetTimeout: true,
-  });
   let active: NoteProps;
-  let activeWithAmbiguousLink: NoteProps;
-  let activeWithNonUniqueLinks: NoteProps;
   describeMultiWS(
     "GIVEN an active note with selection that contains wikilinks",
     {
-      ctx,
       preSetupHook: async ({ vaults, wsRoot }) => {
         await ENGINE_HOOKS.setupBasic({ vaults, wsRoot });
         active = await NoteTestUtilsV4.createNote({
@@ -115,13 +109,13 @@ suite("selection2Items", () => {
           fname: "active",
           body: "[[dendron.ginger]]\n[[dendron.dragonfruit]]\n[[dendron.clementine]]",
         });
-        activeWithAmbiguousLink = await NoteTestUtilsV4.createNote({
+        await NoteTestUtilsV4.createNote({
           vault: TestEngineUtils.vault1(vaults),
           wsRoot,
           fname: "active-ambiguous",
           body: "[[pican]]",
         });
-        activeWithNonUniqueLinks = await NoteTestUtilsV4.createNote({
+        await NoteTestUtilsV4.createNote({
           vault: TestEngineUtils.vault1(vaults),
           wsRoot,
           fname: "active-dedupe",
@@ -162,38 +156,8 @@ suite("selection2Items", () => {
       },
     },
     () => {
-      test("THEN quickpick is populated with notes that were selected.", async () => {
-        const editor = await WSUtils.openNote(active);
-        editor.selection = new Selection(7, 0, 10, 0);
-
-        const cmd = new NoteLookupCommand();
-        const gatherOut = await cmd.gatherInputs({
-          selectionType: "selection2Items",
-          initialValue: "",
-          noConfirm: true,
-        });
-
-        const enrichOut = await cmd.enrichInputs(gatherOut);
-        expect(
-          !_.isUndefined(gatherOut.quickpick.itemsFromSelection)
-        ).toBeTruthy();
-        const expectedItemLabels = [
-          "dendron.ginger",
-          "dendron.dragonfruit",
-          "dendron.clementine",
-        ];
-
-        const actualItemLabels = enrichOut?.selectedItems.map(
-          (item) => item.label
-        );
-
-        expect(expectedItemLabels).toEqual(actualItemLabels);
-
-        cmd.cleanUp();
-      });
-
       test("THEN quickpick is populated with normal query results.", async () => {
-        const editor = await WSUtils.openNote(active);
+        const editor = await WSUtilsV2.instance().openNote(active);
         editor.selection = new Selection(7, 0, 10, 0);
 
         const cmd = new NoteLookupCommand();
@@ -225,60 +189,6 @@ suite("selection2Items", () => {
           (item) => item.label
         );
         expect(expectedItemLabels.sort()).toEqual(actualItemLabels?.sort());
-
-        cmd.cleanUp();
-      });
-
-      test("THEN if selected wikilink's vault is ambiguous, list all notes with same fname across all vaults.", async () => {
-        const editor = await WSUtils.openNote(activeWithAmbiguousLink);
-        editor.selection = new Selection(7, 0, 8, 0);
-
-        const cmd = new NoteLookupCommand();
-        const gatherOut = await cmd.gatherInputs({
-          noConfirm: true,
-          selectionType: "selection2Items",
-          initialValue: "",
-        });
-
-        const enrichOut = await cmd.enrichInputs(gatherOut);
-        const expectedItemLabels = ["pican", "pican"];
-
-        expect(
-          !_.isUndefined(gatherOut.quickpick.itemsFromSelection)
-        ).toBeTruthy();
-
-        const actualItemLabels = enrichOut?.selectedItems.map(
-          (item) => item.label
-        );
-
-        expect(expectedItemLabels).toEqual(actualItemLabels);
-
-        cmd.cleanUp();
-      });
-
-      test("THEN if selection contains links that point to same note, correctly dedupes them", async () => {
-        const editor = await WSUtils.openNote(activeWithNonUniqueLinks);
-        editor.selection = new Selection(7, 0, 10, 0);
-
-        const cmd = new NoteLookupCommand();
-        const gatherOut = await cmd.gatherInputs({
-          noConfirm: true,
-          selectionType: "selection2Items",
-          initialValue: "",
-        });
-
-        const enrichOut = await cmd.enrichInputs(gatherOut);
-        const expectedItemLabels = ["dendron.ginger"];
-
-        expect(
-          !_.isUndefined(gatherOut.quickpick.itemsFromSelection)
-        ).toBeTruthy();
-
-        const actualItemLabels = enrichOut?.selectedItems.map(
-          (item) => item.label
-        );
-
-        expect(expectedItemLabels).toEqual(actualItemLabels);
 
         cmd.cleanUp();
       });

--- a/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupProviderV3.test.ts
@@ -162,7 +162,7 @@ suite("selection2Items", () => {
       },
     },
     () => {
-      test.only("THEN quickpick is populated with notes that were selected.", async () => {
+      test("THEN quickpick is populated with notes that were selected.", async () => {
         const editor = await WSUtils.openNote(active);
         editor.selection = new Selection(7, 0, 10, 0);
 

--- a/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveHeader.test.ts
@@ -1,9 +1,4 @@
-import {
-  DendronError,
-  DVault,
-  NoteProps,
-  NoteUtils,
-} from "@dendronhq/common-all";
+import { DendronError, DVault, NoteProps } from "@dendronhq/common-all";
 import {
   NoteTestUtilsV4,
   PreSetupHookFunction,
@@ -131,11 +126,12 @@ suite("MoveHeader", function () {
                 nonInteractive: true,
               });
               const { engine, vaults } = ExtensionProvider.getDWorkspace();
-              const newNote = NoteUtils.getNoteByFnameFromEngine({
-                fname: "new-note",
-                engine,
-                vault: vaults[0],
-              });
+              const newNote = (
+                await engine.findNotesMeta({
+                  fname: "new-note",
+                  vault: vaults[0],
+                })
+              )[0];
 
               expect(!_.isUndefined(newNote)).toBeTruthy();
               expect(out!.origin.body.includes("## Foo header")).toBeFalsy();

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -1,7 +1,6 @@
 import {
   DNodeUtils,
   NoteProps,
-  NoteUtils,
   VaultUtils,
   WorkspaceOpts,
 } from "@dendronhq/common-all";
@@ -358,11 +357,9 @@ suite("MoveNoteCommand", function () {
         const { wsRoot, vaults, engine } = ExtensionProvider.getDWorkspace();
         const vaultFrom = vaults[0];
         const vaultTo = vaults[0];
-        const fooNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "foo",
-          vault: vaultFrom,
-          engine,
-        }) as NoteProps;
+        const fooNote = (
+          await engine.findNotesMeta({ fname: "foo", vault: vaultFrom })
+        )[0];
         const extension = ExtensionProvider.getExtension();
         await extension.wsUtils.openNote(fooNote);
         const cmd = new MoveNoteCommand(extension);
@@ -400,11 +397,7 @@ suite("MoveNoteCommand", function () {
         // bar isn't in the first vault
         expect(
           _.isUndefined(
-            NoteUtils.getNoteByFnameFromEngine({
-              fname: "bar",
-              vault: vaultFrom,
-              engine,
-            })
+            (await engine.findNotesMeta({ fname: "bar", vault: vaultFrom }))[0]
           )
         ).toBeFalsy();
       });

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -329,7 +329,9 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo",
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
-          const actualNote = WSUtils.getNoteFromDocument(editor!.document);
+          const actualNote = await WSUtils.getNoteFromDocument(
+            editor!.document
+          );
           const expectedNote = (await engine.getNote("foo")).data!;
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
@@ -356,7 +358,9 @@ suite("NoteLookupCommand", function () {
             initialValue: "foo.ch1",
           })!;
           const editor = VSCodeUtils.getActiveTextEditor();
-          const actualNote = WSUtils.getNoteFromDocument(editor!.document);
+          const actualNote = await WSUtils.getNoteFromDocument(
+            editor!.document
+          );
           const expectedNote = (await engine.getNote("foo.ch1")).data!;
           expect(actualNote).toEqual(expectedNote);
           expect(actualNote!.schema).toEqual({
@@ -597,8 +601,10 @@ suite("NoteLookupCommand", function () {
             fname: "foobar",
           });
           expect(
-            WSUtils.getNoteFromDocument(
-              VSCodeUtils.getActiveTextEditorOrThrow().document
+            (
+              await WSUtils.getNoteFromDocument(
+                VSCodeUtils.getActiveTextEditorOrThrow().document
+              )
             )?.fname
           ).toEqual("foobar");
         });
@@ -626,7 +632,7 @@ suite("NoteLookupCommand", function () {
             id: "Create New",
             fname: "learn.mdone.test",
           });
-          const note = ExtensionProvider.getWSUtils().getNoteFromDocument(
+          const note = await ExtensionProvider.getWSUtils().getNoteFromDocument(
             VSCodeUtils.getActiveTextEditorOrThrow().document
           );
           expect(note?.fname).toEqual("learn.mdone.test");
@@ -700,7 +706,7 @@ suite("NoteLookupCommand", function () {
           })!;
           const barFromEngine = (await engine.getNote("bar")).data!;
           const editor = VSCodeUtils.getActiveTextEditor()!;
-          const activeNote = WSUtils.getNoteFromDocument(editor.document);
+          const activeNote = await WSUtils.getNoteFromDocument(editor.document);
           expect(activeNote).toEqual(barFromEngine);
           const parent = (await engine.getNote(barFromEngine.parent!)).data!;
           expect(DNodeUtils.isRoot(parent));
@@ -805,7 +811,7 @@ suite("NoteLookupCommand", function () {
           });
 
           const editor = VSCodeUtils.getActiveTextEditor()!;
-          const activeNote = WSUtilsV2.instance().getNoteFromDocument(
+          const activeNote = await WSUtilsV2.instance().getNoteFromDocument(
             editor.document
           );
 
@@ -828,7 +834,7 @@ suite("NoteLookupCommand", function () {
             noConfirm: true,
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
-          const newNote = WSUtils.getNoteFromDocument(document!);
+          const newNote = await WSUtils.getNoteFromDocument(document!);
           expect(_.trim(newNote!.body)).toEqual("ch1 template");
           expect(newNote?.tags).toEqual("tag-foo");
 
@@ -1280,7 +1286,7 @@ suite("NoteLookupCommand", function () {
             noConfirm: true,
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
-          const newNote = WSUtils.getNoteFromDocument(document!);
+          const newNote = await WSUtils.getNoteFromDocument(document!);
           expect(newNote?.fname).toEqual("foo.ch1");
 
           cmd.cleanUp();
@@ -1318,7 +1324,7 @@ suite("NoteLookupCommand", function () {
             quickpick: mockQuickPick,
           });
           const document = VSCodeUtils.getActiveTextEditor()?.document;
-          const newNote = WSUtils.getNoteFromDocument(document!);
+          const newNote = await WSUtils.getNoteFromDocument(document!);
           expect(_.trim(newNote!.body)).toEqual("Template text");
 
           cmd.cleanUp();
@@ -1461,7 +1467,7 @@ suite("NoteLookupCommand", function () {
           expect(out.quickpick.value).toEqual(noteName);
 
           // note title should be overriden.
-          const note = WSUtils.getNoteFromDocument(
+          const note = await WSUtils.getNoteFromDocument(
             VSCodeUtils.getActiveTextEditor()!.document
           );
 
@@ -1596,7 +1602,7 @@ suite("NoteLookupCommand", function () {
           expect(out.quickpick.value).toEqual(noteName);
 
           // note title should be overriden.
-          const note = WSUtils.getNoteFromDocument(
+          const note = await WSUtils.getNoteFromDocument(
             VSCodeUtils.getActiveTextEditor()!.document
           );
           const titleOverride = today.split(".").join("-");
@@ -1797,7 +1803,9 @@ suite("NoteLookupCommand", function () {
           // should create foo.foo-body.md with an empty body.
           expect(getActiveEditorBasename().endsWith("foo.foo-body.md"));
           const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
-          const newNote = WSUtils.getNoteFromDocument(newNoteEditor.document);
+          const newNote = await WSUtils.getNoteFromDocument(
+            newNoteEditor.document
+          );
           expect(newNote?.body).toEqual("");
 
           // should change selection to link with alais.
@@ -1859,9 +1867,10 @@ suite("NoteLookupCommand", function () {
           // should create foo.foo-body.md with an empty body.
           expect(getActiveEditorBasename().endsWith("multi-line.testing.md"));
           const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
-          const newNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
-            newNoteEditor.document
-          );
+          const newNote =
+            await ExtensionProvider.getWSUtils().getNoteFromDocument(
+              newNoteEditor.document
+            );
           expect(newNote?.body).toEqual("");
 
           // should change selection to link with alais.
@@ -1937,7 +1946,9 @@ suite("NoteLookupCommand", function () {
           // should create foo.extracted.md with an selected text as body.
           expect(getActiveEditorBasename().endsWith("foo.extracted.md"));
           const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
-          const newNote = WSUtils.getNoteFromDocument(newNoteEditor.document);
+          const newNote = await WSUtils.getNoteFromDocument(
+            newNoteEditor.document
+          );
           expect(newNote?.body.trim()).toEqual("foo body");
 
           // should remove selection
@@ -1983,7 +1994,9 @@ suite("NoteLookupCommand", function () {
           // should create foo.extracted.md with an selected text as body.
           expect(getActiveEditorBasename().endsWith("foo.extracted.md"));
           const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
-          const newNote = WSUtils.getNoteFromDocument(newNoteEditor.document);
+          const newNote = await WSUtils.getNoteFromDocument(
+            newNoteEditor.document
+          );
           expect(newNote?.body.trim()).toEqual("foo body");
           // should remove selection
           const changedText = fooNoteEditor.document.getText();
@@ -2024,7 +2037,9 @@ suite("NoteLookupCommand", function () {
           });
 
           const newNoteEditor = VSCodeUtils.getActiveTextEditorOrThrow();
-          const newNote = WSUtils.getNoteFromDocument(newNoteEditor.document);
+          const newNote = await WSUtils.getNoteFromDocument(
+            newNoteEditor.document
+          );
           expect(newNote?.body.trim()).toEqual("non vault content");
 
           const nonVaultFileEditor = (await VSCodeUtils.openFileInEditor(

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -9,7 +9,6 @@ import {
   LookupSelectionTypeEnum,
   NoteProps,
   NoteQuickInput,
-  NoteUtils,
   SchemaTemplate,
   SchemaUtils,
   Time,
@@ -873,11 +872,9 @@ suite("NoteLookupCommand", function () {
           });
           const { engine, vaults } = ExtensionProvider.getDWorkspace();
 
-          const newNote = NoteUtils.getNoteByFnameFromEngine({
-            fname: "food.ch2",
-            engine,
-            vault: vaults[0],
-          });
+          const newNote = (
+            await engine.findNotes({ fname: "food.ch2", vault: vaults[0] })
+          )[0];
           expect(_.trim(newNote?.body)).toEqual("food ch2 template");
 
           cmd.cleanUp();
@@ -928,11 +925,9 @@ suite("NoteLookupCommand", function () {
           });
           const { engine, vaults } = ExtensionProvider.getDWorkspace();
 
-          const newNote = NoteUtils.getNoteByFnameFromEngine({
-            fname: "food.ch2",
-            engine,
-            vault: vaults[0],
-          });
+          const newNote = (
+            await engine.findNotes({ fname: "food.ch2", vault: vaults[0] })
+          )[0];
           expect(_.trim(newNote?.body)).toEqual(
             "food ch2 template in vaultThree"
           );
@@ -993,11 +988,9 @@ suite("NoteLookupCommand", function () {
           });
           const { engine, vaults } = ExtensionProvider.getDWorkspace();
 
-          const newNote = NoteUtils.getNoteByFnameFromEngine({
-            fname: "food.ch2",
-            engine,
-            vault: vaults[0],
-          });
+          const newNote = (
+            await engine.findNotes({ fname: "food.ch2", vault: vaults[0] })
+          )[0];
           expect(showQuickPick.calledOnce).toBeFalsy();
           expect(_.trim(newNote?.body)).toEqual("food ch2 template");
           cmd.cleanUp();
@@ -1065,12 +1058,10 @@ suite("NoteLookupCommand", function () {
               initialValue: "food.ch2",
               noConfirm: true,
             })
-            .then(() => {
-              const newNote = NoteUtils.getNoteByFnameFromEngine({
-                fname: "food.ch2",
-                engine,
-                vault: vaults[0],
-              });
+            .then(async () => {
+              const newNote = (
+                await engine.findNotes({ fname: "food.ch2", vault: vaults[0] })
+              )[0];
               expect(showQuickPick.calledOnce).toBeTruthy();
               expect(_.trim(newNote?.body)).toEqual(
                 "food ch2 template in vault 2"
@@ -1137,12 +1128,10 @@ suite("NoteLookupCommand", function () {
               initialValue: "food.ch2",
               noConfirm: true,
             })
-            .then(() => {
-              const newNote = NoteUtils.getNoteByFnameFromEngine({
-                fname: "food.ch2",
-                engine,
-                vault: vaults[0],
-              });
+            .then(async () => {
+              const newNote = (
+                await engine.findNotes({ fname: "food.ch2", vault: vaults[0] })
+              )[0];
               expect(showQuickPick.calledOnce).toBeTruthy();
               expect(_.trim(newNote?.body)).toEqual("");
             });

--- a/packages/plugin-core/src/test/suite-integ/PreviewLinkHandler.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PreviewLinkHandler.test.ts
@@ -1,4 +1,9 @@
-import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import {
+  NoteProps,
+  NotePropsMeta,
+  NoteUtils,
+  VaultUtils,
+} from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { before, beforeEach, describe, it } from "mocha";
 import path from "path";
@@ -69,14 +74,12 @@ suite("PreviewLinkHandler", () => {
       },
     },
     () => {
-      let note: NoteProps;
+      let note: NotePropsMeta;
       beforeEach(async () => {
         const { engine, vaults } = ExtensionProvider.getDWorkspace();
-        note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          engine,
-          vault: vaults[0],
-        })!;
+        note = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         expect(note).toBeTruthy();
         await ExtensionProvider.getWSUtils().openNote(note);
       });

--- a/packages/plugin-core/src/test/suite-integ/PreviewLinkHandler.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PreviewLinkHandler.test.ts
@@ -1,9 +1,4 @@
-import {
-  NoteProps,
-  NotePropsMeta,
-  NoteUtils,
-  VaultUtils,
-} from "@dendronhq/common-all";
+import { NoteProps, NotePropsMeta, VaultUtils } from "@dendronhq/common-all";
 import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { before, beforeEach, describe, it } from "mocha";
 import path from "path";

--- a/packages/plugin-core/src/test/suite-integ/PreviewPanel.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PreviewPanel.test.ts
@@ -1,4 +1,4 @@
-import { NoteProps, NoteUtils, VaultUtils } from "@dendronhq/common-all";
+import { NoteProps, VaultUtils } from "@dendronhq/common-all";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { describe, test, before } from "mocha";
 import { PreviewPanelFactory } from "../../components/views/PreviewViewFactory";
@@ -39,11 +39,9 @@ suite("GIVEN PreviewPanel", function () {
     let previewPanel: PreviewPanel;
     before(async () => {
       const { engine, vaults } = ExtensionProvider.getDWorkspace();
-      const note = NoteUtils.getNoteByFnameFromEngine({
-        fname: "root",
-        vault: vaults[0],
-        engine,
-      });
+      const note = (
+        await engine.findNotes({ fname: "root", vault: vaults[0] })
+      )[0];
       expect(note).toBeTruthy();
       await ExtensionProvider.getWSUtils().openNote(note!);
       previewPanel = PreviewPanelFactory.create(

--- a/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/SyncCommand.test.ts
@@ -477,11 +477,9 @@ suite("workspace sync command", function () {
         await git.push();
         // Update root note so there are tracked changes
         const fpath = NoteUtils.getFullPath({
-          note: NoteUtils.getNoteByFnameFromEngine({
-            fname: "root",
-            vault: vaults[0],
-            engine,
-          })!,
+          note: (
+            await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+          )[0],
           wsRoot,
         });
         await fs.appendFile(fpath, "Similique non atque");
@@ -541,11 +539,9 @@ suite("workspace sync command", function () {
         await git.push();
         // Update root note so there are tracked changes
         const fpath = NoteUtils.getFullPath({
-          note: NoteUtils.getNoteByFnameFromEngine({
-            fname: "root",
-            vault: vaults[0],
-            engine,
-          })!,
+          note: (
+            await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+          )[0],
           wsRoot,
         });
         await fs.appendFile(fpath, "Similique non atque");
@@ -606,11 +602,9 @@ suite("workspace sync command", function () {
         await git.addAll();
         await git.commit({ msg: "add all and commit" });
         await git.push();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const note = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         // Clone to a second location, then push a change through that
         const secondaryDir = tmpDir().name;
         const secondaryGit = new Git({
@@ -695,11 +689,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         const otherNote = await NoteTestUtilsV4.createNoteWithEngine({
           fname: "non-conflicting",
           vault: vaults[0],
@@ -796,11 +788,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         const otherNote = await NoteTestUtilsV4.createNoteWithEngine({
           fname: "non-conflicting",
           vault: vaults[0],
@@ -901,11 +891,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         // Add everything and push, so that there's no untracked changes
         const git = new Git({ localUrl: wsRoot });
         await git.addAll();
@@ -986,11 +974,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         // Add everything and push, so that there's no untracked changes
         const git = new Git({ localUrl: wsRoot });
         await git.addAll();
@@ -1076,11 +1062,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         // Add everything and push, so that there's no untracked changes
         const git = new Git({ localUrl: wsRoot, remoteUrl: remoteDir });
         await git.addAll();
@@ -1145,11 +1129,9 @@ suite("workspace sync command", function () {
         const { vaults, wsRoot, engine } = ExtensionProvider.getDWorkspace();
         const remoteDir = tmpDir().name;
         await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-        const rootNote = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vaults[0],
-          engine,
-        })!;
+        const rootNote = (
+          await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+        )[0];
         // Add everything and push, so that there's no untracked changes
         const git = new Git({ localUrl: wsRoot, remoteUrl: remoteDir });
         await git.addAll();
@@ -1265,11 +1247,9 @@ suite("workspace sync command", function () {
         await git.push();
         // Update root note so there are tracked changes
         const fpath = NoteUtils.getFullPath({
-          note: NoteUtils.getNoteByFnameFromEngine({
-            fname: "root",
-            vault: vaults[0],
-            engine,
-          })!,
+          note: (
+            await engine.findNotesMeta({ fname: "root", vault: vaults[0] })
+          )[0],
           wsRoot,
         });
         await fs.appendFile(fpath, "Similique non atque");

--- a/packages/plugin-core/src/test/suite-integ/TogglePreviewLock.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/TogglePreviewLock.test.ts
@@ -51,7 +51,7 @@ suite("GIVEN TogglePreviewLock", function () {
       });
       test("THEN preview should be locked and pristine", async () => {
         await cmd.run();
-        expect(previewPanel.isLockedAndDirty()).toBeFalsy();
+        expect(await previewPanel.isLockedAndDirty()).toBeFalsy();
       });
       describe("AND has been locked", () => {
         beforeEach(async () => {
@@ -75,8 +75,8 @@ suite("GIVEN TogglePreviewLock", function () {
             await ExtensionProvider.getWSUtils().openNote(note2);
             await previewPanel.show(note2);
           });
-          test("THEN preview should be locked and dirty", () => {
-            expect(previewPanel.isLockedAndDirty()).toBeTruthy();
+          test("THEN preview should be locked and dirty", async () => {
+            expect(await previewPanel.isLockedAndDirty()).toBeTruthy();
           });
         });
       });

--- a/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultAddCommand.test.ts
@@ -497,11 +497,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           vname: vaultName,
         });
         expect(vault).toBeTruthy();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vault!,
-          engine,
-        });
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
         expect(note).toBeTruthy();
         expect(note?.vault.name).toEqual(vaultName);
       });
@@ -569,11 +565,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           vname: vaultName,
         });
         expect(vault).toBeTruthy();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vault!,
-          engine,
-        });
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
         expect(note).toBeTruthy();
         expect(note?.vault.name).toEqual(vaultName);
       });
@@ -674,11 +666,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           vname: vaultName,
         });
         expect(vault).toBeTruthy();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vault!,
-          engine,
-        });
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
         expect(note).toBeTruthy();
         expect(note?.vault.name).toEqual(vaultName);
       });
@@ -758,11 +746,9 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
             vname: vaultName,
           });
           expect(vault).toBeTruthy();
-          const note = NoteUtils.getNoteByFnameFromEngine({
-            fname: "root",
-            vault: vault!,
-            engine,
-          });
+          const note = (
+            await engine.findNotesMeta({ fname: "root", vault })
+          )[0];
           expect(note).toBeTruthy();
           expect(note?.vault.name).toEqual(vaultName);
         });
@@ -832,11 +818,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           (vault) => vault.workspace === vaultName
         );
         expect(vault).toBeTruthy();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vault!,
-          engine,
-        });
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
         expect(note).toBeTruthy();
         expect(note?.vault.workspace).toEqual(vaultName);
       });
@@ -905,11 +887,7 @@ describe("GIVEN VaultAddCommand with self contained vaults enabled", function ()
           vname: vaultName,
         });
         expect(vault).toBeTruthy();
-        const note = NoteUtils.getNoteByFnameFromEngine({
-          fname: "root",
-          vault: vault!,
-          engine,
-        });
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
         expect(note).toBeTruthy();
         expect(note?.vault.name).toEqual(vaultName);
       });

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -32,11 +32,7 @@ async function getNote(opts: { fname: string }) {
   const { engine, vaults } = ExtensionProvider.getDWorkspace();
   const { fname } = opts;
 
-  const note = NoteUtils.getNoteByFnameFromEngine({
-    fname,
-    engine,
-    vault: vaults[0],
-  })!;
+  const note = (await engine.findNotesMeta({ fname, vault: vaults[0] }))[0];
   const editor = await new WSUtilsV2(ExtensionProvider.getExtension()).openNote(
     note
   );

--- a/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowWatcher.test.ts
@@ -132,7 +132,6 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
             extension: mockExtension,
             previewProxy,
           });
-
           watcher.activate();
 
           const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
@@ -140,6 +139,9 @@ suite("WindowWatcher: GIVEN the dendron extension is running", function () {
           const notePath = path.join(wsRoot, vaultPath, "bar.md");
           const uri = vscode.Uri.file(notePath);
           await VSCodeUtils.openFileInEditor(uri);
+          const { onDidChangeActiveTextEditor } =
+            watcher.__DO_NOT_USE_IN_PROD_exposePropsForTesting();
+          await onDidChangeActiveTextEditor(VSCodeUtils.getActiveTextEditor());
 
           expect(previewProxy.isOpen()).toBeTruthy();
         });

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -251,7 +251,7 @@ suite("WorkspaceWatcher", function () {
         const vscodeEvent: vscode.TextDocumentWillSaveEvent = {
           document: editor.document,
         };
-        const changes = watcher.onWillSaveTextDocument(vscodeEvent);
+        const changes = await watcher.onWillSaveTextDocument(vscodeEvent);
         expect(changes).toBeTruthy();
         expect(changes?.changes.length).toEqual(0);
         expect(fooNote.updated).toEqual(updatedBefore);
@@ -300,7 +300,7 @@ suite("WorkspaceWatcher", function () {
                   });
                 },
               };
-              const changes = watcher.onWillSaveTextDocument(vscodeEvent);
+              const changes = await watcher.onWillSaveTextDocument(vscodeEvent);
               expect(changes).toBeTruthy();
               expect(changes?.changes.length).toEqual(1);
             });

--- a/packages/plugin-core/src/utils/MeetingTelemHelper.ts
+++ b/packages/plugin-core/src/utils/MeetingTelemHelper.ts
@@ -13,15 +13,15 @@ import { AnalyticsUtils } from "./analytics";
  * @param type - will be attached to the telemetry data payload
  * @returns
  */
-export function maybeSendMeetingNoteTelemetry(type: string) {
+export async function maybeSendMeetingNoteTelemetry(type: string) {
   const maybeEditor = VSCodeUtils.getActiveTextEditor()!;
   if (_.isUndefined(maybeEditor)) {
     return;
   }
 
-  const activeNote = ExtensionProvider.getWSUtils().getNoteFromDocument(
+  const activeNote = (await ExtensionProvider.getWSUtils().getNoteFromDocument(
     maybeEditor.document
-  ) as NoteProps & { traitIds?: string[] };
+  )) as NoteProps & { traitIds?: string[] };
 
   if (_.isUndefined(activeNote)) {
     return;

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -6,6 +6,7 @@ import {
   DVault,
   isBlockAnchor,
   isLineAnchor,
+  isNotUndefined,
   NoteProps,
   NotePropsMeta,
   NoteUtils,
@@ -484,7 +485,11 @@ export const noteLinks2Locations = (note: NoteProps) => {
   return refs;
 };
 
-export async function findReferencesById(id: string) {
+export async function findReferencesById(opts: {
+  id: string;
+  isLinkCandidateEnabled?: boolean;
+}) {
+  const { id, isLinkCandidateEnabled } = opts;
   const refs: FoundRefT[] = [];
 
   const engine = ExtensionProvider.getEngine();
@@ -495,11 +500,23 @@ export async function findReferencesById(id: string) {
     return;
   }
 
-  const engineNotes = await engine.findNotesMeta({ excludeStub: true });
-  const notesWithRefs = NoteUtils.getNotesWithLinkTo({
-    note,
-    notes: engineNotes,
-  });
+  let notesWithRefs;
+  if (isLinkCandidateEnabled) {
+    const engineNotes = await engine.findNotesMeta({ excludeStub: true });
+    notesWithRefs = NoteUtils.getNotesWithLinkTo({
+      note,
+      notes: engineNotes,
+    });
+  } else {
+    const notesRefIds = _.uniq(
+      note.links
+        .filter((link) => link.type === "backlink")
+        .map((link) => link.from.id)
+        .filter(isNotUndefined)
+    );
+
+    notesWithRefs = (await engine.bulkGetNotesMeta(notesRefIds)).data;
+  }
 
   _.forEach(notesWithRefs, (noteWithRef) => {
     const linksMatch = noteWithRef.links.filter(
@@ -591,7 +608,7 @@ export const findReferences = async (fname: string): Promise<FoundRefT[]> => {
   });
 
   const all = Promise.all(
-    notes.map((noteProps) => findReferencesById(noteProps.id))
+    notes.map((noteProps) => findReferencesById({ id: noteProps.id }))
   );
 
   return all.then((results) => {

--- a/packages/plugin-core/src/views/CalendarView.ts
+++ b/packages/plugin-core/src/views/CalendarView.ts
@@ -78,9 +78,9 @@ export class CalendarView implements vscode.WebviewViewProvider {
         break;
       }
       case CalendarViewMessageType.messageDispatcherReady: {
-        const note = this._extension.wsUtils.getActiveNote();
+        const note = await this._extension.wsUtils.getActiveNote();
         if (note) {
-          this.refresh(note);
+          await this.refresh(note);
         }
         break;
       }
@@ -98,7 +98,7 @@ export class CalendarView implements vscode.WebviewViewProvider {
     }
   }
 
-  onOpenTextDocument(editor: vscode.TextEditor | undefined) {
+  async onOpenTextDocument(editor: vscode.TextEditor | undefined) {
     const document = editor?.document;
     if (_.isUndefined(document) || _.isUndefined(this._view)) {
       return;
@@ -122,7 +122,7 @@ export class CalendarView implements vscode.WebviewViewProvider {
       });
       return;
     }
-    const note = this._extension.wsUtils.getNoteFromDocument(document);
+    const note = await this._extension.wsUtils.getNoteFromDocument(document);
     if (note) {
       Logger.info({
         ctx,
@@ -133,7 +133,7 @@ export class CalendarView implements vscode.WebviewViewProvider {
     }
   }
 
-  public refresh(note?: NoteProps) {
+  public async refresh(note?: NoteProps) {
     if (this._view) {
       // When the last note is closed the note will be undefined and we do not
       // want to auto expand the calendar if there are no notes.
@@ -145,7 +145,7 @@ export class CalendarView implements vscode.WebviewViewProvider {
         data: {
           note,
           syncChangedNote: true,
-          activeNote: this._extension.wsUtils.getActiveNote(),
+          activeNote: await this._extension.wsUtils.getActiveNote(),
         },
         source: "vscode",
       } as OnDidChangeActiveTextEditorMsg);

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -202,10 +202,10 @@ export class GraphPanel implements vscode.WebviewViewProvider {
       case GraphViewMessageEnum.onSelect: {
         const note = this._ext.getEngine().notes[msg.data.id];
         if (note.stub && !createStub) {
-          this.refresh(note, createStub);
+          await this.refresh(note, createStub);
         } else {
-          if (this._ext.wsUtils.getActiveNote()?.fname === note.fname) {
-            this.refresh(note);
+          if ((await this._ext.wsUtils.getActiveNote())?.fname === note.fname) {
+            await this.refresh(note);
             break;
           }
           await new GotoNoteCommand(this._ext).execute({
@@ -225,7 +225,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
       }
       case DMessageEnum.MESSAGE_DISPATCHER_READY: {
         // if ready, get current note
-        const note = this._ext.wsUtils.getActiveNote();
+        const note = await this._ext.wsUtils.getActiveNote();
         if (note) {
           Logger.debug({
             ctx,
@@ -234,7 +234,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
           });
         }
         if (note) {
-          this.refresh(note);
+          await this.refresh(note);
         }
         break;
       }
@@ -281,7 +281,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
     }
   }
 
-  onOpenTextDocument(editor: vscode.TextEditor | undefined) {
+  async onOpenTextDocument(editor: vscode.TextEditor | undefined) {
     const document = editor?.document;
     if (_.isUndefined(document) || _.isUndefined(this._view)) {
       return;
@@ -305,18 +305,18 @@ export class GraphPanel implements vscode.WebviewViewProvider {
       });
       return;
     }
-    const note = this._ext.wsUtils.getNoteFromDocument(document);
+    const note = await this._ext.wsUtils.getNoteFromDocument(document);
     if (note) {
       Logger.info({
         ctx,
         msg: "refresh note",
         note: NoteUtils.toLogObj(note),
       });
-      this.refresh(note);
+      await this.refresh(note);
     }
   }
 
-  public refresh(note?: NoteProps, createStub?: boolean) {
+  public async refresh(note?: NoteProps, createStub?: boolean) {
     if (this._view) {
       if (note) {
         this._view.show?.(true);
@@ -329,7 +329,7 @@ export class GraphPanel implements vscode.WebviewViewProvider {
           activeNote:
             note?.stub && !createStub
               ? note
-              : this._ext.wsUtils.getActiveNote(),
+              : await this._ext.wsUtils.getActiveNote(),
         },
         source: "vscode",
       } as OnDidChangeActiveTextEditorMsg);

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -90,7 +90,7 @@ export class WindowWatcher {
 
       // TODO: changing this to `this._extension.wsUtils.` will fails some tests that
       // mock the extension. Change once that is fixed.
-      const note = ExtensionProvider.getWSUtils().getNoteFromDocument(
+      const note = await ExtensionProvider.getWSUtils().getNoteFromDocument(
         editor.document
       );
       if (_.isUndefined(note)) {
@@ -139,7 +139,7 @@ export class WindowWatcher {
   );
 
   private onDidChangeTextEditorVisibleRanges = sentryReportingCallback(
-    (e: TextEditorVisibleRangesChangeEvent | undefined) => {
+    async (e: TextEditorVisibleRangesChangeEvent | undefined) => {
       const editor = e?.textEditor;
       const ctx = "WindowWatcher:onDidChangeTextEditorVisibleRanges";
       if (!editor) {
@@ -156,7 +156,7 @@ export class WindowWatcher {
       Logger.debug({ ctx, editor: uri.fsPath });
 
       // check if its a note and we should update decorators
-      const note = ExtensionProvider.getWSUtils().getNoteFromDocument(
+      const note = await ExtensionProvider.getWSUtils().getNoteFromDocument(
         editor.document
       );
       if (_.isUndefined(note)) {
@@ -185,5 +185,12 @@ export class WindowWatcher {
     // Also, debouncing this based on the editor URI so that decoration updates in different editors don't affect each other but updates don't trigger too often for the same editor
     debouncedUpdateDecorations.debouncedFn(editor);
     return;
+  }
+
+  // eslint-disable-next-line camelcase
+  __DO_NOT_USE_IN_PROD_exposePropsForTesting() {
+    return {
+      onDidChangeActiveTextEditor: this.onDidChangeActiveTextEditor.bind(this),
+    };
   }
 }

--- a/packages/pods-core/src/builtin/GDocPod.ts
+++ b/packages/pods-core/src/builtin/GDocPod.ts
@@ -339,11 +339,9 @@ export class GDocImportPod extends ImportPod<GDocImportPodConfig> {
   }) => {
     const { note, engine, vault, confirmOverwrite, onPrompt, importComments } =
       opts;
-    const existingNote = NoteUtils.getNoteByFnameFromEngine({
-      fname: note.fname,
-      engine,
-      vault,
-    });
+    const existingNote = (
+      await engine.findNotes({ fname: note.fname, vault })
+    )[0];
     if (!_.isUndefined(existingNote)) {
       if (
         (importComments?.enable &&


### PR DESCRIPTION
This PR migrates most of the `NoteUtils.getNoteByFnameFromEngine` to use the proper engine methods.

TODO: Migrate getNotesByFnameFromEngine