### PR TITLE
fix(workspace): custom color decoration for hashtags

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1185,11 +1185,7 @@ export class NoteUtils {
    * @param fname The fname of note that you want to get the color of.
    * @returns The color, and whether this color was randomly generated or explicitly defined.
    */
-  static color(opts: {
-    fname: string;
-    vault?: DVault;
-    note?: NoteProps | NotePropsMeta;
-  }): {
+  static color(opts: { fname: string; vault?: DVault; note?: NotePropsMeta }): {
     color: string;
     type: "configured" | "generated";
   } {

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -1185,16 +1185,24 @@ export class NoteUtils {
    * @param fname The fname of note that you want to get the color of.
    * @returns The color, and whether this color was randomly generated or explicitly defined.
    */
-  static color(opts: { fname: string; vault?: DVault }): {
+  static color(opts: {
+    fname: string;
+    vault?: DVault;
+    note?: NoteProps | NotePropsMeta;
+  }): {
     color: string;
     type: "configured" | "generated";
   } {
+    const { fname, note } = opts;
     // TODO: Re-enable the ancestor color logic later
     // const ancestors = NoteUtils.ancestors({ ...opts, includeSelf: true });
     // for (const note of ancestors) {
     //   if (note.color) return { color: note.color, type: "configured" };
     // }
-    return { color: randomColor(opts.fname), type: "generated" };
+    if (note && note.color) {
+      return { color: note.color, type: "configured" };
+    }
+    return { color: randomColor(fname), type: "generated" };
   }
 
   /** Get the ancestors of a note, in the order of the closest to farthest.

--- a/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/util/noteUtils.spec.ts
@@ -1,5 +1,7 @@
 import { InvalidFilenameReason, NoteUtils } from "@dendronhq/common-all";
+import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import _ from "lodash";
+import { runEngineTestV5 } from "../../..";
 
 const validFnames = ["foo", "bar", "foo.bar", "foo bar"];
 const invalidFnamesAndReasons = {
@@ -97,6 +99,36 @@ describe("NoteUtils", () => {
           });
         });
       });
+    });
+  });
+  describe("GIVEN tag color is configured in frontmatter", () => {
+    test("THEN tags should have the configured color", async () => {
+      await runEngineTestV5(
+        async ({ vaults, wsRoot }) => {
+          const note = await NoteTestUtilsV4.createNote({
+            fname: "foo",
+            vault: vaults[0],
+            wsRoot,
+          });
+          note.color = "#cc99ff";
+          const result = NoteUtils.color({ fname: "foo", note });
+          expect(result.type).toEqual("configured");
+          expect(result.color).toEqual("#cc99ff");
+        },
+        { expect }
+      );
+    });
+  });
+
+  describe("GIVEN tag color is not configured in frontmatter", () => {
+    test("THEN tags should have a random color", async () => {
+      await runEngineTestV5(
+        async () => {
+          const result = NoteUtils.color({ fname: "foo" });
+          expect(result.type).toEqual("generated");
+        },
+        { expect }
+      );
     });
   });
 });

--- a/packages/unified/src/decorations/frontmatter.ts
+++ b/packages/unified/src/decorations/frontmatter.ts
@@ -24,7 +24,7 @@ export const decorateFrontmatter: Decorator<
   FrontmatterContent,
   DecorationsForDecorateFrontmatter
 > = async (opts) => {
-  const { node: frontmatter, config, engine } = opts;
+  const { node: frontmatter, config, engine, note } = opts;
   const { value: contents, position } = frontmatter;
   // Decorate the timestamps
 
@@ -71,6 +71,7 @@ export const decorateFrontmatter: Decorator<
         lineOffset,
         config,
         engine,
+        note,
       });
       tagDecorations.push(...decorations);
       errors.push(...errors);

--- a/packages/unified/src/decorations/hashTags.ts
+++ b/packages/unified/src/decorations/hashTags.ts
@@ -1,5 +1,6 @@
 import {
   IntermediateDendronConfig,
+  NoteProps,
   NoteUtils,
   Position,
   position2VSCodeRange,
@@ -22,13 +23,14 @@ export function isDecorationHashTag(
 export const decorateHashTag: Decorator<HashTag, DecorationHashTag> = (
   opts
 ) => {
-  const { node: hashtag, engine, config } = opts;
+  const { node: hashtag, engine, config, note } = opts;
   const { position } = hashtag;
   return decorateTag({
     fname: hashtag.fname,
     engine,
     position,
     config,
+    note,
   });
 };
 
@@ -38,16 +40,19 @@ export async function decorateTag({
   position,
   lineOffset,
   config,
+  note,
 }: {
   fname: string;
   engine: ReducedDEngine;
   position: Position;
   lineOffset?: number;
   config: IntermediateDendronConfig;
+  note?: NoteProps;
 }) {
   let color: string | undefined;
   const { color: foundColor, type: colorType } = NoteUtils.color({
     fname,
+    note,
     // engine,
   });
   if (colorType === "configured" || !config.noRandomlyColoredTags) {

--- a/packages/unified/src/remark/dendronPub.ts
+++ b/packages/unified/src/remark/dendronPub.ts
@@ -304,6 +304,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         if (mode !== ProcMode.IMPORT && value.startsWith(TAGS_HIERARCHY)) {
           const { color: maybeColor, type: colorType } = NoteUtils.color({
             fname: value,
+            note: noteToRender,
             vault,
           });
           const enableRandomlyColoredTagsConfig =


### PR DESCRIPTION
Related issue: https://github.com/dendronhq/dendron/issues/3605
This PR aims to fix the issue with Dendron not recognizing color code set at the frontmatter.

Previously, the NoteUtils's color method looked up the ancestors of fname provided and returned configured/generated color.
With this fix, we provide note to render(one with the frontmatter) to color method and it returns the generated/configured color accordingly.