### PR TITLE
chore(workspace): Migrate getNotesByFname to engine methods

### DIFF
--- a/packages/plugin-core/src/commands/CreateDailyJournal.ts
+++ b/packages/plugin-core/src/commands/CreateDailyJournal.ts
@@ -188,10 +188,9 @@ export class CreateDailyJournalCommand extends CreateNoteWithTraitCommand {
       `.${journalConfig.dailyDomain}`;
     const fileName = fname + `.md`;
 
-    const existingTemplates = NoteUtils.getNotesByFnameFromEngine({
-      fname,
-      engine: this._extension.getEngine(),
-    });
+    const existingTemplates = await this._extension
+      .getEngine()
+      .findNotesMeta({ fname });
 
     const maybeVault = journalConfig.dailyVault
       ? VaultUtils.getVaultByName({

--- a/packages/plugin-core/src/commands/CreateMeetingNoteCommand.ts
+++ b/packages/plugin-core/src/commands/CreateMeetingNoteCommand.ts
@@ -137,10 +137,11 @@ export class CreateMeetingNoteCommand extends CreateNoteWithTraitCommand {
   private async createTemplateFileIfNotExisting(): Promise<boolean> {
     const fname = CreateMeetingNoteCommand.MEETING_TEMPLATE_FNAME + ".md";
 
-    const existingMeetingTemplates = NoteUtils.getNotesByFnameFromEngine({
-      fname: CreateMeetingNoteCommand.MEETING_TEMPLATE_FNAME,
-      engine: this._ext.getEngine(),
-    });
+    const existingMeetingTemplates = await this._extension
+      .getEngine()
+      .findNotesMeta({
+        fname: CreateMeetingNoteCommand.MEETING_TEMPLATE_FNAME,
+      });
 
     const vault = PickerUtilsV2.getVaultForOpenEditor();
     const vaultPath = vault2Path({

--- a/packages/plugin-core/src/commands/Goto.ts
+++ b/packages/plugin-core/src/commands/Goto.ts
@@ -2,7 +2,6 @@ import {
   DendronError,
   DVault,
   ERROR_STATUS,
-  NoteUtils,
   RespV3,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -96,11 +95,7 @@ export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
     }
 
     // get note
-    const notes = NoteUtils.getNotesByFnameFromEngine({
-      fname,
-      engine,
-      vault,
-    });
+    const notes = await engine.findNotesMeta({ fname, vault });
     if (notes.length === 0) {
       return {
         error: new DendronError({ message: "selection is not a note" }),

--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -115,10 +115,7 @@ export class GotoNoteCommand extends BasicCommand<
 
   private async maybeSetOptsFromExistingNote(opts: GoToNoteCommandOpts) {
     const engine = this.extension.getEngine();
-    const notes = NoteUtils.getNotesByFnameFromEngine({
-      fname: opts.qs!,
-      engine,
-    });
+    const notes = await engine.findNotesMeta({ fname: opts.qs });
     if (notes.length === 1) {
       // There's just one note, so that's the one we'll go with.
       opts.vault = notes[0].vault;

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -426,21 +426,18 @@ export class MoveHeaderCommand extends BasicCommand<
    * @param dest Note that was the destination of move header commnad
    * @returns
    */
-  updateLinksInNote(opts: {
+  async updateLinksInNote(opts: {
     note: NoteProps;
     engine: IEngineAPIService;
     linksToUpdate: DLink[];
     dest: NoteProps;
   }) {
     const { note, engine, linksToUpdate, dest } = opts;
+    const notesWithSameName = await engine.findNotesMeta({ fname: dest.fname });
     return _.reduce(
       linksToUpdate,
       (note: NoteProps, linkToUpdate: DLink) => {
         const oldLink = LinkUtils.dlink2DNoteLink(linkToUpdate);
-        const notesWithSameName = NoteUtils.getNotesByFnameFromEngine({
-          fname: dest.fname,
-          engine,
-        });
 
         // original link had vault prefix?
         //   keep it
@@ -521,7 +518,7 @@ export class MoveHeaderCommand extends BasicCommand<
           anchorNamesToUpdate,
           config
         );
-        const modifiedNote = this.updateLinksInNote({
+        const modifiedNote = await this.updateLinksInNote({
           note: _note,
           engine,
           linksToUpdate,

--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -632,9 +632,7 @@ export class NoteLookupCommand extends BaseCommand<
     const engine = ExtensionProvider.getEngine();
 
     const vaultsWithMatchingFile = new Set(
-      NoteUtils.getNotesByFnameFromEngine({ fname, engine }).map(
-        (n) => n.vault.fsPath
-      )
+      (await engine.findNotesMeta({ fname })).map((n) => n.vault.fsPath)
     );
 
     // Try to get the default vault value.

--- a/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
+++ b/packages/plugin-core/src/components/views/PreviewLinkHandler.ts
@@ -113,7 +113,7 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
     // If not, see if there's a matching asset (including in assets folder, outside vaults, or even an absolute path)
     const { wsRoot, vaults } = this._ext.getDWorkspace();
     const currentNote = data?.id
-      ? this._ext.getEngine().notes[data.id]
+      ? (await this._ext.getEngine().getNoteMeta(data.id)).data
       : undefined;
     const { fullPath } =
       (await findNonNoteFile({

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -96,11 +96,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
           Logger.error({ msg: `${refAtPos.vaultName} is not defined` });
         }
       }
-      const notes = NoteUtils.getNotesByFnameFromEngine({
-        fname: refAtPos.ref,
-        engine,
-        vault,
-      });
+      const notes = await engine.findNotesMeta({ fname: refAtPos.ref, vault });
       const uris = notes.map((note) => NoteUtils.getURI({ note, wsRoot }));
       const out = uris.map((uri) => new Location(uri, new Position(0, 0)));
       if (out.length > 1) {

--- a/packages/plugin-core/src/features/ReferenceHoverProvider.ts
+++ b/packages/plugin-core/src/features/ReferenceHoverProvider.ts
@@ -3,7 +3,7 @@ import {
   containsNonDendronUri,
   DendronError,
   DVault,
-  NoteProps,
+  NotePropsMeta,
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -167,11 +167,10 @@ export default class ReferenceHoverProvider implements vscode.HoverProvider {
       }
 
       // Check if what's being referenced is a note.
-      let note: NoteProps;
-      const maybeNotes = NoteUtils.getNotesByFnameFromEngine({
+      // If vault is specified, search only that vault. Otherwise search all vaults.
+      let note: NotePropsMeta;
+      const maybeNotes = await engine.findNotesMeta({
         fname: refAtPos.ref,
-        engine,
-        // If vault is specified, search only that vault. Otherwise search all vaults.
         vault,
       });
       if (maybeNotes.length === 0) {

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -1,6 +1,5 @@
 import {
   CONSTANTS,
-  NoteUtils,
   TAGS_HIERARCHY,
   USERS_HIERARCHY,
   VaultUtils,
@@ -63,14 +62,14 @@ suite("completionProvider", function () {
         expect(compList).toBeTruthy();
         // Suggested top level notes
         expect(compList!.items.length).toEqual(6);
-        for (const item of compList!.items) {
-          // All suggested items exist
-          const found = NoteUtils.getNotesByFnameFromEngine({
-            fname: item.label as string,
-            engine,
-          });
-          expect(found.length > 0).toBeTruthy();
-        }
+        const results = await Promise.all(
+          compList!.items.map(async (item) => {
+            return engine.findNotesMeta({ fname: item.label as string });
+          })
+        );
+        results.forEach((result) => {
+          expect(result.length > 0).toBeTruthy();
+        });
         // check that same vault items are sorted before other items
         const sortedItems = _.sortBy(
           compList?.items,
@@ -150,15 +149,17 @@ suite("completionProvider", function () {
         expect(items).toBeTruthy();
         // Suggested all the notes
         expect(items!.items.length).toEqual(2);
-        for (const item of items!.items) {
-          // All suggested items exist
-          const found = NoteUtils.getNotesByFnameFromEngine({
-            fname: `${TAGS_HIERARCHY}${item.label}`,
-            engine,
-          });
-          expect(found.length > 0).toBeTruthy();
+        const results = await Promise.all(
+          items!.items.map(async (item) => {
+            return engine.findNotesMeta({
+              fname: `${TAGS_HIERARCHY}${item.label}`,
+            });
+          })
+        );
+        results.forEach((result) => {
+          expect(result.length > 0).toBeTruthy();
           expect(items?.items![0].insertText).toEqual("bar");
-        }
+        });
       });
     }
   );
@@ -205,14 +206,16 @@ suite("completionProvider", function () {
         expect(items).toBeTruthy();
         // Suggested all the notes
         expect(items!.length).toEqual(2);
-        for (const item of items!) {
-          // All suggested items exist
-          const found = NoteUtils.getNotesByFnameFromEngine({
-            fname: `${TAGS_HIERARCHY}${item.label}`,
-            engine,
-          });
-          expect(found.length > 0).toBeTruthy();
-        }
+        const results = await Promise.all(
+          items!.map(async (item) => {
+            return engine.findNotesMeta({
+              fname: `${TAGS_HIERARCHY}${item.label}`,
+            });
+          })
+        );
+        results.forEach((result) => {
+          expect(result.length > 0).toBeTruthy();
+        });
       });
     }
   );
@@ -260,15 +263,17 @@ suite("completionProvider", function () {
           expect(items).toBeTruthy();
           // Suggested all the notes
           expect(items!.length).toEqual(2);
-          for (const item of items!) {
-            // All suggested items exist
-            const found = NoteUtils.getNotesByFnameFromEngine({
-              fname: `${USERS_HIERARCHY}${item.label}`,
-              engine,
-            });
-            expect(found.length > 0).toBeTruthy();
+          const results = await Promise.all(
+            items!.map(async (item) => {
+              return engine.findNotesMeta({
+                fname: `${USERS_HIERARCHY}${item.label}`,
+              });
+            })
+          );
+          results.forEach((result) => {
+            expect(result.length > 0).toBeTruthy();
             expect(items![0].insertText).toEqual("bar");
-          }
+          });
         });
       });
 

--- a/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReloadIndex.test.ts
@@ -185,7 +185,7 @@ suite("GIVEN ReloadIndex", function () {
       const engine = await new ReloadIndexCommand().run();
       const { vaults } = ExtensionProvider.getDWorkspace();
       expect(engine).toBeTruthy();
-      const allNotes = await engine?.findNotes({ fname: "root" });
+      const allNotes = await engine?.findNotesMeta({ fname: "root" });
 
       const notes = _.sortBy(allNotes, (note) =>
         path.basename(note.vault.fsPath)

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -602,10 +602,7 @@ export async function findReferencesById(opts: {
 export const findReferences = async (fname: string): Promise<FoundRefT[]> => {
   const engine = ExtensionProvider.getEngine();
   // clean for anchor
-  const notes = NoteUtils.getNotesByFnameFromEngine({
-    fname,
-    engine,
-  });
+  const notes = await engine.findNotesMeta({ fname });
 
   const all = Promise.all(
     notes.map((noteProps) => findReferencesById({ id: noteProps.id }))

--- a/packages/plugin-core/src/views/CalendarView.ts
+++ b/packages/plugin-core/src/views/CalendarView.ts
@@ -59,13 +59,15 @@ export class CalendarView implements vscode.WebviewViewProvider {
           data: msg.data,
         });
         const { id, fname } = msg.data;
-        let note: NoteProps | undefined;
         // eslint-disable-next-line no-cond-assign
-        if (id && (note = this._extension.getEngine().notes[id])) {
-          await new GotoNoteCommand(this._extension).execute({
-            qs: note.fname,
-            vault: note.vault,
-          });
+        if (id) {
+          const note = (await this._extension.getEngine().getNoteMeta(id)).data;
+          if (note) {
+            await new GotoNoteCommand(this._extension).execute({
+              qs: note.fname,
+              vault: note.vault,
+            });
+          }
         } else if (fname) {
           await new CreateDailyJournalCommand(this._extension).execute({
             fname,

--- a/packages/plugin-core/src/views/GraphPanel.ts
+++ b/packages/plugin-core/src/views/GraphPanel.ts
@@ -200,7 +200,14 @@ export class GraphPanel implements vscode.WebviewViewProvider {
     ).graph.createStub;
     switch (msg.type) {
       case GraphViewMessageEnum.onSelect: {
-        const note = this._ext.getEngine().notes[msg.data.id];
+        const note = (await this._ext.getEngine().getNote(msg.data.id)).data;
+        if (!note) {
+          Logger.error({
+            ctx,
+            msg: `Note ${msg.data.id} not found in engine`,
+          });
+          break;
+        }
         if (note.stub && !createStub) {
           await this.refresh(note, createStub);
         } else {

--- a/packages/plugin-core/src/web/views/preview/PreviewLinkHandler.ts
+++ b/packages/plugin-core/src/web/views/preview/PreviewLinkHandler.ts
@@ -79,8 +79,8 @@ export class PreviewLinkHandler implements IPreviewLinkHandler {
     // TODO: Add back functionality
     // // If not, see if there's a matching asset (including in assets folder, outside vaults, or even an absolute path)
     // const currentNote = data?.id
-    //   ? this._ext.getEngine().notes[data.id]
-    //   : undefined;
+    //  ? (await this._ext.getEngine().getNoteMeta(data.id)).data
+    //  : undefined;
     // const { fullPath } =
     //   (await findNonNoteFile({
     //     fpath: path.normalize(uri.fsPath),

--- a/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
+++ b/packages/pods-core/src/v2/pods/export/AirtableExportPodV2.ts
@@ -128,7 +128,7 @@ export class AirtableExportPodV2
 
   async exportNotes(input: NoteProps[]): Promise<AirtableExportReturnType> {
     input = this.cleanNotes(input, _.get(this._config, "filters.fname"));
-    const resp = this.getPayloadForNotes(input);
+    const resp = await this.getPayloadForNotes(input);
     if (resp.error) {
       return {
         data: {},
@@ -174,13 +174,15 @@ export class AirtableExportPodV2
    * @param notes
    * @returns
    */
-  private getPayloadForNotes(notes: NoteProps[]): RespV3<{
-    create: AirtableFieldsMap[];
-    update: any[];
-  }> {
+  private async getPayloadForNotes(notes: NoteProps[]): Promise<
+    RespV3<{
+      create: AirtableFieldsMap[];
+      update: any[];
+    }>
+  > {
     const logger = createLogger("AirtablePublishPodV2");
 
-    const resp = AirtableUtils.notesToSrcFieldMap({
+    const resp = await AirtableUtils.notesToSrcFieldMap({
       notes,
       srcFieldMapping: this._config.sourceFieldMapping,
       logger,

--- a/packages/unified/src/SiteUtils.ts
+++ b/packages/unified/src/SiteUtils.ts
@@ -239,10 +239,7 @@ export class SiteUtils {
   //   const notesForHierarchy = _.clone(engine.notes);
 
   //   // get the domain note
-  //   const notes = NoteUtils.getNotesByFnameFromEngine({
-  //     fname: domain,
-  //     engine,
-  //   });
+  //   const notes = await engine.findNotes({ fname: domain });
   //   // logger.info({
   //   //   ctx: "filterByHierarchy:candidates",
   //   //   domain,


### PR DESCRIPTION
Similar to https://github.com/dendronhq/dendron/pull/3581, except this PR migrates the `getNotesByFnameFromEngine`