### PR TITLE
enhance: experimental inline note references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ publish-local:
 
 build-plugin:
 	dendron dev prep_plugin && rm package.json
-	dendron dev package_plugin
+	env FAST=1 SKIP_SENTRY=1 LOG_LEVEL=info dendron dev package_plugin
 
 docs-push:
 	cd docs && zip -r generated-api-docs.zip generated-api-docs

--- a/packages/common-all/src/constants/configs/dev.ts
+++ b/packages/common-all/src/constants/configs/dev.ts
@@ -42,4 +42,8 @@ export const DEV: DendronConfigEntryCollection<DendronDevConfig> = {
     label: "Enable Engine V3",
     desc: "Uses engine v3 as default backend",
   },
+  enableExperimentalInlineNoteRef: {
+    label: "Enable inline note references.",
+    desc: "Uses inline note references in Editor",
+  },
 };

--- a/packages/common-all/src/types/configs/dev/DendronDevConfig.ts
+++ b/packages/common-all/src/types/configs/dev/DendronDevConfig.ts
@@ -54,6 +54,10 @@ export type DendronDevConfig = {
    * False (Default) -> Continue to use engine v3 as backend
    */
   enableEngineV3?: boolean;
+  /**
+   * Feature flag to enable note references
+   */
+  enableExperimentalInlineNoteRef?: boolean;
 };
 
 /**

--- a/packages/common-all/src/types/editor.ts
+++ b/packages/common-all/src/types/editor.ts
@@ -7,6 +7,7 @@ export enum DECORATION_TYPES {
   wikiLink = "wikiLink",
   brokenWikilink = "brokenWikilink",
   noteRef = "noteRef",
+  brokenNoteRef = "brokenNoteRef",
   alias = "alias",
   taskNote = "taskNote",
 }

--- a/packages/common-all/src/types/editor.ts
+++ b/packages/common-all/src/types/editor.ts
@@ -6,6 +6,7 @@ export enum DECORATION_TYPES {
   blockAnchor = "blockAnchor",
   wikiLink = "wikiLink",
   brokenWikilink = "brokenWikilink",
+  noteRef = "noteRef",
   alias = "alias",
   taskNote = "taskNote",
 }

--- a/packages/common-all/src/types/editor.ts
+++ b/packages/common-all/src/types/editor.ts
@@ -11,7 +11,8 @@ export enum DECORATION_TYPES {
   taskNote = "taskNote",
 }
 
-export type Decoration = {
+export type Decoration<T = any> = {
   type: DECORATION_TYPES;
   range: VSRange;
+  data?: T;
 };

--- a/packages/common-all/src/util/index.ts
+++ b/packages/common-all/src/util/index.ts
@@ -14,11 +14,11 @@ export * from "./treeUtil";
 export class DefaultMap<K = string, V = any> extends Map<K, V> {
   private defaultMethod: () => V;
 
-  get(key: K) {
+  get(key: K): V {
     if (!this.has(key)) {
       this.set(key, this.defaultMethod());
     }
-    return super.get(key);
+    return super.get(key) as V;
   }
   constructor(defaultMethod: () => V) {
     super();

--- a/packages/common-all/src/util/index.ts
+++ b/packages/common-all/src/util/index.ts
@@ -1,9 +1,27 @@
-export * from "./responseUtil";
-export * from "./orderedMatchter";
+export { URI } from "vscode-uri";
 export * from "./cache";
 export * from "./compat";
-export * from "./regex";
 export * from "./dateFormatUtil";
-export * from "./treeUtil";
+export * from "./orderedMatchter";
+export * from "./regex";
+export * from "./responseUtil";
 export * from "./stringUtil";
-export { URI } from "vscode-uri";
+export * from "./treeUtil";
+
+/**
+ * Defaultdict from Python
+ */
+export class DefaultMap<K = string, V = any> extends Map<K, V> {
+  private defaultMethod: () => V;
+
+  get(key: K) {
+    if (!this.has(key)) {
+      this.set(key, this.defaultMethod());
+    }
+    return super.get(key);
+  }
+  constructor(defaultMethod: () => V) {
+    super();
+    this.defaultMethod = defaultMethod;
+  }
+}

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -189,65 +189,6 @@ export function makeColorTranslucent(color: string, translucency: number) {
   return color;
 }
 
