### PR TITLE
chore: add telemetry and inform if localhost is blocked

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -90,6 +90,7 @@ export enum ExtensionEvents {
   ShowKeybindingConflictRejected = "Show_Keybinding_Conflict_Rejected",
   DeprecationNoticeShow = "DeprecationNoticeShow",
   DeprecationNoticeAccept = "DeprecationNoticeAccept",
+  LocalhostBlocked = "LocalhostBlocked",
 }
 
 export enum LookupEvents {

--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -90,7 +90,9 @@ export enum ExtensionEvents {
   ShowKeybindingConflictRejected = "Show_Keybinding_Conflict_Rejected",
   DeprecationNoticeShow = "DeprecationNoticeShow",
   DeprecationNoticeAccept = "DeprecationNoticeAccept",
-  LocalhostBlocked = "LocalhostBlocked",
+  LocalhostBlockedNotified = "LocalhostBlocked_Notified",
+  LocalhostBlockedAccepted = "LocalhostBlocked_Accepted",
+  LocalhostBlockedRejected = "LocalhostBlocked_Rejected",
 }
 
 export enum LookupEvents {

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -331,6 +331,8 @@ export async function _activate(
 
       // show interactive elements when **extension starts**
       if (!opts?.skipInteractiveElements) {
+        // check if localhost is blocked
+        await StartupUtils.showWhitelistingLocalhostDocsIfNecessary();
         // check for missing default config keys and prompt for a backfill.
         StartupUtils.showMissingDefaultConfigMessageIfNecessary({
           ext: ws,

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -15,6 +15,7 @@ import { DConfig, readMD } from "@dendronhq/common-server";
 import {
   DEPRECATED_PATHS,
   DoctorActionsEnum,
+  execa,
   InactvieUserMsgStatusEnum,
   MetadataService,
   MigrationChangeSetStatus,
@@ -543,5 +544,29 @@ export class StartupUtils {
     AnalyticsUtils.track(VSCodeEvents.V100ReleaseNotesShown);
 
     MetadataService.instance().v100ReleaseMessageShown = true;
+  }
+
+  /**
+   * this method pings the localhost and checks if it is available. Incase local is blocked off,
+   * displays a toaster with a link to troubleshooting docs
+   */
+  static async showWhitelistingLocalhostDocsIfNecessary() {
+    const { failed } = await execa("ping", ["127.0.0.1"]);
+    if (failed) {
+      vscode.window
+        .showWarningMessage(
+          "Dendron is facing issues while connecting with localhost. Please ensure that you don't have anything running that can block localhost.",
+          ...["Open troubleshooting docs"]
+        )
+        .then((resp) => {
+          if (resp === "Open troubleshooting docs") {
+            vscode.commands.executeCommand(
+              "vscode.open",
+              "https://wiki.dendron.so/notes/a6c03f9b-8959-4d67-8394-4d204ab69bfe/#whitelisting-localhost"
+            );
+          }
+        });
+      AnalyticsUtils.track(ExtensionEvents.LocalhostBlocked);
+    }
   }
 }

--- a/packages/plugin-core/src/utils/StartupUtils.ts
+++ b/packages/plugin-core/src/utils/StartupUtils.ts
@@ -551,8 +551,9 @@ export class StartupUtils {
    * displays a toaster with a link to troubleshooting docs
    */
   static async showWhitelistingLocalhostDocsIfNecessary() {
-    const { failed } = await execa("ping", ["127.0.0.1"]);
+    const { failed } = await execa.command("ping 127.0.0.1");
     if (failed) {
+      AnalyticsUtils.track(ExtensionEvents.LocalhostBlockedNotified);
       vscode.window
         .showWarningMessage(
           "Dendron is facing issues while connecting with localhost. Please ensure that you don't have anything running that can block localhost.",
@@ -560,13 +561,15 @@ export class StartupUtils {
         )
         .then((resp) => {
           if (resp === "Open troubleshooting docs") {
+            AnalyticsUtils.track(ExtensionEvents.LocalhostBlockedAccepted);
             vscode.commands.executeCommand(
               "vscode.open",
               "https://wiki.dendron.so/notes/a6c03f9b-8959-4d67-8394-4d204ab69bfe/#whitelisting-localhost"
             );
+          } else {
+            AnalyticsUtils.track(ExtensionEvents.LocalhostBlockedRejected);
           }
         });
-      AnalyticsUtils.track(ExtensionEvents.LocalhostBlocked);
     }
   }
 }


### PR DESCRIPTION
This PR aims to add a check to see if localhost is available at the time of Dendron init. Incase of blocked localhost, we send a warning toaster reporting the same with a link to see [troubleshooting docs](https://wiki.dendron.so/notes/a6c03f9b-8959-4d67-8394-4d204ab69bfe/#whitelisting-localhost).
- Task: [[show error message when localhost is blocked|task.2022.09.13.show-error-message-when-localhost-is-blocked]]


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)