### PR TITLE
chore: update default for searchMode config for new and existing users

### DIFF
--- a/packages/common-all/src/types/configs/publishing/publishing.ts
+++ b/packages/common-all/src/types/configs/publishing/publishing.ts
@@ -115,6 +115,6 @@ export function genDefaultPublishingConfig(): DendronPublishingConfig {
     enableRandomlyColoredTags: true,
     enableTaskNotes: true,
     enablePrettyLinks: true,
-    searchMode: SearchMode.SEARCH,
+    searchMode: SearchMode.LOOKUP,
   };
 }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -594,6 +594,9 @@ export class ConfigUtils {
         enablePreviewV2: true,
       },
     };
+    const mergedPublishingConfig = _.merge(genDefaultPublishingConfig(), {
+      searchMode: SearchMode.SEARCH,
+    });
     return _.merge(
       {
         version: 5,
@@ -601,7 +604,7 @@ export class ConfigUtils {
         commands: genDefaultCommandConfig(),
         workspace: { ...genDefaultWorkspaceConfig() },
         preview: genDefaultPreviewConfig(),
-        publishing: genDefaultPublishingConfig(),
+        publishing: mergedPublishingConfig,
       } as StrictConfigV5,
       defaults
     );
@@ -967,7 +970,7 @@ export class ConfigUtils {
     if (!isConfigV4 && defaultMode) {
       return defaultMode;
     }
-    return SearchMode.SEARCH;
+    return SearchMode.LOOKUP;
   }
   // set
   static setProp<K extends keyof StrictConfigV4>(

--- a/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/dendron-cli/commands/__snapshots__/seedCLICommand.spec.ts.snap
@@ -125,7 +125,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -281,7 +281,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -419,7 +419,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
 "
 `;
 
@@ -529,7 +529,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/seedSvc.spec.ts.snap
@@ -119,7 +119,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -275,7 +275,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -413,7 +413,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
 "
 `;
 
@@ -523,7 +523,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -785,7 +785,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:
@@ -905,7 +905,7 @@ publishing:
     enableRandomlyColoredTags: true
     enableTaskNotes: true
     enablePrettyLinks: true
-    searchMode: search
+    searchMode: lookup
     duplicateNoteBehavior:
         action: useVault
         payload:


### PR DESCRIPTION
This PR aims to set searchMode config to `search` for new users and  the value `lookup` for  existing dendron users that have published site.
# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)