### PR TITLE
enhance(workspace): support adding existing vault to the workspace

### DIFF
--- a/packages/common-all/src/vault.ts
+++ b/packages/common-all/src/vault.ts
@@ -70,7 +70,7 @@ export class VaultUtils {
     if (VaultUtils.isSelfContained(vault)) {
       // Return the path to the notes folder inside the vault. This is for
       // compatibility with existing code.
-      return path.join(vault.fsPath, FOLDERS.NOTES);
+      return normalizeUnixPath(path.join(vault.fsPath, FOLDERS.NOTES));
     }
     if (vault.workspace) {
       return path.join(vault.workspace, vault.fsPath);

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -393,6 +393,10 @@
         "title": "Dendron: Remove Vault"
       },
       {
+        "command": "dendron.createNewVault",
+        "title": "Dendron: Create New Vault"
+      },
+      {
         "command": "dendron.vaultConvert",
         "title": "Dendron: Vault Convert"
       },
@@ -806,6 +810,10 @@
         },
         {
           "command": "dendron.vaultAdd",
+          "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.createNewVault",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -389,8 +389,8 @@
         "title": "Dendron: Vault Add"
       },
       {
-        "command": "dendron.vaultRemove",
-        "title": "Dendron: Vault Remove"
+        "command": "dendron.removeVault",
+        "title": "Dendron: Remove Vault"
       },
       {
         "command": "dendron.vaultConvert",
@@ -809,7 +809,7 @@
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
-          "command": "dendron.vaultRemove",
+          "command": "dendron.removeVault",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
@@ -1108,7 +1108,7 @@
         },
         {
           "when": "explorerResourceIsFolder && dendron:pluginActive && shellExecutionSupported",
-          "command": "dendron.vaultRemove",
+          "command": "dendron.removeVault",
           "group": "2_workspace"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -393,8 +393,8 @@
         "title": "Dendron: Remove Vault"
       },
       {
-        "command": "dendron.vaultConvert",
-        "title": "Dendron: Vault Convert"
+        "command": "dendron.convertVault",
+        "title": "Dendron: Convert Vault"
       },
       {
         "command": "dendron.createNewVault",
@@ -821,7 +821,7 @@
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
-          "command": "dendron.vaultConvert",
+          "command": "dendron.convertVault",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -393,12 +393,16 @@
         "title": "Dendron: Remove Vault"
       },
       {
+        "command": "dendron.vaultConvert",
+        "title": "Dendron: Vault Convert"
+      },
+      {
         "command": "dendron.createNewVault",
         "title": "Dendron: Create New Vault"
       },
       {
-        "command": "dendron.vaultConvert",
-        "title": "Dendron: Vault Convert"
+        "command": "dendron.addExistingVault",
+        "title": "Dendron: Add Existing Vault"
       },
       {
         "command": "dendron.initWS",
@@ -813,15 +817,19 @@
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
-          "command": "dendron.createNewVault",
-          "when": "dendron:pluginActive && shellExecutionSupported"
-        },
-        {
           "command": "dendron.removeVault",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {
           "command": "dendron.vaultConvert",
+          "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.createNewVault",
+          "when": "dendron:pluginActive && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.addExistingVault",
           "when": "dendron:pluginActive && shellExecutionSupported"
         },
         {

--- a/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
+++ b/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
@@ -179,13 +179,22 @@ export class AddExistingVaultCommand extends BasicCommand<
     sourceType: VaultRemoteSource
   ): Promise<CommandOpts | undefined> {
     if (sourceType === VaultType.LOCAL) {
-      const vaultDestination = await this.gatherDestinationFolder();
-      if (!vaultDestination) return;
+      const sourcePath = await this.gatherDestinationFolder();
+      if (!sourcePath) return;
+      const placeHolder = path.basename(sourcePath);
+      const sourceName =
+        (await VSCodeUtils.showInputBox({
+          prompt: "Name of new vault (optional, press enter to skip)",
+          placeHolder,
+        })) || placeHolder;
 
-      const sourceName = await VSCodeUtils.showInputBox({
-        prompt: "Name of new vault (optional, press enter to skip)",
-        placeHolder: path.basename(vaultDestination),
-      });
+      const vaultDestination = path.join(
+        this._ext.getDWorkspace().wsRoot,
+        FOLDERS.DEPENDENCIES,
+        FOLDERS.LOCAL_DEPENDENCY,
+        sourceName
+      );
+      await fs.copy(sourcePath, vaultDestination);
 
       return {
         type: sourceType,

--- a/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
+++ b/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
@@ -160,7 +160,7 @@ export class AddExistingVaultCommand extends BasicCommand<
 
   async gatherDestinationFolder() {
     const defaultUri = Uri.file(this._ext.getDWorkspace().wsRoot);
-    // Prompt user where to create new vault
+    // opens the workspace root by default and prompts user to select vault
     const options: OpenDialogOptions = {
       canSelectMany: false,
       openLabel: "Select vault to add",

--- a/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
+++ b/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
@@ -1,0 +1,506 @@
+import {
+  asyncLoopOneAtATime,
+  ConfigUtils,
+  CONSTANTS,
+  DendronError,
+  DVault,
+  DWorkspace,
+  FOLDERS,
+  IntermediateDendronConfig,
+  SelfContainedVault,
+  VaultRemoteSource,
+  VaultUtils,
+  WorkspaceEvents,
+} from "@dendronhq/common-all";
+import {
+  DConfig,
+  GitUtils,
+  pathForVaultRoot,
+  simpleGit,
+} from "@dendronhq/common-server";
+import {
+  Git,
+  WorkspaceService,
+  WorkspaceUtils,
+} from "@dendronhq/engine-server";
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
+import {
+  commands,
+  OpenDialogOptions,
+  ProgressLocation,
+  QuickPickItem,
+  Uri,
+  window,
+} from "vscode";
+import { PickerUtilsV2 } from "../components/lookup/utils";
+import { DENDRON_COMMANDS, DENDRON_REMOTE_VAULTS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { Logger } from "../logger";
+import { AnalyticsUtils } from "../utils/analytics";
+import { PluginFileUtils } from "../utils/files";
+import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {
+  type: VaultRemoteSource;
+  path: string;
+  pathRemote?: string;
+  name?: string;
+  isSelfContained?: boolean;
+};
+
+type CommandOutput = { vaults: DVault[] };
+
+export { CommandOpts as VaultAddCommandOpts };
+
+type SourceQuickPickEntry = QuickPickItem & { src: string };
+
+enum VaultType {
+  LOCAL = "local",
+  REMOTE = "remote",
+}
+
+export class AddExistingVaultCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.ADD_EXISTING_VAULT.key;
+
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
+
+  generateRemoteEntries = (): SourceQuickPickEntry[] => {
+    return DENDRON_REMOTE_VAULTS.map(
+      ({ name: label, description, data: src }): SourceQuickPickEntry => {
+        return { label, description, src };
+      }
+    ).concat([
+      {
+        label: "custom",
+        description: "custom endpoint",
+        alwaysShow: true,
+        src: "",
+      },
+    ]);
+  };
+
+  /** A regular, non-self contained vault. */
+  async gatherVaultStandard(
+    sourceType: VaultRemoteSource,
+    vaultDestination: string
+  ): Promise<CommandOpts | undefined> {
+    let sourceName: string | undefined;
+    if (sourceType === VaultType.REMOTE) {
+      // eslint-disable-next-line  no-async-promise-executor
+      const out = new Promise<CommandOpts | undefined>(async (resolve) => {
+        const qp = VSCodeUtils.createQuickPick<SourceQuickPickEntry>();
+        qp.ignoreFocusOut = true;
+        qp.placeholder = "choose a preset or enter a custom git endpoint";
+        qp.items = this.generateRemoteEntries();
+        qp.onDidAccept(async () => {
+          const value = qp.value;
+          const selected = qp.selectedItems[0];
+          if (selected.label === "custom") {
+            if (PickerUtilsV2.isInputEmpty(value)) {
+              return window.showInformationMessage("please enter an endpoint");
+            }
+            selected.src = qp.value;
+          }
+          const sourceRemotePath = selected.src;
+          const path2Vault =
+            selected.label === "custom"
+              ? GitUtils.getRepoNameFromURL(sourceRemotePath)
+              : selected.label;
+          const placeHolder = path2Vault;
+          sourceName = await VSCodeUtils.showInputBox({
+            prompt: "Name of new vault (optional, press enter to skip)",
+            value: placeHolder,
+          });
+          qp.hide();
+          return resolve({
+            type: sourceType!,
+            name: sourceName,
+            path: vaultDestination,
+            pathRemote: sourceRemotePath,
+          });
+        });
+        qp.show();
+      });
+      return out;
+    }
+    const placeHolder = path.basename(vaultDestination);
+    sourceName = await VSCodeUtils.showInputBox({
+      prompt: "Name of new vault (optional, press enter to skip)",
+      placeHolder,
+    });
+    return {
+      type: sourceType,
+      name: sourceName,
+      path: vaultDestination,
+    };
+  }
+
+  async gatherDestinationFolder() {
+    const defaultUri = Uri.file(this._ext.getDWorkspace().wsRoot);
+    // Prompt user where to create new vault
+    const options: OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: "Select vault to add",
+      canSelectFiles: false,
+      canSelectFolders: true,
+      defaultUri,
+    };
+    const folder = await VSCodeUtils.openFilePicker(options);
+    if (_.isUndefined(folder)) {
+      return;
+    }
+    return folder;
+  }
+
+  async gatherVaultSelfContained(
+    sourceType: VaultRemoteSource,
+    vaultDestination: string
+  ): Promise<CommandOpts | undefined> {
+    if (sourceType === VaultType.LOCAL) {
+      const sourceName = await VSCodeUtils.showInputBox({
+        prompt: "Name of new vault (optional, press enter to skip)",
+        placeHolder: path.basename(vaultDestination),
+      });
+
+      return {
+        type: sourceType,
+        name: sourceName,
+        path: vaultDestination,
+        isSelfContained: true,
+      };
+    } else {
+      // Remote vault
+      const remote = await VSCodeUtils.showInputBox({
+        title: "Remote URL",
+        prompt: "Enter the URL for the git remote",
+        placeHolder: "git@github.com:dendronhq/dendron.git",
+        ignoreFocusOut: true,
+      });
+      // Cancelled
+      if (PickerUtilsV2.isInputEmpty(remote)) return;
+
+      // Calculate the vault name from the remote.
+      const vaultName: string | undefined = GitUtils.getRepoNameFromURL(remote);
+
+      const sourceName = await VSCodeUtils.showInputBox({
+        prompt: "Name of new vault (optional, press enter to skip)",
+        value: vaultName,
+      });
+
+      return {
+        type: sourceType,
+        name: sourceName,
+        path: vaultDestination,
+        pathRemote: remote,
+        isSelfContained: true,
+      };
+    }
+  }
+
+  async gatherInputs(): Promise<CommandOpts | undefined> {
+    const sourceTypeSelected = await VSCodeUtils.showQuickPick([
+      { label: VaultType.LOCAL, picked: true },
+      { label: VaultType.REMOTE },
+    ]);
+    if (!sourceTypeSelected) {
+      return;
+    }
+    const sourceType = sourceTypeSelected.label;
+    const vaultDestination = await this.gatherDestinationFolder();
+    if (!vaultDestination) return;
+
+    const { config } = this._ext.getDWorkspace();
+    if (config.dev?.enableSelfContainedVaults) {
+      return this.gatherVaultSelfContained(sourceType, vaultDestination);
+    } else {
+      // A "standard", non self contained vault
+      return this.gatherVaultStandard(sourceType, vaultDestination);
+    }
+  }
+
+  async handleRemoteRepo(
+    opts: CommandOpts
+  ): Promise<{ vaults: DVault[]; workspace?: DWorkspace }> {
+    const { vaults, workspace } = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Adding remote vault",
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({
+          message: "cloning repo",
+        });
+        const baseDir = this._ext.getDWorkspace().wsRoot;
+        const git = simpleGit({ baseDir });
+        await git.clone(opts.pathRemote!, opts.path);
+        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
+          repoPath: opts.path,
+          wsRoot: this._ext.getDWorkspace().wsRoot,
+          repoUrl: opts.pathRemote!,
+        });
+        if (_.size(vaults) === 1 && opts.name) {
+          vaults[0].name = opts.name;
+        }
+        // add all vaults
+        progress.report({
+          message: "adding vault",
+        });
+        const wsRoot = this._ext.getDWorkspace().wsRoot;
+        const wsService = new WorkspaceService({ wsRoot });
+
+        if (workspace) {
+          await wsService.addWorkspace({ workspace });
+          await this.addWorkspaceToWorkspace(workspace);
+        } else {
+          // Some things, like updating config, can't be parallelized so needs to be done one at a time
+          for (const vault of vaults) {
+            // eslint-disable-next-line no-await-in-loop
+            await wsService.createVault({ vault });
+            // eslint-disable-next-line no-await-in-loop
+            await this.addVaultToWorkspace(vault);
+          }
+        }
+        return { vaults, workspace };
+      }
+    );
+    return { vaults, workspace };
+  }
+
+  async handleRemoteRepoSelfContained(
+    opts: CommandOpts
+  ): Promise<{ vaults: DVault[] }> {
+    return window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Adding remote vault",
+        cancellable: false,
+      },
+      async (progress) => {
+        const { wsRoot } = this._ext.getDWorkspace();
+        progress.report({
+          message: "cloning repo",
+          increment: 0,
+        });
+        const { name, pathRemote: remoteUrl } = opts;
+        const localUrl = opts.path;
+        if (!remoteUrl) {
+          throw new DendronError({
+            message:
+              "Remote vault has no remote set. This should never happen, please send a bug report if you encounter this.",
+          });
+        }
+
+        await fs.ensureDir(localUrl);
+        const git = new Git({ localUrl, remoteUrl });
+        // `.` so it clones into the `localUrl` directory, not into a subdirectory of that
+        await git.clone(".");
+        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
+          repoPath: localUrl,
+          wsRoot,
+          repoUrl: remoteUrl,
+        });
+        if (_.size(vaults) === 1 && name) {
+          vaults[0].name = name;
+        }
+        // add all vaults
+        const increment = 100 / (vaults.length + 1);
+        progress.report({
+          message:
+            vaults.length === 1
+              ? "adding vault"
+              : `adding ${vaults.length} vaults`,
+          increment,
+        });
+        const wsService = new WorkspaceService({ wsRoot });
+
+        if (workspace) {
+          // This is a backwards-compatibility fix until workspace vaults are
+          // deprecated. If what we cloned was a workspace, then move it where
+          // Dendron expects it, because we can't override the path.
+          const clonedWSPath = path.join(wsRoot, workspace.name);
+          await fs.move(localUrl, clonedWSPath);
+          // Because we moved the workspace, we also have to recompute the vaults config.
+          workspace.vaults = (
+            await GitUtils.getVaultsFromRepo({
+              repoPath: clonedWSPath,
+              repoUrl: remoteUrl,
+              wsRoot,
+            })
+          ).vaults;
+          // Then handle the workspace vault as usual, without self contained vault stuff
+          await wsService.addWorkspace({ workspace });
+          await this.addWorkspaceToWorkspace(workspace);
+        } else {
+          // Some things, like updating config, can't be parallelized so needs
+          // to be done one at a time
+          await asyncLoopOneAtATime(vaults, async (vault) => {
+            if (VaultUtils.isSelfContained(vault)) {
+              await this.checkAndWarnTransitiveDeps({ vault, wsRoot });
+              await wsService.createSelfContainedVault({
+                vault,
+                addToConfig: true,
+                newVault: false,
+              });
+            } else {
+              await wsService.createVault({ vault });
+            }
+            await this.addVaultToWorkspace(vault);
+            progress.report({ increment });
+          });
+        }
+        wsService.dispose();
+        return { vaults, workspace };
+      }
+    );
+  }
+
+  /** If a self contained vault contains transitive dependencies, warn the user
+   * that they won't be accessible.
+   *
+   * Adding transitive deps is not supported yet, this check can be removed once
+   * support is added.
+   */
+  async checkAndWarnTransitiveDeps(opts: {
+    vault: SelfContainedVault;
+    wsRoot: string;
+  }) {
+    const vaultRootPath = pathForVaultRoot(opts);
+    try {
+      if (
+        await fs.pathExists(
+          path.join(vaultRootPath, CONSTANTS.DENDRON_CONFIG_FILE)
+        )
+      ) {
+        const vaultConfig = DConfig.getRaw(
+          vaultRootPath
+        ) as IntermediateDendronConfig;
+        if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
+          await AnalyticsUtils.trackForNextRun(
+            WorkspaceEvents.TransitiveDepsWarningShow
+          );
+          // Wait for the user to accept the prompt, otherwise window will
+          // reload before they see the warning
+          const openDocsOption = "Open documentation & continue";
+          const select = await VSCodeUtils.showMessage(
+            MessageSeverity.WARN,
+            "The vault you added depends on other vaults, which is not supported.",
+            {
+              modal: true,
+              detail:
+                "You may be unable to access these transitive vaults. The vault itself should continue to work. Please see for [details]()",
+            },
+            {
+              title: "Continue",
+              isCloseAffordance: true,
+            },
+            { title: openDocsOption }
+          );
+          if (select?.title === openDocsOption) {
+            // Open a page in the default browser that describes what transitive
+            // dependencies are, and how to add them.
+            await PluginFileUtils.openWithDefaultApp(
+              "https://wiki.dendron.so/notes/q9yo0y7czv8mxlkbnw1ugj1"
+            );
+          }
+        }
+      }
+    } catch (err) {
+      // If anything does fail, ignore the error. This check is not crucial to
+      // adding a vault, it's better if we let the user keep adding.
+      Logger.warn({
+        ctx: "VaultAddCommand.handleRemoteRepoSelfContained",
+        err,
+      });
+    }
+  }
+
+  async addWorkspaceToWorkspace(workspace: DWorkspace) {
+    const wsRoot = this._ext.getDWorkspace().wsRoot;
+    const vaults = workspace.vaults;
+    // Some things, like updating workspace file, can't be parallelized so needs to be done one at a time
+    for (const vault of vaults) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.addVaultToWorkspace(vault);
+    }
+    // add to gitignore
+    await GitUtils.addToGitignore({
+      addPath: workspace.name,
+      root: wsRoot,
+      noCreateIfMissing: true,
+    });
+
+    const workspaceDir = path.join(wsRoot, workspace.name);
+    await fs.ensureDir(workspaceDir);
+    await GitUtils.addToGitignore({
+      addPath: ".dendron.cache.*",
+      root: workspaceDir,
+    });
+  }
+
+  async addVaultToWorkspace(vault: DVault) {
+    return WorkspaceUtils.addVaultToWorkspace({
+      vault,
+      wsRoot: this._ext.getDWorkspace().wsRoot,
+    });
+  }
+
+  /**
+   * Returns all vaults added
+   * @param opts
+   * @returns
+   */
+  async execute(opts: CommandOpts) {
+    const ctx = "AddExistingVaultCommand";
+    let vaults: DVault[] = [];
+    Logger.info({ ctx, msg: "enter", opts });
+    if (opts.type === VaultType.REMOTE) {
+      if (opts.isSelfContained) {
+        ({ vaults } = await this.handleRemoteRepoSelfContained(opts));
+      } else {
+        ({ vaults } = await this.handleRemoteRepo(opts));
+      }
+    } else {
+      const wsRoot = this._ext.getDWorkspace().wsRoot;
+      const fsPath = VaultUtils.normVaultPath({
+        vault: { fsPath: opts.path },
+        wsRoot,
+      });
+      const wsService = new WorkspaceService({ wsRoot });
+      const vault: DVault = {
+        fsPath,
+      };
+      // Make sure these don't get set to undefined, or serialization breaks
+      if (await fs.pathExists(path.join(opts.path, FOLDERS.NOTES))) {
+        vault.selfContained = true;
+      }
+      if (opts.name) {
+        vault.name = opts.name;
+      }
+
+      if (VaultUtils.isSelfContained(vault)) {
+        await wsService.createSelfContainedVault({
+          vault,
+          addToConfig: true,
+          addToCodeWorkspace: false,
+          newVault: false,
+        });
+      } else {
+        await wsService.createVault({ vault });
+      }
+      await this.addVaultToWorkspace(vault);
+      vaults = [vault];
+    }
+    window.showInformationMessage("finished adding vault");
+    await commands.executeCommand("workbench.action.reloadWindow");
+    return { vaults };
+  }
+}

