### PR TITLE
chore(build): disable nightly workflow in forks

### DIFF
--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build:
+    # Don't run this job outside of the Dendronhq organization https://github.com/prisma/prisma/issues/3539#issuecomment-690260573
+    if: github.repository_owner == 'dendronhq'
+  
     environment: plugin-production
 
     timeout-minutes: 30


### PR DESCRIPTION
## Motivation

Noticed after forking dendron that I was getting a github actions error message once per evening about a failing publish job.

## Commit

- [ ] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)
- [x] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/QN46JTSWpEkDkr94TJ85w)
- [x] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
  - Fixes https://github.com/dendronhq/dendron/issues/3674

## Code

- [x] code should follow [Code Conventions](https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e)
- [ ] sticking to existing conventions instead of creating new ones 

## Tests

N/A, doesn't modify application code . 

## Docs

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR (NOTE: submit the PR against the `dev` branch of the dendron-site repo)  (no)


- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/ce9b9b29-d85b-492b-b76d-5e0c5dc52b03) or [Packages](https://wiki.dendron.so/notes/ok9ifke0zsfxnnh7xog79z5) (no)

## Notes

- Credit for the fix comes from https://github.com/prisma/prisma/issues/3539#issuecomment-690260573