### PR TITLE
fix(lookup): cancel note creation during "Create Note with Template" if template was not selected

### DIFF
--- a/packages/plugin-core/src/commands/NoteLookupCommand.ts
+++ b/packages/plugin-core/src/commands/NoteLookupCommand.ts
@@ -40,6 +40,7 @@ import {
   LookupSplitType,
   LookupSplitTypeEnum,
 } from "../components/lookup/ButtonTypes";
+import { CREATE_NEW_LABEL } from "../components/lookup/constants";
 import { ILookupControllerV3 } from "../components/lookup/LookupControllerV3Interface";
 import {
   ILookupProviderV3,
@@ -656,6 +657,12 @@ export class NoteLookupCommand extends BaseCommand<
         targetNote: nodeNew,
         engine,
       });
+    } else {
+      // template note is not selected. cancel note creation.
+      window.showInformationMessage(
+        `No template selected. Cancelling note creation.`
+      );
+      return;
     }
 
     // only enable selection 2 link
@@ -750,6 +757,14 @@ export class NoteLookupCommand extends BaseCommand<
       logger: this.L,
       providerId: "createNewWithTemplate",
     });
+
+    // this needs to be checked because note lookup provider
+    // assumes user selected `create new` when `selectionItems` is empty.
+    // without this, hitting enter when the template picker has nothing listed
+    // will result in note creation with an empty template applied.
+    if (templateNote && templateNote.id === CREATE_NEW_LABEL) {
+      return;
+    }
 
     return templateNote;
   }

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -667,6 +667,65 @@ suite("NoteLookupCommand", function () {
           cmd.cleanUp();
           getTemplateStub.restore();
         });
+
+        test("AND create new with template, but cancelled or nothing selected", async () => {
+          const extension = ExtensionProvider.getExtension();
+          const { vaults, engine } = extension.getDWorkspace();
+          const cmd = new NoteLookupCommand();
+          stubVaultPick(vaults);
+
+          const mockQuickPick = createMockQuickPick({
+            value: "foobarbaz",
+            selectedItems: [
+              NotePickerUtils.createNewWithTemplateItem({
+                fname: "foobarbaz",
+              }),
+            ],
+          });
+          const lc = extension.lookupControllerFactory.create({
+            nodeType: "note",
+          });
+          const lp = extension.noteLookupProviderFactory.create("lookup", {
+            allowNewNote: true,
+            allowNewNoteWithTemplate: true,
+            noHidePickerOnAccept: false,
+          });
+          await lc.prepareQuickPick({
+            initialValue: "foobarbaz",
+            provider: lp,
+            placeholder: "",
+          });
+          cmd.controller = lc;
+          cmd.provider = lp;
+
+          const getTemplateStub = sinon
+            .stub(cmd, "getTemplateForNewNote" as keyof NoteLookupCommand)
+            .returns(Promise.resolve(undefined));
+          mockQuickPick.showNote = async (uri) => {
+            return vscode.window.showTextDocument(uri);
+          };
+
+          const cmdSpy = sinon.spy(cmd, "acceptNewWithTemplateItem");
+          await cmd.execute({
+            quickpick: mockQuickPick,
+            controller: lc,
+            provider: lp,
+            selectedItems: mockQuickPick.selectedItems,
+          });
+          const acceptNewWithTemplateItemOut = await cmdSpy.returnValues[0];
+
+          // accept result is undefined
+          expect(acceptNewWithTemplateItemOut).toEqual(undefined);
+
+          // foobarbaz is not created if template selection is cancelled, or selection was empty.
+          const maybeFooBarBazNotes = await engine.findNotes({
+            fname: "foobarbaz",
+          });
+          expect(maybeFooBarBazNotes.length).toEqual(0);
+          cmdSpy.restore();
+          cmd.cleanUp();
+          getTemplateStub.restore();
+        });
       }
     );
 

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -675,10 +675,10 @@ suite("NoteLookupCommand", function () {
           stubVaultPick(vaults);
 
           const mockQuickPick = createMockQuickPick({
-            value: "foobarbaz",
+            value: "capers-are-not-berries",
             selectedItems: [
               NotePickerUtils.createNewWithTemplateItem({
-                fname: "foobarbaz",
+                fname: "capers-are-not-berries",
               }),
             ],
           });
@@ -691,7 +691,7 @@ suite("NoteLookupCommand", function () {
             noHidePickerOnAccept: false,
           });
           await lc.prepareQuickPick({
-            initialValue: "foobarbaz",
+            initialValue: "capers-are-not-berries",
             provider: lp,
             placeholder: "",
           });
@@ -719,7 +719,7 @@ suite("NoteLookupCommand", function () {
 
           // foobarbaz is not created if template selection is cancelled, or selection was empty.
           const maybeFooBarBazNotes = await engine.findNotes({
-            fname: "foobarbaz",
+            fname: "capers-are-not-berries",
           });
           expect(maybeFooBarBazNotes.length).toEqual(0);
           cmdSpy.restore();


### PR DESCRIPTION
# fix(lookup): cancel note creation during "Create Note with Template" if template was not selected
This PR:
- fixes an issue where `Create Note with Template` will create an empty note even when no template is selected.
- also fixes an issue where the an empty note was assumed as a template when the user hits enter while the template selector quickpick showed no select-able items.
   - this was caused because note lookup provider will assume "Create New" as a selection when `selectedItems` is an empty list.

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)