--- a/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
+++ b/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
@@ -207,8 +207,19 @@ export class AddExistingVaultCommand extends BasicCommand<
 
   async gatherInputs(): Promise<CommandOpts | undefined> {
     const sourceTypeSelected = await VSCodeUtils.showQuickPick([
-      { label: VaultType.LOCAL, picked: true },
-      { label: VaultType.REMOTE },
+      {
+        label: VaultType.LOCAL,
+        picked: true,
+        detail: "eg. /home/dendron/hello-vault",
+        description:
+          "A local vault is a Dendron vault that is present in your computer",
+      },
+      {
+        label: VaultType.REMOTE,
+        detail: "eg. git@github.com:dendronhq/dendron-site.git",
+        description:
+          "A remote vault is a Dendron vault that is available at a git endpoint",
+      },
     ]);
     if (!sourceTypeSelected) {
       return;
@@ -497,8 +508,8 @@ export class AddExistingVaultCommand extends BasicCommand<
       await this.addVaultToWorkspace(vault);
       vaults = [vault];
     }
-    window.showInformationMessage("finished adding vault");
     await commands.executeCommand("workbench.action.reloadWindow");
+    window.showInformationMessage("finished adding vault");
     return { vaults };
   }
 }

--- a/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
+++ b/packages/plugin-core/src/commands/AddExistingVaultCommand.ts
@@ -6,11 +6,11 @@ import {
   DVault,
   DWorkspace,
   FOLDERS,
-  IntermediateDendronConfig,
   SelfContainedVault,
   VaultRemoteSource,
   VaultUtils,
   WorkspaceEvents,
+  DendronConfig,
 } from "@dendronhq/common-all";
 import {
   DConfig,
@@ -380,9 +380,7 @@ export class AddExistingVaultCommand extends BasicCommand<
           path.join(vaultRootPath, CONSTANTS.DENDRON_CONFIG_FILE)
         )
       ) {
-        const vaultConfig = DConfig.getRaw(
-          vaultRootPath
-        ) as IntermediateDendronConfig;
+        const vaultConfig = DConfig.getRaw(vaultRootPath) as DendronConfig;
         if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
           await AnalyticsUtils.trackForNextRun(
             WorkspaceEvents.TransitiveDepsWarningShow

--- a/packages/plugin-core/src/commands/ConvertVaultCommand.ts
+++ b/packages/plugin-core/src/commands/ConvertVaultCommand.ts
@@ -24,9 +24,9 @@ type CommandOpts = {
 
 type CommandOutput = { updatedVault: DVault | null };
 
-export { CommandOpts as VaultConvertCommandOpts };
+export { CommandOpts as ConvertVaultCommandOpts };
 
-export class VaultConvertCommand extends BasicCommand<
+export class ConvertVaultCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
@@ -119,7 +119,7 @@ export class VaultConvertCommand extends BasicCommand<
   }
 
   async gatherInputs(opts?: CommandOpts): Promise<CommandOpts | undefined> {
-    const ctx = "VaultConvertCommand:gatherInputs";
+    const ctx = "ConvertVaultCommand:gatherInputs";
     let { vault, type, remoteUrl } = opts || {};
     // Let the user select the vault
     if (!vault) vault = await this.gatherVault();
@@ -175,7 +175,7 @@ export class VaultConvertCommand extends BasicCommand<
    * @returns
    */
   async execute(opts: CommandOpts) {
-    const ctx = "VaultConvertCommand";
+    const ctx = "ConvertVaultCommand";
     const { vault, type, remoteUrl } = opts;
     const { wsRoot } = this._ext.getDWorkspace();
     if (!vault || !type)

--- a/packages/plugin-core/src/commands/ConvertVaultCommand.ts
+++ b/packages/plugin-core/src/commands/ConvertVaultCommand.ts
@@ -30,7 +30,7 @@ export class ConvertVaultCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
-  key = DENDRON_COMMANDS.VAULT_CONVERT.key;
+  key = DENDRON_COMMANDS.CONVERT_VAULT.key;
   constructor(private _ext: IDendronExtension) {
     super();
   }

--- a/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
@@ -1,49 +1,14 @@
-import {
-  asyncLoopOneAtATime,
-  ConfigUtils,
-  CONSTANTS,
-  DendronError,
-  DVault,
-  DWorkspace,
-  IntermediateDendronConfig,
-  SelfContainedVault,
-  VaultRemoteSource,
-  VaultUtils,
-  WorkspaceEvents,
-} from "@dendronhq/common-all";
-import {
-  DConfig,
-  GitUtils,
-  pathForVaultRoot,
-  simpleGit,
-} from "@dendronhq/common-server";
-import {
-  Git,
-  WorkspaceService,
-  WorkspaceUtils,
-} from "@dendronhq/engine-server";
-import fs from "fs-extra";
+import { DVault, VaultUtils } from "@dendronhq/common-all";
+import { WorkspaceService, WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
-import path from "path";
-import {
-  commands,
-  OpenDialogOptions,
-  ProgressLocation,
-  QuickPickItem,
-  Uri,
-  window,
-} from "vscode";
-import { PickerUtilsV2 } from "../components/lookup/utils";
-import { DENDRON_COMMANDS, DENDRON_REMOTE_VAULTS } from "../constants";
+import { commands, OpenDialogOptions, Uri, window } from "vscode";
+import { DENDRON_COMMANDS } from "../constants";
 import { IDendronExtension } from "../dendronExtensionInterface";
 import { Logger } from "../logger";
-import { AnalyticsUtils } from "../utils/analytics";
-import { PluginFileUtils } from "../utils/files";
-import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
+import { VSCodeUtils } from "../vsCodeUtils";
 import { BasicCommand } from "./base";
 
 type CommandOpts = {
-  type: VaultRemoteSource;
   path: string;
   pathRemote?: string;
   name?: string;
@@ -54,13 +19,6 @@ type CommandOutput = { vaults: DVault[] };
 
 export { CommandOpts as VaultAddCommandOpts };
 
-type SourceQuickPickEntry = QuickPickItem & { src: string };
-
-enum VaultType {
-  LOCAL = "local",
-  REMOTE = "remote",
-}
-
 export class CreateNewVaultCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
@@ -69,75 +27,6 @@ export class CreateNewVaultCommand extends BasicCommand<
 
   constructor(private _ext: IDendronExtension) {
     super();
-  }
-
-  generateRemoteEntries = (): SourceQuickPickEntry[] => {
-    return DENDRON_REMOTE_VAULTS.map(
-      ({ name: label, description, data: src }): SourceQuickPickEntry => {
-        return { label, description, src };
-      }
-    ).concat([
-      {
-        label: "custom",
-        description: "custom endpoint",
-        alwaysShow: true,
-        src: "",
-      },
-    ]);
-  };
-
-  /** A regular, non-self contained vault. */
-  async gatherVaultStandard(
-    sourceType: VaultRemoteSource,
-    vaultDestination: string
-  ): Promise<CommandOpts | undefined> {
-    let sourceName: string | undefined;
-    if (sourceType === VaultType.REMOTE) {
-      // eslint-disable-next-line  no-async-promise-executor
-      const out = new Promise<CommandOpts | undefined>(async (resolve) => {
-        const qp = VSCodeUtils.createQuickPick<SourceQuickPickEntry>();
-        qp.ignoreFocusOut = true;
-        qp.placeholder = "choose a preset or enter a custom git endpoint";
-        qp.items = this.generateRemoteEntries();
-        qp.onDidAccept(async () => {
-          const value = qp.value;
-          const selected = qp.selectedItems[0];
-          if (selected.label === "custom") {
-            if (PickerUtilsV2.isInputEmpty(value)) {
-              return window.showInformationMessage("please enter an endpoint");
-            }
-            selected.src = qp.value;
-          }
-          const sourceRemotePath = selected.src;
-          const path2Vault =
-            selected.label === "custom"
-              ? GitUtils.getRepoNameFromURL(sourceRemotePath)
-              : selected.label;
-          const placeHolder = path2Vault;
-          sourceName = await VSCodeUtils.showInputBox({
-            prompt: "Name of new vault (optional, press enter to skip)",
-            value: placeHolder,
-          });
-          qp.hide();
-          return resolve({
-            type: sourceType!,
-            name: sourceName,
-            path: vaultDestination,
-            pathRemote: sourceRemotePath,
-          });
-        });
-        qp.show();
-      });
-      return out;
-    }
-    sourceName = await VSCodeUtils.showInputBox({
-      prompt: "Name of new vault (optional, press enter to skip)",
-    });
-    return {
-      type: sourceType,
-      name: sourceName,
-      path: vaultDestination,
-    };
   }
 
   async gatherDestinationFolder() {
@@ -157,292 +46,29 @@ export class CreateNewVaultCommand extends BasicCommand<
     return folder;
   }
 
-  async gatherVaultSelfContained(
-    sourceType: VaultRemoteSource,
-    vaultDestination: string
+  async gatherVault(
+    vaultDestination: string,
+    enableSelfContainedVaults?: boolean
   ): Promise<CommandOpts | undefined> {
     // If the vault name already exists, creating a vault with the same name would break things
+    const sourceName = await VSCodeUtils.showInputBox({
+      prompt: "Name of new vault (optional, press enter to skip)",
+    });
 
-    if (sourceType === VaultType.LOCAL) {
-      // Local vault
-      const sourceName = await VSCodeUtils.showInputBox({
-        prompt: "Name of new vault (optional, press enter to skip)",
-      });
-
-      return {
-        type: sourceType,
-        name: sourceName,
-        path: vaultDestination,
-        isSelfContained: true,
-      };
-    } else {
-      // Remote vault
-      const remote = await VSCodeUtils.showInputBox({
-        title: "Remote URL",
-        prompt: "Enter the URL for the git remote",
-        placeHolder: "git@github.com:dendronhq/dendron.git",
-        ignoreFocusOut: true,
-      });
-      // Cancelled
-      if (PickerUtilsV2.isInputEmpty(remote)) return;
-
-      // Calculate the vault name from the remote.
-      const vaultName: string | undefined = GitUtils.getRepoNameFromURL(remote);
-
-      const sourceName = await VSCodeUtils.showInputBox({
-        prompt: "Name of new vault (optional, press enter to skip)",
-        value: vaultName,
-      });
-
-      return {
-        type: sourceType,
-        name: sourceName,
-        path: vaultDestination,
-        pathRemote: remote,
-        isSelfContained: true,
-      };
-    }
+    return {
+      name: sourceName,
+      path: vaultDestination,
+      isSelfContained: enableSelfContainedVaults,
+    };
   }
 
   async gatherInputs(): Promise<CommandOpts | undefined> {
-    const sourceTypeSelected = await VSCodeUtils.showQuickPick([
-      { label: VaultType.LOCAL, picked: true },
-      { label: VaultType.REMOTE },
-    ]);
-    if (!sourceTypeSelected) {
-      return;
-    }
-    const sourceType = sourceTypeSelected.label;
     const vaultDestination = await this.gatherDestinationFolder();
     if (!vaultDestination) return;
 
     const { config } = this._ext.getDWorkspace();
-    if (config.dev?.enableSelfContainedVaults) {
-      return this.gatherVaultSelfContained(sourceType, vaultDestination);
-    } else {
-      // A "standard", non self contained vault
-      return this.gatherVaultStandard(sourceType, vaultDestination);
-    }
-  }
-
-  async handleRemoteRepo(
-    opts: CommandOpts
-  ): Promise<{ vaults: DVault[]; workspace?: DWorkspace }> {
-    const { vaults, workspace } = await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: "Adding remote vault",
-        cancellable: false,
-      },
-      async (progress) => {
-        progress.report({
-          message: "cloning repo",
-        });
-        const baseDir = this._ext.getDWorkspace().wsRoot;
-        const git = simpleGit({ baseDir });
-        await git.clone(opts.pathRemote!, opts.path);
-        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
-          repoPath: opts.path,
-          wsRoot: this._ext.getDWorkspace().wsRoot,
-          repoUrl: opts.pathRemote!,
-        });
-        if (_.size(vaults) === 1 && opts.name) {
-          vaults[0].name = opts.name;
-        }
-        // add all vaults
-        progress.report({
-          message: "adding vault",
-        });
-        const wsRoot = this._ext.getDWorkspace().wsRoot;
-        const wsService = new WorkspaceService({ wsRoot });
-
-        if (workspace) {
-          await wsService.addWorkspace({ workspace });
-          await this.addWorkspaceToWorkspace(workspace);
-        } else {
-          // Some things, like updating config, can't be parallelized so needs to be done one at a time
-          for (const vault of vaults) {
-            // eslint-disable-next-line no-await-in-loop
-            await wsService.createVault({ vault });
-            // eslint-disable-next-line no-await-in-loop
-            await this.addVaultToWorkspace(vault);
-          }
-        }
-        return { vaults, workspace };
-      }
-    );
-    return { vaults, workspace };
-  }
-
-  async handleRemoteRepoSelfContained(
-    opts: CommandOpts
-  ): Promise<{ vaults: DVault[] }> {
-    return window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: "Adding remote vault",
-        cancellable: false,
-      },
-      async (progress) => {
-        const { wsRoot } = this._ext.getDWorkspace();
-        progress.report({
-          message: "cloning repo",
-          increment: 0,
-        });
-        const { name, pathRemote: remoteUrl } = opts;
-        const localUrl = opts.path;
-        if (!remoteUrl) {
-          throw new DendronError({
-            message:
-              "Remote vault has no remote set. This should never happen, please send a bug report if you encounter this.",
-          });
-        }
-
-        await fs.ensureDir(localUrl);
-        const git = new Git({ localUrl, remoteUrl });
-        // `.` so it clones into the `localUrl` directory, not into a subdirectory of that
-        await git.clone(".");
-        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
-          repoPath: localUrl,
-          wsRoot,
-          repoUrl: remoteUrl,
-        });
-        if (_.size(vaults) === 1 && name) {
-          vaults[0].name = name;
-        }
-        // add all vaults
-        const increment = 100 / (vaults.length + 1);
-        progress.report({
-          message:
-            vaults.length === 1
-              ? "adding vault"
-              : `adding ${vaults.length} vaults`,
-          increment,
-        });
-        const wsService = new WorkspaceService({ wsRoot });
-
-        if (workspace) {
-          // This is a backwards-compatibility fix until workspace vaults are
-          // deprecated. If what we cloned was a workspace, then move it where
-          // Dendron expects it, because we can't override the path.
-          const clonedWSPath = path.join(wsRoot, workspace.name);
-          await fs.move(localUrl, clonedWSPath);
-          // Because we moved the workspace, we also have to recompute the vaults config.
-          workspace.vaults = (
-            await GitUtils.getVaultsFromRepo({
-              repoPath: clonedWSPath,
-              repoUrl: remoteUrl,
-              wsRoot,
-            })
-          ).vaults;
-          // Then handle the workspace vault as usual, without self contained vault stuff
-          await wsService.addWorkspace({ workspace });
-          await this.addWorkspaceToWorkspace(workspace);
-        } else {
-          // Some things, like updating config, can't be parallelized so needs
-          // to be done one at a time
-          await asyncLoopOneAtATime(vaults, async (vault) => {
-            if (VaultUtils.isSelfContained(vault)) {
-              await this.checkAndWarnTransitiveDeps({ vault, wsRoot });
-              await wsService.createSelfContainedVault({
-                vault,
-                addToConfig: true,
-                newVault: false,
-              });
-            } else {
-              await wsService.createVault({ vault });
-            }
-            await this.addVaultToWorkspace(vault);
-            progress.report({ increment });
-          });
-        }
-        wsService.dispose();
-        return { vaults, workspace };
-      }
-    );
-  }
-
-  /** If a self contained vault contains transitive dependencies, warn the user
-   * that they won't be accessible.
-   *
-   * Adding transitive deps is not supported yet, this check can be removed once
-   * support is added.
-   */
-  async checkAndWarnTransitiveDeps(opts: {
-    vault: SelfContainedVault;
-    wsRoot: string;
-  }) {
-    const vaultRootPath = pathForVaultRoot(opts);
-    try {
-      if (
-        await fs.pathExists(
-          path.join(vaultRootPath, CONSTANTS.DENDRON_CONFIG_FILE)
-        )
-      ) {
-        const vaultConfig = DConfig.getRaw(
-          vaultRootPath
-        ) as IntermediateDendronConfig;
-        if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
-          await AnalyticsUtils.trackForNextRun(
-            WorkspaceEvents.TransitiveDepsWarningShow
-          );
-          // Wait for the user to accept the prompt, otherwise window will
-          // reload before they see the warning
-          const openDocsOption = "Open documentation & continue";
-          const select = await VSCodeUtils.showMessage(
-            MessageSeverity.WARN,
-            "The vault you added depends on other vaults, which is not supported.",
-            {
-              modal: true,
-              detail:
-                "You may be unable to access these transitive vaults. The vault itself should continue to work. Please see for [details]()",
-            },
-            {
-              title: "Continue",
-              isCloseAffordance: true,
-            },
-            { title: openDocsOption }
-          );
-          if (select?.title === openDocsOption) {
-            // Open a page in the default browser that describes what transitive
-            // dependencies are, and how to add them.
-            await PluginFileUtils.openWithDefaultApp(
-              "https://wiki.dendron.so/notes/q9yo0y7czv8mxlkbnw1ugj1"
-            );
-          }
-        }
-      }
-    } catch (err) {
-      // If anything does fail, ignore the error. This check is not crucial to
-      // adding a vault, it's better if we let the user keep adding.
-      Logger.warn({
-        ctx: "VaultAddCommand.handleRemoteRepoSelfContained",
-        err,
-      });
-    }
-  }
-
-  async addWorkspaceToWorkspace(workspace: DWorkspace) {
-    const wsRoot = this._ext.getDWorkspace().wsRoot;
-    const vaults = workspace.vaults;
-    // Some things, like updating workspace file, can't be parallelized so needs to be done one at a time
-    for (const vault of vaults) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.addVaultToWorkspace(vault);
-    }
-    // add to gitignore
-    await GitUtils.addToGitignore({
-      addPath: workspace.name,
-      root: wsRoot,
-      noCreateIfMissing: true,
-    });
-
-    const workspaceDir = path.join(wsRoot, workspace.name);
-    await fs.ensureDir(workspaceDir);
-    await GitUtils.addToGitignore({
-      addPath: ".dendron.cache.*",
-      root: workspaceDir,
-    });
+    const enableSelfContainedVaults = config.dev?.enableSelfContainedVaults;
+    return this.gatherVault(vaultDestination, enableSelfContainedVaults);
   }
 
   async addVaultToWorkspace(vault: DVault) {
@@ -458,47 +84,40 @@ export class CreateNewVaultCommand extends BasicCommand<
    * @returns
    */
   async execute(opts: CommandOpts) {
-    const ctx = "CreateVaultCommand";
+    const ctx = "CreateNewVaultCommand";
     let vaults: DVault[] = [];
     Logger.info({ ctx, msg: "enter", opts });
-    if (opts.type === VaultType.REMOTE) {
-      if (opts.isSelfContained) {
-        ({ vaults } = await this.handleRemoteRepoSelfContained(opts));
-      } else {
-        ({ vaults } = await this.handleRemoteRepo(opts));
-      }
-    } else {
-      const wsRoot = this._ext.getDWorkspace().wsRoot;
-      const fsPath = VaultUtils.normVaultPath({
-        vault: { fsPath: opts.path },
-        wsRoot,
-      });
-      const wsService = new WorkspaceService({ wsRoot });
-      const vault: DVault = {
-        fsPath,
-      };
-      // Make sure these don't get set to undefined, or serialization breaks
-      if (opts.isSelfContained) {
-        vault.selfContained = true;
-      }
-      if (opts.name) {
-        vault.name = opts.name;
-      }
-
-      if (VaultUtils.isSelfContained(vault)) {
-        await wsService.createSelfContainedVault({
-          vault,
-          addToConfig: true,
-          addToCodeWorkspace: false,
-          newVault: true,
-        });
-      } else {
-        await wsService.createVault({ vault });
-      }
-      await this.addVaultToWorkspace(vault);
-      vaults = [vault];
+    const wsRoot = this._ext.getDWorkspace().wsRoot;
+    const fsPath = VaultUtils.normVaultPath({
+      vault: { fsPath: opts.path },
+      wsRoot,
+    });
+    const wsService = new WorkspaceService({ wsRoot });
+    const vault: DVault = {
+      fsPath,
+    };
+    // Make sure these don't get set to undefined, or serialization breaks
+    if (opts.isSelfContained) {
+      vault.selfContained = true;
     }
-    window.showInformationMessage("finished adding vault");
+    if (opts.name) {
+      vault.name = opts.name;
+    }
+
+    if (VaultUtils.isSelfContained(vault)) {
+      await wsService.createSelfContainedVault({
+        vault,
+        addToConfig: true,
+        addToCodeWorkspace: false,
+        newVault: true,
+      });
+    } else {
+      await wsService.createVault({ vault });
+    }
+    await this.addVaultToWorkspace(vault);
+    vaults = [vault];
+
+    window.showInformationMessage("finished creating a new vault");
     await commands.executeCommand("workbench.action.reloadWindow");
     return { vaults };
   }

--- a/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
@@ -1,0 +1,505 @@
+import {
+  asyncLoopOneAtATime,
+  ConfigUtils,
+  CONSTANTS,
+  DendronError,
+  DVault,
+  DWorkspace,
+  IntermediateDendronConfig,
+  SelfContainedVault,
+  VaultRemoteSource,
+  VaultUtils,
+  WorkspaceEvents,
+} from "@dendronhq/common-all";
+import {
+  DConfig,
+  GitUtils,
+  pathForVaultRoot,
+  simpleGit,
+} from "@dendronhq/common-server";
+import {
+  Git,
+  WorkspaceService,
+  WorkspaceUtils,
+} from "@dendronhq/engine-server";
+import fs from "fs-extra";
+import _ from "lodash";
+import path from "path";
+import {
+  commands,
+  OpenDialogOptions,
+  ProgressLocation,
+  QuickPickItem,
+  Uri,
+  window,
+} from "vscode";
+import { PickerUtilsV2 } from "../components/lookup/utils";
+import { DENDRON_COMMANDS, DENDRON_REMOTE_VAULTS } from "../constants";
+import { IDendronExtension } from "../dendronExtensionInterface";
+import { Logger } from "../logger";
+import { AnalyticsUtils } from "../utils/analytics";
+import { PluginFileUtils } from "../utils/files";
+import { MessageSeverity, VSCodeUtils } from "../vsCodeUtils";
+import { BasicCommand } from "./base";
+
+type CommandOpts = {
+  type: VaultRemoteSource;
+  path: string;
+  pathRemote?: string;
+  name?: string;
+  isSelfContained?: boolean;
+};
+
+type CommandOutput = { vaults: DVault[] };
+
+export { CommandOpts as VaultAddCommandOpts };
+
+type SourceQuickPickEntry = QuickPickItem & { src: string };
+
+enum VaultType {
+  LOCAL = "local",
+  REMOTE = "remote",
+}
+
+export class CreateNewVaultCommand extends BasicCommand<
+  CommandOpts,
+  CommandOutput
+> {
+  key = DENDRON_COMMANDS.CREATE_NEW_VAULT.key;
+
+  constructor(private _ext: IDendronExtension) {
+    super();
+  }
+
+  generateRemoteEntries = (): SourceQuickPickEntry[] => {
+    return DENDRON_REMOTE_VAULTS.map(
+      ({ name: label, description, data: src }): SourceQuickPickEntry => {
+        return { label, description, src };
+      }
+    ).concat([
+      {
+        label: "custom",
+        description: "custom endpoint",
+        alwaysShow: true,
+        src: "",
+      },
+    ]);
+  };
+
+  /** A regular, non-self contained vault. */
+  async gatherVaultStandard(
+    sourceType: VaultRemoteSource,
+    vaultDestination: string
+  ): Promise<CommandOpts | undefined> {
+    let sourceName: string | undefined;
+    if (sourceType === VaultType.REMOTE) {
+      // eslint-disable-next-line  no-async-promise-executor
+      const out = new Promise<CommandOpts | undefined>(async (resolve) => {
+        const qp = VSCodeUtils.createQuickPick<SourceQuickPickEntry>();
+        qp.ignoreFocusOut = true;
+        qp.placeholder = "choose a preset or enter a custom git endpoint";
+        qp.items = this.generateRemoteEntries();
+        qp.onDidAccept(async () => {
+          const value = qp.value;
+          const selected = qp.selectedItems[0];
+          if (selected.label === "custom") {
+            if (PickerUtilsV2.isInputEmpty(value)) {
+              return window.showInformationMessage("please enter an endpoint");
+            }
+            selected.src = qp.value;
+          }
+          const sourceRemotePath = selected.src;
+          const path2Vault =
+            selected.label === "custom"
+              ? GitUtils.getRepoNameFromURL(sourceRemotePath)
+              : selected.label;
+          const placeHolder = path2Vault;
+          sourceName = await VSCodeUtils.showInputBox({
+            prompt: "Name of new vault (optional, press enter to skip)",
+            value: placeHolder,
+          });
+          qp.hide();
+          return resolve({
+            type: sourceType!,
+            name: sourceName,
+            path: vaultDestination,
+            pathRemote: sourceRemotePath,
+          });
+        });
+        qp.show();
+      });
+      return out;
+    }
+    sourceName = await VSCodeUtils.showInputBox({
+      prompt: "Name of new vault (optional, press enter to skip)",
+    });
+    return {
+      type: sourceType,
+      name: sourceName,
+      path: vaultDestination,
+    };
+  }
+
+  async gatherDestinationFolder() {
+    const defaultUri = Uri.file(this._ext.getDWorkspace().wsRoot);
+    // Prompt user where to create new vault
+    const options: OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: "Select Vault Destination",
+      canSelectFiles: false,
+      canSelectFolders: true,
+      defaultUri,
+    };
+    const folder = await VSCodeUtils.openFilePicker(options);
+    if (_.isUndefined(folder)) {
+      return;
+    }
+    return folder;
+  }
+
+  async gatherVaultSelfContained(
+    sourceType: VaultRemoteSource,
+    vaultDestination: string
+  ): Promise<CommandOpts | undefined> {
+    // If the vault name already exists, creating a vault with the same name would break things
+
+    if (sourceType === VaultType.LOCAL) {
+      // Local vault
+      const sourceName = await VSCodeUtils.showInputBox({
+        prompt: "Name of new vault (optional, press enter to skip)",
+      });
+
+      return {
+        type: sourceType,
+        name: sourceName,
+        path: vaultDestination,
+        isSelfContained: true,
+      };
+    } else {
+      // Remote vault
+      const remote = await VSCodeUtils.showInputBox({
+        title: "Remote URL",
+        prompt: "Enter the URL for the git remote",
+        placeHolder: "git@github.com:dendronhq/dendron.git",
+        ignoreFocusOut: true,
+      });
+      // Cancelled
+      if (PickerUtilsV2.isInputEmpty(remote)) return;
+
+      // Calculate the vault name from the remote.
+      const vaultName: string | undefined = GitUtils.getRepoNameFromURL(remote);
+
+      const sourceName = await VSCodeUtils.showInputBox({
+        prompt: "Name of new vault (optional, press enter to skip)",
+        value: vaultName,
+      });
+
+      return {
+        type: sourceType,
+        name: sourceName,
+        path: vaultDestination,
+        pathRemote: remote,
+        isSelfContained: true,
+      };
+    }
+  }
+
+  async gatherInputs(): Promise<CommandOpts | undefined> {
+    const sourceTypeSelected = await VSCodeUtils.showQuickPick([
+      { label: VaultType.LOCAL, picked: true },
+      { label: VaultType.REMOTE },
+    ]);
+    if (!sourceTypeSelected) {
+      return;
+    }
+    const sourceType = sourceTypeSelected.label;
+    const vaultDestination = await this.gatherDestinationFolder();
+    if (!vaultDestination) return;
+
+    const { config } = this._ext.getDWorkspace();
+    if (config.dev?.enableSelfContainedVaults) {
+      return this.gatherVaultSelfContained(sourceType, vaultDestination);
+    } else {
+      // A "standard", non self contained vault
+      return this.gatherVaultStandard(sourceType, vaultDestination);
+    }
+  }
+
+  async handleRemoteRepo(
+    opts: CommandOpts
+  ): Promise<{ vaults: DVault[]; workspace?: DWorkspace }> {
+    const { vaults, workspace } = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Adding remote vault",
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({
+          message: "cloning repo",
+        });
+        const baseDir = this._ext.getDWorkspace().wsRoot;
+        const git = simpleGit({ baseDir });
+        await git.clone(opts.pathRemote!, opts.path);
+        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
+          repoPath: opts.path,
+          wsRoot: this._ext.getDWorkspace().wsRoot,
+          repoUrl: opts.pathRemote!,
+        });
+        if (_.size(vaults) === 1 && opts.name) {
+          vaults[0].name = opts.name;
+        }
+        // add all vaults
+        progress.report({
+          message: "adding vault",
+        });
+        const wsRoot = this._ext.getDWorkspace().wsRoot;
+        const wsService = new WorkspaceService({ wsRoot });
+
+        if (workspace) {
+          await wsService.addWorkspace({ workspace });
+          await this.addWorkspaceToWorkspace(workspace);
+        } else {
+          // Some things, like updating config, can't be parallelized so needs to be done one at a time
+          for (const vault of vaults) {
+            // eslint-disable-next-line no-await-in-loop
+            await wsService.createVault({ vault });
+            // eslint-disable-next-line no-await-in-loop
+            await this.addVaultToWorkspace(vault);
+          }
+        }
+        return { vaults, workspace };
+      }
+    );
+    return { vaults, workspace };
+  }
+
+  async handleRemoteRepoSelfContained(
+    opts: CommandOpts
+  ): Promise<{ vaults: DVault[] }> {
+    return window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Adding remote vault",
+        cancellable: false,
+      },
+      async (progress) => {
+        const { wsRoot } = this._ext.getDWorkspace();
+        progress.report({
+          message: "cloning repo",
+          increment: 0,
+        });
+        const { name, pathRemote: remoteUrl } = opts;
+        const localUrl = opts.path;
+        if (!remoteUrl) {
+          throw new DendronError({
+            message:
+              "Remote vault has no remote set. This should never happen, please send a bug report if you encounter this.",
+          });
+        }
+
+        await fs.ensureDir(localUrl);
+        const git = new Git({ localUrl, remoteUrl });
+        // `.` so it clones into the `localUrl` directory, not into a subdirectory of that
+        await git.clone(".");
+        const { vaults, workspace } = await GitUtils.getVaultsFromRepo({
+          repoPath: localUrl,
+          wsRoot,
+          repoUrl: remoteUrl,
+        });
+        if (_.size(vaults) === 1 && name) {
+          vaults[0].name = name;
+        }
+        // add all vaults
+        const increment = 100 / (vaults.length + 1);
+        progress.report({
+          message:
+            vaults.length === 1
+              ? "adding vault"
+              : `adding ${vaults.length} vaults`,
+          increment,
+        });
+        const wsService = new WorkspaceService({ wsRoot });
+
+        if (workspace) {
+          // This is a backwards-compatibility fix until workspace vaults are
+          // deprecated. If what we cloned was a workspace, then move it where
+          // Dendron expects it, because we can't override the path.
+          const clonedWSPath = path.join(wsRoot, workspace.name);
+          await fs.move(localUrl, clonedWSPath);
+          // Because we moved the workspace, we also have to recompute the vaults config.
+          workspace.vaults = (
+            await GitUtils.getVaultsFromRepo({
+              repoPath: clonedWSPath,
+              repoUrl: remoteUrl,
+              wsRoot,
+            })
+          ).vaults;
+          // Then handle the workspace vault as usual, without self contained vault stuff
+          await wsService.addWorkspace({ workspace });
+          await this.addWorkspaceToWorkspace(workspace);
+        } else {
+          // Some things, like updating config, can't be parallelized so needs
+          // to be done one at a time
+          await asyncLoopOneAtATime(vaults, async (vault) => {
+            if (VaultUtils.isSelfContained(vault)) {
+              await this.checkAndWarnTransitiveDeps({ vault, wsRoot });
+              await wsService.createSelfContainedVault({
+                vault,
+                addToConfig: true,
+                newVault: false,
+              });
+            } else {
+              await wsService.createVault({ vault });
+            }
+            await this.addVaultToWorkspace(vault);
+            progress.report({ increment });
+          });
+        }
+        wsService.dispose();
+        return { vaults, workspace };
+      }
+    );
+  }
+
+  /** If a self contained vault contains transitive dependencies, warn the user
+   * that they won't be accessible.
+   *
+   * Adding transitive deps is not supported yet, this check can be removed once
+   * support is added.
+   */
+  async checkAndWarnTransitiveDeps(opts: {
+    vault: SelfContainedVault;
+    wsRoot: string;
+  }) {
+    const vaultRootPath = pathForVaultRoot(opts);
+    try {
+      if (
+        await fs.pathExists(
+          path.join(vaultRootPath, CONSTANTS.DENDRON_CONFIG_FILE)
+        )
+      ) {
+        const vaultConfig = DConfig.getRaw(
+          vaultRootPath
+        ) as IntermediateDendronConfig;
+        if (ConfigUtils.getVaults(vaultConfig)?.length > 1) {
+          await AnalyticsUtils.trackForNextRun(
+            WorkspaceEvents.TransitiveDepsWarningShow
+          );
+          // Wait for the user to accept the prompt, otherwise window will
+          // reload before they see the warning
+          const openDocsOption = "Open documentation & continue";
+          const select = await VSCodeUtils.showMessage(
+            MessageSeverity.WARN,
+            "The vault you added depends on other vaults, which is not supported.",
+            {
+              modal: true,
+              detail:
+                "You may be unable to access these transitive vaults. The vault itself should continue to work. Please see for [details]()",
+            },
+            {
+              title: "Continue",
+              isCloseAffordance: true,
+            },
+            { title: openDocsOption }
+          );
+          if (select?.title === openDocsOption) {
+            // Open a page in the default browser that describes what transitive
+            // dependencies are, and how to add them.
+            await PluginFileUtils.openWithDefaultApp(
+              "https://wiki.dendron.so/notes/q9yo0y7czv8mxlkbnw1ugj1"
+            );
+          }
+        }
+      }
+    } catch (err) {
+      // If anything does fail, ignore the error. This check is not crucial to
+      // adding a vault, it's better if we let the user keep adding.
+      Logger.warn({
+        ctx: "VaultAddCommand.handleRemoteRepoSelfContained",
+        err,
+      });
+    }
+  }
+
+  async addWorkspaceToWorkspace(workspace: DWorkspace) {
+    const wsRoot = this._ext.getDWorkspace().wsRoot;
+    const vaults = workspace.vaults;
+    // Some things, like updating workspace file, can't be parallelized so needs to be done one at a time
+    for (const vault of vaults) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.addVaultToWorkspace(vault);
+    }
+    // add to gitignore
+    await GitUtils.addToGitignore({
+      addPath: workspace.name,
+      root: wsRoot,
+      noCreateIfMissing: true,
+    });
+
+    const workspaceDir = path.join(wsRoot, workspace.name);
+    await fs.ensureDir(workspaceDir);
+    await GitUtils.addToGitignore({
+      addPath: ".dendron.cache.*",
+      root: workspaceDir,
+    });
+  }
+
+  async addVaultToWorkspace(vault: DVault) {
+    return WorkspaceUtils.addVaultToWorkspace({
+      vault,
+      wsRoot: this._ext.getDWorkspace().wsRoot,
+    });
+  }
+
+  /**
+   * Returns all vaults added
+   * @param opts
+   * @returns
+   */
+  async execute(opts: CommandOpts) {
+    const ctx = "CreateVaultCommand";
+    let vaults: DVault[] = [];
+    Logger.info({ ctx, msg: "enter", opts });
+    if (opts.type === VaultType.REMOTE) {
+      if (opts.isSelfContained) {
+        ({ vaults } = await this.handleRemoteRepoSelfContained(opts));
+      } else {
+        ({ vaults } = await this.handleRemoteRepo(opts));
+      }
+    } else {
+      const wsRoot = this._ext.getDWorkspace().wsRoot;
+      const fsPath = VaultUtils.normVaultPath({
+        vault: { fsPath: opts.path },
+        wsRoot,
+      });
+      const wsService = new WorkspaceService({ wsRoot });
+      const vault: DVault = {
+        fsPath,
+      };
+      // Make sure these don't get set to undefined, or serialization breaks
+      if (opts.isSelfContained) {
+        vault.selfContained = true;
+      }
+      if (opts.name) {
+        vault.name = opts.name;
+      }
+
+      if (VaultUtils.isSelfContained(vault)) {
+        await wsService.createSelfContainedVault({
+          vault,
+          addToConfig: true,
+          addToCodeWorkspace: false,
+          newVault: true,
+        });
+      } else {
+        await wsService.createVault({ vault });
+      }
+      await this.addVaultToWorkspace(vault);
+      vaults = [vault];
+    }
+    window.showInformationMessage("finished adding vault");
+    await commands.executeCommand("workbench.action.reloadWindow");
+    return { vaults };
+  }
+}

