### PR TITLE
chore(internal): track remote information on init

### DIFF
--- a/packages/common-all/src/analytics.ts
+++ b/packages/common-all/src/analytics.ts
@@ -131,6 +131,7 @@ export enum SurveyEvents {
 
 export enum GitEvents {
   ContributorsFound = "ContributorsFound",
+  TopLevelRepoFound = "TopLevelRepoFound",
 }
 
 export enum ConfigEvents {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -876,6 +876,22 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     return contributors.filter(isNotUndefined);
   }
 
+  async getToplevelRepo() {
+    // if self contained vault,
+    //   if tracked remotely, wsRoot should be a repo
+    //   else, nothing to get. undefined
+    // if not self contained,
+    //   if tracked remotely, wsRoot should be a repo
+    //   else, top level repo is ambiguous even if the vaults are remotely tracked.
+    const git = new Git({ localUrl: this.wsRoot });
+    try {
+      const remote = await git.getRemoteUrl();
+      console.log({ remote });
+    } finally {
+      console.log("foo");
+    }
+  }
+
   async commitAndAddAll({
     engine,
   }: {

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -885,7 +885,7 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
    *   In this case, it is ambiguous what the top level is, and we assume the top level is not tracked remotely.
    * @returns remote url or undefined
    */
-  async getToplevelRemoteUrl(): Promise<string | undefined> {
+  async getTopLevelRemoteUrl(): Promise<string | undefined> {
     const git = new Git({ localUrl: this.wsRoot });
     const remoteUrl = await git.getRemoteUrl();
     return remoteUrl;

--- a/packages/engine-server/src/workspace/service.ts
+++ b/packages/engine-server/src/workspace/service.ts
@@ -876,20 +876,19 @@ export class WorkspaceService implements Disposable, IWorkspaceService {
     return contributors.filter(isNotUndefined);
   }
 
-  async getToplevelRepo() {
-    // if self contained vault,
-    //   if tracked remotely, wsRoot should be a repo
-    //   else, nothing to get. undefined
-    // if not self contained,
-    //   if tracked remotely, wsRoot should be a repo
-    //   else, top level repo is ambiguous even if the vaults are remotely tracked.
+  /**
+   * Try to get the url of the top level repository.
+   * If self contained vault, workspace root should be the top level if remotely tracked.
+   * If not self contained, workspace root should be the top level if remotely tracked.
+   * If not self contained vault, and workspace root doesn't have a remote url,
+   *   This means nothing is remotely tracked, or some vaults in the workspace is tracked, not the workspace itself.
+   *   In this case, it is ambiguous what the top level is, and we assume the top level is not tracked remotely.
+   * @returns remote url or undefined
+   */
+  async getToplevelRemoteUrl(): Promise<string | undefined> {
     const git = new Git({ localUrl: this.wsRoot });
-    try {
-      const remote = await git.getRemoteUrl();
-      console.log({ remote });
-    } finally {
-      console.log("foo");
-    }
+    const remoteUrl = await git.getRemoteUrl();
+    return remoteUrl;
   }
 
   async commitAndAddAll({

--- a/packages/engine-test-utils/src/__tests__/engine-server/topics/git.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/topics/git.spec.ts
@@ -3,6 +3,7 @@ import { Git } from "@dendronhq/engine-server";
 import { GitTestUtils } from "../../../utils";
 import fs from "fs-extra";
 import path from "path";
+import { testWithEngine } from "../../../engine";
 
 describe("isRepo", () => {
   test("no repo", async () => {
@@ -35,5 +36,55 @@ describe("isRepo", () => {
     fs.writeFileSync(path.join(root, "gamma.md"), "hello");
     const changes = await git.hasChanges();
     expect(changes).toBeTruthy();
+  });
+});
+
+describe("GIVEN a remotely tracked repo", () => {
+  describe("getRemote", () => {
+    testWithEngine(
+      "THEN getRemote correctly returns remote",
+      async ({ wsRoot }) => {
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        const git = new Git({ localUrl: wsRoot });
+        const out = await git.getRemote();
+        expect(out).toEqual("origin");
+      }
+    );
+  });
+  describe("getRemoteUrl", () => {
+    testWithEngine(
+      "THEN getRemoteUrl correctly returns remote url",
+      async ({ wsRoot }) => {
+        const remoteDir = tmpDir().name;
+        await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+        const git = new Git({ localUrl: wsRoot });
+        const out = await git.getRemoteUrl();
+        expect(out).toEqual(remoteDir);
+      }
+    );
+  });
+});
+
+describe("GIVEN no repo", () => {
+  describe("getRemote", () => {
+    testWithEngine(
+      "THEN getRemote correctly returns undefined",
+      async ({ wsRoot }) => {
+        const git = new Git({ localUrl: wsRoot });
+        const out = await git.getRemote();
+        expect(out).toEqual(undefined);
+      }
+    );
+  });
+  describe("getRemoteUrl", () => {
+    testWithEngine(
+      "THEN getRemoteUrl correctly returns undefined",
+      async ({ wsRoot }) => {
+        const git = new Git({ localUrl: wsRoot });
+        const out = await git.getRemoteUrl();
+        expect(out).toEqual(undefined);
+      }
+    );
   });
 });

--- a/packages/plugin-core/src/test/suite-integ/workspaceActivator.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/workspaceActivator.test.ts
@@ -1,0 +1,153 @@
+import { WorkspaceService } from "@dendronhq/engine-server";
+import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { describeMultiWS } from "../testUtilsV3";
+import { describe } from "mocha";
+import { expect } from "../testUtilsv2";
+import { trackTopLevelRepoFound } from "../../workspace/workspaceActivator";
+import sinon from "sinon";
+import _ from "lodash";
+
+suite("workspaceActivator", function () {
+  describe("trackTopLevelRepoFound", () => {
+    describeMultiWS(
+      "GIVEN a workspace tracked remotely",
+      {
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      },
+      () => {
+        describe("WHEN https", () => {
+          describe("AND GitHub", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("https://github.com/foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "https",
+                provider: "github.com",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+          describe("AND GitLab", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("https://gitlab.com/foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "https",
+                provider: "gitlab.com",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+          describe("AND arbitrary provider", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("https://some.host/foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "https",
+                provider: "some.host",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+        });
+
+        describe("WHEN git", () => {
+          describe("AND GitHub", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("git@github.com:foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "git",
+                provider: "github.com",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+          describe("AND GitLab", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("git@gitlab.com:foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "git",
+                provider: "gitlab.com",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+          describe("AND arbitrary provider", () => {
+            test("THEN correctly track top level repo info", async () => {
+              const { wsRoot } = ExtensionProvider.getDWorkspace();
+              const wsService = new WorkspaceService({ wsRoot });
+              const urlStub = sinon
+                .stub(wsService, "getTopLevelRemoteUrl")
+                .returns(Promise.resolve("git@some.host:foo/bar.git"));
+              const out = await trackTopLevelRepoFound({ wsService });
+              expect(out).toBeTruthy();
+              expect(_.omit(out, "path")).toEqual({
+                protocol: "git",
+                provider: "some.host",
+              });
+
+              // hashed path is same every time
+              const out2 = await trackTopLevelRepoFound({ wsService });
+              expect(out2).toBeTruthy();
+              expect(out).toEqual(out2);
+              urlStub.restore();
+            });
+          });
+        });
+      }
+    );
+  });
+});

--- a/packages/plugin-core/src/test/suite-integ/workspaceActivator.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/workspaceActivator.test.ts
@@ -149,5 +149,24 @@ suite("workspaceActivator", function () {
         });
       }
     );
+
+    describeMultiWS(
+      "GIVEN a workspace not tracked",
+      {
+        preSetupHook: ENGINE_HOOKS.setupBasic,
+      },
+      () => {
+        test("THEN top level repo info is not tracked", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const wsService = new WorkspaceService({ wsRoot });
+          const urlStub = sinon
+            .stub(wsService, "getTopLevelRemoteUrl")
+            .returns(Promise.resolve(undefined));
+          const out = await trackTopLevelRepoFound({ wsService });
+          expect(out).toEqual(undefined);
+          urlStub.restore();
+        });
+      }
+    );
   });
 });

--- a/packages/plugin-core/src/workspace/workspaceActivator.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivator.ts
@@ -117,6 +117,7 @@ function analyzeWorkspace({ wsService }: { wsService: WorkspaceService }) {
     .catch((err) => {
       Sentry.captureException(err);
     });
+  wsService.getToplevelRepo();
 }
 
 async function getOrPromptWSRoot(workspaceFolders: string[]) {


### PR DESCRIPTION
# chore(internal): track remote information on init
This PR:
- adds a new event `GitEvents.TopLevelRepoFound`, which tracks the hash of the remote url if the workspace has a top level remote repo.
- For remotely tracked self contained vault and workspace vault, this would be the repo at wsRoot.
- If a repo is not found in wsRoot, either it is not tracked remotely, or in the case of a workspace, individual vaults may be tracked by not the workspace itself. We don't count this as a "top repo" as it is ambiguous. 

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [x] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [x] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)