-/** A map that automatically inserts a value provided by the factory when a missing key is looked up.
- *
- * Modeled after python's `defaultdict`.
- *
- * Mind that `get` may mutate the map, which may be unintuitive.
- *
- * Example usage:
- *
- * ```ts
- * const myMap = new DefaultMap<string, string[]>(() => []);
- * myMap.get("foo").push("bar");
- * ```
- */
-export class DefaultMap<K, V> {
-  private _internalMap = new Map<K, V>();
-  private _factory: (key: K) => V;
-
-  public constructor(factory: (key: K) => V) {
-    this._factory = factory;
-  }
-
-  public get(key: K) {
-    let value = this._internalMap.get(key);
-    if (_.isUndefined(value)) {
-      value = this._factory(key);
-      this._internalMap.set(key, value);
-    }
-    return value;
-  }
-
-  public set(key: K, value: V) {
-    return this._internalMap.set(key, value);
-  }
-
-  public has(key: K) {
-    return this._internalMap.has(key);
-  }
-
-  public keys() {
-    return this._internalMap.keys();
-  }
-
-  public values() {
-    return this._internalMap.values();
-  }
-
-  public entries() {
-    return this._internalMap.entries();
-  }
-
-  public delete(key: K) {
-    return this._internalMap.delete(key);
-  }
-
-  public get size() {
-    return this._internalMap.size;
-  }
-}
-
 /** Memoizes function results, but allows a custom function to decide if the
  * value needs to be recalculated.
  *

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -464,8 +464,8 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       );
       await TimeUtils.sleep(2 * 60 * 1000);
     } else {
-      this.print("sleeping 6s for local npm registry to have packages ready");
-      await TimeUtils.sleep(6 * 1000);
+      this.print("sleeping 20s for local npm registry to have packages ready");
+      await TimeUtils.sleep(20 * 1000);
     }
 
     this.print("install deps...");

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -464,7 +464,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       );
       await TimeUtils.sleep(2 * 60 * 1000);
     } else {
-      const localSleepSeconds = 10;
+      const localSleepSeconds = 15;
       this.print(
         `sleeping ${localSleepSeconds}s for local npm registry to have packages ready`
       );

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -464,8 +464,11 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       );
       await TimeUtils.sleep(2 * 60 * 1000);
     } else {
-      this.print("sleeping 20s for local npm registry to have packages ready");
-      await TimeUtils.sleep(20 * 1000);
+      const localSleepSeconds = 10;
+      this.print(
+        `sleeping ${localSleepSeconds}s for local npm registry to have packages ready`
+      );
+      await TimeUtils.sleep(localSleepSeconds * 1000);
     }
 
     this.print("install deps...");

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -26,6 +26,10 @@ export class ExtensionProvider {
     return ExtensionProvider.extension;
   }
 
+  static getState() {
+    return ExtensionProvider.extension.getState();
+  }
+
   static getDWorkspace() {
     return ExtensionProvider.getExtension().getDWorkspace();
   }

--- a/packages/plugin-core/src/ExtensionProvider.ts
+++ b/packages/plugin-core/src/ExtensionProvider.ts
@@ -26,8 +26,8 @@ export class ExtensionProvider {
     return ExtensionProvider.extension;
   }
 
-  static getState() {
-    return ExtensionProvider.extension.getState();
+  static getCommentThreadsState() {
+    return ExtensionProvider.extension.getCommentThreadsState();
   }
 
   static getDWorkspace() {

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -81,7 +81,7 @@ export interface IDendronExtension {
   pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
 
   getClientAPIRootUrl(): Promise<string>;
-  getState(): {
+  getCommentThreadsState(): {
     inlineNoteRefs: DefaultMap<string, Map<string, vscode.CommentThread>>;
   };
 

--- a/packages/plugin-core/src/dendronExtensionInterface.ts
+++ b/packages/plugin-core/src/dendronExtensionInterface.ts
@@ -1,10 +1,11 @@
 import {
+  DefaultMap,
   DWorkspaceV2,
   WorkspaceSettings,
   WorkspaceType,
 } from "@dendronhq/common-all";
 import { execa, IWorkspaceService } from "@dendronhq/engine-server";
-import vscode from "vscode";
+import vscode, { CommentController } from "vscode";
 import { ILookupControllerV3Factory } from "./components/lookup/LookupControllerV3Interface";
 import {
   INoteLookupProviderFactory,
@@ -70,6 +71,7 @@ export interface IDendronExtension {
   noteLookupProviderFactory: INoteLookupProviderFactory;
   schemaLookupProviderFactory: ISchemaLookupProviderFactory;
   workspaceImpl?: DWorkspaceV2;
+  noteRefCommentController: CommentController;
 
   activateWatchers(): Promise<void>;
   /**
@@ -79,6 +81,9 @@ export interface IDendronExtension {
   pauseWatchers<T = void>(cb: () => Promise<T>): Promise<T>;
 
   getClientAPIRootUrl(): Promise<string>;
+  getState(): {
+    inlineNoteRefs: DefaultMap<string, Map<string, vscode.CommentThread>>;
+  };
 
   /** Shorthand for previously existing function getWorkspaceImplOrThrow() */
   getDWorkspace(): DWorkspaceV2;

--- a/packages/plugin-core/src/features/NoteRefComment.ts
+++ b/packages/plugin-core/src/features/NoteRefComment.ts
@@ -1,0 +1,24 @@
+import { RenderNoteResp } from "@dendronhq/common-all";
+import {
+  Comment,
+  CommentAuthorInformation,
+  CommentMode,
+  MarkdownString,
+} from "vscode";
+
+export class NoteRefComment implements Comment {
+  public body: MarkdownString;
+  public mode: CommentMode;
+  public author: CommentAuthorInformation;
+
+  constructor(renderResp: RenderNoteResp) {
+    this.mode = CommentMode.Preview;
+    this.author = { name: "" };
+    const mdString = renderResp.error
+      ? new MarkdownString(`Error: ${renderResp.error}`)
+      : new MarkdownString(renderResp.data);
+    mdString.supportHtml = true;
+    mdString.isTrusted = true;
+    this.body = mdString;
+  }
+}

