### PR TITLE
fix(publish): prevent "Table of content" overflowing container

### DIFF
--- a/packages/nextjs-template/components/DendronNotePage.tsx
+++ b/packages/nextjs-template/components/DendronNotePage.tsx
@@ -128,7 +128,7 @@ export default function Note({
               <DendronNoteGiscusWidget note={note} config={config} />
             </Col>
             <Col xs={0} md={6}>
-              <DendronTOC note={note} />
+              <DendronTOC note={note} offsetTop={HEADER.HEIGHT} />
             </Col>
           </Row>
         </Col>


### PR DESCRIPTION
We accidentally removed `offsetTop` at some point which is responsible for keeping `DendronTOC` below the header.
This PR adds this prop back.

Preview of the issue: https://www.loom.com/share/caf8f308ed20469a808c2ebc77e29597

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
