### PR TITLE
chore(internal): mark `LookupSelectionType` and `LookupSelectionTypeEnum` as deprecated

### DIFF
--- a/packages/common-all/src/types/lookup.ts
+++ b/packages/common-all/src/types/lookup.ts
@@ -1,3 +1,10 @@
+/**
+ * @deprecated
+ *
+ * This should not be used in configs that are public-facing.
+ * There are a few references to this remaining, but they are all internal-only and will be cleaned up.
+ * Use {@link LookupSelectionModeEnum} instead
+ */
 export enum LookupSelectionTypeEnum {
   "selection2link" = "selection2link",
   "selectionExtract" = "selectionExtract",
@@ -5,6 +12,13 @@ export enum LookupSelectionTypeEnum {
   "none" = "none",
 }
 
+/**
+ * @deprecated
+ *
+ * This should not be used in configs that are public-facing.
+ * There are a few references to this remaining, but they are all internal-only and will be cleaned up.
+ * Use {@link LookupSelectionMode} instead
+ */
 export type LookupSelectionType = keyof typeof LookupSelectionTypeEnum;
 
 export enum LookupNoteTypeEnum {


### PR DESCRIPTION
# chore: mark `LookupSelectionType` and `LookupSelectionTypeEnum` as deprecated
- The enum values have been renamed a while ago but these types still remain in use internal-only.
  - All internal uses of this will be cleaned up as part of config migration ctl.
- This was not marked as deprecated and in turn has been used in a public facing config.
- To prevent further use of it, marking it as deprecated.

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.