### PR TITLE
chore(internal): remove references of deprecated methods

### DIFF
--- a/packages/plugin-core/src/WSUtils.ts
+++ b/packages/plugin-core/src/WSUtils.ts
@@ -12,7 +12,6 @@ import { DENDRON_COMMANDS } from "./constants";
 import { ExtensionProvider } from "./ExtensionProvider";
 import { Logger } from "./logger";
 import { VSCodeUtils } from "./vsCodeUtils";
-import { getDWorkspace } from "./workspace";
 
 /**
  * Prefer to use WSUtilsV2 instead of this class to prevent circular dependencies.
@@ -134,7 +133,7 @@ export class WSUtils {
     vault: DVault,
     fnameWithExtension: string
   ) {
-    const wsRoot = getDWorkspace().wsRoot;
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
     const vpath = vault2Path({ vault, wsRoot });
     const notePath = path.join(vpath, fnameWithExtension);
     const editor = await VSCodeUtils.openFileInEditor(
@@ -150,7 +149,7 @@ export class WSUtils {
     vault: DVault;
     fname: string;
   }) {
-    const { wsRoot } = getDWorkspace();
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
     const vpath = vault2Path({ vault, wsRoot });
     const notePath = path.join(vpath, `${fname}.md`);
     const editor = await VSCodeUtils.openFileInEditor(

--- a/packages/plugin-core/src/commands/ConfigurePodCommand.ts
+++ b/packages/plugin-core/src/commands/ConfigurePodCommand.ts
@@ -11,8 +11,8 @@ import { Uri } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { VSCodeUtils } from "../vsCodeUtils";
 import { showPodQuickPickItemsV4 } from "../utils/pods";
-import { getExtension } from "../workspace";
 import { BasicCommand } from "./base";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -25,11 +25,13 @@ export class ConfigurePodCommand extends BasicCommand<
   CommandOutput
 > {
   public pods: PodClassEntryV4[];
+  private extension: IDendronExtension;
   key = DENDRON_COMMANDS.CONFIGURE_POD.key;
 
-  constructor(_name?: string) {
+  constructor(ext: IDendronExtension, _name?: string) {
     super(_name);
     this.pods = getAllExportPods();
+    this.extension = ext;
   }
 
   async gatherInputs(): Promise<CommandInput | undefined> {
@@ -53,7 +55,7 @@ export class ConfigurePodCommand extends BasicCommand<
     const podClass = opts.podClass;
     const ctx = { ctx: "ConfigurePod" };
     this.L.info({ ctx, opts });
-    const podsDir = getExtension().podsDir;
+    const podsDir = this.extension.podsDir;
     const configPath = PodUtils.genConfigFile({ podsDir, podClass });
     await VSCodeUtils.openFileInEditor(Uri.file(configPath));
   }

--- a/packages/plugin-core/src/commands/CopyNoteRef.ts
+++ b/packages/plugin-core/src/commands/CopyNoteRef.ts
@@ -14,11 +14,11 @@ import { Position, Range, Selection, TextEditor, window } from "vscode";
 import { DendronClientUtilsV2 } from "../clientUtils";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { clipboard } from "../utils";
 import { EditorUtils } from "../utils/EditorUtils";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getEngine } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -29,6 +29,13 @@ export class CopyNoteRefCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.COPY_NOTE_REF.key;
+  private extension: IDendronExtension;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+  }
+
   async sanityCheck() {
     if (_.isUndefined(VSCodeUtils.getActiveTextEditor())) {
       return "No document open";
@@ -70,7 +77,7 @@ export class CopyNoteRefCommand extends BasicCommand<
       const { startAnchor, endAnchor } = await EditorUtils.getSelectionAnchors({
         editor,
         selection,
-        engine: getEngine(),
+        engine: this.extension.getEngine(),
       });
       linkData.anchorStart = startAnchor;
       if (!_.isUndefined(startAnchor) && !isBlockAnchor(startAnchor)) {

--- a/packages/plugin-core/src/commands/CopyNoteURL.ts
+++ b/packages/plugin-core/src/commands/CopyNoteURL.ts
@@ -3,10 +3,11 @@ import { WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { Selection, window } from "vscode";
 import { CONFIG, DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { clipboard } from "../utils";
 import { EditorUtils } from "../utils/EditorUtils";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { DendronExtension, getDWorkspace } from "../workspace";
+import { DendronExtension } from "../workspace";
 import { WSUtils } from "../WSUtils";
 import { BasicCommand } from "./base";
 
@@ -19,6 +20,13 @@ export class CopyNoteURLCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.COPY_NOTE_URL.key;
+  private extension: IDendronExtension;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+  }
+
   async gatherInputs(): Promise<any> {
     return {};
   }
@@ -32,7 +40,7 @@ export class CopyNoteURLCommand extends BasicCommand<
   }
 
   async execute() {
-    const config = getDWorkspace().config;
+    const { config } = this.extension.getDWorkspace();
     const publishingConfig = ConfigUtils.getPublishingConfig(config);
     const urlRoot =
       publishingConfig.siteUrl ||
@@ -52,7 +60,7 @@ export class CopyNoteURLCommand extends BasicCommand<
       window.showErrorMessage("You need to be in a note to use this command");
       return;
     }
-    const engine = getDWorkspace().engine;
+    const { engine } = this.extension.getDWorkspace();
 
     // add the anchor if one is selected and exists
     const { selection, editor } = VSCodeUtils.getSelection();

--- a/packages/plugin-core/src/commands/ExportPod.ts
+++ b/packages/plugin-core/src/commands/ExportPod.ts
@@ -13,8 +13,8 @@ import {
   showPodQuickPickItemsV4,
   withProgressOpts,
 } from "../utils/pods";
-import { getExtension, getDWorkspace } from "../workspace";
 import { BaseCommand } from "./base";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOutput = void;
 
@@ -29,10 +29,12 @@ export class ExportPodCommand extends BaseCommand<
 > {
   public pods: PodClassEntryV4[];
   key = DENDRON_COMMANDS.EXPORT_POD.key;
+  private extension: IDendronExtension;
 
-  constructor(_name?: string) {
+  constructor(ext: IDendronExtension, _name?: string) {
     super(_name);
     this.pods = getAllExportPods();
+    this.extension = ext;
   }
 
   async gatherInputs(): Promise<CommandInput | undefined> {
@@ -47,7 +49,7 @@ export class ExportPodCommand extends BaseCommand<
 
   async enrichInputs(inputs: CommandInput): Promise<CommandOpts | undefined> {
     const podChoice = inputs.podChoice;
-    const podsDir = getExtension().podsDir;
+    const podsDir = this.extension.podsDir;
     const podClass = podChoice.podClass;
     const maybeConfig = PodUtils.getConfig({ podsDir, podClass });
     if (maybeConfig.error) {
@@ -64,7 +66,7 @@ export class ExportPodCommand extends BaseCommand<
   async execute(opts: CommandOpts) {
     const ctx = { ctx: "ExportPod" };
     this.L.info({ ctx, opts });
-    const { wsRoot, vaults } = getDWorkspace();
+    const { wsRoot, vaults } = this.extension.getDWorkspace();
     if (!wsRoot) {
       throw Error("ws root not defined");
     }
@@ -73,7 +75,7 @@ export class ExportPodCommand extends BaseCommand<
       withProgressOpts,
     };
     const pod = new opts.podChoice.podClass(); // eslint-disable-line new-cap
-    const engine = getExtension().getEngine();
+    const engine = this.extension.getEngine();
     await pod.execute({
       config: opts.config,
       engine,

--- a/packages/plugin-core/src/commands/GoUpCommand.ts
+++ b/packages/plugin-core/src/commands/GoUpCommand.ts
@@ -4,8 +4,8 @@ import path from "path";
 import { Uri, window } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -13,6 +13,10 @@ type CommandOpts = {};
 type CommandOutput = void;
 
 export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
+
   key = DENDRON_COMMANDS.GO_UP_HIERARCHY.key;
   async gatherInputs(): Promise<any> {
     return {};
@@ -23,7 +27,7 @@ export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
       window.showErrorMessage("no active document found");
       return;
     }
-    const engine = getDWorkspace().engine;
+    const engine = this._ext.getEngine();
     const nparent = await DNodeUtils.findClosestParentWithEngine(
       path.basename(maybeTextEditor.document.uri.fsPath, ".md"),
       engine,
@@ -34,7 +38,7 @@ export class GoUpCommand extends BasicCommand<CommandOpts, CommandOutput> {
     );
     const nppath = NoteUtils.getFullPath({
       note: nparent,
-      wsRoot: getDWorkspace().wsRoot,
+      wsRoot: this._ext.getDWorkspace().wsRoot,
     });
     await VSCodeUtils.openFileInEditor(Uri.file(nppath));
     return;

--- a/packages/plugin-core/src/commands/Goto.ts
+++ b/packages/plugin-core/src/commands/Goto.ts
@@ -18,7 +18,7 @@ import { ExtensionProvider } from "../ExtensionProvider";
 import { EditorUtils } from "../utils/EditorUtils";
 import { getURLAt } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
+import { getExtension } from "../workspace";
 import { BasicCommand } from "./base";
 import { GotoNoteCommand } from "./GotoNote";
 import { GoToNoteCommandOutput, TargetKind } from "./GoToNoteInterface";
@@ -137,7 +137,7 @@ export class GotoCommand extends BasicCommand<CommandOpts, CommandOutput> {
       env.openExternal(Uri.parse(externalLink.replace("\\", "/"))); // make sure vscode doesn't choke on "\"s
       assetPath = externalLink;
     } else {
-      const wsRoot = getDWorkspace().wsRoot;
+      const { wsRoot } = this._ext.getDWorkspace();
 
       if (externalLink.startsWith("asset")) {
         const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();

--- a/packages/plugin-core/src/commands/ImportPod.ts
+++ b/packages/plugin-core/src/commands/ImportPod.ts
@@ -11,6 +11,7 @@ import {
 import _ from "lodash";
 import { ProgressLocation, Uri, window } from "vscode";
 import { DENDRON_COMMANDS, Oauth2Pods } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import {
   getGlobalState,
   launchGoogleOAuthFlow,
@@ -22,7 +23,6 @@ import {
   handleConflict,
 } from "../utils/pods";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
 import { BaseCommand } from "./base";
 import { ReloadIndexCommand } from "./ReloadIndex";
 
@@ -58,7 +58,7 @@ export class ImportPodCommand extends BaseCommand<
   async enrichInputs(inputs: CommandInput): Promise<CommandOpts | undefined> {
     const podChoice = inputs.podChoice;
     const podClass = podChoice.podClass;
-    const podsDir = getExtension().podsDir;
+    const podsDir = ExtensionProvider.getPodsDir();
     try {
       const resp = PodUtils.getConfig({ podsDir, podClass });
       if (resp.error) {
@@ -109,7 +109,7 @@ export class ImportPodCommand extends BaseCommand<
   async execute(opts: CommandOpts) {
     const ctx = { ctx: "ImportPod" };
     this.L.info({ ctx, msg: "enter", podChoice: opts.podChoice.id });
-    const wsRoot = getDWorkspace().wsRoot;
+    const { wsRoot, engine, vaults } = ExtensionProvider.getDWorkspace();
     const utilityMethods = {
       getGlobalState,
       updateGlobalState,
@@ -121,9 +121,8 @@ export class ImportPodCommand extends BaseCommand<
     if (!wsRoot) {
       throw Error("ws root not defined");
     }
-    const { engine, vaults } = getDWorkspace();
     const pod = new opts.podChoice.podClass() as ImportPod; // eslint-disable-line new-cap
-    const fileWatcher = getExtension().fileWatcher;
+    const fileWatcher = ExtensionProvider.getExtension().fileWatcher;
     if (fileWatcher) {
       fileWatcher.pause = true;
     }

--- a/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
+++ b/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
@@ -3,8 +3,8 @@ import _ from "lodash";
 import { window } from "vscode";
 import { DendronClientUtilsV2 } from "../clientUtils";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getEngine } from "../workspace";
 import { WSUtils } from "../WSUtils";
 import { BasicCommand } from "./base";
 
@@ -22,6 +22,12 @@ export class InsertNoteIndexCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.INSERT_NOTE_INDEX.key;
+  private extension: IDendronExtension;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+  }
 
   // TODO: make this into a util once the cli version is implemented.
   // NOTE: the marker flag is not exposed to the plugin yet.
@@ -34,7 +40,9 @@ export class InsertNoteIndexCommand extends BasicCommand<
     const listItems = notes.map((note) => {
       const link = NoteUtils.createWikiLink({
         note,
-        useVaultPrefix: DendronClientUtilsV2.shouldUseVaultPrefix(getEngine()),
+        useVaultPrefix: DendronClientUtilsV2.shouldUseVaultPrefix(
+          this.extension.getEngine()
+        ),
         alias: { mode: "title" },
       });
       return `- ${link}`;
@@ -65,14 +73,14 @@ export class InsertNoteIndexCommand extends BasicCommand<
       window.showErrorMessage("Active file is not a Dendron note.");
       return opts;
     }
-    const engine = getEngine();
+    const engine = this.extension.getEngine();
     const bulkResp = await engine.bulkGetNotesMeta(activeNote.children);
     const children = bulkResp.data;
     if (children.length === 0) {
       window.showInformationMessage("This note does not have any child notes.");
       return opts;
     }
-    const config = getDWorkspace().config;
+    const { config } = this.extension.getDWorkspace();
 
     const insertNoteIndexConfig =
       ConfigUtils.getCommands(config).insertNoteIndex;

--- a/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
+++ b/packages/plugin-core/src/commands/InsertNoteIndexCommand.ts
@@ -22,11 +22,9 @@ export class InsertNoteIndexCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.INSERT_NOTE_INDEX.key;
-  private extension: IDendronExtension;
 
-  constructor(ext: IDendronExtension) {
+  constructor(private _ext: IDendronExtension) {
     super();
-    this.extension = ext;
   }
 
   // TODO: make this into a util once the cli version is implemented.
@@ -41,7 +39,7 @@ export class InsertNoteIndexCommand extends BasicCommand<
       const link = NoteUtils.createWikiLink({
         note,
         useVaultPrefix: DendronClientUtilsV2.shouldUseVaultPrefix(
-          this.extension.getEngine()
+          this._ext.getEngine()
         ),
         alias: { mode: "title" },
       });
@@ -73,14 +71,14 @@ export class InsertNoteIndexCommand extends BasicCommand<
       window.showErrorMessage("Active file is not a Dendron note.");
       return opts;
     }
-    const engine = this.extension.getEngine();
+    const engine = this._ext.getEngine();
     const bulkResp = await engine.bulkGetNotesMeta(activeNote.children);
     const children = bulkResp.data;
     if (children.length === 0) {
       window.showInformationMessage("This note does not have any child notes.");
       return opts;
     }
-    const { config } = this.extension.getDWorkspace();
+    const { config } = this._ext.getDWorkspace();
 
     const insertNoteIndexConfig =
       ConfigUtils.getCommands(config).insertNoteIndex;

--- a/packages/plugin-core/src/commands/OpenLink.ts
+++ b/packages/plugin-core/src/commands/OpenLink.ts
@@ -7,9 +7,10 @@ import path from "path";
 import { env, Uri, window } from "vscode";
 import { PickerUtilsV2 } from "../components/lookup/utils";
 import { DENDRON_COMMANDS } from "../constants";
+import { ExtensionProvider } from "../ExtensionProvider";
 import { getURLAt } from "../utils/md";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
+import { getExtension } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -51,7 +52,7 @@ export class OpenLinkCommand extends BasicCommand<CommandOpts, CommandOutput> {
       env.openExternal(Uri.parse(text.replace("\\", "/"))); // make sure vscode doesn't choke on "\"s
       assetPath = text;
     } else {
-      const wsRoot = getDWorkspace().wsRoot;
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
 
       if (text.startsWith("asset")) {
         const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();

--- a/packages/plugin-core/src/commands/RandomNote.ts
+++ b/packages/plugin-core/src/commands/RandomNote.ts
@@ -2,8 +2,8 @@ import { ConfigUtils, NotePropsMeta, NoteUtils } from "@dendronhq/common-all";
 import _ from "lodash";
 import { Uri, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {};
@@ -17,13 +17,16 @@ export class RandomNoteCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.RANDOM_NOTE.key;
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
 
   async gatherInputs(): Promise<CommandInput | undefined> {
     return {};
   }
 
   async execute(_opts: CommandOpts): Promise<CommandOutput> {
-    const { engine, config } = getDWorkspace();
+    const { engine, config } = this._ext.getDWorkspace();
 
     // If no pattern is specified for include, then include all notes for the search set.
     const randomNoteConfig = ConfigUtils.getCommands(config).randomNote;

--- a/packages/plugin-core/src/commands/RenameNoteV2a.ts
+++ b/packages/plugin-core/src/commands/RenameNoteV2a.ts
@@ -14,7 +14,6 @@ import { DendronContext, DENDRON_COMMANDS } from "../constants";
 import { ExtensionProvider } from "../ExtensionProvider";
 import { FileItem } from "../external/fileutils/FileItem";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
 import { BaseCommand } from "./base";
 import { AutoCompleter } from "../utils/autoCompleter";
 import { AutoCompletableRegistrar } from "../utils/registers/AutoCompletableRegistrar";
@@ -107,7 +106,8 @@ export class RenameNoteV2aCommand extends BaseCommand<
     const vault = PickerUtilsV2.getOrPromptVaultForOpenEditor();
     const move = inputs.move[0];
     const fname = move.newLoc.fname;
-    const vpath = vault2Path({ vault, wsRoot: getDWorkspace().wsRoot });
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const vpath = vault2Path({ vault, wsRoot });
     const newUri = Uri.file(path.join(vpath, fname + ".md"));
     return {
       files: [{ oldUri, newUri }],
@@ -134,7 +134,7 @@ export class RenameNoteV2aCommand extends BaseCommand<
   async execute(opts: CommandOpts) {
     const ctx = "RenameNoteV2a";
     this.L.info({ ctx, msg: "enter", opts });
-    const ext = getExtension();
+    const ext = ExtensionProvider.getExtension();
     try {
       const { files } = opts;
       const { newUri, oldUri } = files[0];
@@ -143,9 +143,10 @@ export class RenameNoteV2aCommand extends BaseCommand<
       }
       const engine = ext.getEngine();
       const oldFname = DNodeUtils.fname(oldUri.fsPath);
+      const { wsRoot } = ExtensionProvider.getDWorkspace();
       const vault = VaultUtils.getVaultByFilePath({
         fsPath: oldUri.fsPath,
-        wsRoot: getDWorkspace().wsRoot,
+        wsRoot,
         vaults: engine.vaults,
       });
 

--- a/packages/plugin-core/src/commands/RestoreVault.ts
+++ b/packages/plugin-core/src/commands/RestoreVault.ts
@@ -6,8 +6,8 @@ import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { WSUtils } from "../WSUtils";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getExtension, getDWorkspace } from "../workspace";
 import { BaseCommand } from "./base";
+import { ExtensionProvider } from "../ExtensionProvider";
 
 type CommandOpts = { src: string };
 
@@ -23,7 +23,8 @@ export class RestoreVaultCommand extends BaseCommand<
 > {
   key = DENDRON_COMMANDS.RESTORE_VAULT.key;
   async gatherInputs(): Promise<any> {
-    const snapshots = path.join(getDWorkspace().wsRoot as string, "snapshots");
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const snapshots = path.join(wsRoot, "snapshots");
 
     const choices = readdirSync(snapshots)
       .sort()
@@ -37,7 +38,8 @@ export class RestoreVaultCommand extends BaseCommand<
   }
 
   async enrichInputs(inputs: CommandInput): Promise<CommandOpts | undefined> {
-    const snapshots = path.join(getDWorkspace().wsRoot as string, "snapshots");
+    const { wsRoot } = ExtensionProvider.getDWorkspace();
+    const snapshots = path.join(wsRoot, "snapshots");
     const { data } = inputs;
     const src = path.join(snapshots, data);
     if (!fs.existsSync(src)) {
@@ -48,8 +50,8 @@ export class RestoreVaultCommand extends BaseCommand<
   }
 
   async execute(opts: CommandOpts) {
-    const ext = getExtension();
-    const { engine, vaults, wsRoot } = getDWorkspace();
+    const ext = ExtensionProvider.getExtension();
+    const { engine, vaults, wsRoot } = ExtensionProvider.getDWorkspace();
     try {
       const { src } = opts;
       const pod = new SnapshotImportPod();

--- a/packages/plugin-core/src/commands/SnapshotVault.ts
+++ b/packages/plugin-core/src/commands/SnapshotVault.ts
@@ -5,7 +5,7 @@ import {
 } from "@dendronhq/pods-core";
 import { window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
-import { getDWorkspace } from "../workspace";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { BaseCommand } from "./base";
 
 type CommandOpts = {};
@@ -20,6 +20,9 @@ export class SnapshotVaultCommand extends BaseCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.SNAPSHOT_VAULT.key;
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
   async gatherInputs(): Promise<any> {
     return {};
   }
@@ -30,9 +33,9 @@ export class SnapshotVaultCommand extends BaseCommand<
 
   async execute(_opts: CommandOpts) {
     const pod = new SnapshotExportPod();
-    const { engine } = getDWorkspace();
+    const { engine } = this._ext.getDWorkspace();
     const vault = engine.vaults[0];
-    const wsRoot = getDWorkspace().wsRoot as string;
+    const { wsRoot } = this._ext.getDWorkspace();
     const { data: snapshotDirPath } = await pod.execute({
       vaults: [vault],
       wsRoot,

--- a/packages/plugin-core/src/commands/VaultConvert.ts
+++ b/packages/plugin-core/src/commands/VaultConvert.ts
@@ -10,11 +10,11 @@ import { DENDRON_COMMANDS } from "../constants";
 import { BasicCommand } from "./base";
 import { ProgressLocation, QuickPickItem, window } from "vscode";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace, getExtension } from "../workspace";
+import { getExtension } from "../workspace";
 import { Logger } from "../logger";
 import { ReloadIndexCommand } from "./ReloadIndex";
-import { ExtensionProvider } from "../ExtensionProvider";
 import { GitUtils } from "@dendronhq/common-server";
+import { IDendronExtension } from "../dendronExtensionInterface";
 
 type CommandOpts = {
   type: VaultRemoteSource;
@@ -31,9 +31,12 @@ export class VaultConvertCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.VAULT_CONVERT.key;
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
 
   async gatherVault(): Promise<DVault | undefined> {
-    const { vaults } = getDWorkspace();
+    const { vaults } = this._ext.getDWorkspace();
     return (
       await VSCodeUtils.showQuickPick(
         vaults.map((ent) => ({
@@ -152,9 +155,7 @@ export class VaultConvertCommand extends BasicCommand<
       }
     }
 
-    if (
-      ExtensionProvider.getDWorkspace().config.dev?.enableSelfContainedVaults
-    ) {
+    if (this._ext.getDWorkspace().config.dev?.enableSelfContainedVaults) {
       // If self contained vaults are enabled, we'll move the vault into the
       // `dependencies` folder. We should ask the user if they are okay with us
       // moving the folder.
@@ -176,7 +177,7 @@ export class VaultConvertCommand extends BasicCommand<
   async execute(opts: CommandOpts) {
     const ctx = "VaultConvertCommand";
     const { vault, type, remoteUrl } = opts;
-    const { wsRoot } = getDWorkspace();
+    const { wsRoot } = this._ext.getDWorkspace();
     if (!vault || !type)
       throw new DendronError({
         message:

--- a/packages/plugin-core/src/commands/VaultRemoveCommand.ts
+++ b/packages/plugin-core/src/commands/VaultRemoveCommand.ts
@@ -3,9 +3,9 @@ import { WorkspaceService } from "@dendronhq/engine-server";
 import _ from "lodash";
 import { commands, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { getDWorkspace } from "../workspace";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {
@@ -25,9 +25,12 @@ export class VaultRemoveCommand extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.VAULT_REMOVE.key;
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
   async gatherInputs(opts?: CommandOpts): Promise<any> {
-    const { vaults } = getDWorkspace();
-    const wsRoot = getDWorkspace().wsRoot as string;
+    const { vaults } = this._ext.getDWorkspace();
+    const { wsRoot } = this._ext.getDWorkspace();
     /**
      * check added for contextual-ui. If the args are passed to the gather inputs,
      * there is no need to show quickpick to select a vault
@@ -58,7 +61,7 @@ export class VaultRemoveCommand extends BasicCommand<
     const ctx = "VaultRemove";
     // NOTE: relative vault
     const { vault } = opts;
-    const wsRoot = getDWorkspace().wsRoot as string;
+    const { wsRoot } = this._ext.getDWorkspace();
     const wsService = new WorkspaceService({ wsRoot });
     Logger.info({ ctx, msg: "preRemoveVault", vault });
     await wsService.removeVault({ vault, updateWorkspace: true });

--- a/packages/plugin-core/src/commands/pods/ConfigureServiceConnection.ts
+++ b/packages/plugin-core/src/commands/pods/ConfigureServiceConnection.ts
@@ -3,8 +3,8 @@ import path from "path";
 import { QuickPickItem, Uri, window } from "vscode";
 import { PodUIControls } from "../../components/pods/PodControls";
 import { DENDRON_COMMANDS } from "../../constants";
+import { IDendronExtension } from "../../dendronExtensionInterface";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getExtension } from "../../workspace";
 import { BasicCommand } from "../base";
 
 type CommandOutput = void;
@@ -16,12 +16,18 @@ export class ConfigureServiceConnection extends BasicCommand<
   CommandOutput
 > {
   key = DENDRON_COMMANDS.CONFIGURE_SERVICE_CONNECTION.key;
+  private extension: IDendronExtension;
+
+  constructor(ext: IDendronExtension) {
+    super();
+    this.extension = ext;
+  }
 
   async execute(_opts: CommandOpts) {
     const ctx = { ctx: "ConfigureServiceConnection" };
     this.L.info({ ctx, msg: "enter" });
     let configFilePath: string;
-    const mngr = new ExternalConnectionManager(getExtension().podsDir);
+    const mngr = new ExternalConnectionManager(this.extension.podsDir);
     const allServiceConfigs = await mngr.getAllValidConfigs();
     const items = allServiceConfigs.map<QuickPickItem>((value) => {
       return { label: value.connectionId, description: value.serviceType };

--- a/packages/plugin-core/src/features/codeActionProvider.ts
+++ b/packages/plugin-core/src/features/codeActionProvider.ts
@@ -116,7 +116,8 @@ export const refactorProvider: CodeActionProvider = {
         isPreferred: true,
         kind: CodeActionKind.RefactorInline,
         command: {
-          command: new RenameHeaderCommand().key,
+          command: new RenameHeaderCommand(ExtensionProvider.getExtension())
+            .key,
           title: "Rename Header",
           arguments: [{ source: ContextualUIEvents.ContextualUICodeAction }],
         },
@@ -152,7 +153,7 @@ export const refactorProvider: CodeActionProvider = {
         isPreferred: true,
         kind: CodeActionKind.RefactorInline,
         command: {
-          command: new CopyNoteRefCommand().key,
+          command: new CopyNoteRefCommand(ExtensionProvider.getExtension()).key,
           title: "Copy Header Reference",
           arguments: [{ source: ContextualUIEvents.ContextualUICodeAction }],
         },

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -46,7 +46,7 @@ import { ExtensionProvider } from "../ExtensionProvider";
 import { Logger } from "../logger";
 import { sentryReportingCallback } from "../utils/analytics";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { DendronExtension, getDWorkspace, getExtension } from "../workspace";
+import { DendronExtension } from "../workspace";
 import { WSUtils } from "../WSUtils";
 
 function padWithZero(n: number): string {
@@ -477,7 +477,7 @@ export async function provideBlockCompletionItems(
   Logger.debug({ ctx, found });
 
   const timestampStart = process.hrtime();
-  const engine = getDWorkspace().engine;
+  const engine = ExtensionProvider.getEngine();
 
   let otherFile = false;
   let note: NotePropsMeta | undefined;
@@ -529,9 +529,10 @@ export async function provideBlockCompletionItems(
     insertValueOnly = true;
   }
 
-  const blocks = await getExtension()
-    .getEngine()
-    .getNoteBlocks({ id: note.id, filterByAnchorType });
+  const blocks = await ExtensionProvider.getEngine().getNoteBlocks({
+    id: note.id,
+    filterByAnchorType,
+  });
   if (
     _.isUndefined(blocks.data) ||
     blocks.error?.severity === ERROR_SEVERITY.FATAL

--- a/packages/plugin-core/src/pluginSchemaUtils.ts
+++ b/packages/plugin-core/src/pluginSchemaUtils.ts
@@ -1,5 +1,5 @@
 import { SchemaUtils } from "@dendronhq/common-all";
-import { getDWorkspace } from "./workspace";
+import { ExtensionProvider } from "./ExtensionProvider";
 
 /**
  * Wrapper around SchemaUtils which can fills out values available in the
@@ -7,13 +7,14 @@ import { getDWorkspace } from "./workspace";
  */
 export class PluginSchemaUtils {
   public static doesSchemaExist(id: string) {
+    const { engine } = ExtensionProvider.getDWorkspace();
     return SchemaUtils.doesSchemaExist({
       id,
-      engine: getDWorkspace().engine,
+      engine,
     });
   }
 
   public static async getSchema(id: string) {
-    return getDWorkspace().engine.getSchema(id);
+    return ExtensionProvider.getEngine().getSchema(id);
   }
 }

