### PR TITLE
fix(internal): correct reading of error tack

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "format": "lerna exec --parallel -- yarn format",
     "format:pkg": "prettier --write",
     "lint": "eslint . --ext ts,tsx",
-    "lerna:typecheck": "lerna exec --parallel --ignore @dendronhq/common-assets --ignore @dendronhq/nextjs-template --ignore @dendronhq/dendron-plugin-views -- tsc -p tsconfig.build.json --noEmit",
+    "lerna:typecheck": "lerna exec --parallel --ignore @dendronhq/common-assets --ignore @dendronhq/dendron-plugin-views -- tsc -p tsconfig.build.json --noEmit",
     "bootstrap:bootstrap": "npx yarn --network-timeout 600000 --frozen-lockfile && yarn gen:meta",
     "bootstrap:build": "node bootstrap/scripts/buildAll.js",
     "bootstrap:buildCI": "node bootstrap/scripts/buildAllForTest.js",

--- a/packages/nextjs-template/.gitignore
+++ b/packages/nextjs-template/.gitignore
@@ -49,3 +49,7 @@ custom/*
 !custom/NoOp.tsx
 builds
 test-results/
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/packages/nextjs-template/components/DendronSearch.tsx
+++ b/packages/nextjs-template/components/DendronSearch.tsx
@@ -79,7 +79,7 @@ enum PlaceholderText {
 }
 
 function DendronSearchComponent(props: DendronCommonProps & SearchProps) {
-  const { noteIndex, dendronRouter, search, error, loading, notes } = props;
+  const { noteIndex, dendronRouter, search, error, notes } = props;
 
   const engine = useEngineAppSelector((state) => state.engine);
   const defaultSearchMode = engine.config

--- a/packages/nextjs-template/components/DendronTreeMenu.tsx
+++ b/packages/nextjs-template/components/DendronTreeMenu.tsx
@@ -12,7 +12,7 @@ import _ from "lodash";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { DataNode } from "rc-tree/lib/interface";
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useCombinedSelector } from "../features";
 import { DENDRON_STYLE_CONSTANTS } from "../styles/constants";
 import { useDendronRouter } from "../utils/hooks";
@@ -61,6 +61,7 @@ export default function DendronTreeMenu(
     });
 
     setActiveNoteIds(newActiveNoteIds);
+    return undefined;
   }, [props.noteIndex, dendronRouter.query.id, noteActiveId, tree]);
 
   const { notes, collapsed, setCollapsed } = props;

--- a/packages/nextjs-template/components/MermaidScript.tsx
+++ b/packages/nextjs-template/components/MermaidScript.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import Script from "next/script";
-import { useEngineAppSelector } from "../features/engine/hooks";
 import { createLogger } from "@dendronhq/common-frontend";
 
 interface MermaidScriptProps {
@@ -9,7 +8,6 @@ interface MermaidScriptProps {
 
 export const MermaidScript: React.FC<MermaidScriptProps> = (props) => {
   const [loadMermaid, setLoadMermaid] = React.useState(false);
-  const engine = useEngineAppSelector((state) => state.engine);
   const { noteBody } = props;
 
   useEffect(() => {

--- a/packages/nextjs-template/env/client.js
+++ b/packages/nextjs-template/env/client.js
@@ -4,10 +4,10 @@ const { clientEnv, clientSchema } = require("./schema");
 
 const _clientEnv = parse(clientSchema, clientEnv);
 
-if (_clientEnv.error) {
+if (_clientEnv.isErr()) {
   throw _clientEnv.error;
 }
 
 module.exports = {
-  env: _clientEnv.data
+  env: _clientEnv.value
 };

--- a/packages/nextjs-template/hooks/useIFrameHeightAdjuster.tsx
+++ b/packages/nextjs-template/hooks/useIFrameHeightAdjuster.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const updateIFrameHeight = () => {
   const iframes = document.querySelectorAll("iframe");
-  iframes.forEach((iframe, i) => {
+  iframes.forEach((iframe) => {
     if (iframe) {
       const height = iframe!.contentWindow!.document.body.offsetHeight;
       iframe.style.height = `${height}px`;

--- a/packages/nextjs-template/hooks/useToggle.tsx
+++ b/packages/nextjs-template/hooks/useToggle.tsx
@@ -5,7 +5,7 @@ import { __String } from "typescript";
 const DevNoticeKey = "next-template-notice-slow-toggle";
 export const useToggle = (
   defaultVal: boolean = true,
-  key: string = DevNoticeKey
+  _key: string = DevNoticeKey
 ) => {
   const [val, setVal] = useState(defaultVal);
   const toggle = (override?: boolean) => setVal(!isUndefined(override) || !val);

--- a/packages/nextjs-template/next-env.d.ts
+++ b/packages/nextjs-template/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/nextjs-template/pages/notes/[id].tsx
+++ b/packages/nextjs-template/pages/notes/[id].tsx
@@ -1,6 +1,6 @@
 import { DendronError, error2PlainObject } from "@dendronhq/common-all";
 import _ from "lodash";
-import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
+import { GetStaticPaths, GetStaticProps } from "next";
 import { prepChildrenForCollection } from "../../components/DendronCollection";
 import DendronNotePage, {
   DendronNotePageProps,
@@ -23,9 +23,7 @@ export const getStaticPaths: GetStaticPaths<DendronNotePageParams> =
 export const getStaticProps: GetStaticProps<
   DendronNotePageProps,
   DendronNotePageParams
-> = async (
-  { params },
-) => {
+> = async ({ params }) => {
   if (!params) {
     throw Error("params required");
   }

--- a/packages/nextjs-template/pages/refs/[id].tsx
+++ b/packages/nextjs-template/pages/refs/[id].tsx
@@ -1,8 +1,4 @@
-import {
-  DendronError,
-  error2PlainObject,
-  NoteProps,
-} from "@dendronhq/common-all";
+import { DendronError, error2PlainObject } from "@dendronhq/common-all";
 import { DendronNote } from "@dendronhq/common-frontend";
 import _ from "lodash";
 import {
@@ -16,22 +12,12 @@ import DendronCustomHead from "../../components/DendronCustomHead";
 import { getNoteRefs, getRefBody } from "../../utils/build";
 import { DendronCommonProps } from "../../utils/types";
 
-export type NotePageProps = InferGetStaticPropsType<typeof getStaticProps> &
+type NotePageProps = InferGetStaticPropsType<typeof getStaticProps> &
   DendronCommonProps & {
     customHeadContent: string | null;
-    noteIndex: NoteProps;
-    note: NoteProps;
   };
 
-export default function NoteRef({
-  note,
-  body,
-  collectionChildren,
-  noteIndex,
-  customHeadContent,
-  config,
-  ...rest
-}: NotePageProps) {
+export default function NoteRef({ body, customHeadContent }: NotePageProps) {
   return (
     <>
       {customHeadContent && <DendronCustomHead content={customHeadContent} />}

--- a/packages/nextjs-template/tsconfig.build.json
+++ b/packages/nextjs-template/tsconfig.build.json
@@ -1,26 +1,22 @@
 {
   "extends": "../../tsconfig.build.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2019",
-    "lib": ["es2019", "es2020.string"],
-    "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
     "strict": true,
-    "declaration": true,
-    "types": ["node"],
-    // --- checks
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    // --- language features
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "jsx": "react-jsx"
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "declaration": false,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
   },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "**/*-spec.ts"]
 }