--- a/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
@@ -35,7 +35,7 @@ export class CreateNewVaultCommand extends BasicCommand<
     // Prompt user where to create new vault
     const options: OpenDialogOptions = {
       canSelectMany: false,
-      openLabel: "Select Vault Destination",
+      openLabel: "Pick or create a folder for your new vault",
       canSelectFiles: false,
       canSelectFolders: true,
       defaultUri,
@@ -118,8 +118,8 @@ export class CreateNewVaultCommand extends BasicCommand<
     await this.addVaultToWorkspace(vault);
     vaults = [vault];
 
-    window.showInformationMessage("finished creating a new vault");
     await commands.executeCommand("workbench.action.reloadWindow");
+    window.showInformationMessage("finished creating a new vault");
     return { vaults };
   }
 }

--- a/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
+++ b/packages/plugin-core/src/commands/CreateNewVaultCommand.ts
@@ -1,6 +1,7 @@
 import { DVault, VaultUtils } from "@dendronhq/common-all";
 import { WorkspaceService, WorkspaceUtils } from "@dendronhq/engine-server";
 import _ from "lodash";
+import path from "path";
 import { commands, OpenDialogOptions, Uri, window } from "vscode";
 import { DENDRON_COMMANDS } from "../constants";
 import { IDendronExtension } from "../dendronExtensionInterface";