--- a/packages/plugin-core/src/features/ReferenceHoverProvider.ts
+++ b/packages/plugin-core/src/features/ReferenceHoverProvider.ts
@@ -197,7 +197,7 @@ export default class ReferenceHoverProvider implements vscode.HoverProvider {
         note = maybeNotes[0];
       }
 
-      // For notes, let's use the noteRef functionality to render the referenced portion.
+      // For notes, let's use the noteRef functionality to render the referenced portion. ^tiagtt7sjzyw
       const referenceText = ["![["];
       if (refAtPos.vaultName)
         referenceText.push(`dendron://${refAtPos.vaultName}/`);

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -388,22 +388,24 @@ export async function updateDecorations(editor: TextEditor): Promise<{
     }
 
     // begin: apply inline note refs
-    const noteRefDecorators: DendronNoteRefDecoration[] =
-      vscodeDecorations.filter((ent) => {
-        return ent.type === EDITOR_DECORATION_TYPES.noteRef;
-      }) as DendronNoteRefDecoration[];
+    if (config.dev?.enableExperimentalInlineNoteRef) {
+      const noteRefDecorators: DendronNoteRefDecoration[] =
+        vscodeDecorations.filter((ent) => {
+          return ent.type === EDITOR_DECORATION_TYPES.noteRef;
+        }) as DendronNoteRefDecoration[];
 
-    Logger.debug({
-      ctx,
-      msg: "noteRefDecorators",
-      noteRefDecorators: noteRefDecorators.map((ent) => {
-        return { range: ent.decoration.range, link: ent.data.link };
-      }),
-    });
-    await addInlineNoteRefs({
-      decorations: noteRefDecorators,
-      document: editor.document,
-    });
+      Logger.debug({
+        ctx,
+        msg: "noteRefDecorators",
+        noteRefDecorators: noteRefDecorators.map((ent) => {
+          return { range: ent.decoration.range, link: ent.data.link };
+        }),
+      });
+      await addInlineNoteRefs({
+        decorations: noteRefDecorators,
+        document: editor.document,
+      });
+    }
 
     // Clear out any old decorations left over from last pass
     for (const type of _.values(EDITOR_DECORATION_TYPES)) {

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -142,7 +142,7 @@ function renderNoteRef({
     id: fakeNote.id,
     note: fakeNote,
     dest: DendronASTDest.HTML,
-    flavor: ProcFlavor.PREVIEW,
+    flavor: ProcFlavor.HOVER_PREVIEW,
   });
 }
 
@@ -187,6 +187,7 @@ export class NoteRefComment implements Comment {
       ? new MarkdownString(`Error: ${renderResp.error}`)
       : new MarkdownString(renderResp.data);
     mdString.supportHtml = true;
+    mdString.isTrusted = true;
     this.body = mdString;
   }
 }

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -280,7 +280,6 @@ async function addInlineNoteRefs(opts: {
           [new NoteRefComment(renderResp)]
         );
         thread.canReply = false;
-        thread.collapsibleState = CommentThreadCollapsibleState.Expanded;
         thread.label = ent.data.noteMeta.title;
         newNoteRefThreadMap.set(key, thread);
       }

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -137,6 +137,7 @@ function renderNoteRef({
     // And using the reference as the text of the note
     contents: reference,
   });