--- a/packages/nextjs-template/tsconfig.json
+++ b/packages/nextjs-template/tsconfig.json
@@ -1,31 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "typeRoots": ["./types"]
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-  ],
-  "exclude": [
-    "node_modules"
-  ],
+  "extends": "./tsconfig.build.json"
 }

--- a/packages/nextjs-template/utils/getStaticPropsUtil.tsx
+++ b/packages/nextjs-template/utils/getStaticPropsUtil.tsx
@@ -1,11 +1,9 @@
-import { GetStaticProps, GetStaticPropsContext } from "next";
+import { GetStaticProps } from "next";
 import { prepChildrenForCollection } from "../components/DendronCollection";
 import { DendronNotePageProps } from "../components/DendronNotePage";
 import { getConfig, getCustomHead, getNoteBody, getNotes } from "./build";
 
-export const getStaticProps: GetStaticProps = async (
-  context: GetStaticPropsContext
-) => {
+export const getStaticProps: GetStaticProps = async () => {
   const { noteIndex: note, notes } = getNotes();
   const body = await getNoteBody(note.id);
   const config = await getConfig();


### PR DESCRIPTION
This PR's aim is to fix an error that occurs while [building nextjs-template](https://github.com/dendronhq/dendron/actions/runs/3201841712/jobs/5230211157#step:10:27).
These changes where missed when doing https://github.com/dendronhq/dendron/pull/3630

In addition this PR does a cleanup in `nextjs-template` so that it is possible to let it run through `run lerna:typecheck`.