### PR TITLE
fix: npm overrides for packages with vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,5 +148,9 @@
   "resolutions": {
     "trim": "0.0.3",
     "d3-color": "3.1.0"
+  },
+  "overrides": {
+    "trim": "0.0.3",
+    "d3-color": "3.1.0"
   }
 }


### PR DESCRIPTION
## fix: npm overrides for packages with vulnerabilities

Quick fix to add an overrides field for packages with vulnerabilities. This is in addition to the 'resolutions' field which was previously added, but 'resolutions' is only recognized by yarn and not npm. 

This is an attempted fix at the vulnerabilities warning in dendron-cli.