### PR TITLE
fix(workspace): engine init with note candidates enabled

### DIFF
--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -133,7 +133,7 @@ export class FileStorage implements DStore {
         const ctx = "_addLinkCandidates";
         const start = process.hrtime();
         // this mutates existing note objects so we don't need to reset the notes
-        await this._addLinkCandidates(_.values(this.notes));
+        this._addLinkCandidates();
         const duration = getDurationMilliseconds(start);
         this.logger.info({ ctx, duration });
       }
@@ -635,35 +635,36 @@ export class FileStorage implements DStore {
     });
   }
 
-  _addLinkCandidates(allNotes: NoteProps[]) {
-    return Promise.all(
-      _.map(allNotes, async (noteFrom: NoteProps) => {
-        try {
-          const maxNoteLength = ConfigUtils.getWorkspace(
-            this.config
-          ).maxNoteLength;
-          if (
-            noteFrom.body.length <
-            (maxNoteLength || CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
-          ) {
-            const linkCandidates = await LinkUtils.findLinkCandidates({
-              note: noteFrom,
-              engine: this.engine,
-              config: this.config,
-            });
-            noteFrom.links = noteFrom.links.concat(linkCandidates);
-          }
-        } catch (err: any) {
-          const error = error2PlainObject(err);
-          this.logger.error({
-            error,
-            noteFrom,
-            message: "issue with link candidates",
+  private _addLinkCandidates() {
+    return _.map(this.notes, (noteFrom: NoteProps) => {
+      try {
+        const maxNoteLength = ConfigUtils.getWorkspace(
+          this.config
+        ).maxNoteLength;
+        if (
+          noteFrom.body.length <
+          (maxNoteLength || CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
+        ) {
+          const linkCandidates = LinkUtils.findLinkCandidatesSync({
+            note: noteFrom,
+            noteDicts: {
+              notesById: this.notes,
+              notesByFname: this.noteFnames,
+            },
+            config: this.config,
           });
-          return;
+          noteFrom.links = noteFrom.links.concat(linkCandidates);
         }
-      })
-    );
+      } catch (err: any) {
+        const error = error2PlainObject(err);
+        this.logger.error({
+          error,
+          noteFrom,
+          message: "issue with link candidates",
+        });
+        return;
+      }
+    });
   }
 
   async _initNotes(vault: DVault): Promise<{

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -26,6 +26,8 @@ import {
   LINK_NAME,
   NoteBlock,
   NoteChangeEntry,
+  NoteDicts,
+  NoteDictsUtils,
   NoteProps,
   NotePropsMeta,
   NoteUtils,
@@ -364,6 +366,85 @@ const getLinkCandidates = async ({
       );
     })
   );
+  return linkCandidates;
+};
+
+/**
+ * Use this version during engine initialization on the engine side, where the
+ * entire set of noteDicts is available. This version uses local data so it's
+ * much faster.
+ * @param param0
+ * @returns
+ */
+const getLinkCandidatesSync = ({
+  ast,
+  note,
+  noteDicts,
+}: {
+  ast: DendronASTNode;
+  note: NoteProps;
+  noteDicts: NoteDicts;
+}) => {
+  const textNodes: Text[] = [];
+  visit(
+    ast,
+    [DendronASTTypes.TEXT],
+    (node: Text, _index: number, parent: Parent | undefined) => {
+      if (parent?.type === "paragraph" || parent?.type === "tableCell") {
+        textNodes.push(node);
+      }
+    }
+  );
+
+  const linkCandidates: DLink[] = [];
+
+  _.map(textNodes, (textNode: Text) => {
+    const value = textNode.value as string;
+
+    value.split(/\s+/).map((word) => {
+      const possibleCandidates = NoteDictsUtils.findByFname(
+        word,
+        noteDicts,
+        note.vault
+      )
+        // await engine.findNotesMeta({ fname: word, vault: note.vault })
+        .filter((note) => note.stub !== true);
+
+      linkCandidates.push(
+        ...possibleCandidates.map((candidate): DLink => {
+          const startColumn = value.indexOf(word) + 1;
+          const endColumn = startColumn + word.length;
+
+          const position: Position = {
+            start: {
+              line: textNode.position!.start.line,
+              column: startColumn,
+              offset: textNode.position!.start.offset
+                ? textNode.position!.start.offset + startColumn - 1
+                : undefined,
+            },
+            end: {
+              line: textNode.position!.start.line,
+              column: endColumn,
+              offset: textNode.position!.start.offset
+                ? textNode.position!.start.offset + endColumn - 1
+                : undefined,
+            },
+          };
+          return {
+            type: "linkCandidate",
+            from: NoteUtils.toNoteLoc(note),
+            value: value.trim(),
+            position,
+            to: {
+              fname: word,
+              vaultName: VaultUtils.getName(candidate.vault),
+            },
+          };
+        })
+      );
+    });
+  });
   return linkCandidates;
 };
 
@@ -811,6 +892,43 @@ export class LinkUtils {
     const tree = remark.parse(content) as DendronASTNode;
     const linkCandidates: DLink[] = await getLinkCandidates({
       engine,
+      ast: tree,
+      note,
+    });
+    return linkCandidates;
+  }
+
+  /**
+   *  Use this version during engine initialization on the engine side, where
+   *  the entire set of noteDicts is available. This version uses local data so
+   *  it's much faster.
+   * @param param0
+   * @returns
+   */
+  static findLinkCandidatesSync({
+    note,
+    noteDicts,
+    config,
+  }: {
+    note: NoteProps;
+    noteDicts: NoteDicts;
+    config: IntermediateDendronConfig;
+  }) {
+    const content = note.body;
+
+    const remark = MDUtilsV5.procRemarkParse(
+      { mode: ProcMode.FULL },
+      {
+        noteToRender: note,
+        fname: note.fname,
+        vault: note.vault,
+        dest: DendronASTDest.MD_DENDRON,
+        config,
+      }
+    );
+    const tree = remark.parse(content) as DendronASTNode;
+    const linkCandidates: DLink[] = getLinkCandidatesSync({
+      noteDicts,
       ast: tree,
       note,
     });


### PR DESCRIPTION
## fix(workspace): engine init with note candidates enabled

Fixing a regression caused by https://github.com/dendronhq/dendron/pull/3482. 

Note candidates were doing an API call for each word in each note. This change reverts the logic to use a local note dictionary set, but with the restriction that this is only used within engine initialization.