### PR TITLE
fix(workspace): go to definition for wikilink with header

### DIFF
--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -96,7 +96,7 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
           Logger.error({ msg: `${refAtPos.vaultName} is not defined` });
         }
       }
-      const notes = await (
+      const notes = (
         await engine.findNotesMeta({ fname: refAtPos.ref, vault })
       ).filter((note) => !note.id.startsWith(NoteUtils.FAKE_ID_PREFIX));
       const uris = notes.map((note) => NoteUtils.getURI({ note, wsRoot }));

--- a/packages/plugin-core/src/features/DefinitionProvider.ts
+++ b/packages/plugin-core/src/features/DefinitionProvider.ts
@@ -96,7 +96,9 @@ export default class DefinitionProvider implements vscode.DefinitionProvider {
           Logger.error({ msg: `${refAtPos.vaultName} is not defined` });
         }
       }
-      const notes = await engine.findNotesMeta({ fname: refAtPos.ref, vault });
+      const notes = await (
+        await engine.findNotesMeta({ fname: refAtPos.ref, vault })
+      ).filter((note) => !note.id.startsWith(NoteUtils.FAKE_ID_PREFIX));
       const uris = notes.map((note) => NoteUtils.getURI({ note, wsRoot }));
       const out = uris.map((uri) => new Location(uri, new Position(0, 0)));
       if (out.length > 1) {


### PR DESCRIPTION
This PR aims to fix the issue with `Go to Definition` not working correctly when used on wikilinks with header.
- [bug](https://www.loom.com/share/00570ddc70244549a6c1748e4d91dce5)
- task: [[dendron://private/task.2022.10.02.go-to-definition-doesnt-work-inside-the-same-header-on-newly-created-notes]]


The Reference Hover provider creates a new note with same name but id with prefix `fake-` to render hover. This PR aims to filter those references in definition provider