--- a/packages/plugin-core/src/pluginVaultUtils.ts
+++ b/packages/plugin-core/src/pluginVaultUtils.ts
@@ -1,5 +1,5 @@
 import { DVault, VaultUtils } from "@dendronhq/common-all";
-import { getDWorkspace } from "./workspace";
+import { ExtensionProvider } from "./ExtensionProvider";
 
 /**
  * Wrapper around common-all VaultUtils which provides defaults
@@ -16,10 +16,10 @@ export class PluginVaultUtils {
     vaults?: DVault[];
   }): DVault {
     if (!wsRoot) {
-      wsRoot = getDWorkspace().wsRoot;
+      wsRoot = ExtensionProvider.getDWorkspace().wsRoot;
     }
     if (!vaults) {
-      vaults = getDWorkspace().vaults;
+      vaults = ExtensionProvider.getDWorkspace().vaults;
     }
 
     return VaultUtils.getVaultByFilePath({

--- a/packages/plugin-core/src/test/suite-integ/ChangeWorkspace.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ChangeWorkspace.test.ts
@@ -6,7 +6,7 @@ import { window } from "vscode";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WorkspaceType } from "@dendronhq/common-all";
 import { expect } from "../testUtilsv2";
-import { getDWorkspace } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 
 // eslint-disable-next-line prefer-arrow-callback
 suite("GIVEN ChangeWorkspace command", function () {
@@ -33,7 +33,7 @@ suite("GIVEN ChangeWorkspace command", function () {
       let openWS: sinon.SinonStub;
       let newWSRoot: string;
       before(async () => {
-        const { wsRoot: currentWSRoot } = getDWorkspace();
+        const { wsRoot: currentWSRoot } = ExtensionProvider.getDWorkspace();
         openWS = sinon.stub(VSCodeUtils, "openWS").resolves();
 
         const out = await setupLegacyWorkspaceMulti({
@@ -62,7 +62,7 @@ suite("GIVEN ChangeWorkspace command", function () {
       let openWS: sinon.SinonStub;
       let newWSRoot: string;
       before(async () => {
-        const { wsRoot: currentWSRoot } = getDWorkspace();
+        const { wsRoot: currentWSRoot } = ExtensionProvider.getDWorkspace();
         openWS = sinon.stub(VSCodeUtils, "openWS").resolves();
 
         const out = await setupLegacyWorkspaceMulti({

--- a/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CompletionProvider.test.ts
@@ -15,7 +15,6 @@ import {
   provideCompletionItems,
 } from "../../features/completionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace } from "../../workspace";
 import { WSUtilsV2 } from "../../WSUtilsV2";
 import { expect } from "../testUtilsv2";
 import {
@@ -312,7 +311,7 @@ suite("completionProvider", function () {
     () => {
       let items: CompletionItem[] | undefined;
       before(async () => {
-        const { vaults, engine } = getDWorkspace();
+        const { vaults, engine } = ExtensionProvider.getDWorkspace();
         await new WSUtilsV2(ExtensionProvider.getExtension()).openNote(
           (
             await engine.findNotesMeta({

--- a/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigurePod.spec.ts
@@ -7,20 +7,17 @@ import {
 } from "@dendronhq/pods-core";
 import { ensureDirSync } from "fs-extra";
 import path from "path";
-// // You can import and use all API from the 'vscode' module
-// // as well as import your extension to test it
-import * as vscode from "vscode";
 import { ConfigurePodCommand } from "../../commands/ConfigurePodCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("ConfigurePod", function () {
   let root: DirResult;
-  let ctx: vscode.ExtensionContext;
   let podsDir: string;
 
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {
       root = tmpDir();
       podsDir = path.join(root.name, "pods");
@@ -31,8 +28,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async ({}) => {
-        const cmd = new ConfigurePodCommand();
+      onInit: async () => {
+        const cmd = new ConfigurePodCommand(ExtensionProvider.getExtension());
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         cmd.gatherInputs = async () => {
           return { podClass: podChoice.podClass };
@@ -52,8 +49,8 @@ suite("ConfigurePod", function () {
     runLegacyMultiWorkspaceTest({
       ctx,
       preSetupHook: ENGINE_HOOKS.setupBasic,
-      onInit: async ({}) => {
-        const cmd = new ConfigurePodCommand();
+      onInit: async () => {
+        const cmd = new ConfigurePodCommand(ExtensionProvider.getExtension());
         const podChoice = podClassEntryToPodItemV4(JSONExportPod);
         const podClass = podChoice.podClass;
         cmd.gatherInputs = async () => {

--- a/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConfigureServiceConnection.spec.ts
@@ -29,7 +29,9 @@ suite("ConfigureServiceConnection", function () {
       },
       () => {
         test("THEN new service config must be created", async () => {
-          const cmd = new ConfigureServiceConnection();
+          const cmd = new ConfigureServiceConnection(
+            ExtensionProvider.getExtension()
+          );
           sinon.stub(vscode.window, "showQuickPick").returns(
             Promise.resolve({
               label: "Create New Service Connection",
@@ -62,7 +64,9 @@ suite("ConfigureServiceConnection", function () {
       },
       () => {
         test("THEN service config of selected connection Id must open", async () => {
-          const cmd = new ConfigureServiceConnection();
+          const cmd = new ConfigureServiceConnection(
+            ExtensionProvider.getExtension()
+          );
           sinon.stub(vscode.window, "showQuickPick").returns(
             Promise.resolve({
               label: "airtable-2",

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteRef.test.ts
@@ -45,7 +45,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
             expect(link).toEqual(`![[bar#foo]]`);
           });
         }
@@ -63,7 +65,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 4);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
             expect(link).toEqual(`![[bar#foo]]`);
           });
         }
@@ -93,7 +97,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
             expect(link).toEqual(`![[bar#foo]]`);
           });
         }
@@ -131,7 +137,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(8, 0, 8, 0);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
             expect(link).toEqual("![[bar#^test-anchor]]");
           });
         }
@@ -169,7 +177,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(8, 0, 11, 0);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
 
             // make sure the link is correct
             expect(link!.startsWith("![[bar#^test-anchor:#^"));
@@ -212,7 +222,9 @@ suite("CopyNoteRef", function () {
             "foo.md"
           );
           await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-          const link = await new CopyNoteRefCommand().run();
+          const link = await new CopyNoteRefCommand(
+            ExtensionProvider.getExtension()
+          ).run();
           expect(link).toEqual("![[dendron://vault1/foo]]");
         });
       }
@@ -235,7 +247,9 @@ suite("CopyNoteRef", function () {
             "foo.md"
           );
           await VSCodeUtils.openFileInEditor(vscode.Uri.file(notePath));
-          const link = await new CopyNoteRefCommand().run();
+          const link = await new CopyNoteRefCommand(
+            ExtensionProvider.getExtension()
+          ).run();
           expect(link).toEqual("![[foo]]");
         });
       }
@@ -252,7 +266,9 @@ suite("CopyNoteRef", function () {
           const engine = ExtensionProvider.getEngine();
           const note = (await engine.getNoteMeta("foo")).data!;
           await WSUtils.openNote(note);
-          const link = await new CopyNoteRefCommand().run();
+          const link = await new CopyNoteRefCommand(
+            ExtensionProvider.getExtension()
+          ).run();
           expect(link).toEqual("![[foo]]");
         });
       }
@@ -282,7 +298,9 @@ suite("CopyNoteRef", function () {
             const note = (await engine.getNoteMeta("bar")).data!;
             const editor = await WSUtils.openNote(note);
             editor.selection = new vscode.Selection(7, 0, 7, 12);
-            const link = await new CopyNoteRefCommand().run();
+            const link = await new CopyNoteRefCommand(
+              ExtensionProvider.getExtension()
+            ).run();
             expect(link).toEqual("![[bar#foo]]");
           });
         }

--- a/packages/plugin-core/src/test/suite-integ/CopyNoteUrl.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CopyNoteUrl.test.ts
@@ -43,7 +43,9 @@ suite("GIVEN CopyNoteUrlV2", function () {
           const fname = NOTE_PRESETS_V4.NOTE_WITH_BLOCK_ANCHOR_TARGET.fname;
           const editor = await WSUtils.openNoteByPath({ vault, fname });
           editor.selection = new vscode.Selection(10, 0, 10, 5);
-          const link = await new CopyNoteURLCommand().execute();
+          const link = await new CopyNoteURLCommand(
+            ExtensionProvider.getExtension()
+          ).execute();
           const url = [ROOT_URL, "notes", `${fname}#^block-id`].join("/");
           expect(link).toEqual(url);
         });
@@ -72,7 +74,9 @@ suite("GIVEN CopyNoteUrlV2", function () {
           const fname = NOTE_PRESETS_V4.NOTE_WITH_ANCHOR_TARGET.fname;
           const editor = await WSUtils.openNoteByPath({ vault, fname });
           editor.selection = new vscode.Selection(7, 0, 7, 12);
-          const link = await new CopyNoteURLCommand().run();
+          const link = await new CopyNoteURLCommand(
+            ExtensionProvider.getExtension()
+          ).run();
           const url = [ROOT_URL, "notes", `${fname}#h1`].join("/");
           expect(link).toEqual(url);
         });
@@ -96,7 +100,9 @@ suite("GIVEN CopyNoteUrlV2", function () {
           const vault = vaults[0];
           const fname = "foo";
           await WSUtils.openNoteByPath({ vault, fname });
-          const link = await new CopyNoteURLCommand().execute();
+          const link = await new CopyNoteURLCommand(
+            ExtensionProvider.getExtension()
+          ).execute();
           const url = _.join([ROOT_URL, "notes", `${fname}`], "/");
           expect(link).toEqual(url);
         });
@@ -124,7 +130,9 @@ suite("GIVEN CopyNoteUrlV2", function () {
           const vault = vaults[0];
           const fname = "foo";
           await WSUtils.openNoteByPath({ vault, fname });
-          const link = await new CopyNoteURLCommand().execute();
+          const link = await new CopyNoteURLCommand(
+            ExtensionProvider.getExtension()
+          ).execute();
           const url = _.join(
             [ROOT_URL, ASSET_PREFIX, "notes", `${fname}`],
             "/"

--- a/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GoUpCommand.test.ts
@@ -1,15 +1,13 @@
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
-import * as vscode from "vscode";
 import { GoUpCommand } from "../../commands/GoUpCommand";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("GoUpCommand", function () {
-  let ctx: vscode.ExtensionContext;
-
-  ctx = setupBeforeAfter(this, {});
+  const ctx = setupBeforeAfter(this, {});
 
   test("basic", (done) => {
     runLegacyMultiWorkspaceTest({
@@ -18,7 +16,7 @@ suite("GoUpCommand", function () {
       onInit: async ({ engine }) => {
         const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
-        await new GoUpCommand().run();
+        await new GoUpCommand(ExtensionProvider.getExtension()).run();
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
             "root.md"
@@ -36,7 +34,7 @@ suite("GoUpCommand", function () {
       onInit: async ({ engine }) => {
         const note = (await engine.getNoteMeta("foo.ch1")).data!;
         await WSUtils.openNote(note);
-        await new GoUpCommand().run();
+        await new GoUpCommand(ExtensionProvider.getExtension()).run();
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.uri.fsPath.endsWith(
             "foo.md"

--- a/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ImportPod.test.ts
@@ -10,14 +10,12 @@ import { ensureDirSync } from "fs-extra";
 import path from "path";
 // // You can import and use all API from the 'vscode' module
 // // as well as import your extension to test it
-import * as vscode from "vscode";
 import { ImportPodCommand } from "../../commands/ImportPod";
-import { getDWorkspace } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 
 suite("ImportPod", function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this, {
+  const ctx = setupBeforeAfter(this, {
     beforeHook: () => {},
   });
 
@@ -50,7 +48,7 @@ suite("ImportPod", function () {
           };
         };
         const pod = fakePod();
-        const engine = getDWorkspace().engine;
+        const engine = ExtensionProvider.getEngine();
         await PODS_CORE.JSON.IMPORT.BASIC.testFunc({
           engine,
           wsRoot,

--- a/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/InsertNoteIndexCommand.test.ts
@@ -26,7 +26,9 @@ suite("InsertNoteIndex", function () {
         },
         onInit: async ({ engine }) => {
           const foo = (await engine.getNoteMeta("foo")).data!;
-          const cmd = new InsertNoteIndexCommand();
+          const cmd = new InsertNoteIndexCommand(
+            ExtensionProvider.getExtension()
+          );
 
           await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -52,7 +54,9 @@ suite("InsertNoteIndex", function () {
         },
         onInit: async ({ engine }) => {
           const foo = (await engine.getNoteMeta("foo")).data!;
-          const cmd = new InsertNoteIndexCommand();
+          const cmd = new InsertNoteIndexCommand(
+            ExtensionProvider.getExtension()
+          );
 
           await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -99,7 +103,9 @@ suite("InsertNoteIndex", function () {
           );
 
           const foo = (await engine.getNoteMeta("foo")).data!;
-          const cmd = new InsertNoteIndexCommand();
+          const cmd = new InsertNoteIndexCommand(
+            ExtensionProvider.getExtension()
+          );
 
           await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -137,7 +143,9 @@ suite("InsertNoteIndex", function () {
           );
 
           const foo = (await engine.getNoteMeta("foo")).data!;
-          const cmd = new InsertNoteIndexCommand();
+          const cmd = new InsertNoteIndexCommand(
+            ExtensionProvider.getExtension()
+          );
 
           await WSUtils.openNote(foo);
           const editor = VSCodeUtils.getActiveTextEditorOrThrow();
@@ -187,7 +195,9 @@ suite("InsertNoteIndex", function () {
         const rootNote = (await engine.getNoteMeta("root")).data!;
         await ExtensionProvider.getWSUtils().openNote(rootNote);
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
-        const cmd = new InsertNoteIndexCommand();
+        const cmd = new InsertNoteIndexCommand(
+          ExtensionProvider.getExtension()
+        );
         editor.selection = new vscode.Selection(9, 0, 9, 0);
         await cmd.execute({});
         const body = editor.document.getText();
@@ -231,7 +241,9 @@ suite("InsertNoteIndex", function () {
         const rootNote = (await engine.getNoteMeta("root")).data!;
         await ExtensionProvider.getWSUtils().openNote(rootNote);
         const editor = VSCodeUtils.getActiveTextEditorOrThrow();
-        const cmd = new InsertNoteIndexCommand();
+        const cmd = new InsertNoteIndexCommand(
+          ExtensionProvider.getExtension()
+        );
         editor.selection = new vscode.Selection(9, 0, 9, 0);
         await cmd.execute({});
         const body = editor.document.getText();

--- a/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupJournal.test.ts
@@ -8,7 +8,7 @@ import _ from "lodash";
 import { describe } from "mocha";
 import * as vscode from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
-import { getDWorkspace } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { WSUtils } from "../../WSUtils";
 import { expect, getNoteFromTextEditor } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
@@ -29,7 +29,7 @@ suite("Journal Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const engine = getDWorkspace().engine;
+          const engine = ExtensionProvider.getEngine();
           const note = (await engine.findNotesMeta({ fname, vault }))[0];
           await WSUtils.openNote(note!);
           await new NoteLookupCommand().run({
@@ -67,7 +67,7 @@ suite("Journal Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = "daily";
-          const engine = getDWorkspace().engine;
+          const engine = ExtensionProvider.getEngine();
           const note = (await engine.findNotesMeta({ fname, vault }))[0];
           await WSUtils.openNote(note!);
           await new NoteLookupCommand().run({

--- a/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/LookupScratch.test.ts
@@ -8,7 +8,7 @@ import { NOTE_PRESETS_V4 } from "@dendronhq/common-test-utils";
 import { describe } from "mocha";
 import * as vscode from "vscode";
 import { NoteLookupCommand } from "../../commands/NoteLookupCommand";
-import { getDWorkspace } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { WSUtils } from "../../WSUtils";
 import { expect, getNoteFromTextEditor } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
@@ -29,7 +29,7 @@ suite("Scratch Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[0];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const engine = getDWorkspace().engine;
+          const engine = ExtensionProvider.getEngine();
           const note = (await engine.findNotesMeta({ fname, vault }))[0];
           const editor = await WSUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);
@@ -96,7 +96,7 @@ suite("Scratch Notes", function () {
         onInit: async ({ vaults }) => {
           const vault = vaults[1];
           const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
-          const engine = getDWorkspace().engine;
+          const engine = ExtensionProvider.getEngine();
           const note = (await engine.findNotesMeta({ fname, vault }))[0];
           const editor = await WSUtils.openNote(note!);
           const SIMPLE_SELECTION = new vscode.Selection(7, 0, 7, 12);

--- a/packages/plugin-core/src/test/suite-integ/PasteLink.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PasteLink.test.ts
@@ -2,8 +2,8 @@ import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
 import ogs from "open-graph-scraper";
 import sinon from "sinon";
 import { PasteLinkCommand } from "../../commands/PasteLink";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import * as utils from "../../utils";
-import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS, setupBeforeAfter } from "../testUtilsV3";
@@ -45,7 +45,7 @@ suite("pasteLink", function () {
     () => {
       test("THEN gets link with metadata", async () => {
         // You can access the workspace inside the test like this:
-        const { engine } = getDWorkspace();
+        const { engine } = ExtensionProvider.getDWorkspace();
         const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");
@@ -68,7 +68,7 @@ suite("pasteLink", function () {
     () => {
       test("THEN trims link title", async () => {
         // You can access the workspace inside the test like this:
-        const { engine } = getDWorkspace();
+        const { engine } = ExtensionProvider.getDWorkspace();
         const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");
@@ -91,7 +91,7 @@ suite("pasteLink", function () {
     () => {
       test("THEN gets raw link", async () => {
         // You can access the workspace inside the test like this:
-        const { engine } = getDWorkspace();
+        const { engine } = ExtensionProvider.getDWorkspace();
         const note = (await engine.getNoteMeta("foo")).data!;
         await WSUtils.openNote(note);
         utils.clipboard.writeText("https://dendron.so");

--- a/packages/plugin-core/src/test/suite-integ/PublishPod.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/PublishPod.test.ts
@@ -15,6 +15,7 @@ import path from "path";
 // // as well as import your extension to test it
 import * as vscode from "vscode";
 import { PublishPodCommand } from "../../commands/PublishPod";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
 import {
@@ -43,7 +44,7 @@ suite("PublishV2", function () {
         // when a user runs publish pod, they are presented with a list of pods
         // to execute
         // this mocks that command so that Markdown is the only option
-        const cmd = new PublishPodCommand();
+        const cmd = new PublishPodCommand(ExtensionProvider.getExtension());
         const podChoice = podClassEntryToPodItemV4(MarkdownPublishPod);
         cmd.gatherInputs = async () => {
           return { podChoice };
@@ -66,7 +67,7 @@ suite("PublishV2", function () {
     () => {
       test("THEN show error when required arg not present", (done) => {
         // You can access the workspace inside the test like this:
-        const cmd = new PublishPodCommand();
+        const cmd = new PublishPodCommand(ExtensionProvider.getExtension());
         const podChoice = podClassEntryToPodItemV4(AirtablePublishPod);
         cmd.gatherInputs = async () => {
           return { podChoice };
@@ -104,7 +105,7 @@ suite("PublishV2", function () {
         const refTargetFname = NOTE_PRESETS_V4.NOTE_WITH_NOTE_REF_LINK.fname;
         const fpath = path.join(vpath, `${refTargetFname}.md`);
         await VSCodeUtils.openFileInEditor(vscode.Uri.file(fpath));
-        const cmd = new PublishPodCommand();
+        const cmd = new PublishPodCommand(ExtensionProvider.getExtension());
         const podChoice = podClassEntryToPodItemV4(MarkdownPublishPod);
         cmd.gatherInputs = async () => {
           return { podChoice };

--- a/packages/plugin-core/src/test/suite-integ/RandomNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RandomNoteCommand.test.ts
@@ -4,6 +4,7 @@ import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import * as vscode from "vscode";
 import { RandomNoteCommand } from "../../commands/RandomNote";
 import { DENDRON_COMMANDS } from "../../constants";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { expect } from "../testUtilsv2";
 import {
@@ -52,7 +53,7 @@ function basicTest({
         { wsRoot }
       );
 
-      await new RandomNoteCommand().run();
+      await new RandomNoteCommand(ExtensionProvider.getExtension()).run();
       validateFn();
       done();
     },
@@ -60,8 +61,7 @@ function basicTest({
 }
 
 suite(DENDRON_COMMANDS.RANDOM_NOTE.key, function () {
-  let ctx: vscode.ExtensionContext;
-  ctx = setupBeforeAfter(this, {});
+  const ctx = setupBeforeAfter(this, {});
 
   test("include pattern only", (done) => {
     const validateFn = function () {

--- a/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RefactorHierarchy.test.ts
@@ -11,9 +11,9 @@ import { RefactorHierarchyCommandV2 } from "../../commands/RefactorHierarchyV2";
 import { expect } from "../testUtilsv2";
 import { runLegacyMultiWorkspaceTest, setupBeforeAfter } from "../testUtilsV3";
 import sinon from "sinon";
-import { getEngine } from "../../workspace";
 import { DNodeProps, DVault } from "@dendronhq/common-all";
 import { NoteLookupProviderSuccessResp } from "../../components/lookup/LookupProviderV3Interface";
+import { ExtensionProvider } from "../../ExtensionProvider";
 
 suite("RefactorHierarchy", function () {
   const ctx = setupBeforeAfter(this, {
@@ -96,7 +96,7 @@ suite("RefactorHierarchy", function () {
               noConfirm: true,
             });
 
-            const engine = getEngine();
+            const engine = ExtensionProvider.getEngine();
             const { vaults, wsRoot } = engine;
             const vault = vaults[0];
             const vpath = vault2Path({ vault, wsRoot });
@@ -150,7 +150,7 @@ suite("RefactorHierarchy", function () {
               noConfirm: true,
             });
 
-            const engine = getEngine();
+            const engine = ExtensionProvider.getEngine();
             const { vaults, wsRoot } = engine;
             const vault = vaults[0];
             const vpath = vault2Path({ vault, wsRoot });
@@ -190,7 +190,7 @@ suite("RefactorHierarchy", function () {
           onInit: async () => {
             const cmd = new RefactorHierarchyCommandV2();
 
-            const engine = getEngine();
+            const engine = ExtensionProvider.getEngine();
             const { wsRoot } = engine;
 
             const capturedNotes = [note, noteOne, noteTwo];
@@ -258,7 +258,7 @@ suite("RefactorHierarchy", function () {
           onInit: async () => {
             const cmd = new RefactorHierarchyCommandV2();
 
-            const engine = getEngine();
+            const engine = ExtensionProvider.getEngine();
             const { wsRoot } = engine;
 
             const capturedNotes = [refFooTest, refBarTest, refEggTest];
@@ -292,7 +292,7 @@ suite("RefactorHierarchy", function () {
           preSetupHook,
           onInit: async () => {
             const cmd = new RefactorHierarchyCommandV2();
-            const engine = getEngine();
+            const engine = ExtensionProvider.getEngine();
             const capturedNotes = await cmd.getCapturedNotes({
               scope: undefined,
               matchRE: new RegExp("dendron.ref"),

--- a/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ReferenceProvider.test.ts
@@ -10,7 +10,6 @@ import * as vscode from "vscode";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import ReferenceProvider from "../../features/ReferenceProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
-import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import {
@@ -177,7 +176,10 @@ suite("GIVEN ReferenceProvider", function () {
           const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithTarget1, noteWithTarget2].map((note) =>
-              NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
+              NoteUtils.getFullPath({
+                note,
+                wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
+              })
             )
           );
           done();
@@ -207,7 +209,10 @@ suite("GIVEN ReferenceProvider", function () {
           const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithTarget1, noteWithTarget2].map((note) =>
-              NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
+              NoteUtils.getFullPath({
+                note,
+                wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
+              })
             )
           );
           done();
@@ -235,7 +240,10 @@ suite("GIVEN ReferenceProvider", function () {
           const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithLink].map((note) =>
-              NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
+              NoteUtils.getFullPath({
+                note,
+                wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
+              })
             )
           );
           done();
@@ -264,7 +272,10 @@ suite("GIVEN ReferenceProvider", function () {
           const links = await provideForNote(editor);
           expect(links!.map((l) => l.uri.fsPath)).toEqual(
             [noteWithLink].map((note) =>
-              NoteUtils.getFullPath({ note, wsRoot: getDWorkspace().wsRoot })
+              NoteUtils.getFullPath({
+                note,
+                wsRoot: ExtensionProvider.getDWorkspace().wsRoot,
+              })
             )
           );
           done();

--- a/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameHeader.test.ts
@@ -8,6 +8,7 @@ import {
   RenameHeaderCommand,
   CommandOutput,
 } from "../../commands/RenameHeader";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { WSUtils } from "../../WSUtils";
 import { expect, LocationTestUtils } from "../testUtilsv2";
 import {
@@ -86,7 +87,9 @@ suite("RenameNote", function () {
         sandbox
           .stub(vscode.window, "showInputBox")
           .returns(Promise.resolve("Foo Bar"));
-        const out = (await new RenameHeaderCommand().run({})) as CommandOutput;
+        const out = (await new RenameHeaderCommand(
+          ExtensionProvider.getExtension()
+        ).run({})) as CommandOutput;
 
         const updateResps = out!.data?.filter((resp) => {
           return resp.status === "update";
@@ -125,7 +128,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -181,7 +186,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -240,7 +247,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -294,7 +303,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-link", vault: vaults[0] })
@@ -345,7 +356,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -401,7 +414,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -457,7 +472,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo [[Bar|note.bar]] Baz"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -513,7 +530,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -575,7 +594,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -642,7 +663,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })
@@ -710,7 +733,9 @@ suite("RenameNote", function () {
             .stub(vscode.window, "showInputBox")
             .returns(Promise.resolve("Foo Bar"));
           try {
-            await new RenameHeaderCommand().run({});
+            await new RenameHeaderCommand(ExtensionProvider.getExtension()).run(
+              {}
+            );
 
             const afterRename = (
               await engine.findNotes({ fname: "has-header", vault: vaults[0] })

--- a/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameProvider.test.ts
@@ -3,8 +3,8 @@ import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
 import { before, beforeEach, describe } from "mocha";
 import vscode from "vscode";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import RenameProvider from "../../features/RenameProvider";
-import { getDWorkspace } from "../../workspace";
 import { WSUtils } from "../../WSUtils";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
@@ -100,7 +100,7 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const active = (
             await engine.findNotes({ fname: "active", vault: vaults[0] })
           )[0];
@@ -114,7 +114,7 @@ suite("RenameProvider", function () {
         });
 
         test("AND target note is correctly renamed", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const newTarget = (
             await engine.findNotes({ fname: "new-target", vault: vaults[0] })
           )[0];
@@ -122,7 +122,7 @@ suite("RenameProvider", function () {
         });
         test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(13);
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
               fname: "note-with-link",
@@ -224,7 +224,7 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const active = (
             await engine.findNotes({
               fname: "active",
@@ -240,7 +240,7 @@ suite("RenameProvider", function () {
         });
 
         test("AND target note is correctly renamed", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const newTarget = (
             await engine.findNotes({
               fname: "new-target",
@@ -251,7 +251,7 @@ suite("RenameProvider", function () {
         });
         test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(12);
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
               fname: "note-with-link",
@@ -326,7 +326,7 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const active = (
             await engine.findNotes({
               fname: "active",
@@ -338,7 +338,7 @@ suite("RenameProvider", function () {
         });
 
         test("AND target note is correctly renamed", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const newTarget = (
             await engine.findNotes({
               fname: "tags.new-target",
@@ -349,7 +349,7 @@ suite("RenameProvider", function () {
         });
         test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(10);
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
               fname: "note-with-link",
@@ -413,7 +413,7 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const active = (
             await engine.findNotes({
               fname: "active",
@@ -424,7 +424,7 @@ suite("RenameProvider", function () {
         });
 
         test("AND target note is correctly renamed", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const newTarget = (
             await engine.findNotes({
               fname: "tags.new-target",
@@ -435,7 +435,7 @@ suite("RenameProvider", function () {
         });
         test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(10);
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
               fname: "note-with-link",
@@ -502,7 +502,7 @@ suite("RenameProvider", function () {
           executeOut = await provider.executeRename({ newName: "new-target" });
         });
         test("THEN correctly renamed at symbol position", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const active = (
             await engine.findNotes({
               fname: "active",
@@ -514,7 +514,7 @@ suite("RenameProvider", function () {
         });
 
         test("AND target note is correctly renamed", async () => {
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const newTarget = (
             await engine.findNotes({
               fname: "user.new-target",
@@ -525,7 +525,7 @@ suite("RenameProvider", function () {
         });
         test("THEN references to target note is correctly updated", async () => {
           expect(executeOut?.changed.length).toEqual(10);
-          const { vaults, engine } = getDWorkspace();
+          const { vaults, engine } = ExtensionProvider.getDWorkspace();
           const noteWithLink = (
             await engine.findNotes({
               fname: "note-with-link",

--- a/packages/plugin-core/src/test/suite-integ/StartServer.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/StartServer.test.ts
@@ -3,7 +3,7 @@ import { TestEngineUtils } from "@dendronhq/engine-test-utils";
 import { describe } from "mocha";
 import path from "path";
 import sinon, { SinonStub } from "sinon";
-import { getExtension } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { expect, resetCodeWorkspace } from "../testUtilsv2";
 import { setupBeforeAfter } from "../testUtilsV3";
 
@@ -25,7 +25,7 @@ suite("StartServer", function () {
     test("ok", function (done) {
       ServerUtils.execServerNode({
         scriptPath: path.join(__dirname, "..", "..", "server.js"),
-        logPath: getExtension().context.logPath,
+        logPath: ExtensionProvider.getExtension().context.logPath,
       }).then(({ port }) => {
         expect(port > 0).toBeTruthy();
         done();

--- a/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultConvert.test.ts
@@ -25,7 +25,7 @@ suite("GIVEN VaultConvert", function () {
       let remote: string;
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand();
+        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -67,7 +67,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND converting that back to a local vault", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand();
+          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -115,7 +115,7 @@ suite("GIVEN VaultConvert", function () {
       let remote: string;
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand();
+        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
         sinon.stub(cmd, "promptForFolderMove").resolves(true);
@@ -180,7 +180,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND converting that back to a local vault", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand();
+          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
           sinon.stub(cmd, "promptForFolderMove").resolves(true);
@@ -237,7 +237,7 @@ suite("GIVEN VaultConvert", function () {
     () => {
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand();
+        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -261,7 +261,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND running the conversion command again", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand();
+          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("remote");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 

--- a/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/VaultRemoveCommand.test.ts
@@ -95,7 +95,7 @@ suite("GIVEN VaultRemoveCommand", function () {
         wsName: remoteWsName,
       });
       stubQuickPick({ fsPath: remoteVaultName, workspace: remoteWsName });
-      await new VaultRemoveCommand().run();
+      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
       const config = getConfig();
       expect(ConfigUtils.getVaults(config)).toEqual(vaults);
       expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
@@ -116,7 +116,7 @@ suite("GIVEN VaultRemoveCommand", function () {
         // @ts-ignore
         data: vaultToRemove,
       });
-      await new VaultRemoveCommand().run();
+      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
       // Shouldn't delete the actual files
       expect(
@@ -190,7 +190,7 @@ suite("GIVEN VaultRemoveCommand", function () {
             // @ts-ignore
             data: vaultToRemove,
           });
-          await new VaultRemoveCommand().run();
+          await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
           // after remove, we have 2 vaults in dendron.yml
           const postRunConfig = DConfig.readConfigSync(wsRoot);
@@ -217,7 +217,7 @@ suite("GIVEN VaultRemoveCommand", function () {
           // @ts-ignore
           data: vaultToRemove,
         });
-        await new VaultRemoveCommand().run();
+        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
         // Shouldn't delete the actual files
         expect(
@@ -258,7 +258,7 @@ suite("GIVEN VaultRemoveCommand", function () {
           // @ts-ignore
           data: vaultToRemove,
         });
-        await new VaultRemoveCommand().run();
+        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
         // Shouldn't delete the actual files
         expect(
@@ -308,7 +308,7 @@ suite("GIVEN VaultRemoveCommand", function () {
       VSCodeUtils.showQuickPick = () => {
         return { data: vaultsAfter[1] };
       };
-      await new VaultRemoveCommand().run();
+      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
       const configNew = readYAML(configPath) as IntermediateDendronConfig;
       // confirm that duplicateNoteBehavior setting is gone
@@ -345,7 +345,7 @@ suite("GIVEN VaultRemoveCommand", function () {
       VSCodeUtils.showQuickPick = () => {
         return { data: vaultsAfter[1] };
       };
-      await new VaultRemoveCommand().run();
+      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
 
       const config = DConfig.getRaw(wsRoot) as IntermediateDendronConfig;
 
@@ -365,7 +365,9 @@ suite("GIVEN VaultRemoveCommand", function () {
         const args = {
           fsPath: path.join(wsRoot, vaults[1].fsPath),
         };
-        await new VaultRemoveCommand().run(args);
+        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run(
+          args
+        );
         const config = getConfig();
         expect(ConfigUtils.getVaults(config)).toNotEqual(vaults);
         expect(
@@ -388,7 +390,9 @@ suite("GIVEN VaultRemoveCommand", function () {
         const args = {
           fsPath: path.join(wsRoot, remoteWsName, remoteVaultName),
         };
-        await new VaultRemoveCommand().run(args);
+        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run(
+          args
+        );
         const config = getConfig();
         expect(ConfigUtils.getVaults(config)).toEqual(vaults);
         expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceInit.test.ts
@@ -1,6 +1,6 @@
 import { WorkspaceType } from "@dendronhq/common-all";
 import { ENGINE_HOOKS } from "@dendronhq/engine-test-utils";
-import { getDWorkspace } from "../../workspace";
+import { ExtensionProvider } from "../../ExtensionProvider";
 import { expect } from "../testUtilsv2";
 import {
   describeMultiWS,
@@ -22,13 +22,13 @@ runSuiteButSkipForWindows()(
       },
       () => {
         test("THEN initializes correctly", async () => {
-          const { engine } = getDWorkspace();
+          const { engine } = ExtensionProvider.getDWorkspace();
           const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
         });
 
         test("THEN is of NATIVE type", (done) => {
-          const { type } = getDWorkspace();
+          const { type } = ExtensionProvider.getDWorkspace();
           expect(type).toEqual(WorkspaceType.NATIVE);
           done();
         });
@@ -44,13 +44,13 @@ runSuiteButSkipForWindows()(
       },
       () => {
         test("THEN initializes correctly", async () => {
-          const { engine } = getDWorkspace();
+          const { engine } = ExtensionProvider.getDWorkspace();
           const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
         });
 
         test("THEN is of CODE type", (done) => {
-          const { type } = getDWorkspace();
+          const { type } = ExtensionProvider.getDWorkspace();
           expect(type).toEqual(WorkspaceType.CODE);
           done();
         });
@@ -65,13 +65,13 @@ runSuiteButSkipForWindows()(
       },
       () => {
         test("THEN initializes correctly", async () => {
-          const { engine } = getDWorkspace();
+          const { engine } = ExtensionProvider.getDWorkspace();
           const testNote = (await engine.getNoteMeta("foo")).data!;
           expect(testNote).toBeTruthy();
         });
 
         test("THEN is of CODE type", (done) => {
-          const { type } = getDWorkspace();
+          const { type } = ExtensionProvider.getDWorkspace();
           expect(type).toEqual(WorkspaceType.CODE);
           done();
         });

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -65,7 +65,7 @@ import { Logger } from "../logger";
 import { StateService } from "../services/stateService";
 import { WorkspaceConfig } from "../settings";
 import { VSCodeUtils } from "../vsCodeUtils";
-import { DendronExtension, getDWorkspace } from "../workspace";
+import { DendronExtension } from "../workspace";
 import { BlankInitializer } from "../workspace/blankInitializer";
 import { WorkspaceInitFactory } from "../workspace/WorkspaceInitFactory";
 import { _activate } from "../_extension";
@@ -317,7 +317,7 @@ export async function runLegacySingleWorkspaceTest(
     skipMigrations: true,
     skipTreeView: true,
   });
-  const engine = getDWorkspace().engine;
+  const engine = ExtensionProvider.getEngine();
   await opts.onInit({ wsRoot, vaults, engine });
 
   cleanupVSCodeContextSubscriptions(opts.ctx!);
@@ -341,7 +341,7 @@ export async function runLegacyMultiWorkspaceTest(
       : true,
     skipTreeView: true,
   });
-  const engine = getDWorkspace().engine;
+  const engine = ExtensionProvider.getEngine();
   await opts.onInit({ wsRoot, vaults, engine });
 
   cleanupVSCodeContextSubscriptions(opts.ctx!);

--- a/packages/plugin-core/src/test/testUtilsv2.ts
+++ b/packages/plugin-core/src/test/testUtilsv2.ts
@@ -24,9 +24,10 @@ import {
 } from "vscode";
 import { SetupWorkspaceOpts } from "../commands/SetupWorkspace";
 import { CONFIG } from "../constants";
-import { DendronExtension, getDWorkspace } from "../workspace";
+import { DendronExtension } from "../workspace";
 import { createMockConfig } from "./testUtils";
 import { _activate } from "../_extension";
+import { ExtensionProvider } from "../ExtensionProvider";
 
 export type SetupCodeConfigurationV2 = {
   configOverride?: { [key: string]: any };
@@ -124,8 +125,9 @@ export async function resetCodeWorkspace() {
 export const getNoteFromTextEditor = (): NoteProps => {
   const txtPath = window.activeTextEditor?.document.uri.fsPath as string;
   const vault = { fsPath: path.dirname(txtPath) };
+  const { wsRoot } = ExtensionProvider.getDWorkspace();
   const fullPath = DNodeUtils.getFullPath({
-    wsRoot: getDWorkspace().wsRoot,
+    wsRoot,
     vault,
     basename: path.basename(txtPath),
   });

--- a/packages/plugin-core/src/utils/site.ts
+++ b/packages/plugin-core/src/utils/site.ts
@@ -34,7 +34,7 @@ export class NextJSPublishUtils {
   static async prepareNextJSExportPod() {
     const ws = ExtensionProvider.getDWorkspace();
     const wsRoot = ws.wsRoot;
-    const cmd = new ExportPodCommand();
+    const cmd = new ExportPodCommand(ExtensionProvider.getExtension());
 
     let nextPath = NextjsExportPodUtils.getNextRoot(wsRoot);
     const podConfig: NextjsExportConfig = {

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -111,7 +111,8 @@ export function getEngine() {
 }
 
 export function resolveRelToWSRoot(fpath: string): string {
-  return resolvePath(fpath, getDWorkspace().wsRoot as string);
+  const { wsRoot } = ExtensionProvider.getDWorkspace();
+  return resolvePath(fpath, wsRoot);
 }
 
 /** Given file uri that is within a vault within the current workspace returns the vault. */


### PR DESCRIPTION
This PR aims to remove references to deprecated methods (getEngine, getExtension and getDWorkspace) in code and updates with new.

It is not a clean sweep. There are still few references left for `getExtension` where we use services not supported by `ExtensionProvider.getExtension()` yet.
  - `_extensions.ts`
  - `Goto.ts` // uses rootWorkspace
  - `OpenLink.ts` // uses rootWorkspace
  - `SeedCommandBase.ts` // uses seed service
  - `VaultConvert.ts` // uses workspace service
  - `src/external/memo/utils/utils.ts`
  - `SyncCommand.test.ts` // uses setConfig method of workspace service
  - `seedBrowserInitializer.ts` // uses seed service