### PR TITLE
enhance(sync): selection export scope for pods v2

### DIFF
--- a/packages/dendron-cli/src/commands/exportPodV2.ts
+++ b/packages/dendron-cli/src/commands/exportPodV2.ts
@@ -319,7 +319,8 @@ export class ExportPodV2CLICommand extends CLICommand<
   }) {
     if (
       opts.destination === "clipboard" &&
-      opts.exportScope !== PodExportScope.Note
+      opts.exportScope !== PodExportScope.Note &&
+      opts.exportScope !== PodExportScope.Selection
     ) {
       throw new DendronError({
         message:

--- a/packages/plugin-core/src/commands/CopyAsCommand.ts
+++ b/packages/plugin-core/src/commands/CopyAsCommand.ts
@@ -52,7 +52,7 @@ export class CopyAsCommand extends BasicCommand<
       case CopyAsFormat.JSON: {
         const config: JSONV2PodConfig = {
           destination: "clipboard",
-          exportScope: PodExportScope.Note,
+          exportScope: PodExportScope.Selection,
           podType: PodV2Types.JSONExportV2,
           podId: "copyAs.json", // dummy value, required property
         };
@@ -61,9 +61,10 @@ export class CopyAsCommand extends BasicCommand<
       case CopyAsFormat.MARKDOWN: {
         const config: MarkdownV2PodConfig = {
           destination: "clipboard",
-          exportScope: PodExportScope.Note,
+          exportScope: PodExportScope.Selection,
           podType: PodV2Types.MarkdownExportV2,
           podId: "copyAs.markdown", // dummy value, required property
+          addFrontmatterTitle: false,
         };
         return PodCommandFactory.createPodCommandForStoredConfig({ config });
       }

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -482,7 +482,10 @@ export class PodUIControls {
       },
     ];
     // Cannot have clipboard be the destination on a multi-note export
-    if (exportScope === PodExportScope.Note) {
+    if (
+      exportScope === PodExportScope.Note ||
+      exportScope === PodExportScope.Selection
+    ) {
       const picked = await vscode.window.showQuickPick(items);
 
       if (!picked) {
@@ -529,6 +532,9 @@ export class PodUIControls {
 
       case PodExportScope.Workspace:
         return "Exports all notes in the Dendron workspace";
+
+      case PodExportScope.Selection:
+        return "Export the selection from currently opened note";
 
       default:
         assertUnreachable(scope);

--- a/packages/plugin-core/src/components/pods/PodControls.ts
+++ b/packages/plugin-core/src/components/pods/PodControls.ts
@@ -534,7 +534,7 @@ export class PodUIControls {
         return "Exports all notes in the Dendron workspace";
 
       case PodExportScope.Selection:
-        return "Export the selection from currently opened note";
+        return "Export the selected text from currently opened note";
 
       default:
         assertUnreachable(scope);

--- a/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/BaseExportPodCommand.test.ts
@@ -270,7 +270,7 @@ suite("BaseExportPodCommand", function () {
     );
 
     describeSingleWS(
-      "WHEN exporting a note with selection",
+      "WHEN exporting with selection scope",
       {
         postSetupHook: ENGINE_HOOKS.setupBasic,
       },
@@ -292,17 +292,11 @@ suite("BaseExportPodCommand", function () {
           }
 
           const payload = await cmd.enrichInputs({
-            exportScope: PodExportScope.Note,
+            exportScope: PodExportScope.Selection,
           });
           expect((payload?.payload as NoteProps[])[0].fname).toEqual("root");
           expect((payload?.payload as NoteProps[]).length).toEqual(1);
-
-          if (payload) {
-            const result = await cmd.getPropsForSelectionScopeIfNecessary(
-              payload
-            );
-            expect(result.payload[0].body).toEqual("# Welcome to Dendron");
-          }
+          expect(payload?.payload[0].body).toEqual("# Welcome to Dendron");
         });
       }
     );

--- a/packages/pods-core/src/v2/podConfig/PodV2Types.ts
+++ b/packages/pods-core/src/v2/podConfig/PodV2Types.ts
@@ -15,6 +15,7 @@ export enum PodV2Types {
 export enum PodExportScope {
   Note = "Note",
   Lookup = "Lookup",
+  Selection = "Selection",
   Hierarchy = "Hierarchy",
   Vault = "Vault",
   Workspace = "Workspace",


### PR DESCRIPTION
This PR aims to support selection scope while exporting a note with export pod v2. This also benefits the `Copy As` command. 

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)