### PR TITLE
chore/query interface kevin

### DIFF
--- a/packages/common-all/src/FuseEngine.ts
+++ b/packages/common-all/src/FuseEngine.ts
@@ -265,26 +265,27 @@ export class FuseEngine {
   }
 
   async updateNotesIndex(noteChanges: NoteChangeEntry[]) {
-    noteChanges.forEach((change) => {
-      switch (change.status) {
-        case "create": {
-          this.addNoteToIndex(change.note);
-          break;
+    return Promise.all(
+      noteChanges.map(async (change) => {
+        switch (change.status) {
+          case "create": {
+            return this.addNoteToIndex(change.note);
+          }
+          case "delete": {
+            return this.removeNoteFromIndex(change.note);
+          }
+          case "update": {
+            // Fuse has no update. Must remove old and add new
+            await this.removeNoteFromIndex(change.prevNote);
+            await this.addNoteToIndex(change.note);
+            return;
+          }
+          default:
+            break;
         }
-        case "delete": {
-          this.removeNoteFromIndex(change.note);
-          break;
-        }
-        case "update": {
-          // Fuse has no update. Must remove old and add new
-          this.removeNoteFromIndex(change.prevNote);
-          this.addNoteToIndex(change.note);
-          break;
-        }
-        default:
-          break;
-      }
-    });
+        return;
+      })
+    );
   }
 
   async removeNoteFromIndex(note: NoteProps) {

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -6,7 +6,7 @@ import { ERROR_SEVERITY, ERROR_STATUS } from "../constants";
 import { DLogger } from "../DLogger";
 import { DNodeUtils, NoteUtils } from "../dnode";
 import { DendronCompositeError, DendronError } from "../error";
-import { IQueryStore, INoteStore, FuseMetadataStore } from "../store";
+import { INoteStore, IQueryStore } from "../store";
 import {
   BulkGetNoteMetaResp,
   BulkGetNoteResp,

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -6,7 +6,6 @@ import { ERROR_SEVERITY, ERROR_STATUS } from "../constants";
 import { DLogger } from "../DLogger";
 import { DNodeUtils, NoteUtils } from "../dnode";
 import { DendronCompositeError, DendronError } from "../error";
-import { FuseEngine } from "../FuseEngine";
 import { INoteStore } from "../store";
 import { INoteQueryable } from "../store/IDataQuery";
 import {
@@ -43,8 +42,6 @@ import { VaultUtils } from "../vault";
  * DendronEngineV3Web
  */
 export abstract class EngineV3Base implements ReducedDEngine {
-  // TODO: remove
-  protected abstract fuseEngine: FuseEngine;
   protected noteStore;
   protected noteQueryable;
   protected logger;
@@ -281,7 +278,7 @@ export abstract class EngineV3Base implements ReducedDEngine {
 
     changes.push({ note: noteToDelete, status: "delete" });
     // Update metadata for all other changes
-    await this.fuseEngine.updateNotesIndex(changes);
+    await this.noteQueryable.updateIndex(changes);
     await this.updateNoteMetadataStore(changes);
 
     this.logger.info({

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -8,16 +8,19 @@ import { DNodeUtils, NoteUtils } from "../dnode";
 import { DendronCompositeError, DendronError } from "../error";
 import { FuseEngine } from "../FuseEngine";
 import { INoteStore } from "../store";
+import { INoteQueryable } from "../store/IDataQuery";
 import {
   BulkGetNoteMetaResp,
   BulkGetNoteResp,
-  BulkWriteNotesResp,
   BulkWriteNotesOpts,
+  BulkWriteNotesResp,
   DeleteNoteResp,
+  DLink,
   EngineDeleteOpts,
   EngineWriteOptsV2,
   FindNotesMetaResp,
   FindNotesResp,
+  GetNoteMetaResp,
   GetNoteResp,
   NoteChangeEntry,
   NoteProps,
@@ -29,8 +32,6 @@ import {
   RenameNoteResp,
   RespV3,
   WriteNoteResp,
-  GetNoteMetaResp,
-  DLink,
 } from "../types";
 import { DVault } from "../types/DVault";
 import { FindNoteOpts } from "../types/FindNoteOpts";
@@ -43,12 +44,22 @@ import { VaultUtils } from "../vault";
  */
 export abstract class EngineV3Base implements ReducedDEngine {
   protected abstract fuseEngine: FuseEngine;
+  protected noteStore;
+  protected noteQueryable;
+  protected logger;
+  public vaults;
 
-  constructor(
-    protected noteStore: INoteStore<string>,
-    protected logger: DLogger,
-    public vaults: DVault[]
-  ) {}
+  constructor(opts: {
+    noteStore: INoteStore<string>;
+    noteQueryable: INoteQueryable;
+    logger: DLogger;
+    vaults: DVault[];
+  }) {
+    this.noteStore = opts.noteStore;
+    this.noteQueryable = opts.noteQueryable;
+    this.logger = opts.logger;
+    this.vaults = opts.vaults;
+  }
 
   /**
    * See {@link DEngine.getNote}

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -6,7 +6,7 @@ import { ERROR_SEVERITY, ERROR_STATUS } from "../constants";
 import { DLogger } from "../DLogger";
 import { DNodeUtils, NoteUtils } from "../dnode";
 import { DendronCompositeError, DendronError } from "../error";
-import { IQueryStore, INoteStore } from "../store";
+import { IQueryStore, INoteStore, FuseMetadataStore } from "../store";
 import {
   BulkGetNoteMetaResp,
   BulkGetNoteResp,
@@ -45,17 +45,20 @@ export abstract class EngineV3Base implements ReducedDEngine {
   protected queryStore;
   protected logger;
   public vaults;
+  public wsRoot;
 
   constructor(opts: {
     noteStore: INoteStore<string>;
     queryStore: IQueryStore;
     logger: DLogger;
     vaults: DVault[];
+    wsRoot: string;
   }) {
     this.noteStore = opts.noteStore;
     this.queryStore = opts.queryStore;
     this.logger = opts.logger;
     this.vaults = opts.vaults;
+    this.wsRoot = opts.wsRoot;
   }
 
   /**
@@ -319,9 +322,9 @@ export abstract class EngineV3Base implements ReducedDEngine {
       .map((resp) => resp.data!);
 
     if (!_.isUndefined(vault)) {
-      modifiedNotes = modifiedNotes.filter((ent) =>
-        VaultUtils.isEqualV2(vault, ent.vault)
-      );
+      modifiedNotes = modifiedNotes.filter((ent) => {
+        return VaultUtils.isEqual(vault, ent.vault, this.wsRoot);
+      });
     }
 
     return modifiedNotes;

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -40,11 +40,12 @@ export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
     }) as NotePropsMeta[];
     return ResultAsync.fromSafePromise(Promise.resolve(items));
   }
+
   querySchemas(
-    key: string,
-    opts: INoteQueryOpts
-  ): ResultAsync<any, DendronError<StatusCodes | undefined>> {
-    throw new Error("Method not implemented.");
+    qs: string
+  ): ResultAsync<{ id: string }[], DendronError<StatusCodes | undefined>> {
+    const schemaIds = this.fuseEngine.querySchema({ qs });
+    return ResultAsync.fromSafePromise(Promise.resolve(schemaIds));
   }
 
   removeSchemaFromIndex(

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -1,0 +1,23 @@
+import { ResultAsync } from "neverthrow";
+import { DendronError } from "../error";
+import { NotePropsMeta, RespV3 } from "../types";
+import { INoteQueryable } from "./IDataQuery";
+import { INoteMetadataStore } from "./IMetadataStore";
+
+export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
+  get(key: string): Promise<RespV3<NotePropsMeta>> {
+    throw new Error("Method not implemented.");
+  }
+  find(opts: any): Promise<RespV3<NotePropsMeta[]>> {
+    throw new Error("Method not implemented.");
+  }
+  write(key: string, data: NotePropsMeta): Promise<RespV3<string>> {
+    throw new Error("Method not implemented.");
+  }
+  delete(key: string): Promise<RespV3<string>> {
+    throw new Error("Method not implemented.");
+  }
+  query(key: string): ResultAsync<NotePropsMeta[], DendronError> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { ResultAsync } from "neverthrow";
 import { DendronError } from "../error";
 import { FuseEngine } from "../FuseEngine";
-import { NotePropsMeta, RespV3 } from "../types";
+import { NoteChangeEntry, NotePropsMeta, RespV3 } from "../types";
 import { INoteQueryable, INoteQueryOpts } from "./IDataQuery";
 import { INoteMetadataStore } from "./IMetadataStore";
 
@@ -27,6 +27,7 @@ export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
   delete(key: string): Promise<RespV3<string>> {
     throw new Error("Method not implemented.");
   }
+
   query(
     qs: string,
     opts: INoteQueryOpts
@@ -36,5 +37,16 @@ export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
       ...opts,
     }) as NotePropsMeta[];
     return ResultAsync.fromSafePromise(Promise.resolve(items));
+  }
+
+  updateIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError> {
+    return ResultAsync.fromPromise(
+      this.fuseEngine.updateNotesIndex(changes),
+      (err) =>
+        new DendronError({
+          message: "issue updating index",
+          innerError: err as Error,
+        })
+    );
   }
 }

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -1,10 +1,20 @@
+import _ from "lodash";
 import { ResultAsync } from "neverthrow";
 import { DendronError } from "../error";
+import { FuseEngine } from "../FuseEngine";
 import { NotePropsMeta, RespV3 } from "../types";
-import { INoteQueryable } from "./IDataQuery";
+import { INoteQueryable, INoteQueryOpts } from "./IDataQuery";
 import { INoteMetadataStore } from "./IMetadataStore";
 
 export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
+  fuseEngine: FuseEngine;
+
+  constructor(opts?: { fuzzThreshold: number }) {
+    this.fuseEngine = new FuseEngine({
+      fuzzThreshold: _.defaults(opts, { fuzzThreshold: 0.2 }).fuzzThreshold,
+    });
+  }
+
   get(key: string): Promise<RespV3<NotePropsMeta>> {
     throw new Error("Method not implemented.");
   }
@@ -17,7 +27,14 @@ export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
   delete(key: string): Promise<RespV3<string>> {
     throw new Error("Method not implemented.");
   }
-  query(key: string): ResultAsync<NotePropsMeta[], DendronError> {
-    throw new Error("Method not implemented.");
+  query(
+    qs: string,
+    opts: INoteQueryOpts
+  ): ResultAsync<NotePropsMeta[], DendronError> {
+    const items = this.fuseEngine.queryNote({
+      qs,
+      ...opts,
+    }) as NotePropsMeta[];
+    return ResultAsync.fromSafePromise(Promise.resolve(items));
   }
 }

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -80,7 +80,8 @@ export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
 
   updateNotesIndex(
     changes: NoteChangeEntry[]
-  ): ResultAsync<void, DendronError<StatusCodes | undefined>> {
+  ): ResultAsync<void, DendronError> {
+    // @ts-ignore
     return ResultAsync.fromPromise(
       this.fuseEngine.updateNotesIndex(changes),
       (err) =>

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -1,18 +1,100 @@
+import { StatusCodes } from "http-status-codes";
 import _ from "lodash";
 import { ResultAsync } from "neverthrow";
+import { SchemaUtils } from "../dnode";
 import { DendronError } from "../error";
 import { FuseEngine } from "../FuseEngine";
-import { NoteChangeEntry, NotePropsMeta, RespV3 } from "../types";
-import { INoteQueryable, INoteQueryOpts } from "./IDataQuery";
+import {
+  NoteChangeEntry,
+  NotePropsByIdDict,
+  NotePropsMeta,
+  RespV3,
+  SchemaModuleDict,
+  SchemaModuleProps,
+} from "../types";
+import { INoteQueryOpts, IQueryStore } from "./IDataQuery";
 import { INoteMetadataStore } from "./IMetadataStore";
 
-export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
+export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
   fuseEngine: FuseEngine;
 
   constructor(opts?: { fuzzThreshold: number }) {
     this.fuseEngine = new FuseEngine({
       fuzzThreshold: _.defaults(opts, { fuzzThreshold: 0.2 }).fuzzThreshold,
     });
+  }
+
+  // @ts-ignore
+  addSchemaToIndex(schema: SchemaModuleProps) {
+    this.fuseEngine.schemaIndex.add(SchemaUtils.getModuleRoot(schema));
+    return ResultAsync.fromSafePromise(Promise.resolve());
+  }
+
+  queryNotes(
+    qs: string,
+    opts: INoteQueryOpts
+  ): ResultAsync<NotePropsMeta[], DendronError<StatusCodes | undefined>> {
+    const items = this.fuseEngine.queryNote({
+      qs,
+      ...opts,
+    }) as NotePropsMeta[];
+    return ResultAsync.fromSafePromise(Promise.resolve(items));
+  }
+  querySchemas(
+    key: string,
+    opts: INoteQueryOpts
+  ): ResultAsync<any, DendronError<StatusCodes | undefined>> {
+    throw new Error("Method not implemented.");
+  }
+
+  removeSchemaFromIndex(
+    schema: SchemaModuleProps
+  ): ResultAsync<void, DendronError> {
+    this.fuseEngine.removeSchemaFromIndex(schema);
+    return ResultAsync.fromSafePromise(Promise.resolve());
+  }
+
+  replaceNotesIndex(props: NotePropsByIdDict): ResultAsync<void, DendronError> {
+    return ResultAsync.fromPromise(
+      this.fuseEngine.replaceNotesIndex(props),
+      (err) =>
+        new DendronError({
+          message: "issue replacing index",
+          innerError: err as Error,
+        })
+    );
+  }
+
+  replaceSchemasIndex(
+    props: SchemaModuleDict
+  ): ResultAsync<void, DendronError> {
+    return ResultAsync.fromPromise(
+      this.fuseEngine.replaceSchemaIndex(props),
+      (err) =>
+        new DendronError({
+          message: "issue replacing index",
+          innerError: err as Error,
+        })
+    );
+  }
+
+  updateNotesIndex(
+    changes: NoteChangeEntry[]
+  ): ResultAsync<void, DendronError<StatusCodes | undefined>> {
+    return ResultAsync.fromPromise(
+      this.fuseEngine.updateNotesIndex(changes),
+      (err) =>
+        new DendronError({
+          message: "issue updating index",
+          innerError: err as Error,
+        })
+    );
+  }
+  updateSchemasIndex(): ResultAsync<
+    void,
+    DendronError<StatusCodes | undefined>
+  > {
+    throw new Error("Method not implemented.");
   }
 
   get(key: string): Promise<RespV3<NotePropsMeta>> {
@@ -26,27 +108,5 @@ export class FuseMetadataStore implements INoteQueryable, INoteMetadataStore {
   }
   delete(key: string): Promise<RespV3<string>> {
     throw new Error("Method not implemented.");
-  }
-
-  query(
-    qs: string,
-    opts: INoteQueryOpts
-  ): ResultAsync<NotePropsMeta[], DendronError> {
-    const items = this.fuseEngine.queryNote({
-      qs,
-      ...opts,
-    }) as NotePropsMeta[];
-    return ResultAsync.fromSafePromise(Promise.resolve(items));
-  }
-
-  updateIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError> {
-    return ResultAsync.fromPromise(
-      this.fuseEngine.updateNotesIndex(changes),
-      (err) =>
-        new DendronError({
-          message: "issue updating index",
-          innerError: err as Error,
-        })
-    );
   }
 }

--- a/packages/common-all/src/store/FuseMetadataStore.ts
+++ b/packages/common-all/src/store/FuseMetadataStore.ts
@@ -8,14 +8,12 @@ import {
   NoteChangeEntry,
   NotePropsByIdDict,
   NotePropsMeta,
-  RespV3,
   SchemaModuleDict,
   SchemaModuleProps,
 } from "../types";
 import { INoteQueryOpts, IQueryStore } from "./IDataQuery";
-import { INoteMetadataStore } from "./IMetadataStore";
 
-export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
+export class FuseQueryStore implements IQueryStore {
   fuseEngine: FuseEngine;
 
   constructor(opts?: { fuzzThreshold: number }) {
@@ -24,10 +22,17 @@ export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
     });
   }
 
-  // @ts-ignore
   addSchemaToIndex(schema: SchemaModuleProps) {
-    this.fuseEngine.schemaIndex.add(SchemaUtils.getModuleRoot(schema));
-    return ResultAsync.fromSafePromise(Promise.resolve());
+    return ResultAsync.fromPromise(
+      Promise.resolve(
+        this.fuseEngine.schemaIndex.add(SchemaUtils.getModuleRoot(schema))
+      ),
+      (err) =>
+        new DendronError({
+          message: "issue adding schema to index",
+          innerError: err as Error,
+        })
+    );
   }
 
   queryNotes(
@@ -82,9 +87,9 @@ export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
   updateNotesIndex(
     changes: NoteChangeEntry[]
   ): ResultAsync<void, DendronError> {
-    // @ts-ignore
     return ResultAsync.fromPromise(
-      this.fuseEngine.updateNotesIndex(changes),
+      // return signature requires us to return void vs void[]
+      this.fuseEngine.updateNotesIndex(changes).then(() => {}),
       (err) =>
         new DendronError({
           message: "issue updating index",
@@ -96,19 +101,6 @@ export class FuseMetadataStore implements IQueryStore, INoteMetadataStore {
     void,
     DendronError<StatusCodes | undefined>
   > {
-    throw new Error("Method not implemented.");
-  }
-
-  get(key: string): Promise<RespV3<NotePropsMeta>> {
-    throw new Error("Method not implemented.");
-  }
-  find(opts: any): Promise<RespV3<NotePropsMeta[]>> {
-    throw new Error("Method not implemented.");
-  }
-  write(key: string, data: NotePropsMeta): Promise<RespV3<string>> {
-    throw new Error("Method not implemented.");
-  }
-  delete(key: string): Promise<RespV3<string>> {
     throw new Error("Method not implemented.");
   }
 }

--- a/packages/common-all/src/store/IDataQuery.ts
+++ b/packages/common-all/src/store/IDataQuery.ts
@@ -25,7 +25,7 @@ export interface IQueryStore {
   querySchemas(
     qs: string,
     opts?: INoteQueryOpts
-  ): ResultAsync<any, DendronError>;
+  ): ResultAsync<{ id: string }[], DendronError>;
   updateNotesIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError>;
   updateSchemasIndex(): ResultAsync<void, DendronError>;
   replaceNotesIndex(props: NotePropsByIdDict): ResultAsync<void, DendronError>;

--- a/packages/common-all/src/store/IDataQuery.ts
+++ b/packages/common-all/src/store/IDataQuery.ts
@@ -1,5 +1,12 @@
 import { ResultAsync } from "neverthrow";
-import { DendronError, NoteChangeEntry, NotePropsMeta } from "..";
+import {
+  DendronError,
+  NoteChangeEntry,
+  NotePropsByIdDict,
+  NotePropsMeta,
+  SchemaModuleDict,
+  SchemaModuleProps,
+} from "..";
 
 export type INoteQueryOpts = {
   /**
@@ -10,10 +17,23 @@ export type INoteQueryOpts = {
   onlyDirectChildren?: boolean;
 };
 
-export interface IDataQueryable<K, V> {
-  query(key: K, opts: INoteQueryOpts): ResultAsync<V, DendronError>;
-}
+export interface IQueryStore {
+  queryNotes(
+    qs: string,
+    opts: INoteQueryOpts
+  ): ResultAsync<NotePropsMeta[], DendronError>;
+  querySchemas(
+    qs: string,
+    opts?: INoteQueryOpts
+  ): ResultAsync<any, DendronError>;
+  updateNotesIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError>;
+  updateSchemasIndex(): ResultAsync<void, DendronError>;
+  replaceNotesIndex(props: NotePropsByIdDict): ResultAsync<void, DendronError>;
+  replaceSchemasIndex(props: SchemaModuleDict): ResultAsync<void, DendronError>;
 
-export type INoteQueryable = IDataQueryable<string, NotePropsMeta[]> & {
-  updateIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError>;
-};
+  removeSchemaFromIndex(
+    schema: SchemaModuleProps
+  ): ResultAsync<void, DendronError>;
+
+  addSchemaToIndex(schema: SchemaModuleProps): ResultAsync<void, DendronError>;
+}

--- a/packages/common-all/src/store/IDataQuery.ts
+++ b/packages/common-all/src/store/IDataQuery.ts
@@ -1,5 +1,5 @@
 import { ResultAsync } from "neverthrow";
-import { DendronError, NotePropsMeta } from "..";
+import { DendronError, NoteChangeEntry, NotePropsMeta } from "..";
 
 export type INoteQueryOpts = {
   /**
@@ -14,4 +14,6 @@ export interface IDataQueryable<K, V> {
   query(key: K, opts: INoteQueryOpts): ResultAsync<V, DendronError>;
 }
 
-export type INoteQueryable = IDataQueryable<string, NotePropsMeta[]>;
+export type INoteQueryable = IDataQueryable<string, NotePropsMeta[]> & {
+  updateIndex(changes: NoteChangeEntry[]): ResultAsync<void, DendronError>;
+};

--- a/packages/common-all/src/store/IDataQuery.ts
+++ b/packages/common-all/src/store/IDataQuery.ts
@@ -1,8 +1,17 @@
 import { ResultAsync } from "neverthrow";
 import { DendronError, NotePropsMeta } from "..";
 
+export type INoteQueryOpts = {
+  /**
+   * Original query string (which can contain minor modifications such as mapping '/'->'.')
+   * This string is added for sorting the lookup results when there is exact match with
+   * original query. */
+  originalQS: string;
+  onlyDirectChildren?: boolean;
+};
+
 export interface IDataQueryable<K, V> {
-  query(key: K): ResultAsync<V, DendronError>;
+  query(key: K, opts: INoteQueryOpts): ResultAsync<V, DendronError>;
 }
 
 export type INoteQueryable = IDataQueryable<string, NotePropsMeta[]>;

--- a/packages/common-all/src/store/IDataQuery.ts
+++ b/packages/common-all/src/store/IDataQuery.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "neverthrow";
+import { DendronError, NotePropsMeta } from "..";
+
+export interface IDataQueryable<K, V> {
+  query(key: K): ResultAsync<V, DendronError>;
+}
+
+export type INoteQueryable = IDataQueryable<string, NotePropsMeta[]>;

--- a/packages/common-all/src/store/IMetadataStore.ts
+++ b/packages/common-all/src/store/IMetadataStore.ts
@@ -1,0 +1,4 @@
+import { NotePropsMeta } from "../types";
+import { IDataStore } from "./IDataStore";
+
+export type INoteMetadataStore = IDataStore<string, NotePropsMeta>;

--- a/packages/common-all/src/store/NoteMetadataStore.ts
+++ b/packages/common-all/src/store/NoteMetadataStore.ts
@@ -7,8 +7,9 @@ import { FindNoteOpts } from "../types/FindNoteOpts";
 import { cleanName, isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
 import { IDataStore } from "./IDataStore";
+import { INoteMetadataStore } from "./IMetadataStore";
 
-export class NoteMetadataStore implements IDataStore<string, NotePropsMeta> {
+export class NoteMetadataStore implements INoteMetadataStore {
   /**
    * Map of noteId -> noteProp metadata
    */

--- a/packages/common-all/src/store/NoteMetadataStore.ts
+++ b/packages/common-all/src/store/NoteMetadataStore.ts
@@ -6,7 +6,6 @@ import { NotePropsMeta, NotePropsByFnameDict, RespV3 } from "../types";
 import { FindNoteOpts } from "../types/FindNoteOpts";
 import { cleanName, isNotUndefined } from "../utils";
 import { VaultUtils } from "../vault";
-import { IDataStore } from "./IDataStore";
 import { INoteMetadataStore } from "./IMetadataStore";
 
 export class NoteMetadataStore implements INoteMetadataStore {

--- a/packages/common-all/src/store/index.ts
+++ b/packages/common-all/src/store/index.ts
@@ -6,3 +6,6 @@ export * from "./NoteStore";
 export * from "./ISchemaStore";
 export * from "./SchemaMetadataStore";
 export * from "./SchemaStore";
+export * from "./FuseMetadataStore";
+export * from "./IMetadataStore";
+export * from "./IDataQuery";

--- a/packages/common-all/src/types/ReducedDEngine.ts
+++ b/packages/common-all/src/types/ReducedDEngine.ts
@@ -5,6 +5,7 @@ import { DEngine } from "./typesv2";
  */
 export type ReducedDEngine = Pick<
   DEngine,
+  | "wsRoot"
   | "getNote"
   | "getNoteMeta"
   | "bulkGetNotes"

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -1,5 +1,9 @@
 import { URI } from "vscode-uri";
+import { Decoration, DendronConfig, Diagnostic } from ".";
 import { IDendronError } from "../error";
+import { VSRange } from "./compat";
+import { DVault } from "./DVault";
+import { FindNoteOpts } from "./FindNoteOpts";
 import {
   DNodeProps,
   DNodeType,
@@ -12,11 +16,7 @@ import {
   SchemaProps,
 } from "./foundation";
 import { DHookDict } from "./hooks";
-import { VSRange } from "./compat";
-import { Decoration, DendronConfig, Diagnostic } from ".";
 import { DendronASTDest, ProcFlavor } from "./unified";
-import { FindNoteOpts } from "./FindNoteOpts";
-import { DVault } from "./DVault";
 
 export type OptionalExceptFor<T, TRequired extends keyof T> = Partial<T> &
   Pick<T, TRequired>;

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -806,13 +806,13 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
   async querySchema(queryString: string): Promise<QuerySchemaResp> {
     const ctx = "DEngine:querySchema";
 
-    const schemaIds = await this.queryStore
-      .querySchemas(queryString)
-      .map((ent) => ent.id);
+    const schemaIds = await this.queryStore.querySchemas(queryString);
     if (schemaIds.isErr()) {
       return { error: schemaIds.error };
     }
-    const responses = await this._schemaStore.bulkGetMetadata(schemaIds.value);
+    const responses = await this._schemaStore.bulkGetMetadata(
+      schemaIds.value.map((ent) => ent.id)
+    );
     const schemas = responses.map((resp) => resp.data).filter(isNotUndefined);
     this.logger.info({ ctx, msg: "exit" });
     return {

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -26,7 +26,7 @@ import {
   error2PlainObject,
   ERROR_SEVERITY,
   ERROR_STATUS,
-  FuseMetadataStore,
+  FuseQueryStore,
   GetDecorationsOpts,
   GetDecorationsResp,
   GetNoteBlocksOpts,
@@ -34,7 +34,6 @@ import {
   GetSchemaResp,
   IDendronError,
   IFileStore,
-  INoteMetadataStore,
   INoteStore,
   ISchemaStore,
   isNotUndefined,
@@ -107,7 +106,6 @@ type DendronEngineOptsV3 = {
   fileStore: IFileStore;
   noteStore: INoteStore<string>;
   queryStore: IQueryStore;
-  metadataStore: INoteMetadataStore;
   schemaStore: ISchemaStore<string>;
   logger: DLogger;
   config: DendronConfig;
@@ -150,14 +148,12 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       LOGGER.error(stringifyError(error));
     }
 
-    const metadataStore = new FuseMetadataStore();
+    const queryStore = new FuseQueryStore();
     const fileStore = new NodeJSFileStore();
-    const queryStore = metadataStore as IQueryStore;
 
     return new DendronEngineV3({
       wsRoot,
       vaults: ConfigUtils.getVaults(config),
-      metadataStore,
       queryStore,
       noteStore: new NoteStore(
         fileStore,

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -1049,4 +1049,5 @@ export const ENGINE_WRITE_PRESETS = {
 };
 export const ENGINE_WRITE_PRESETS_MULTI = {
   NOTES: NOTES_MULTI,
+  SCHEMAS: {},
 };

--- a/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
+++ b/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
@@ -15,7 +15,7 @@ import {
   ERROR_STATUS,
   Event,
   EventEmitter,
-  FuseMetadataStore,
+  FuseQueryStore,
   IDendronError,
   IFileStore,
   INoteStore,
@@ -60,7 +60,7 @@ export class DendronEngineV3Web
       logger: new ConsoleLogger(),
       noteStore,
       vaults,
-      queryStore: new FuseMetadataStore() as IQueryStore,
+      queryStore: new FuseQueryStore() as IQueryStore,
       wsRoot: wsRootURI.fsPath,
     });
     this.wsRootURI = wsRootURI;

--- a/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
+++ b/packages/plugin-core/src/web/engine/DendronEngineV3Web.ts
@@ -15,10 +15,11 @@ import {
   ERROR_STATUS,
   Event,
   EventEmitter,
-  FuseEngine,
+  FuseMetadataStore,
   IDendronError,
   IFileStore,
   INoteStore,
+  IQueryStore,
   NoteChangeEntry,
   NoteDicts,
   NoteDictsUtils,
@@ -47,19 +48,22 @@ export class DendronEngineV3Web
   implements ReducedDEngine, EngineEventEmitter
 {
   private _onNoteChangedEmitter = new EventEmitter<NoteChangeEntry[]>();
-  protected fuseEngine: FuseEngine;
+  private wsRootURI: URI;
 
   constructor(
-    @inject("wsRoot") private wsRoot: URI,
+    @inject("wsRoot") wsRootURI: URI,
     @inject("vaults") vaults: DVault[],
     @inject("IFileStore") private fileStore: IFileStore, // TODO: Engine shouldn't be aware of FileStore. Currently still needed because of Init Logic
     @inject("INoteStore") noteStore: INoteStore<string>
   ) {
-    super(noteStore, new ConsoleLogger(), vaults);
-
-    this.fuseEngine = new FuseEngine({
-      fuzzThreshold: 0.2, // TODO: Pull from config: ConfigUtils.getLookup(props.config).note.fuzzThreshold,
+    super({
+      logger: new ConsoleLogger(),
+      noteStore,
+      vaults,
+      queryStore: new FuseMetadataStore() as IQueryStore,
+      wsRoot: wsRootURI.fsPath,
     });
+    this.wsRootURI = wsRootURI;
   }
 
   get onEngineNoteStateChanged(): Event<NoteChangeEntry[]> {
@@ -89,7 +93,7 @@ export class DendronEngineV3Web
           }),
         };
       }
-      this.fuseEngine.replaceNotesIndex(notes);
+      this.queryStore.replaceNotesIndex(notes);
       const bulkWriteOpts = _.values(notes).map((note) => {
         const noteMeta: NotePropsMeta = _.omit(note, ["body", "contentHash"]);
 
@@ -332,7 +336,7 @@ export class DendronEngineV3Web
     // TODO: Add schema
 
     // Propragate metadata for all other changes
-    await this.fuseEngine.updateNotesIndex(changes);
+    await this.queryStore.updateNotesIndex(changes);
     await this.updateNoteMetadataStore(changes);
 
     this._onNoteChangedEmitter.fire(changes);
@@ -383,7 +387,7 @@ export class DendronEngineV3Web
       vaults.map(async (vault) => {
         // Get list of files from filesystem
         const maybeFiles = await this.fileStore.readDir({
-          root: Utils.joinPath(this.wsRoot, VaultUtils.getRelPath(vault)),
+          root: Utils.joinPath(this.wsRootURI, VaultUtils.getRelPath(vault)),
           include: ["*.md"],
         });
 
@@ -419,7 +423,7 @@ export class DendronEngineV3Web
         // };
 
         const { data: notesDict, error } = await new NoteParserV2(
-          this.wsRoot
+          this.wsRootURI
         ).parseFiles(filteredFiles, vault);
         if (error) {
           errors = errors.concat(error);

--- a/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
+++ b/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
@@ -25,10 +25,12 @@ export class MockEngineAPIService implements ReducedDEngine {
   // private noteProps: NoteProps[];
 
   private store: NoteMetadataStore;
+  public wsRoot: string;
 
   constructor() {
     // this.noteProps = [];
     this.store = new NoteMetadataStore();
+    this.wsRoot = "";
   }
 
   async init() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,6 +4249,11 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
+"@types/lodash@^4.14.186":
+  version "4.14.186"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
+  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
+
 "@types/lru-cache@^5.1.1":
   version "5.1.1"
   resolved "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
@@ -4491,10 +4496,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^17.0.39":
-  version "17.0.50"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz#39abb4f7098f546cfcd6b51207c90c4295ee81fc"
-  integrity sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==
+"@types/react@17.0.38":
+  version "17.0.38"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
chore: implement IQueryStore

https://github.com/dendronhq/dendron/pull/3642

This is a slightly scaled back version of `prototype-query-interface-for-engine`
We are introducing an `IQueryStore` (formerly `IQueryable`) that is responsible for proxying all free text queries. 

Combining metadata store with the query store is still on the table but I wanted to limit the scope of this change and only combine it if necessary (will be better apparent when we try to merge SQLite)
Note that `IQueryStore` is non-generic by design, it has separate commands for `queryNote` and `querySchema` and returns `NotePropsMeta` for notes. 
Until we have need for a more generic interface, the current design optimizes for ease of integration. 

Also did some refactoring: 
- EngineBaseV3 now handles `queryNotes` for `DendronEngineV3`
- constructor for `EngineBaseV3` takes an object instead of positional params for easier refactoring