### PR TITLE
fix: correctly update dendron.yml when adding / deleting vaults

### DIFF
--- a/packages/engine-server/src/seed/service.ts
+++ b/packages/engine-server/src/seed/service.ts
@@ -10,7 +10,7 @@ import {
   ConfigUtils,
   SeedVault,
 } from "@dendronhq/common-all";
-import { simpleGit, writeYAML } from "@dendronhq/common-server";
+import { DConfig, simpleGit, writeYAML } from "@dendronhq/common-server";
 import fs from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -118,7 +118,7 @@ export class SeedService {
     onUpdatedWorkspace?: () => Promise<void>;
   }) {
     const ws = new WorkspaceService({ wsRoot });
-    const config = ws.config;
+    const config = DConfig.readConfigSync(wsRoot);
     const id = SeedUtils.getSeedId({ ...seed });
 
     const seeds = ConfigUtils.getWorkspace(config).seeds || {};

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -246,7 +246,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
    * @returns `{vaults}` that have been added
    */
   async addWorkspace({ workspace }: { workspace: DWorkspace }) {
-    const config = this.config;
+    const config = DConfig.readConfigSync(this.wsRoot);
     const allWorkspaces = ConfigUtils.getWorkspace(config).workspaces || {};
     allWorkspaces[workspace.name] = _.omit(workspace, ["name", "vaults"]);
     // update vault

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -289,12 +289,16 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       updateConfig: true,
       updateWorkspace: false,
     });
+    let { config } = opts;
 
     // if we are updating the config, we should make sure
     // we don't include the local overrides
-    const config = updateConfig
-      ? DConfig.readConfigSync(this.wsRoot)
-      : this.config;
+    if (config === undefined) {
+      config = this.config;
+      if (updateConfig) {
+        config = DConfig.readConfigSync(this.wsRoot);
+      }
+    }
 
     // Normalize the vault path to unix style (forward slashes) which is better for cross-compatibility
     vault.fsPath = normalizeUnixPath(vault.fsPath);

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -275,8 +275,8 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
    *
    * @param opts.vault - {@link DVault} to add to workspace
    * @param opts.config - if passed it, make modifications on passed in config instead of {wsRoot}/dendron.yml
-   * @param opts.writeConfig - default: true, add to dendron.yml
-   * @param opts.addToWorkspace - default: false, add to dendron.code-workspace. Make sure to keep false for Native workspaces.
+   * @param opts.updateConfig - default: true, add to dendron.yml
+   * @param opts.updateWorkspace - default: false, add to dendron.code-workspace. Make sure to keep false for Native workspaces.
    * @returns
    */
   async addVault(
@@ -285,11 +285,16 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
       config?: IntermediateDendronConfig;
     } & AddRemoveCommonOpts
   ) {
-    const { vault, config, updateConfig, updateWorkspace } = _.defaults(opts, {
-      config: this.config,
+    const { vault, updateConfig, updateWorkspace } = _.defaults(opts, {
       updateConfig: true,
       updateWorkspace: false,
     });
+
+    // if we are updating the config, we should make sure
+    // we don't include the local overrides
+    const config = updateConfig
+      ? DConfig.readConfigSync(this.wsRoot)
+      : this.config;
 
     // Normalize the vault path to unix style (forward slashes) which is better for cross-compatibility
     vault.fsPath = normalizeUnixPath(vault.fsPath);
@@ -955,11 +960,16 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
    * @param param0
    */
   async removeVault(opts: { vault: DVault } & AddRemoveCommonOpts) {
-    const config = this.config;
     const { vault, updateConfig, updateWorkspace } = _.defaults(opts, {
       updateConfig: true,
       updateWorkspace: false,
     });
+
+    // if we are updating the config, we should make sure
+    // we don't include the local overrides
+    const config = updateConfig
+      ? DConfig.readConfigSync(this.wsRoot)
+      : this.config;
 
     const vaults = ConfigUtils.getVaults(config);
     const vaultsAfterReject = _.reject(vaults, (ent: DVault) => {


### PR DESCRIPTION
# fix: correctly update dendron.yml when adding / deleting vaults

This PR:
- fixes an issue with vault add / remove where overridden vaults in `dendronrc.yml` are merged back into `dendron.yml` when a new vault is create, or an existing vault is deleted.
- NOTE: Ideally this should be done without WorkspaceService having the knowledge pertaining to local config override, but that is left as a future task as it seems our strategy towards handling config with the recent engine v3 migration seems to be unclear at the moment. This PR strictly tackles the issue reported in #3290 

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)