### PR TITLE
fix(workspace): autocomplete for usertags and hashtags

### DIFF
--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/hashtag.spec.ts
@@ -99,7 +99,7 @@ describe("hashtag", () => {
       );
     });
 
-    test("doesn't parse trailing punctuation", () => {
+    test("doesn't parse trailing punctuation except period (.)", () => {
       const resp1 = proc().parse(
         "Dolorem vero sed sapiente #dolores. Et quam id maxime et ratione."
       );
@@ -107,7 +107,7 @@ describe("hashtag", () => {
         DendronASTTypes.HASHTAG
       );
       // @ts-ignore
-      expect(getDescendantNode(expect, resp1, 0, 1).value).toEqual("#dolores");
+      expect(getDescendantNode(expect, resp1, 0, 1).value).toEqual("#dolores.");
 
       const resp2 = proc().parse(
         "Dolorem vero sed sapiente #dolores, et quam id maxime et ratione."

--- a/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/markdown/userTags.spec.ts
@@ -86,7 +86,7 @@ describe("user tags", () => {
       expect(getUserTag(resp).value).toEqual("@7of9");
     });
 
-    test("doesn't parse trailing punctuation", () => {
+    test("doesn't parse trailing punctuation except period (.)", () => {
       const resp1 = proc().parse(
         "Dolorem vero sed sapiente @Hamilton.Margaret. Et quam id maxime et ratione."
       );
@@ -95,7 +95,7 @@ describe("user tags", () => {
       );
       // @ts-ignore
       expect(getDescendantNode(expect, resp1, 0, 1).value).toEqual(
-        "@Hamilton.Margaret"
+        "@Hamilton.Margaret."
       );
 
       const resp2 = proc().parse(

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -78,7 +78,7 @@ import { CreateScratchNoteKeybindingTip } from "./showcase/CreateScratchNoteKeyb
 import semver from "semver";
 import _ from "lodash";
 
-const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.\\#]+)");
+const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.]+)");
 // === Main
 
 // this method is called when your extension is activated

--- a/packages/unified/src/remark/hashtag.ts
+++ b/packages/unified/src/remark/hashtag.ts
@@ -23,8 +23,8 @@ export const PUNCTUATION_MARKS =
 const GOOD_FIRST_CHARACTER = `[^0-9#@|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
 /** Can have numbers and period in the middle */
 const GOOD_MIDDLE_CHARACTER = `[^@#|\\[\\]\\s${PUNCTUATION_MARKS}]`;
-/** Can have numbers, but not period in the end */
-const GOOD_END_CHARACTER = `[^@#|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+/** Can have numbers and period at the end */
+const GOOD_END_CHARACTER = `[^@#|\\[\\]\\s${PUNCTUATION_MARKS}]`;
 
 /** Hashtags have the form #foo, or #foo.bar, or #f123
  *

--- a/packages/unified/src/remark/userTags.ts
+++ b/packages/unified/src/remark/userTags.ts
@@ -13,8 +13,8 @@ import { PUNCTUATION_MARKS } from "./hashtag";
 
 /** Can have period in the middle */
 const GOOD_MIDDLE_CHARACTER = `[^#@|\\[\\]\\s${PUNCTUATION_MARKS}]`;
-/** Can't have period in the end */
-const GOOD_END_CHARACTER = `[^#@|\\[\\]\\s.${PUNCTUATION_MARKS}]`;
+/** Can have period in the end */
+const GOOD_END_CHARACTER = `[^#@|\\[\\]\\s${PUNCTUATION_MARKS}]`;
 
 /** User tags have the form @Lovelace, or @Hamilton.Margaret, or @7of9.
  *


### PR DESCRIPTION
This PR aims to fix the ongoing issue with usertags and hashtags autocomplete after first `.` (eg: #kind. , @johndoe. won't show autocomplete suggestions)
- removed `#` from `MARKDOWN_WORD_PATTERN` to display autocomplete for tags


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)