@@ -50,9 +51,9 @@ export class CreateNewVaultCommand extends BasicCommand<
     vaultDestination: string,
     enableSelfContainedVaults?: boolean
   ): Promise<CommandOpts | undefined> {
-    // If the vault name already exists, creating a vault with the same name would break things
     const sourceName = await VSCodeUtils.showInputBox({
       prompt: "Name of new vault (optional, press enter to skip)",
+      placeHolder: path.basename(vaultDestination),
     });
 
     return {

--- a/packages/plugin-core/src/commands/RemoveVaultCommand.ts
+++ b/packages/plugin-core/src/commands/RemoveVaultCommand.ts
@@ -65,10 +65,10 @@ export class RemoveVaultCommand extends BasicCommand<
     const wsService = new WorkspaceService({ wsRoot });
     Logger.info({ ctx, msg: "preRemoveVault", vault });
     await wsService.removeVault({ vault, updateWorkspace: true });
+    await commands.executeCommand("workbench.action.reloadWindow");
     window.showInformationMessage(
       "finished removing vault (from dendron). you will still need to delete the notes from your disk"
     );
-    await commands.executeCommand("workbench.action.reloadWindow");
     return { vault };
   }
 }

--- a/packages/plugin-core/src/commands/RemoveVaultCommand.ts
+++ b/packages/plugin-core/src/commands/RemoveVaultCommand.ts
@@ -18,13 +18,13 @@ type CommandOpts = {
 
 type CommandOutput = { vault: DVault };
 
-export { CommandOpts as VaultRemoveCommandOpts };
+export { CommandOpts as RemoveVaultCommandOpts };
 
-export class VaultRemoveCommand extends BasicCommand<
+export class RemoveVaultCommand extends BasicCommand<
   CommandOpts,
   CommandOutput
 > {
-  key = DENDRON_COMMANDS.VAULT_REMOVE.key;
+  key = DENDRON_COMMANDS.REMOVE_VAULT.key;
   constructor(private _ext: IDendronExtension) {
     super();
   }
@@ -58,7 +58,7 @@ export class VaultRemoveCommand extends BasicCommand<
   }
 
   async execute(opts: CommandOpts) {
-    const ctx = "VaultRemove";
+    const ctx = "RemoveVaultCommand";
     // NOTE: relative vault
     const { vault } = opts;
     const { wsRoot } = this._ext.getDWorkspace();

--- a/packages/plugin-core/src/commands/VaultAddCommand.ts
+++ b/packages/plugin-core/src/commands/VaultAddCommand.ts
@@ -205,6 +205,11 @@ export class VaultAddCommand extends BasicCommand<CommandOpts, CommandOutput> {
   }
 
   async gatherInputs(): Promise<CommandOpts | undefined> {
+    window.showWarningMessage(
+      `This command will be deprecated in future releases. 
+      Please use Dendron: Create New Vault to create a new vault and 
+      Dendron: Add Existing Vault to add an existing vault to your workspace.`
+    );
     const sourceTypeSelected = await VSCodeUtils.showQuickPick([
       { label: VaultType.LOCAL, picked: true },
       { label: VaultType.REMOTE },

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -88,6 +88,7 @@ import { MoveSelectionToCommand } from "./MoveSelectionToCommand";
 import { CopyAsCommand } from "./CopyAsCommand";
 import { RemoveVaultCommand } from "./RemoveVaultCommand";
 import { CreateNewVaultCommand } from "./CreateNewVaultCommand";
+import { AddExistingVaultCommand } from "./AddExistingVaultCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -163,6 +164,7 @@ const ALL_COMMANDS = [
   UpgradeSettingsCommand,
   VaultAddCommand,
   CreateNewVaultCommand,
+  AddExistingVaultCommand,
   RemoveVaultCommand,
   VaultConvertCommand,
   ShowWelcomePageCommand,

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -79,7 +79,7 @@ import { TaskStatusCommand } from "./TaskStatus";
 import { UpgradeSettingsCommand } from "./UpgradeSettings";
 import { ValidateEngineCommand } from "./ValidateEngineCommand";
 import { VaultAddCommand } from "./VaultAddCommand";
-import { VaultConvertCommand } from "./VaultConvert";
+import { ConvertVaultCommand } from "./ConvertVaultCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
 import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
@@ -166,7 +166,7 @@ const ALL_COMMANDS = [
   CreateNewVaultCommand,
   AddExistingVaultCommand,
   RemoveVaultCommand,
-  VaultConvertCommand,
+  ConvertVaultCommand,
   ShowWelcomePageCommand,
   LaunchTutorialWorkspaceCommand,
   ConvertLinkCommand,

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -87,6 +87,7 @@ import { CopyCodespaceURL } from "./CopyCodespaceURL";
 import { MoveSelectionToCommand } from "./MoveSelectionToCommand";
 import { CopyAsCommand } from "./CopyAsCommand";
 import { RemoveVaultCommand } from "./RemoveVaultCommand";
+import { CreateNewVaultCommand } from "./CreateNewVaultCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -161,6 +162,7 @@ const ALL_COMMANDS = [
   ApplyTemplateCommand,
   UpgradeSettingsCommand,
   VaultAddCommand,
+  CreateNewVaultCommand,
   RemoveVaultCommand,
   VaultConvertCommand,
   ShowWelcomePageCommand,

--- a/packages/plugin-core/src/commands/index.ts
+++ b/packages/plugin-core/src/commands/index.ts
@@ -80,13 +80,13 @@ import { UpgradeSettingsCommand } from "./UpgradeSettings";
 import { ValidateEngineCommand } from "./ValidateEngineCommand";
 import { VaultAddCommand } from "./VaultAddCommand";
 import { VaultConvertCommand } from "./VaultConvert";
-import { VaultRemoveCommand } from "./VaultRemoveCommand";
 import { RenameNoteCommand } from "./RenameNoteCommand";
 import { CreateNoteCommand } from "./CreateNoteCommand";
 import { MergeNoteCommand } from "./MergeNoteCommand";
 import { CopyCodespaceURL } from "./CopyCodespaceURL";
 import { MoveSelectionToCommand } from "./MoveSelectionToCommand";
 import { CopyAsCommand } from "./CopyAsCommand";
+import { RemoveVaultCommand } from "./RemoveVaultCommand";
 
 /**
  * Note: this does not contain commands that have parametered constructors, as
@@ -161,7 +161,7 @@ const ALL_COMMANDS = [
   ApplyTemplateCommand,
   UpgradeSettingsCommand,
   VaultAddCommand,
-  VaultRemoveCommand,
+  RemoveVaultCommand,
   VaultConvertCommand,
   ShowWelcomePageCommand,
   LaunchTutorialWorkspaceCommand,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -782,6 +782,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Create New Vault`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
+  ADD_EXISTING_VAULT: {
+    key: "dendron.addExistingVault",
+    title: `${CMD_PREFIX} Add Existing Vault`,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+  },
   INIT_WS: {
     key: "dendron.initWS",
     title: `${CMD_PREFIX} Initialize Workspace`,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -777,6 +777,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Vault Convert`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
+  CREATE_NEW_VAULT: {
+    key: "dendron.createNewVault",
+    title: `${CMD_PREFIX} Create New Vault`,
+    when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
+  },
   INIT_WS: {
     key: "dendron.initWS",
     title: `${CMD_PREFIX} Initialize Workspace`,

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -772,9 +772,9 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Remove Vault`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
-  VAULT_CONVERT: {
-    key: "dendron.vaultConvert",
-    title: `${CMD_PREFIX} Vault Convert`,
+  CONVERT_VAULT: {
+    key: "dendron.convertVault",
+    title: `${CMD_PREFIX} Convert Vault`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   CREATE_NEW_VAULT: {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -301,7 +301,7 @@ export const DENDRON_MENUS = {
     },
     {
       when: "explorerResourceIsFolder && dendron:pluginActive && shellExecutionSupported",
-      command: "dendron.vaultRemove",
+      command: "dendron.removeVault",
       group: "2_workspace",
     },
     {
@@ -767,9 +767,9 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     title: `${CMD_PREFIX} Vault Add`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
-  VAULT_REMOVE: {
-    key: "dendron.vaultRemove",
-    title: `${CMD_PREFIX} Vault Remove`,
+  REMOVE_VAULT: {
+    key: "dendron.removeVault",
+    title: `${CMD_PREFIX} Remove Vault`,
     when: `${DendronContext.PLUGIN_ACTIVE} && shellExecutionSupported`,
   },
   VAULT_CONVERT: {

--- a/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
@@ -218,42 +218,6 @@ suite("AddExistingVaultCommand", function () {
         });
       }
     );
-
-    describeSingleWS(
-      "WHEN vault was already in .gitignore",
-      { timeout, modConfigCb: disableSelfContainedVaults },
-      () => {
-        test("THEN vault is not duplicated", async () => {
-          const { wsRoot } = ExtensionProvider.getDWorkspace();
-          const vaultPath = path.join(wsRoot, "vaultRemote");
-          const gitIgnore = path.join(wsRoot, ".gitignore");
-          const remoteDir = tmpDir().name;
-
-          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
-          await fs.writeFile(gitIgnore, "vaultRemote");
-
-          const cmd = new AddExistingVaultCommand(
-            ExtensionProvider.getExtension()
-          );
-          sinon.stub(cmd, "gatherInputs").returns(
-            Promise.resolve({
-              type: "remote",
-              name: "dendron",
-              path: vaultPath,
-              pathRemote: remoteDir,
-            })
-          );
-          await cmd.run();
-
-          expect(
-            await FileTestUtils.assertTimesInFile({
-              fpath: gitIgnore,
-              match: [[1, "vaultRemote"]],
-            })
-          ).toBeTruthy();
-        });
-      }
-    );
   });
 });
 

--- a/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
@@ -39,7 +39,7 @@ suite("AddExistingVaultCommand", function () {
       "WHEN a remote workspace vault is added",
       {
         modConfigCb: disableSelfContainedVaults,
-        timeout,
+        timeout: 1e6,
       },
       () => {
         before(() => {
@@ -355,13 +355,12 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
       });
 
-      test("THEN the vault is added at the destination folder, and is self contained", async () => {
+      test("THEN the vault is added at the dependencies/remote, and is self contained", async () => {
         const cmd = new AddExistingVaultCommand(
           ExtensionProvider.getExtension()
         );
         const { wsRoot } = ExtensionProvider.getDWorkspace();
-        fs.ensureDir(path.join(wsRoot, "testing"));
-        const vaultPath = path.join(wsRoot, "testing", vaultName);
+        const vaultPath = path.join(wsRoot, FOLDERS.DEPENDENCIES, vaultName);
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             type: "remote",
@@ -393,7 +392,10 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         });
         expect(vault?.selfContained).toBeTruthy();
         expect(vault?.name).toEqual(vaultName);
-        expect(vault?.fsPath).toEqual(`testing/${vaultName}`);
+        expect(vault?.fsPath).toEqual(
+          // vault paths always use UNIX style
+          path.posix.join(FOLDERS.DEPENDENCIES, vaultName)
+        );
         expect(vault?.remote?.url).toEqual(remoteDir);
       });
 
@@ -509,7 +511,7 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
 
         const { wsRoot } = ExtensionProvider.getDWorkspace();
         fs.ensureDir(path.join(wsRoot, "testing"));
-        const vaultPath = path.join(wsRoot, "testing", vaultName);
+        const vaultPath = path.join(wsRoot, FOLDERS.DEPENDENCIES, vaultName);
         sinon.stub(cmd, "gatherInputs").returns(
           Promise.resolve({
             type: "remote",
@@ -542,7 +544,7 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         expect(vault?.selfContained).toBeFalsy();
         expect(vault?.fsPath).toEqual(
           // vault paths always use UNIX style
-          path.posix.join("testing", vaultName)
+          path.posix.join(FOLDERS.DEPENDENCIES, vaultName)
         );
         expect(vault?.remote?.url).toEqual(remoteDir);
       });

--- a/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
@@ -2,8 +2,8 @@ import {
   ConfigUtils,
   CONSTANTS,
   FOLDERS,
-  IntermediateDendronConfig,
   VaultUtils,
+  DendronConfig,
 } from "@dendronhq/common-all";
 import {
   DConfig,
@@ -66,7 +66,7 @@ suite("AddExistingVaultCommand", function () {
           );
           await cmd.run();
           const configPath = DConfig.configPath(wsRoot);
-          const configRaw = readYAML(configPath) as IntermediateDendronConfig;
+          const configRaw = readYAML(configPath) as DendronConfig;
           const workspaces = ConfigUtils.getWorkspace(configRaw).workspaces;
           expect(workspaces).toEqual({
             [vname]: {
@@ -257,12 +257,12 @@ suite("AddExistingVaultCommand", function () {
   });
 });
 
-function enableSelfContainedVaults(config: IntermediateDendronConfig) {
+function enableSelfContainedVaults(config: DendronConfig) {
   config.dev!.enableSelfContainedVaults = true;
   return config;
 }
 
-function disableSelfContainedVaults(config: IntermediateDendronConfig) {
+function disableSelfContainedVaults(config: DendronConfig) {
   config.dev!.enableSelfContainedVaults = false;
   return config;
 }

--- a/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
@@ -157,7 +157,7 @@ suite("AddExistingVaultCommand", function () {
     );
 
     describeSingleWS(
-      "WHEN adding a local self conatined vault",
+      "WHEN adding a local self conatined vault with enableSelfConatinedVaults config set to false",
       {
         modConfigCb: disableSelfContainedVaults,
         timeout,
@@ -246,14 +246,20 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
       });
 
-      test("THEN the vault is added to the workspace", async () => {
+      test("THEN the vault is added to the dependencies/localhost", async () => {
         const { wsRoot } = ExtensionProvider.getDWorkspace();
-        const vaultPath = path.join(wsRoot, vaultName);
-        await createVaultWithGit(vaultPath);
+        const sourcePath = path.join(wsRoot, vaultName);
+        await createVaultWithGit(sourcePath);
         const cmd = new AddExistingVaultCommand(
           ExtensionProvider.getExtension()
         );
-        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        const vaultPath = path.join(
+          wsRoot,
+          FOLDERS.DEPENDENCIES,
+          FOLDERS.LOCAL_DEPENDENCY,
+          vaultName
+        );
+        sinon.stub(cmd, "gatherDestinationFolder").resolves(sourcePath);
         await cmd.run();
         expect(await fs.pathExists(vaultPath)).toBeTruthy();
         expect(
@@ -275,7 +281,14 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         });
         expect(vault?.selfContained).toBeFalsy();
         expect(vault?.name).toEqual(vaultName);
-        expect(vault?.fsPath).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(
+          // vault paths always use UNIX style
+          path.posix.join(
+            FOLDERS.DEPENDENCIES,
+            FOLDERS.LOCAL_DEPENDENCY,
+            vaultName
+          )
+        );
       });
     }
   );
@@ -294,15 +307,21 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
       });
 
-      test("THEN the vault is added to the workspace", async () => {
+      test("THEN the vault is added to the dependencies/localhost", async () => {
         const { wsRoot } = ExtensionProvider.getDWorkspace();
-        const vaultPath = path.join(wsRoot, vaultName);
-        await createSelfContainedVaultWithGit(vaultPath);
+        const sourcePath = path.join(wsRoot, vaultName);
+        await createSelfContainedVaultWithGit(sourcePath);
         const cmd = new AddExistingVaultCommand(
           ExtensionProvider.getExtension()
         );
-        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        sinon.stub(cmd, "gatherDestinationFolder").resolves(sourcePath);
         await cmd.run();
+        const vaultPath = path.join(
+          wsRoot,
+          FOLDERS.DEPENDENCIES,
+          FOLDERS.LOCAL_DEPENDENCY,
+          vaultName
+        );
         expect(await fs.pathExists(vaultPath)).toBeTruthy();
         expect(
           await fs.pathExists(
@@ -323,7 +342,14 @@ describe("GIVEN Add Existing Vault Command is run with self contained vaults ena
         });
         expect(vault?.selfContained).toBeTruthy();
         expect(vault?.name).toEqual(vaultName);
-        expect(vault?.fsPath).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(
+          // vault paths always use UNIX style
+          path.posix.join(
+            FOLDERS.DEPENDENCIES,
+            FOLDERS.LOCAL_DEPENDENCY,
+            vaultName
+          )
+        );
       });
       test("THEN the notes in this vault are accessible", async () => {
         // Since we mock the reload window, need to reload index here to pick up the notes in the new vault

--- a/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/AddExistingVaultCommand.test.ts
@@ -1,0 +1,601 @@
+import {
+  ConfigUtils,
+  CONSTANTS,
+  FOLDERS,
+  IntermediateDendronConfig,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import {
+  DConfig,
+  readYAML,
+  readYAMLAsync,
+  tmpDir,
+} from "@dendronhq/common-server";
+import { FileTestUtils } from "@dendronhq/common-test-utils";
+import { checkVaults, GitTestUtils } from "@dendronhq/engine-test-utils";
+import fs from "fs-extra";
+import { before, describe } from "mocha";
+import path from "path";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { AddExistingVaultCommand } from "../../commands/AddExistingVaultCommand";
+import { ReloadIndexCommand } from "../../commands/ReloadIndex";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { expect } from "../testUtilsv2";
+import {
+  createSelfContainedVaultWithGit,
+  createVaultWithGit,
+  createWorkspaceWithGit,
+  describeSingleWS,
+} from "../testUtilsV3";
+
+// these tests can run longer than the default 2s timeout;
+const timeout = 5e3;
+
+suite("AddExistingVaultCommand", function () {
+  describe("GIVEN Add Existing Vault command is run on a workspace with self contained config disabled", () => {
+    describeSingleWS(
+      "WHEN a remote workspace vault is added",
+      {
+        modConfigCb: disableSelfContainedVaults,
+        timeout,
+      },
+      () => {
+        before(() => {
+          sinon.stub(vscode.commands, "executeCommand").resolves({});
+        });
+        test("THEN add vault, workspace to the config", async () => {
+          const { wsRoot, vaults } = ExtensionProvider.getDWorkspace();
+          const remoteDir = tmpDir().name;
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          const gitIgnore = path.join(wsRoot, ".gitignore");
+          const vname = "vaultRemote";
+          const gitIgnoreInsideVault = path.join(wsRoot, vname, ".gitignore");
+          const vpath = path.join(wsRoot, vname);
+          const cmd = new AddExistingVaultCommand(
+            ExtensionProvider.getExtension()
+          );
+          sinon.stub(cmd, "gatherInputs").returns(
+            Promise.resolve({
+              type: "remote",
+              name: "dendron",
+              path: vpath,
+              pathRemote: remoteDir,
+            })
+          );
+          await cmd.run();
+          const configPath = DConfig.configPath(wsRoot);
+          const configRaw = readYAML(configPath) as IntermediateDendronConfig;
+          const workspaces = ConfigUtils.getWorkspace(configRaw).workspaces;
+          expect(workspaces).toEqual({
+            [vname]: {
+              remote: {
+                type: "git",
+                url: remoteDir,
+              },
+            },
+          });
+
+          await checkVaults(
+            {
+              wsRoot,
+              vaults: [
+                {
+                  fsPath: "notes",
+                  name: "dendron",
+                  selfContained: true,
+                  workspace: "vaultRemote",
+                },
+                vaults[0],
+              ],
+            },
+            expect
+          );
+          expect(
+            await FileTestUtils.assertInFile({
+              fpath: gitIgnore,
+              match: ["vaultRemote"],
+            })
+          ).toBeTruthy();
+          expect(
+            await FileTestUtils.assertInFile({
+              fpath: gitIgnoreInsideVault,
+              match: [".dendron.cache.*"],
+            })
+          ).toBeTruthy();
+        });
+      }
+    );
+
+    describeSingleWS(
+      "WHEN adding a standard local vault", // not self conatined
+      {
+        modConfigCb: disableSelfContainedVaults,
+        timeout,
+      },
+      () => {
+        const vaultName = "standard-vault";
+        before(() => {
+          sinon.stub(VSCodeUtils, "showQuickPick").resolves({ label: "local" });
+          sinon.stub(VSCodeUtils, "showInputBox").resolves(vaultName);
+          sinon.stub(vscode.commands, "executeCommand").resolves({});
+        });
+
+        test("THEN the vault is added to the workspace", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const vaultPath = path.join(wsRoot, vaultName);
+          await createVaultWithGit(vaultPath);
+          const cmd = new AddExistingVaultCommand(
+            ExtensionProvider.getExtension()
+          );
+          sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+          await cmd.run();
+          expect(await fs.pathExists(vaultPath)).toBeTruthy();
+          expect(
+            await fs.pathExists(
+              path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+            )
+          ).toBeFalsy();
+          expect(
+            await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+          ).toBeFalsy();
+        });
+
+        test("THEN the vault was added to the workspace config correctly", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const config = DConfig.getOrCreate(wsRoot);
+          const vault = VaultUtils.getVaultByName({
+            vaults: ConfigUtils.getVaults(config),
+            vname: vaultName,
+          });
+          expect(vault?.selfContained).toBeFalsy();
+          expect(vault?.name).toEqual(vaultName);
+          expect(vault?.fsPath).toEqual(vaultName);
+        });
+      }
+    );
+
+    describeSingleWS(
+      "WHEN adding a local self conatined vault",
+      {
+        modConfigCb: disableSelfContainedVaults,
+        timeout,
+      },
+      () => {
+        const vaultName = "sc-vault";
+        before(() => {
+          sinon.stub(VSCodeUtils, "showQuickPick").resolves({ label: "local" });
+          sinon.stub(VSCodeUtils, "showInputBox").resolves(vaultName);
+          sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+        });
+
+        test("THEN the vault is added to the workspace", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const vaultPath = path.join(wsRoot, vaultName);
+          await createSelfContainedVaultWithGit(vaultPath);
+          const cmd = new AddExistingVaultCommand(
+            ExtensionProvider.getExtension()
+          );
+          sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+          await cmd.run();
+          expect(await fs.pathExists(vaultPath)).toBeTruthy();
+          expect(
+            await fs.pathExists(
+              path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+            )
+          ).toBeTruthy();
+          expect(
+            await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+          ).toBeTruthy();
+        });
+
+        test("THEN the vault was added to the workspace config correctly", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const config = DConfig.getOrCreate(wsRoot);
+          const vault = VaultUtils.getVaultByName({
+            vaults: ConfigUtils.getVaults(config),
+            vname: vaultName,
+          });
+          expect(vault?.selfContained).toBeTruthy();
+          expect(vault?.name).toEqual(vaultName);
+          expect(vault?.fsPath).toEqual(vaultName);
+        });
+        test("THEN the notes in this vault are accessible", async () => {
+          // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+          await new ReloadIndexCommand().run();
+          const { engine, vaults } = ExtensionProvider.getDWorkspace();
+          const vault = VaultUtils.getVaultByName({
+            vaults,
+            vname: vaultName,
+          });
+          expect(vault).toBeTruthy();
+          const note = (
+            await engine.findNotesMeta({ fname: "root", vault })
+          )[0];
+          expect(note).toBeTruthy();
+          expect(note?.vault.name).toEqual(vaultName);
+        });
+      }
+    );
+
+    describeSingleWS(
+      "WHEN vault was already in .gitignore",
+      { timeout, modConfigCb: disableSelfContainedVaults },
+      () => {
+        test("THEN vault is not duplicated", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const vaultPath = path.join(wsRoot, "vaultRemote");
+          const gitIgnore = path.join(wsRoot, ".gitignore");
+          const remoteDir = tmpDir().name;
+
+          await GitTestUtils.createRepoForRemoteWorkspace(wsRoot, remoteDir);
+          await fs.writeFile(gitIgnore, "vaultRemote");
+
+          const cmd = new AddExistingVaultCommand(
+            ExtensionProvider.getExtension()
+          );
+          sinon.stub(cmd, "gatherInputs").returns(
+            Promise.resolve({
+              type: "remote",
+              name: "dendron",
+              path: vaultPath,
+              pathRemote: remoteDir,
+            })
+          );
+          await cmd.run();
+
+          expect(
+            await FileTestUtils.assertTimesInFile({
+              fpath: gitIgnore,
+              match: [[1, "vaultRemote"]],
+            })
+          ).toBeTruthy();
+        });
+      }
+    );
+  });
+});
+
+function enableSelfContainedVaults(config: IntermediateDendronConfig) {
+  config.dev!.enableSelfContainedVaults = true;
+  return config;
+}
+
+function disableSelfContainedVaults(config: IntermediateDendronConfig) {
+  config.dev!.enableSelfContainedVaults = false;
+  return config;
+}
+
+describe("GIVEN Add Existing Vault Command is run with self contained vaults enabled", function () {
+  describeSingleWS(
+    "WHEN adding a standard local vault", // not self conatined
+    {
+      modConfigCb: enableSelfContainedVaults,
+      timeout,
+    },
+    () => {
+      const vaultName = "standard-vault";
+      before(() => {
+        sinon.stub(VSCodeUtils, "showQuickPick").resolves({ label: "local" });
+        sinon.stub(VSCodeUtils, "showInputBox").resolves(vaultName);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN the vault is added to the workspace", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultPath = path.join(wsRoot, vaultName);
+        await createVaultWithGit(vaultPath);
+        const cmd = new AddExistingVaultCommand(
+          ExtensionProvider.getExtension()
+        );
+        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        await cmd.run();
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await fs.pathExists(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeFalsy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeFalsy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        const vault = VaultUtils.getVaultByName({
+          vaults: ConfigUtils.getVaults(config),
+          vname: vaultName,
+        });
+        expect(vault?.selfContained).toBeFalsy();
+        expect(vault?.name).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(vaultName);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN adding a local self conatined vault",
+    {
+      modConfigCb: enableSelfContainedVaults,
+      timeout,
+    },
+    () => {
+      const vaultName = "sc-vault";
+      before(() => {
+        sinon.stub(VSCodeUtils, "showQuickPick").resolves({ label: "local" });
+        sinon.stub(VSCodeUtils, "showInputBox").resolves(vaultName);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN the vault is added to the workspace", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultPath = path.join(wsRoot, vaultName);
+        await createSelfContainedVaultWithGit(vaultPath);
+        const cmd = new AddExistingVaultCommand(
+          ExtensionProvider.getExtension()
+        );
+        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        await cmd.run();
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await fs.pathExists(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeTruthy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeTruthy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        const vault = VaultUtils.getVaultByName({
+          vaults: ConfigUtils.getVaults(config),
+          vname: vaultName,
+        });
+        expect(vault?.selfContained).toBeTruthy();
+        expect(vault?.name).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(vaultName);
+      });
+      test("THEN the notes in this vault are accessible", async () => {
+        // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+        await new ReloadIndexCommand().run();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = VaultUtils.getVaultByName({
+          vaults,
+          vname: vaultName,
+        });
+        expect(vault).toBeTruthy();
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
+        expect(note).toBeTruthy();
+        expect(note?.vault.name).toEqual(vaultName);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN adding a remote self contained vault",
+    { modConfigCb: enableSelfContainedVaults, timeout },
+    () => {
+      let vaultName: string;
+      let remoteDir: string;
+      before(async () => {
+        // Create a self contained vault outside the current workspace
+        remoteDir = tmpDir().name;
+        await createSelfContainedVaultWithGit(remoteDir);
+        vaultName = path.basename(remoteDir);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN the vault is added at the destination folder, and is self contained", async () => {
+        const cmd = new AddExistingVaultCommand(
+          ExtensionProvider.getExtension()
+        );
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        fs.ensureDir(path.join(wsRoot, "testing"));
+        const vaultPath = path.join(wsRoot, "testing", vaultName);
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            type: "remote",
+            name: vaultName,
+            path: vaultPath,
+            pathRemote: remoteDir,
+            isSelfContained: true,
+          })
+        );
+        await cmd.run();
+
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeTruthy();
+        expect(
+          await readYAMLAsync(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeTruthy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        const vault = VaultUtils.getVaultByName({
+          vaults: ConfigUtils.getVaults(config),
+          vname: vaultName,
+        });
+        expect(vault?.selfContained).toBeTruthy();
+        expect(vault?.name).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(`testing/${vaultName}`);
+        expect(vault?.remote?.url).toEqual(remoteDir);
+      });
+
+      test("THEN the notes in this vault are accessible", async () => {
+        // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+        await new ReloadIndexCommand().run();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = VaultUtils.getVaultByName({
+          vaults,
+          vname: vaultName,
+        });
+        expect(vault).toBeTruthy();
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
+        expect(note).toBeTruthy();
+        expect(note?.vault.name).toEqual(vaultName);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN adding a remote workspace vault",
+    { modConfigCb: enableSelfContainedVaults, timeout },
+    () => {
+      let vaultName: string;
+      let remoteDir: string;
+      before(async () => {
+        // Create a self contained vault outside the current workspace
+        remoteDir = tmpDir().name;
+        await createWorkspaceWithGit(remoteDir);
+        vaultName = path.basename(remoteDir);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN the vault added, and is a workspace vault", async () => {
+        const cmd = new AddExistingVaultCommand(
+          ExtensionProvider.getExtension()
+        );
+
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultPath = path.join(wsRoot, vaultName);
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            type: "remote",
+            name: vaultName,
+            path: vaultPath,
+            pathRemote: remoteDir,
+          })
+        );
+        await cmd.run();
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await readYAMLAsync(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeTruthy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeFalsy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        await new ReloadIndexCommand().run();
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        expect(ConfigUtils.getVaults(config).length).toEqual(2);
+        const vault = ConfigUtils.getVaults(config).find(
+          (vault) => vault.workspace === vaultName
+        );
+        expect(vault?.selfContained).toBeFalsy();
+        expect(vault?.fsPath).toEqual("vault");
+        expect(config.workspace.workspaces).toBeTruthy();
+        expect(config.workspace.workspaces![vaultName]).toBeTruthy();
+        expect(config.workspace.workspaces![vaultName]?.remote.url).toEqual(
+          remoteDir
+        );
+        expect(vault?.remote?.url).toBeFalsy();
+      });
+
+      test("THEN the notes in this vault are accessible", async () => {
+        // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+        await new ReloadIndexCommand().run();
+        const { engine, wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        const vault = ConfigUtils.getVaults(config).find(
+          (vault) => vault.workspace === vaultName
+        );
+        expect(vault).toBeTruthy();
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
+        expect(note).toBeTruthy();
+        expect(note?.vault.workspace).toEqual(vaultName);
+      });
+    }
+  );
+
+  describeSingleWS(
+    "WHEN adding a remote regular (non self contained) vault",
+    { modConfigCb: enableSelfContainedVaults, timeout },
+    () => {
+      let vaultName: string;
+      let remoteDir: string;
+      before(async () => {
+        // Create a self contained vault outside the current workspace
+        remoteDir = tmpDir().name;
+        await createVaultWithGit(remoteDir);
+        vaultName = path.basename(remoteDir);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN the vault is added to the workspace, and is a regular vault", async () => {
+        const cmd = new AddExistingVaultCommand(
+          ExtensionProvider.getExtension()
+        );
+
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        fs.ensureDir(path.join(wsRoot, "testing"));
+        const vaultPath = path.join(wsRoot, "testing", vaultName);
+        sinon.stub(cmd, "gatherInputs").returns(
+          Promise.resolve({
+            type: "remote",
+            name: vaultName,
+            path: vaultPath,
+            pathRemote: remoteDir,
+          })
+        );
+        await cmd.run();
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeFalsy();
+        expect(
+          await fs.pathExists(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeFalsy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        expect(ConfigUtils.getVaults(config).length).toEqual(2);
+        const vault = VaultUtils.getVaultByName({
+          vaults: ConfigUtils.getVaults(config),
+          vname: vaultName,
+        });
+
+        expect(vault?.selfContained).toBeFalsy();
+        expect(vault?.fsPath).toEqual(
+          // vault paths always use UNIX style
+          path.posix.join("testing", vaultName)
+        );
+        expect(vault?.remote?.url).toEqual(remoteDir);
+      });
+
+      test("THEN the notes in this vault are accessible", async () => {
+        // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+        await new ReloadIndexCommand().run();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = VaultUtils.getVaultByName({
+          vaults,
+          vname: vaultName,
+        });
+        expect(vault).toBeTruthy();
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
+        expect(note).toBeTruthy();
+        expect(note?.vault.name).toEqual(vaultName);
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/suite-integ/ConvertVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConvertVaultCommand.test.ts
@@ -20,7 +20,7 @@ import { ExtensionProvider } from "../../ExtensionProvider";
 suite("GIVEN ConvertVaultCommand", function () {
   describeMultiWS(
     "WHEN converting a local vault to a remote vault",
-    { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
+    { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti, timeout: 5e3 },
     () => {
       let remote: string;
       before(async () => {

--- a/packages/plugin-core/src/test/suite-integ/ConvertVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/ConvertVaultCommand.test.ts
@@ -4,7 +4,7 @@ import { ENGINE_HOOKS_MULTI, GitTestUtils } from "@dendronhq/engine-test-utils";
 import _ from "lodash";
 import path from "path";
 import sinon from "sinon";
-import { VaultConvertCommand } from "../../commands/VaultConvert";
+import { ConvertVaultCommand } from "../../commands/ConvertVaultCommand";
 import { expect } from "../testUtilsv2";
 import { describeMultiWS } from "../testUtilsV3";
 import fs from "fs-extra";
@@ -17,7 +17,7 @@ import {
 } from "@dendronhq/common-all";
 import { ExtensionProvider } from "../../ExtensionProvider";
 
-suite("GIVEN VaultConvert", function () {
+suite("GIVEN ConvertVaultCommand", function () {
   describeMultiWS(
     "WHEN converting a local vault to a remote vault",
     { preSetupHook: ENGINE_HOOKS_MULTI.setupBasicMulti },
@@ -25,7 +25,7 @@ suite("GIVEN VaultConvert", function () {
       let remote: string;
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+        const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -67,7 +67,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND converting that back to a local vault", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+          const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -115,7 +115,7 @@ suite("GIVEN VaultConvert", function () {
       let remote: string;
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+        const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
         sinon.stub(cmd, "promptForFolderMove").resolves(true);
@@ -180,7 +180,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND converting that back to a local vault", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+          const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("local");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
           sinon.stub(cmd, "promptForFolderMove").resolves(true);
@@ -237,7 +237,7 @@ suite("GIVEN VaultConvert", function () {
     () => {
       before(async () => {
         const { vaults } = ExtensionProvider.getDWorkspace();
-        const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+        const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
         sinon.stub(cmd, "gatherType").resolves("remote");
         sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 
@@ -261,7 +261,7 @@ suite("GIVEN VaultConvert", function () {
       describe("AND running the conversion command again", () => {
         before(async () => {
           const { vaults } = ExtensionProvider.getDWorkspace();
-          const cmd = new VaultConvertCommand(ExtensionProvider.getExtension());
+          const cmd = new ConvertVaultCommand(ExtensionProvider.getExtension());
           sinon.stub(cmd, "gatherType").resolves("remote");
           sinon.stub(cmd, "gatherVault").resolves(vaults[0]);
 

--- a/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
@@ -1,8 +1,8 @@
 import {
   ConfigUtils,
   CONSTANTS,
+  DendronConfig,
   FOLDERS,
-  IntermediateDendronConfig,
   VaultUtils,
 } from "@dendronhq/common-all";
 import { DConfig, readYAMLAsync, vault2Path } from "@dendronhq/common-server";
@@ -63,12 +63,12 @@ suite("CreateNewVault Command", function () {
   });
 });
 
-function enableSelfCOntainedVaults(config: IntermediateDendronConfig) {
+function enableSelfCOntainedVaults(config: DendronConfig) {
   config.dev!.enableSelfContainedVaults = true;
   return config;
 }
 
-function disableSelfContainedVaults(config: IntermediateDendronConfig) {
+function disableSelfContainedVaults(config: DendronConfig) {
   config.dev!.enableSelfContainedVaults = false;
   return config;
 }

--- a/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
@@ -20,7 +20,7 @@ import { expect } from "../testUtilsv2";
 import { describeSingleWS } from "../testUtilsV3";
 
 suite("CreateNewVault Command", function () {
-  describe("GIVEN Create new vault command is run within a workspace with ", () => {
+  describe("GIVEN Create new vault command is run within a workspace", () => {
     describeSingleWS(
       "WHEN ran inside a workspace with dev.enableSelfContainedVaults config set to false",
       { modConfigCb: disableSelfContainedVaults, timeout: 1e4 },
@@ -29,7 +29,7 @@ suite("CreateNewVault Command", function () {
           sinon.stub(VSCodeUtils, "showInputBox").resolves();
           sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
         });
-        test("THEN create a new standard vault", async () => {
+        test("THEN create a new standard vault at selected destination", async () => {
           const { wsRoot } = ExtensionProvider.getDWorkspace();
           const vpath = path.join(wsRoot, "vault2");
           const cmd = new CreateNewVaultCommand(
@@ -87,11 +87,15 @@ describe("GIVEN Create existing vault command is run with self contained vaults 
         sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
       });
 
-      test("THEN new vault is created, and is self contained", async () => {
+      test("THEN new vault is created in dependencies/localhost folder, and is self contained", async () => {
         const cmd = new CreateNewVaultCommand(ExtensionProvider.getExtension());
         const { wsRoot } = ExtensionProvider.getDWorkspace();
-        const vaultPath = path.join(wsRoot, vaultName);
-        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        const vaultPath = path.join(
+          wsRoot,
+          FOLDERS.DEPENDENCIES,
+          FOLDERS.LOCAL_DEPENDENCY,
+          vaultName
+        );
         await cmd.run();
 
         expect(await fs.pathExists(vaultPath)).toBeTruthy();
@@ -114,6 +118,14 @@ describe("GIVEN Create existing vault command is run with self contained vaults 
         });
         expect(vault?.selfContained).toBeTruthy();
         expect(vault?.name).toEqual(vaultName);
+        expect(vault?.fsPath).toEqual(
+          // vault paths always use UNIX style
+          path.posix.join(
+            FOLDERS.DEPENDENCIES,
+            FOLDERS.LOCAL_DEPENDENCY,
+            vaultName
+          )
+        );
       });
 
       test("THEN the notes in this vault are accessible", async () => {

--- a/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
@@ -23,11 +23,11 @@ suite("CreateNewVault Command", function () {
   describe("GIVEN Create new vault command is run within a workspace with ", () => {
     describeSingleWS(
       "WHEN ran inside a workspace with dev.enableSelfContainedVaults config set to false",
-      { modConfigCb: disableSelfContainedVaults, timeout: 5e3 },
+      { modConfigCb: disableSelfContainedVaults, timeout: 1e4 },
       () => {
         before(async () => {
+          sinon.stub(VSCodeUtils, "showInputBox").resolves();
           sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
-          sinon.stub(VSCodeUtils, "showInputBox").resolves("vault2");
         });
         test("THEN create a new standard vault", async () => {
           const { wsRoot } = ExtensionProvider.getDWorkspace();

--- a/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/CreateNewVaultCommand.test.ts
@@ -1,0 +1,134 @@
+import {
+  ConfigUtils,
+  CONSTANTS,
+  FOLDERS,
+  IntermediateDendronConfig,
+  VaultUtils,
+} from "@dendronhq/common-all";
+import { DConfig, readYAMLAsync, vault2Path } from "@dendronhq/common-server";
+import { checkVaults } from "@dendronhq/engine-test-utils";
+import fs from "fs-extra";
+import { before, describe } from "mocha";
+import path from "path";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { CreateNewVaultCommand } from "../../commands/CreateNewVaultCommand";
+import { ReloadIndexCommand } from "../../commands/ReloadIndex";
+import { ExtensionProvider } from "../../ExtensionProvider";
+import { VSCodeUtils } from "../../vsCodeUtils";
+import { expect } from "../testUtilsv2";
+import { describeSingleWS } from "../testUtilsV3";
+
+suite("CreateNewVault Command", function () {
+  describe("GIVEN Create new vault command is run within a workspace with ", () => {
+    describeSingleWS(
+      "WHEN ran inside a workspace with dev.enableSelfContainedVaults config set to false",
+      { modConfigCb: disableSelfContainedVaults, timeout: 5e3 },
+      () => {
+        before(async () => {
+          sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+          sinon.stub(VSCodeUtils, "showInputBox").resolves("vault2");
+        });
+        test("THEN create a new standard vault", async () => {
+          const { wsRoot } = ExtensionProvider.getDWorkspace();
+          const vpath = path.join(wsRoot, "vault2");
+          const cmd = new CreateNewVaultCommand(
+            ExtensionProvider.getExtension()
+          );
+          sinon.stub(cmd, "gatherDestinationFolder").resolves(vpath);
+          await cmd.run();
+
+          const vaultsAfter = ExtensionProvider.getDWorkspace().vaults;
+
+          expect(vaultsAfter.length).toEqual(2);
+          expect(
+            await fs.readdir(vault2Path({ vault: vaultsAfter[1], wsRoot }))
+          ).toEqual([
+            ".dendron.cache.json",
+            ".vscode",
+            "assets",
+            "root.md",
+            "root.schema.yml",
+          ]);
+          await checkVaults(
+            {
+              wsRoot,
+              vaults: vaultsAfter,
+            },
+            expect
+          );
+        });
+      }
+    );
+  });
+});
+
+function enableSelfCOntainedVaults(config: IntermediateDendronConfig) {
+  config.dev!.enableSelfContainedVaults = true;
+  return config;
+}
+
+function disableSelfContainedVaults(config: IntermediateDendronConfig) {
+  config.dev!.enableSelfContainedVaults = false;
+  return config;
+}
+
+describe("GIVEN Create existing vault command is run with self contained vaults enabled", function () {
+  describeSingleWS(
+    "WHEN creating a vault",
+    {
+      modConfigCb: enableSelfCOntainedVaults,
+      timeout: 5e3,
+    },
+    () => {
+      const vaultName = "my-self-contained-vault";
+      before(async () => {
+        sinon.stub(VSCodeUtils, "showInputBox").resolves(vaultName);
+        sinon.stub(vscode.commands, "executeCommand").resolves({}); // stub reload window
+      });
+
+      test("THEN new vault is created, and is self contained", async () => {
+        const cmd = new CreateNewVaultCommand(ExtensionProvider.getExtension());
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const vaultPath = path.join(wsRoot, vaultName);
+        sinon.stub(cmd, "gatherDestinationFolder").resolves(vaultPath);
+        await cmd.run();
+
+        expect(await fs.pathExists(vaultPath)).toBeTruthy();
+        expect(
+          await readYAMLAsync(
+            path.join(vaultPath, CONSTANTS.DENDRON_CONFIG_FILE)
+          )
+        ).toBeTruthy();
+        expect(
+          await fs.pathExists(path.join(vaultPath, FOLDERS.NOTES))
+        ).toBeTruthy();
+      });
+
+      test("THEN the vault was added to the workspace config correctly", async () => {
+        const { wsRoot } = ExtensionProvider.getDWorkspace();
+        const config = DConfig.getOrCreate(wsRoot);
+        const vault = VaultUtils.getVaultByName({
+          vaults: ConfigUtils.getVaults(config),
+          vname: vaultName,
+        });
+        expect(vault?.selfContained).toBeTruthy();
+        expect(vault?.name).toEqual(vaultName);
+      });
+
+      test("THEN the notes in this vault are accessible", async () => {
+        // Since we mock the reload window, need to reload index here to pick up the notes in the new vault
+        await new ReloadIndexCommand().run();
+        const { engine, vaults } = ExtensionProvider.getDWorkspace();
+        const vault = VaultUtils.getVaultByName({
+          vaults,
+          vname: vaultName,
+        });
+        expect(vault).toBeTruthy();
+        const note = (await engine.findNotesMeta({ fname: "root", vault }))[0];
+        expect(note).toBeTruthy();
+        expect(note?.vault.name).toEqual(vaultName);
+      });
+    }
+  );
+});

--- a/packages/plugin-core/src/test/suite-integ/RemoveVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RemoveVaultCommand.test.ts
@@ -80,8 +80,12 @@ function getWorkspaceFile() {
 }
 
 suite("GIVEN RemoveVaultCommand", function () {
+  let executeCmdStub: sinon.SinonStub;
   this.beforeEach(() => {
-    sinon.stub(vscode.commands, "executeCommand").resolves({});
+    executeCmdStub = sinon.stub(vscode.commands, "executeCommand").resolves({});
+  });
+  this.afterEach(() => {
+    executeCmdStub.restore();
   });
 
   describeMultiWS("WHEN removing a workspace vault", {}, () => {

--- a/packages/plugin-core/src/test/suite-integ/RemoveVaultCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RemoveVaultCommand.test.ts
@@ -24,7 +24,7 @@ import path from "path";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { VaultAddCommand } from "../../commands/VaultAddCommand";
-import { VaultRemoveCommand } from "../../commands/VaultRemoveCommand";
+import { RemoveVaultCommand } from "../../commands/RemoveVaultCommand";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { DendronExtension } from "../../workspace";
@@ -79,7 +79,7 @@ function getWorkspaceFile() {
   return settings;
 }
 
-suite("GIVEN VaultRemoveCommand", function () {
+suite("GIVEN RemoveVaultCommand", function () {
   this.beforeEach(() => {
     sinon.stub(vscode.commands, "executeCommand").resolves({});
   });
@@ -95,7 +95,7 @@ suite("GIVEN VaultRemoveCommand", function () {
         wsName: remoteWsName,
       });
       stubQuickPick({ fsPath: remoteVaultName, workspace: remoteWsName });
-      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+      await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
       const config = getConfig();
       expect(ConfigUtils.getVaults(config)).toEqual(vaults);
       expect(ConfigUtils.getWorkspace(config).workspaces).toEqual({});
@@ -112,11 +112,11 @@ suite("GIVEN VaultRemoveCommand", function () {
       const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
       const vaultToRemove = vaults[1];
       sinon.stub(VSCodeUtils, "showQuickPick").resolves({
-        // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+        // RemoveVaultCommand uses this internally, but TypeScript doesn't recognize it for the stub
         // @ts-ignore
         data: vaultToRemove,
       });
-      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+      await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
       // Shouldn't delete the actual files
       expect(
@@ -186,11 +186,11 @@ suite("GIVEN VaultRemoveCommand", function () {
           expect(preRunConfig.workspace.vaults.length).toEqual(3);
 
           sinon.stub(VSCodeUtils, "showQuickPick").resolves({
-            // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+            // RemoveVaultCommand uses this internally, but TypeScript doesn't recognize it for the stub
             // @ts-ignore
             data: vaultToRemove,
           });
-          await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+          await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
           // after remove, we have 2 vaults in dendron.yml
           const postRunConfig = DConfig.readConfigSync(wsRoot);
@@ -213,11 +213,11 @@ suite("GIVEN VaultRemoveCommand", function () {
         const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
         const vaultToRemove = vaults[1];
         sinon.stub(VSCodeUtils, "showQuickPick").resolves({
-          // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+          // RemoveVaultCommand uses this internally, but TypeScript doesn't recognize it for the stub
           // @ts-ignore
           data: vaultToRemove,
         });
-        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+        await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
         // Shouldn't delete the actual files
         expect(
@@ -254,11 +254,11 @@ suite("GIVEN VaultRemoveCommand", function () {
         const { vaults, wsRoot } = ExtensionProvider.getDWorkspace();
         const vaultToRemove = vaults[0];
         sinon.stub(VSCodeUtils, "showQuickPick").resolves({
-          // VaultRemoveCommand uses this internally, but TypeScript doesn't recognize it for the stub
+          // RemoveVaultCommand uses this internally, but TypeScript doesn't recognize it for the stub
           // @ts-ignore
           data: vaultToRemove,
         });
-        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+        await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
         // Shouldn't delete the actual files
         expect(
@@ -308,7 +308,7 @@ suite("GIVEN VaultRemoveCommand", function () {
       VSCodeUtils.showQuickPick = () => {
         return { data: vaultsAfter[1] };
       };
-      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+      await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
       const configNew = readYAML(configPath) as DendronConfig;
       // confirm that duplicateNoteBehavior setting is gone
@@ -345,7 +345,7 @@ suite("GIVEN VaultRemoveCommand", function () {
       VSCodeUtils.showQuickPick = () => {
         return { data: vaultsAfter[1] };
       };
-      await new VaultRemoveCommand(ExtensionProvider.getExtension()).run();
+      await new RemoveVaultCommand(ExtensionProvider.getExtension()).run();
 
       const config = DConfig.getRaw(wsRoot) as DendronConfig;
 
@@ -365,7 +365,7 @@ suite("GIVEN VaultRemoveCommand", function () {
         const args = {
           fsPath: path.join(wsRoot, vaults[1].fsPath),
         };
-        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run(
+        await new RemoveVaultCommand(ExtensionProvider.getExtension()).run(
           args
         );
         const config = getConfig();
@@ -390,7 +390,7 @@ suite("GIVEN VaultRemoveCommand", function () {
         const args = {
           fsPath: path.join(wsRoot, remoteWsName, remoteVaultName),
         };
-        await new VaultRemoveCommand(ExtensionProvider.getExtension()).run(
+        await new RemoveVaultCommand(ExtensionProvider.getExtension()).run(
           args
         );
         const config = getConfig();

--- a/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WorkspaceWatcher.test.ts
@@ -240,6 +240,7 @@ suite("WorkspaceWatcher", function () {
     "GIVEN a basic setup on a single vault workspace",
     {
       postSetupHook: setupBasic,
+      timeout: 5e3,
     },
     () => {
       test("WHEN user saves a file and content has not changed, THEN updated timestamp in frontmatter is not updated", async () => {


### PR DESCRIPTION
This PR aims to 
- fix an windows path issue: https://github.com/dendronhq/dendron/issues/3648
- Adds a new `Create New Vault command`
- Adds a new `Add Existing Vault command`
- Adds a deprecation toaster for `Vault Add` command
- Updates `Vault Remove, Vault Convert` command to have {Verb} {noun} format: `Convert Vault, Remove Vault`
- Docs: https://github.com/dendronhq/dendron-site/pull/675

## Summary
- Create New Vault
when config option `enableSelfConatinedVaults` is set to false: prompt user to select destination folder, create new vault there.
when enableSelfConatinedVaults is set to true, always create a new vault at dependencies/localhost.

- Add Existing vault 
when config option `enableSelfConatinedVaults` is set to false and is a local vault, add the existing vault to the workspace, when enableSelfConatinedVaults is set to false, copy the destination folder to dependencies/localhost and update this path in `dendron.yml`


**BREAKING CHANGES**: Vault Remove, Vault Convert commands are now Remove Vault and Convert Vault respectively. Vault Add is now deprecated and will be removed in future.

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended


## Docs
- [x] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)