### PR TITLE
chore: revert onWillSave method to be sync

### DIFF
--- a/packages/plugin-core/src/WorkspaceWatcher.ts
+++ b/packages/plugin-core/src/WorkspaceWatcher.ts
@@ -296,22 +296,24 @@ export class WorkspaceWatcher {
    * When saving a note, do some book keeping
    * - update the `updated` time in frontmatter
    * - update the note metadata in the engine
+   *
+   * this method needs to be sync since event.WaitUntil can be called
+   * in an asynchronous manner.
    * @param event
    * @returns
    */
-  private async onWillSaveNote(event: TextDocumentWillSaveEvent) {
+  private onWillSaveNote(event: TextDocumentWillSaveEvent) {
     const ctx = "WorkspaceWatcher:onWillSaveNote";
     const uri = event.document.uri;
     const engine = this._extension.getEngine();
     const fname = path.basename(uri.fsPath, ".md");
     const now = Time.now().toMillis();
 
-    const note = (
-      await engine.findNotes({
-        fname,
-        vault: this._extension.wsUtils.getVaultFromUri(uri),
-      })
-    )[0];
+    const note = NoteUtils.getNoteByFnameFromEngine({
+      fname,
+      vault: this._extension.wsUtils.getVaultFromUri(uri),
+      engine,
+    });
 
     // If we can't find the note, don't do anything
     if (!note) {

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -112,6 +112,7 @@ suite("WorkspaceWatcher", function () {
     "GIVEN a basic setup on a single vault workspace",
     {
       postSetupHook: setupBasic,
+      timeout: 1e6,
     },
     () => {
       test("WHEN user renames a file outside of dendron rename command, THEN all of its references are also updated", async () => {
@@ -250,6 +251,14 @@ suite("WorkspaceWatcher", function () {
         const editor = await ExtensionProvider.getWSUtils().openNote(fooNote);
         const vscodeEvent: vscode.TextDocumentWillSaveEvent = {
           document: editor.document,
+          // eslint-disable-next-line no-undef
+          waitUntil: (_args: Thenable<any>) => {
+            _args.then(async () => {
+              // Engine note body hasn't been updated yet
+              const foo = (await engine.getNote("foo.one")).data!;
+              expect(foo.updated).toEqual(updatedBefore);
+            });
+          },
         };
         const changes = await watcher.onWillSaveTextDocument(vscodeEvent);
         expect(changes).toBeTruthy();


### PR DESCRIPTION
Reverted onWillSaveNote method to be sync. This adds back the deprecated `getNoteByFnameFromEngine` reference in `onWillSaveNote` method