### PR TITLE
fix(preview): task notes inside of note references should render correctly

### DIFF
--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/enginev2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/enginev2.spec.ts.snap
@@ -7,15 +7,3 @@ exports[`engine, notes/ render "CUSTOM_FM" 1`] = `
 `;
 
 exports[`engine, notes/ render "EMPTY_NOTE" 1`] = `"<h1 id=\\"empty\\">Empty</h1>"`;
-
-exports[`engine, notes/ render "NOTE_REF_TO_TASK_NOTE" 1`] = `
-"<h1 id=\\"alpha\\">Alpha</h1>
-<ul>
-<li><a href=\\"task-note-id\\"><input type=\\"checkbox\\" disabled class=\\"task-before task-status\\" checked>Task Note</a></li>
-</ul>
-<hr>
-<strong>Backlinks</strong>
-<ul>
-<li><a href=\\"beta\\">Beta (vault1)</a></li>
-</ul>"
-`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/enginev2.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/enginev2.spec.ts.snap
@@ -7,3 +7,15 @@ exports[`engine, notes/ render "CUSTOM_FM" 1`] = `
 `;
 
 exports[`engine, notes/ render "EMPTY_NOTE" 1`] = `"<h1 id=\\"empty\\">Empty</h1>"`;
+
+exports[`engine, notes/ render "NOTE_REF_TO_TASK_NOTE" 1`] = `
+"<h1 id=\\"alpha\\">Alpha</h1>
+<ul>
+<li><a href=\\"task-note-id\\"><input type=\\"checkbox\\" disabled class=\\"task-before task-status\\" checked>Task Note</a></li>
+</ul>
+<hr>
+<strong>Backlinks</strong>
+<ul>
+<li><a href=\\"beta\\">Beta (vault1)</a></li>
+</ul>"
+`;

--- a/packages/engine-test-utils/src/presets/engine-server/render.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/render.ts
@@ -91,7 +91,6 @@ const NOTES = {
       const { data } = await engine.renderNote({
         id: "alpha-id",
       });
-      expect(data).toMatchSnapshot();
       return [
         {
           actual: true,

--- a/packages/engine-test-utils/src/presets/engine-server/render.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/render.ts
@@ -86,6 +86,53 @@ const NOTES = {
       },
     }
   ),
+  NOTE_REF_TO_TASK_NOTE: new TestPresetEntryV4(
+    async ({ engine }) => {
+      const { data } = await engine.renderNote({
+        id: "alpha-id",
+      });
+      expect(data).toMatchSnapshot();
+      return [
+        {
+          actual: true,
+          expected: await AssertUtils.assertInString({
+            body: data!,
+            match: [
+              `<li><a href="task-note-id"><input type="checkbox" disabled class="task-before task-status" checked>Task Note</a></li>`,
+            ],
+          }),
+          msg: "custom fm render",
+        },
+      ];
+    },
+    {
+      preSetupHook: async (opts) => {
+        await NoteTestUtilsV4.createNote({
+          fname: "alpha",
+          body: "- [[task-note]]",
+          vault: opts.vaults[0],
+          wsRoot: opts.wsRoot,
+          props: { id: "alpha-id" },
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "beta",
+          body: "![[alpha]]",
+          vault: opts.vaults[0],
+          wsRoot: opts.wsRoot,
+        });
+        await NoteTestUtilsV4.createNote({
+          fname: "task-note",
+          body: "",
+          custom: {
+            status: "done",
+          },
+          vault: opts.vaults[0],
+          wsRoot: opts.wsRoot,
+          props: { id: "task-note-id" },
+        });
+      },
+    }
+  ),
 };
 
 export const ENGINE_RENDER_PRESETS = {

--- a/packages/unified/src/utilities/getParsingDependencyDicts.ts
+++ b/packages/unified/src/utilities/getParsingDependencyDicts.ts
@@ -100,7 +100,10 @@ async function getBacklinkDependencies(
 
 /**
  * For a given AST, find all note dependencies whose data will be needed for
- * rendering.
+ * rendering. Specifically, we look for:
+ * - WIKI_LINK
+ * - HASHTAG
+ * - USERTAG
  * @param ast the syntax tree to look for dependencies
  * @returns an array of fname-vault? combinations that this tree depends on.
  */
@@ -258,7 +261,7 @@ async function getForwardLinkDependencies(
               ast,
               engine
             );
-
+            allDependencies.push(...getNoteDependencies(ast));
             allDependencies.push(...recursiveDependencies);
             newRecursiveDependencies.push(...recursiveDependencies);
           })


### PR DESCRIPTION
fix(preview): task notes inside of note references should render correctly #3640 

This is related to https://github.com/dendronhq/dendron/issues/3578