+  fakeNote.config = { global: { enablePrettyRefs: false } };
   return engine.renderNote({
     id: fakeNote.id,
     note: fakeNote,

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -32,7 +32,6 @@ import {
   Comment,
   CommentAuthorInformation,
   CommentMode,
-  CommentThreadCollapsibleState,
   DecorationOptions,
   DecorationRangeBehavior,
   Diagnostic,

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -80,10 +80,6 @@ export const EDITOR_DECORATION_TYPES: {
     color: new ThemeColor("editorLink.activeForeground"),
     rangeBehavior: DecorationRangeBehavior.ClosedClosed,
   }),
-  noteRef: window.createTextEditorDecorationType({
-    color: new ThemeColor("editorLink.activeForeground"),
-    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
-  }),
   /** Decoration for wikilinks that do *not* point to valid notes (e.g. broken). */
   brokenWikilink: window.createTextEditorDecorationType({
     color: new ThemeColor("editorWarning.foreground"),
@@ -93,6 +89,15 @@ export const EDITOR_DECORATION_TYPES: {
   /** Decoration for the alias part of wikilinks. */
   alias: window.createTextEditorDecorationType({
     fontStyle: "italic",
+  }),
+  noteRef: window.createTextEditorDecorationType({
+    color: new ThemeColor("editorLink.activeForeground"),
+    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
+  }),
+  brokenNoteRef: window.createTextEditorDecorationType({
+    color: new ThemeColor("editorWarning.foreground"),
+    backgroundColor: new ThemeColor("editorWarning.background"),
+    rangeBehavior: DecorationRangeBehavior.ClosedClosed,
   }),
   taskNote: window.createTextEditorDecorationType({
     rangeBehavior: DecorationRangeBehavior.ClosedClosed,
@@ -441,6 +446,7 @@ function mapDecoration(decoration: Decoration): DendronDecoration | undefined {
     // Some decoration types require special processing to add per-decoration data
     case DECORATION_TYPES.timestamp:
       return mapTimestamp(decoration as DecorationTimestamp);
+    case DECORATION_TYPES.brokenNoteRef:
     case DECORATION_TYPES.noteRef:
       return mapNoteRefLink(decoration as NoteRefDecorator);
     case DECORATION_TYPES.brokenWikilink: // fallthrough deliberate

--- a/packages/plugin-core/src/features/windowDecorations.ts
+++ b/packages/plugin-core/src/features/windowDecorations.ts
@@ -13,7 +13,6 @@ import {
   NotePropsMeta,
   NoteUtils,
   ProcFlavor,
-  RenderNoteResp,
 } from "@dendronhq/common-all";
 import { DConfig } from "@dendronhq/common-server";
 import {
@@ -29,13 +28,9 @@ import {
 import * as Sentry from "@sentry/node";
 import _ from "lodash";
 import {
-  Comment,
-  CommentAuthorInformation,
-  CommentMode,
   DecorationOptions,
   DecorationRangeBehavior,
   Diagnostic,
-  MarkdownString,
   Range,
   TextDocument,
   TextEditor,
@@ -48,6 +43,7 @@ import { Logger } from "../logger";
 import { CodeConfigKeys, DateTimeFormat } from "../types";
 import { delayedFrontmatterWarning } from "../utils/frontmatter";
 import { VSCodeUtils } from "../vsCodeUtils";
+import { NoteRefComment } from "./NoteRefComment";
 
 /** Wait this long in miliseconds before trying to update decorations when a command forces a decoration update. */
 const DECORATION_UPDATE_DELAY = 100;
@@ -180,29 +176,13 @@ export const debouncedUpdateDecorations = debounceAsyncUntilComplete({
   trailing: true,
 });
 
-export class NoteRefComment implements Comment {
-  public body: MarkdownString;
-  public mode: CommentMode;
-  public author: CommentAuthorInformation;
-
-  constructor(renderResp: RenderNoteResp) {
-    this.mode = CommentMode.Preview;
-    this.author = { name: "" };
-    const mdString = renderResp.error
-      ? new MarkdownString(`Error: ${renderResp.error}`)
-      : new MarkdownString(renderResp.data);
-    mdString.supportHtml = true;
-    mdString.isTrusted = true;
-    this.body = mdString;
-  }
-}
-
 async function addInlineNoteRefs(opts: {
   decorations: DendronNoteRefDecoration[];
   document: TextDocument;
 }) {
   const ctx = "addInlineNoteRefs";
-  const inlineNoteRefs = ExtensionProvider.getState().inlineNoteRefs;
+  const inlineNoteRefs =
+    ExtensionProvider.getCommentThreadsState().inlineNoteRefs;
   const docKey = opts.document.uri.toString();
   const lastNoteRefThreadMap = inlineNoteRefs.get(docKey);
   const newNoteRefThreadMap = new Map();

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -85,7 +85,7 @@ export class MockDendronExtension implements IDendronExtension {
     throw new Error("Method not implemented in MockDendronExtension");
   }
 
-  getState(): {
+  getCommentThreadsState(): {
     inlineNoteRefs: DefaultMap<string, Map<string, CommentThread>>;
   } {
     throw new Error("Method not implemented in MockDendronExtension.");

--- a/packages/plugin-core/src/test/MockDendronExtension.ts
+++ b/packages/plugin-core/src/test/MockDendronExtension.ts
@@ -1,4 +1,5 @@
 import {
+  DefaultMap,
   DEngineClient,
   DVault,
   DWorkspaceV2,
@@ -7,6 +8,8 @@ import {
 } from "@dendronhq/common-all";
 import { IWorkspaceService, WorkspaceService } from "@dendronhq/engine-server";
 import {
+  CommentController,
+  CommentThread,
   Disposable,
   ExtensionContext,
   FileSystemWatcher,
@@ -36,6 +39,7 @@ export class MockDendronExtension implements IDendronExtension {
   private _context: ExtensionContext | undefined;
   private _wsRoot: string | undefined;
   private _vaults: DVault[] | undefined;
+  noteRefCommentController: CommentController;
 
   constructor({
     engine,
@@ -52,6 +56,7 @@ export class MockDendronExtension implements IDendronExtension {
     this._context = context;
     this._wsRoot = wsRoot;
     this._vaults = vaults;
+    this.noteRefCommentController = {} as CommentController;
   }
   get podsDir(): string {
     throw new Error("Method not implemented.");
@@ -79,6 +84,13 @@ export class MockDendronExtension implements IDendronExtension {
   get type(): WorkspaceType {
     throw new Error("Method not implemented in MockDendronExtension");
   }
+
+  getState(): {
+    inlineNoteRefs: DefaultMap<string, Map<string, CommentThread>>;
+  } {
+    throw new Error("Method not implemented in MockDendronExtension.");
+  }
+
   get wsUtils(): IWSUtilsV2 {
     return new WSUtilsV2(this);
   }

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -802,7 +802,8 @@ suite("GIVEN NoteReference", () => {
       test("THEN COMMENT is created for controller ", async () => {
         const { editor } = await getNote({ fname: FNAME });
         await updateDecorations(editor);
-        const inlineNoteRefs = ExtensionProvider.getState().inlineNoteRefs;
+        const inlineNoteRefs =
+          ExtensionProvider.getCommentThreadsState().inlineNoteRefs;
         const docKey =
           VSCodeUtils.getActiveTextEditor()!.document.uri.toString();
         const lastNoteRefThreadMap = inlineNoteRefs.get(docKey);

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -393,10 +393,11 @@ suite("GIVEN a text document with decorations", function () {
           const document = editor.document;
           const { allDecorations } = (await updateDecorations(editor))!;
 
-          const wikilinkDecorations = allDecorations!.get(
-            EDITOR_DECORATION_TYPES.wikiLink
-          );
-          expect(wikilinkDecorations!.length).toEqual(10);
+          const wikilinkDecorations = allDecorations!
+            .get(EDITOR_DECORATION_TYPES.wikiLink)!
+            .concat(allDecorations!.get(EDITOR_DECORATION_TYPES.noteRef)!);
+
+          expect(wikilinkDecorations.length).toEqual(10);
           const shouldBeDecorated = [
             "[[#^anchor-1]]",
             "![[#^anchor-1]]",
@@ -411,13 +412,15 @@ suite("GIVEN a text document with decorations", function () {
           ];
           shouldBeDecorated.forEach((text) => {
             expect(
-              isTextDecorated(text, wikilinkDecorations!, document)
+              isTextDecorated(text, wikilinkDecorations, document)
             ).toBeTruthy();
           });
 
-          const brokenWikilinkDecorations = allDecorations!.get(
-            EDITOR_DECORATION_TYPES.brokenWikilink
-          );
+          const brokenWikilinkDecorations = allDecorations!
+            .get(EDITOR_DECORATION_TYPES.brokenWikilink)!
+            .concat(
+              allDecorations!.get(EDITOR_DECORATION_TYPES.brokenNoteRef)!
+            );
           expect(brokenWikilinkDecorations!.length).toEqual(3);
           expect(
             isTextDecorated(
@@ -464,9 +467,9 @@ suite("GIVEN a text document with decorations", function () {
           const document = editor.document;
           const { allDecorations } = (await updateDecorations(editor))!;
 
-          const wikilinkDecorations = allDecorations!.get(
-            EDITOR_DECORATION_TYPES.wikiLink
-          );
+          const wikilinkDecorations = (
+            allDecorations!.get(EDITOR_DECORATION_TYPES.wikiLink) || []
+          ).concat(allDecorations!.get(EDITOR_DECORATION_TYPES.noteRef) || []);
           expect(wikilinkDecorations!.length).toEqual(1);
           expect(
             isTextDecorated("![[foo.bar.*]]", wikilinkDecorations!, document)

--- a/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/WindowDecorations.test.ts
@@ -1,7 +1,7 @@
-import { Awaited, ConfigUtils, NoteUtils } from "@dendronhq/common-all";
+import { Awaited, NoteUtils } from "@dendronhq/common-all";
 import { AssertUtils, NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import { writeFile } from "fs-extra";
-import _, { last } from "lodash";
+import _ from "lodash";
 import { before, describe } from "mocha";
 import path from "path";
 import * as vscode from "vscode";

--- a/packages/plugin-core/src/windowWatcher.ts
+++ b/packages/plugin-core/src/windowWatcher.ts
@@ -77,7 +77,9 @@ export class WindowWatcher {
       if (
         !editor ||
         editor.document.uri.fsPath !==
-          window.activeTextEditor?.document.uri.fsPath
+          window.activeTextEditor?.document.uri.fsPath ||
+        // ignore text editors like the output window
+        editor.document.uri.scheme !== "file"
       ) {
         return;
       }

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -11,6 +11,7 @@ import {
   WorkspaceSettings,
   WorkspaceType,
   BacklinkPanelSortOrder,
+  DefaultMap,
 } from "@dendronhq/common-all";
 import { resolvePath } from "@dendronhq/common-server";
 import {
@@ -147,6 +148,11 @@ export class DendronExtension implements IDendronExtension {
   public type: WorkspaceType;
   public workspaceImpl?: DWorkspaceV2;
   public wsUtils: IWSUtilsV2;
+  public noteRefCommentController: vscode.CommentController;
+  private _inlineNoteRefs: DefaultMap<
+    string,
+    Map<string, vscode.CommentThread>
+  > = new DefaultMap(() => new Map());
 
   static context(): vscode.ExtensionContext {
     return getExtension().context;
@@ -380,6 +386,10 @@ export class DendronExtension implements IDendronExtension {
     this.lookupControllerFactory = new LookupControllerV3Factory(this);
     this.noteLookupProviderFactory = new NoteLookupProviderFactory(this);
     this.schemaLookupProviderFactory = new SchemaLookupProviderFactory(this);
+    this.noteRefCommentController = vscode.comments.createCommentController(
+      "noteRefs",
+      "Show note refs"
+    );
 
     const ctx = "DendronExtension";
     this.L.info({ ctx, msg: "initialized" });
@@ -397,6 +407,12 @@ export class DendronExtension implements IDendronExtension {
       });
     }
     return this.workspaceImpl;
+  }
+
+  getState() {
+    return {
+      inlineNoteRefs: this._inlineNoteRefs,
+    };
   }
 
   /**

--- a/packages/plugin-core/src/workspace.ts
+++ b/packages/plugin-core/src/workspace.ts
@@ -409,7 +409,7 @@ export class DendronExtension implements IDendronExtension {
     return this.workspaceImpl;
   }
 
-  getState() {
+  getCommentThreadsState() {
     return {
       inlineNoteRefs: this._inlineNoteRefs,
     };

--- a/packages/unified/src/decorations/decorations.ts
+++ b/packages/unified/src/decorations/decorations.ts
@@ -53,7 +53,7 @@ function runDecorator(
       return decorateUserTag(opts as DecoratorIn<UserTag>);
     case DendronASTTypes.WIKI_LINK:
       return decorateWikilink(opts as DecoratorIn<WikiLinkNoteV4>);
-    case DendronASTTypes.REF_LINK_V2: // fall-through deliberate
+    case DendronASTTypes.REF_LINK_V2:
       return decorateReference(opts as DecoratorIn<NoteRefNoteV4>);
     default:
       return undefined;

--- a/packages/unified/src/decorations/references.ts
+++ b/packages/unified/src/decorations/references.ts
@@ -10,7 +10,7 @@ export const decorateReference: Decorator<
   const { node: reference, engine, note, config } = opts;
   const { position } = reference;
 
-  const { errors, noteMeta } = await linkedNoteType({
+  const { errors, noteMeta, type } = await linkedNoteType({
     fname: reference.data.link.from.fname,
     anchorStart: reference.data.link.data.anchorStart,
     anchorEnd: reference.data.link.data.anchorEnd,
@@ -19,8 +19,13 @@ export const decorateReference: Decorator<
     note,
     vaults: config.workspace?.vaults ?? [],
   });
+
+  const decorationType =
+    type === DECORATION_TYPES.brokenWikilink
+      ? DECORATION_TYPES.brokenNoteRef
+      : DECORATION_TYPES.noteRef;
   const decoration: DecorationWikilink = {
-    type: DECORATION_TYPES.noteRef,
+    type: decorationType,
     range: position2VSCodeRange(position),
     data: {
       link: reference.data.link,

--- a/packages/unified/src/decorations/references.ts
+++ b/packages/unified/src/decorations/references.ts
@@ -10,7 +10,7 @@ export const decorateReference: Decorator<
   const { node: reference, engine, note, config } = opts;
   const { position } = reference;
 
-  const { errors } = await linkedNoteType({
+  const { errors, noteMeta } = await linkedNoteType({
     fname: reference.data.link.from.fname,
     anchorStart: reference.data.link.data.anchorStart,
     anchorEnd: reference.data.link.data.anchorEnd,
@@ -22,6 +22,10 @@ export const decorateReference: Decorator<
   const decoration: DecorationWikilink = {
     type: DECORATION_TYPES.noteRef,
     range: position2VSCodeRange(position),
+    data: {
+      link: reference.data.link,
+      noteMeta,
+    },
   };
 
   return { errors, decorations: [decoration] };

--- a/packages/unified/src/decorations/references.ts
+++ b/packages/unified/src/decorations/references.ts
@@ -1,4 +1,4 @@
-import { position2VSCodeRange } from "@dendronhq/common-all";
+import { position2VSCodeRange, DECORATION_TYPES } from "@dendronhq/common-all";
 import { NoteRefNoteV4 } from "../types";
 import { Decorator } from "./utils";
 import { DecorationWikilink, linkedNoteType } from "./wikilinks";
@@ -10,7 +10,7 @@ export const decorateReference: Decorator<
   const { node: reference, engine, note, config } = opts;
   const { position } = reference;
 
-  const { type, errors } = await linkedNoteType({
+  const { errors } = await linkedNoteType({
     fname: reference.data.link.from.fname,
     anchorStart: reference.data.link.data.anchorStart,
     anchorEnd: reference.data.link.data.anchorEnd,
@@ -20,7 +20,7 @@ export const decorateReference: Decorator<
     vaults: config.workspace?.vaults ?? [],
   });
   const decoration: DecorationWikilink = {
-    type,
+    type: DECORATION_TYPES.noteRef,
     range: position2VSCodeRange(position),
   };
 

--- a/packages/unified/src/decorations/wikilinks.ts
+++ b/packages/unified/src/decorations/wikilinks.ts
@@ -19,7 +19,10 @@ import { decorateTaskNote, DecorationTaskNote } from "./taskNotes";
 import { Decoration, DECORATION_TYPES, Decorator } from "./utils";
 
 export type DecorationWikilink = Decoration & {
-  type: DECORATION_TYPES.wikiLink | DECORATION_TYPES.brokenWikilink;
+  type:
+    | DECORATION_TYPES.wikiLink
+    | DECORATION_TYPES.brokenWikilink
+    | DECORATION_TYPES.noteRef;
 };
 export type DecorationAlias = Decoration & {
   type: DECORATION_TYPES.alias;

--- a/packages/unified/src/decorations/wikilinks.ts
+++ b/packages/unified/src/decorations/wikilinks.ts
@@ -1,6 +1,7 @@
 import {
   containsNonDendronUri,
   DendronError,
+  DNoteRefLink,
   DVault,
   getTextRange,
   IDendronError,
@@ -18,11 +19,16 @@ import { WikiLinkNoteV4 } from "../types";
 import { decorateTaskNote, DecorationTaskNote } from "./taskNotes";
 import { Decoration, DECORATION_TYPES, Decorator } from "./utils";
 
-export type DecorationWikilink = Decoration & {
-  type:
-    | DECORATION_TYPES.wikiLink
-    | DECORATION_TYPES.brokenWikilink
-    | DECORATION_TYPES.noteRef;
+export type DecorationWikilink = WikiLinkDecorator | NoteRefDecorator;
+
+export type WikiLinkDecorator = Decoration & {
+  type: DECORATION_TYPES.wikiLink | DECORATION_TYPES.brokenWikilink;
+};
+
+export type NoteRefDecorator = Required<
+  Decoration<{ link: DNoteRefLink; noteMeta?: NotePropsMeta }>
+> & {
+  type: DECORATION_TYPES.noteRef;
 };
 export type DecorationAlias = Decoration & {
   type: DECORATION_TYPES.alias;
@@ -94,7 +100,13 @@ export const decorateWikilink: Decorator<
   }
 
   // Highlight the wikilink itself
-  decorations.push({ type, range: wikilinkRange });
+  decorations.push({
+    type,
+    range: wikilinkRange,
+    data: {
+      link: wikiLink,
+    },
+  });
   return { decorations, errors };
 };
 
@@ -134,6 +146,7 @@ export async function linkedNoteType({
   vaults: DVault[];
 }): Promise<{
   type: DECORATION_TYPES.brokenWikilink | DECORATION_TYPES.wikiLink;
+  noteMeta?: NotePropsMeta;
   errors: IDendronError[];
 }> {
   const ctx = "linkedNoteType";
@@ -209,7 +222,11 @@ export async function linkedNoteType({
 
   if (matchingNotes.length > 0) {
     // There are no anchors specified in the link, but we did find matching notes
-    return { type: DECORATION_TYPES.wikiLink, errors: [] };
+    return {
+      type: DECORATION_TYPES.wikiLink,
+      errors: [],
+      noteMeta: matchingNotes[0],
+    };
   }
   // No matching notes, and not a non-note file or web URL. This is just a broken link then.
   return { type: DECORATION_TYPES.brokenWikilink, errors: [] };

--- a/packages/unified/src/decorations/wikilinks.ts
+++ b/packages/unified/src/decorations/wikilinks.ts
@@ -28,7 +28,7 @@ export type WikiLinkDecorator = Decoration & {
 export type NoteRefDecorator = Required<
   Decoration<{ link: DNoteRefLink; noteMeta?: NotePropsMeta }>
 > & {
-  type: DECORATION_TYPES.noteRef;
+  type: DECORATION_TYPES.noteRef | DECORATION_TYPES.brokenNoteRef;
 };
 export type DecorationAlias = Decoration & {
   type: DECORATION_TYPES.alias;

--- a/packages/unified/src/remark/dendronPreview.ts
+++ b/packages/unified/src/remark/dendronPreview.ts
@@ -49,13 +49,14 @@ function modifyWikilinkValueToCommandUri({
     ? AnchorUtils.string2anchor(node.data.anchorHeader)
     : undefined;
 
+  const qs = node.value;
   const goToNoteCommandOpts = {
-    qs: node.value,
+    qs,
     vault,
     anchor,
   };
-
   const encodedArgs = encodeURIComponent(JSON.stringify(goToNoteCommandOpts));
+  node.data.alias = qs;
   node.value = `command:dendron.gotoNote?${encodedArgs}`;
 }
 

--- a/packages/unified/src/remark/dendronPreview.ts
+++ b/packages/unified/src/remark/dendronPreview.ts
@@ -56,7 +56,7 @@ function modifyWikilinkValueToCommandUri({
     anchor,
   };
   const encodedArgs = encodeURIComponent(JSON.stringify(goToNoteCommandOpts));
-  node.data.alias = qs;
+  node.data.alias = node.data.alias || qs;
   node.value = `command:dendron.gotoNote?${encodedArgs}`;
 }
 

--- a/packages/unified/src/remark/dendronPub.ts
+++ b/packages/unified/src/remark/dendronPub.ts
@@ -174,7 +174,11 @@ function shouldInsertTitle({ proc }: { proc: Processor }) {
   const opts = MDUtilsV5.getProcOpts(proc);
   const isNoteRef = !_.isNumber(data.noteRefLvl) && data.noteRefLvl > 0;
   let insertTitle;
-  if (isNoteRef || opts.flavor === ProcFlavor.BACKLINKS_PANEL_HOVER) {
+  if (
+    isNoteRef ||
+    opts.flavor === ProcFlavor.BACKLINKS_PANEL_HOVER ||
+    opts.flavor === ProcFlavor.HOVER_PREVIEW
+  ) {
     insertTitle = false;
   } else {
     const config = data.config as DendronConfig;

--- a/packages/unified/src/remark/index.ts
+++ b/packages/unified/src/remark/index.ts
@@ -1,7 +1,7 @@
 export * from "./dendronPub";
 export * from "./hierarchies";
 export * from "./transformLinks";
-export { convertNoteRefToHAST } from "./noteRefsV2";
+export { convertNoteRefToHAST, NoteRefUtils } from "./noteRefsV2";
 export {
   LinkUtils,
   AnchorUtils,

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -62,6 +62,30 @@ type ConvertNoteRefHelperOpts = ConvertNoteRefOpts & {
   note: NoteProps;
 };
 
+export class NoteRefUtils {
+  static dnodeRefLink2String(link: DNoteRefLink) {
+    const { anchorStart, anchorStartOffset, anchorEnd } = link.data;
+    const { fname, alias } = link.from;
+    const linkText = alias ? `${alias}|${fname}` : fname;
+    let suffix = "";
+
+    const vaultPrefix = link.data.vaultName
+      ? `${CONSTANTS.DENDRON_DELIMETER}${link.data.vaultName}/`
+      : "";
+
+    if (anchorStart) {
+      suffix += `#${anchorStart}`;
+    }
+    if (anchorStartOffset) {
+      suffix += `,${anchorStartOffset}`;
+    }
+    if (anchorEnd) {
+      suffix += `:#${anchorEnd}`;
+    }
+    return `![[${vaultPrefix}${linkText}${suffix}]]`;
+  }
+}
+
 function gatherNoteRefs({
   link,
   vault,
@@ -204,26 +228,7 @@ function attachCompiler(proc: Unified.Processor, _opts?: CompilerOpts) {
 
       // converting to itself (used for doctor commands. preserve existing format)
       if (dest === DendronASTDest.MD_DENDRON) {
-        const { fname, alias } = ndata.link.from;
-
-        const { anchorStart, anchorStartOffset, anchorEnd } = ndata.link.data;
-        const link = alias ? `${alias}|${fname}` : fname;
-        let suffix = "";
-
-        const vaultPrefix = ndata.link.data.vaultName
-          ? `${CONSTANTS.DENDRON_DELIMETER}${ndata.link.data.vaultName}/`
-          : "";
-
-        if (anchorStart) {
-          suffix += `#${anchorStart}`;
-        }
-        if (anchorStartOffset) {
-          suffix += `,${anchorStartOffset}`;
-        }
-        if (anchorEnd) {
-          suffix += `:#${anchorEnd}`;
-        }
-        return `![[${vaultPrefix}${link}${suffix}]]`;
+        return NoteRefUtils.dnodeRefLink2String(ndata.link);
       }
       return;
     };

--- a/test-workspace/dendron.yml
+++ b/test-workspace/dendron.yml
@@ -4,6 +4,7 @@ dev:
   enableExportPodV2: true
   enableSelfContainedVaults: true
   enableEngineV3: true
+  enableExperimentalInlineNoteRef: true
 commands:
   lookup:
     note:


### PR DESCRIPTION
enhance: experimental inline note references

Renders note references inline as comments that display HTML. This makes it possible to use Dendron note references without using the preview
See loom for example: https://www.loom.com/share/458300e3a66f4753aa5cb1875bf4cd60?from_recorder=1&focus_title=1

---

This PR also addresses some other issues (aka scope creep):
- enhance(preview): slight update on hover preview behavior: don't render note title (it takes up a lot of vertical space and is not necessary since your hovering over the note)
- enhance(workspace): perf improvement when shifting focus to non-file panels. window watcher will currently call `updateDecorator` and `refreshBacklinks` on **all** editors (eg. terminal, output pane, etc) 
- fix(commands): urls were broken in hover
- chore: local build failing because of insufficient timeout between publishing to local registry and trying to install from it
