### PR TITLE
chore(internal): consolidate git utils

### DIFF
--- a/packages/common-all/src/git.ts
+++ b/packages/common-all/src/git.ts
@@ -1,0 +1,104 @@
+import _ from "lodash";
+import path from "path";
+import type { DendronConfig, NoteProps } from "./types";
+import { RESERVED_KEYS } from "./constants";
+import { ConfigUtils } from "./utils";
+import { VaultUtils } from "./vault";
+
+const formatString = (opts: { txt: string; note: NoteProps }) => {
+  const { txt, note } = opts;
+  _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+  const noteHierarchy = note.fname.replace(/\./g, "/");
+  return _.template(txt)({ noteHierarchy });
+};
+
+/**
+ *  NOTICE: Lots of the Git code is obtained from https://github.com/KnisterPeter/vscode-github, licened under MIT
+ */
+
+/**
+ * Utilities for working with git urls
+ */
+
+export function canShowGitLink(opts: {
+  config: DendronConfig;
+  note: NoteProps;
+}) {
+  const { config, note } = opts;
+
+  if (
+    _.isBoolean((note.custom || {})[RESERVED_KEYS.GIT_NO_LINK]) &&
+    note.custom[RESERVED_KEYS.GIT_NO_LINK]
+  ) {
+    return false;
+  }
+  const githubConfig = ConfigUtils.getGithubConfig(config);
+  return githubConfig
+    ? _.every([
+        githubConfig.enableEditLink,
+        githubConfig.editLinkText,
+        githubConfig.editRepository,
+        githubConfig.editBranch,
+        githubConfig.editViewMode,
+      ])
+    : false;
+}
+
+export function githubUrl(opts: { note: NoteProps; config: DendronConfig }) {
+  const url = getGithubEditUrl(opts);
+  return url;
+}
+
+export function getGithubEditUrl(opts: {
+  note: NoteProps;
+  config: DendronConfig;
+}) {
+  const { note, config } = opts;
+  const vault = note.vault;
+  const vaults = ConfigUtils.getVaults(config);
+  const mvault = VaultUtils.matchVaultV2({ vault, vaults });
+  const vaultUrl = _.get(mvault, "remote.url", false);
+  const githubConfig = ConfigUtils.getGithubConfig(config);
+  const gitRepoUrl = githubConfig?.editRepository;
+  // if we have a vault, we don't need to include the vault name as an offset
+  if (mvault && vaultUrl) {
+    return _.join(
+      [
+        git2Github(vaultUrl),
+        githubConfig?.editViewMode,
+        githubConfig?.editBranch,
+        note.fname + ".md",
+      ],
+      "/"
+    );
+  }
+
+  let gitNotePath = _.join(
+    [VaultUtils.getRelPath(vault), note.fname + ".md"],
+    "/"
+  );
+  if (_.has(note?.custom, RESERVED_KEYS.GIT_NOTE_PATH)) {
+    gitNotePath = formatString({
+      txt: note.custom[RESERVED_KEYS.GIT_NOTE_PATH],
+      note,
+    });
+  }
+  // this assumes we have a workspace url
+  return _.join(
+    [
+      gitRepoUrl,
+      githubConfig?.editViewMode,
+      githubConfig?.editBranch,
+      gitNotePath,
+    ],
+    "/"
+  );
+}
+
+export function git2Github(gitUrl: string) {
+  // 'git@github.com:kevinslin/dendron-vault.git'
+  // @ts-ignore
+  const [_, userAndRepo] = gitUrl.split(":");
+  const [user, repo] = userAndRepo.split("/");
+  return `https://github.com/${user}/${path.basename(repo, ".git")}`;
+}

--- a/packages/common-all/src/git.ts
+++ b/packages/common-all/src/git.ts
@@ -194,6 +194,10 @@ export function remoteUrlToDependencyPath({
   return vaultName;
 }
 
+/** If this vault had this remote, what path should it be stored under?
+ *
+ * If the remote is null, then you'll get the path should be if the vault was a local vault.
+ */
 export function getDependencyPathWithRemote({
   vault,
   remote,

--- a/packages/common-all/src/git.ts
+++ b/packages/common-all/src/git.ts
@@ -52,11 +52,14 @@ export function githubUrl(opts: { note: NoteProps; config: DendronConfig }) {
 export function getGithubEditUrl(opts: {
   note: NoteProps;
   config: DendronConfig;
+  wsRoot?: string;
 }) {
-  const { note, config } = opts;
+  const { note, config, wsRoot } = opts;
   const vault = note.vault;
   const vaults = ConfigUtils.getVaults(config);
-  const mvault = VaultUtils.matchVaultV2({ vault, vaults });
+  const mvault = wsRoot
+    ? VaultUtils.matchVault({ wsRoot, vault, vaults })
+    : VaultUtils.matchVaultV2({ vault, vaults });
   const vaultUrl = _.get(mvault, "remote.url", false);
   const githubConfig = ConfigUtils.getGithubConfig(config);
   const gitRepoUrl = githubConfig?.editRepository;

--- a/packages/common-all/src/git.ts
+++ b/packages/common-all/src/git.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import path from "path";
-import type { DendronConfig, NoteProps } from "./types";
-import { RESERVED_KEYS } from "./constants";
+import type { DVault, DendronConfig, NoteProps } from "./types";
+import { RESERVED_KEYS, FOLDERS } from "./constants";
 import { ConfigUtils } from "./utils";
 import { VaultUtils } from "./vault";
 
@@ -101,4 +101,135 @@ export function git2Github(gitUrl: string) {
   const [_, userAndRepo] = gitUrl.split(":");
   const [user, repo] = userAndRepo.split("/");
   return `https://github.com/${user}/${path.basename(repo, ".git")}`;
+}
+
+/**
+ * Convert a github repo orul to access token format
+ */
+export function getGithubAccessTokenUrl(opts: {
+  remotePath: string;
+  accessToken: string;
+}) {
+  const { remotePath, accessToken } = opts;
+  let repoPath: string;
+  if (remotePath.startsWith("https://")) {
+    repoPath = remotePath.split("/").slice(-2).join("/");
+  } else {
+    repoPath = opts.remotePath.split(":").slice(-1)[0];
+  }
+  return `https://${accessToken}:x-oauth-basic@github.com/${repoPath}`;
+}
+
+export function getOwnerAndRepoFromURL(url: string) {
+  const [owner, repo] = url.split("/").slice(-2);
+  return { owner, repo };
+}
+
+export function getRepoNameFromURL(url: string): string {
+  return path.basename(url, ".git");
+}
+
+/** Find the dependency path for a vault given the remote url. You can use
+ * this even if the vault has no remote.
+ *
+ * This is the relative path within the dependencies folder, like
+ * `github.com/dendronhq/dendron-site`. For more details see the
+ * [[Self Contained Vaults RFC|dendron://dendron.docs/rfc.42-self-contained-vaults]]
+ */
+export function remoteUrlToDependencyPath({
+  vaultName,
+  url,
+}: {
+  vaultName: string;
+  url?: string;
+}): string {
+  // If no remote URL exists, then it's a local vault. We keep these in a
+  // local-only folder.
+  if (url === undefined) return FOLDERS.LOCAL_DEPENDENCY;
+  // Check if it matches any web URLs like
+  // https://github.com/dendronhq/dendron-site.git This may also look like
+  // http://example.com:8000/dendronhq/dendron-site.git, we skip the port
+  const webMatch =
+    // starts with http:// or https://
+    // followed by the domain, which will continue until we hit /
+    // if we see a port definition like :8000, we skip it for simplicity
+    // then we have the path of the URL, like dendronhq/dendron-site
+    // finally, if there's a `.git` we'll discard that for a cleaner name
+    /^(https?:\/\/)(?<domain>[^/:]+)(:[0-9]+)?\/(?<path>.+?)(\.git)?$/.exec(
+      url
+    );
+  if (webMatch?.groups?.domain && webMatch?.groups?.path) {
+    // matched a HTTP/S git remote
+    return path.join(
+      webMatch.groups.domain,
+      // Normalize for Windows so forward slashes are converted to backward ones
+      path.normalize(webMatch.groups.path)
+    );
+  }
+  // Check if it matches any SSH URLs like
+  // git@github.com:dendronhq/dendron-site.git This may also look like
+  // git@example.com:220/dendronhq/dendron-site.git, we skip the port and the
+  const sshMatch =
+    // SSH urls start with a user, like git@ or gitlab@, which we skip
+    // followed by the domain, which will continue until we hit :
+    // if we see a port definition like :8000, we skip it for simplicity
+    // then we have the path of the URL, like dendronhq/dendron-site
+    // this path may optionally begin with a /, which we'll skip
+    // finally, if there's a `.git` we'll discard that for a cleaner name
+    /^([^@]+@)(?<domain>[^:/]+):([0-9]+\/)?\/?(?<path>.+?)(\.git)?$/.exec(url);
+  if (sshMatch?.groups?.domain && sshMatch?.groups?.path) {
+    // matched a HTTP/S git remote
+    return path.join(
+      sshMatch.groups.domain,
+      // Normalize for Windows so forward slashes are converted to backward ones
+      path.normalize(sshMatch.groups.path)
+    );
+  }
+  // If none of these worked, try to make a fallback path. This may be because
+  // the remote points to a local directory, or because it's something we
+  // didn't expect.
+  const fallback = _.findLast(url.split(/[/\\]/), (part) => part.length > 0);
+  if (fallback) return fallback;
+  // Fallback for the fallback: if all else fails, just use the vault name
+  return vaultName;
+}
+
+export function getDependencyPathWithRemote({
+  vault,
+  remote,
+}: {
+  remote: string | null;
+  vault: DVault;
+}): string {
+  const vaultName =
+    vault.name ??
+    // if the vault has no name, compute one based on the path
+    _.findLast(vault.fsPath.split(/[/\\]/), (part) => part.length > 0) ??
+    // Fall back to fsPath directly if the calculation fails
+    vault.fsPath;
+
+  if (!remote) {
+    // local
+    return path.join(FOLDERS.DEPENDENCIES, FOLDERS.LOCAL_DEPENDENCY, vaultName);
+  } else {
+    return path.join(
+      FOLDERS.DEPENDENCIES,
+      remoteUrlToDependencyPath({
+        vaultName,
+        url: remote,
+      })
+    );
+  }
+}
+
+export function getVaultFromRepo(opts: {
+  repoPath: string;
+  repoUrl: string;
+  wsRoot: string;
+}): DVault {
+  const { repoPath, wsRoot } = opts;
+  return {
+    fsPath: path.relative(wsRoot, repoPath),
+    remote: { type: "git", url: opts.repoUrl },
+  };
 }

--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -39,6 +39,7 @@ export * from "./parse";
 export * from "./BacklinkUtils";
 export * from "./DLinkUtils";
 export * as YamlUtils from "./yaml";
+export * as GitUtils from "./git";
 
 export { axios, AxiosError };
 export { DateTime };

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -34,9 +34,6 @@ export class GitUtils {
   static canShowGitLink(opts: { config: DendronConfig; note: NoteProps }) {
     return CommonGitUtils.canShowGitLink(opts);
   }
-  /**
-   * Convert a github repo orul to access token format
-   */
   static getGithubAccessTokenUrl(opts: {
     remotePath: string;
     accessToken: string;
@@ -64,13 +61,6 @@ export class GitUtils {
     return CommonGitUtils.getRepoNameFromURL(url);
   }
 
-  /** Find the dependency path for a vault given the remote url. You can use
-   * this even if the vault has no remote.
-   *
-   * This is the relative path within the dependencies folder, like
-   * `github.com/dendronhq/dendron-site`. For more details see the
-   * [[Self Contained Vaults RFC|dendron://dendron.docs/rfc.42-self-contained-vaults]]
-   */
   public static remoteUrlToDependencyPath({
     vaultName,
     url,
@@ -81,10 +71,6 @@ export class GitUtils {
     return CommonGitUtils.remoteUrlToDependencyPath({ vaultName, url });
   }
 
-  /** If this vault had this remote, what path should it be stored under?
-   *
-   * If the remote is null, then you'll get the path should be if the vault was a local vault.
-   */
   static getDependencyPathWithRemote({
     vault,
     remote,

--- a/packages/common-server/src/git.ts
+++ b/packages/common-server/src/git.ts
@@ -4,9 +4,8 @@ import {
   DVault,
   DWorkspace,
   NoteProps,
-  RESERVED_KEYS,
-  VaultUtils,
   ConfigUtils,
+  GitUtils as CommonGitUtils,
   FOLDERS,
   DendronConfig,
 } from "@dendronhq/common-all";
@@ -24,13 +23,6 @@ import { vault2Path } from "./filesv2";
 
 export { simpleGit, SimpleGit, SimpleGitResetMode };
 
-const formatString = (opts: { txt: string; note: NoteProps }) => {
-  const { txt, note } = opts;
-  _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
-  const noteHierarchy = note.fname.replace(/\./g, "/");
-  return _.template(txt)({ noteHierarchy });
-};
-
 /**
  *  NOTICE: Lots of the Git code is obtained from https://github.com/KnisterPeter/vscode-github, licened under MIT
  */
@@ -40,24 +32,7 @@ const formatString = (opts: { txt: string; note: NoteProps }) => {
  */
 export class GitUtils {
   static canShowGitLink(opts: { config: DendronConfig; note: NoteProps }) {
-    const { config, note } = opts;
-
-    if (
-      _.isBoolean((note.custom || {})[RESERVED_KEYS.GIT_NO_LINK]) &&
-      note.custom[RESERVED_KEYS.GIT_NO_LINK]
-    ) {
-      return false;
-    }
-    const githubConfig = ConfigUtils.getGithubConfig(config);
-    return githubConfig
-      ? _.every([
-          githubConfig.enableEditLink,
-          githubConfig.editLinkText,
-          githubConfig.editRepository,
-          githubConfig.editBranch,
-          githubConfig.editViewMode,
-        ])
-      : false;
+    return CommonGitUtils.canShowGitLink(opts);
   }
   /**
    * Convert a github repo orul to access token format
@@ -77,11 +52,7 @@ export class GitUtils {
   }
 
   static git2Github(gitUrl: string) {
-    // 'git@github.com:kevinslin/dendron-vault.git'
-    // @ts-ignore
-    const [_, userAndRepo] = gitUrl.split(":");
-    const [user, repo] = userAndRepo.split("/");
-    return `https://github.com/${user}/${path.basename(repo, ".git")}`;
+    return CommonGitUtils.git2Github(gitUrl);
   }
 
   static getGithubEditUrl(opts: {
@@ -89,46 +60,7 @@ export class GitUtils {
     config: DendronConfig;
     wsRoot: string;
   }) {
-    const { note, config, wsRoot } = opts;
-    const vault = note.vault;
-    const vaults = ConfigUtils.getVaults(config);
-    const mvault = VaultUtils.matchVault({ wsRoot, vault, vaults });
-    const vaultUrl = _.get(mvault, "remote.url", false);
-    const githubConfig = ConfigUtils.getGithubConfig(config);
-    const gitRepoUrl = githubConfig?.editRepository;
-    // if we have a vault, we don't need to include the vault name as an offset
-    if (mvault && vaultUrl) {
-      return _.join(
-        [
-          this.git2Github(vaultUrl),
-          githubConfig?.editViewMode,
-          githubConfig?.editBranch,
-          note.fname + ".md",
-        ],
-        "/"
-      );
-    }
-
-    let gitNotePath = _.join(
-      [path.basename(vault.fsPath), note.fname + ".md"],
-      "/"
-    );
-    if (_.has(note?.custom, RESERVED_KEYS.GIT_NOTE_PATH)) {
-      gitNotePath = formatString({
-        txt: note.custom[RESERVED_KEYS.GIT_NOTE_PATH],
-        note,
-      });
-    }
-    // this assumes we have a workspace url
-    return _.join(
-      [
-        gitRepoUrl,
-        githubConfig?.editViewMode,
-        githubConfig?.editBranch,
-        gitNotePath,
-      ],
-      "/"
-    );
+    return CommonGitUtils.getGithubEditUrl(opts);
   }
 
   static getOwnerAndRepoFromURL(url: string) {

--- a/packages/engine-test-utils/src/__tests__/common-all/git.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/git.spec.ts
@@ -12,7 +12,7 @@ const vault: DVault = {
   fsPath: "fooVault",
 };
 
-describe(`GIVEN GitUtils`, () => {
+describe("GIVEN GitUtils", () => {
   describe(`WHEN config is default`, () => {
     const config = ConfigUtils.genDefaultConfig();
     const note = NoteUtils.create({
@@ -20,11 +20,17 @@ describe(`GIVEN GitUtils`, () => {
       fname,
     });
 
-    test(`THEN canShowGitLink should be false`, () => {
+    test("THEN `canShowGitLink` should be false", () => {
       expect(GitUtils.canShowGitLink({ config, note })).toBeFalsy();
     });
+
+    test("THEN `getGithubEditUrl` should return github edit url", () => {
+      expect(GitUtils.getGithubEditUrl({ config, note })).toEqual(
+        "/tree/main/fooVault/foo.md"
+      );
+    });
   });
-  describe(`WHEN config contains github properties`, () => {
+  describe("WHEN config contains github properties", () => {
     const config = ConfigUtils.genDefaultConfig();
 
     config.publishing.github = {
@@ -35,12 +41,19 @@ describe(`GIVEN GitUtils`, () => {
       editViewMode: GithubEditViewModeEnum.edit,
     };
 
-    test(`THEN canShowGitLink should be true`, () => {
-      const note = NoteUtils.create({
-        vault,
-        fname,
-      });
+    const note = NoteUtils.create({
+      vault,
+      fname,
+    });
+
+    test("THEN `canShowGitLink` should be true", () => {
       expect(GitUtils.canShowGitLink({ config, note })).toBeTruthy();
+    });
+
+    test("THEN `getGithubEditUrl` should return github edit url", () => {
+      expect(GitUtils.getGithubEditUrl({ config, note })).toEqual(
+        "https://github.com/kevinslin/dendron-11ty-test/edit/main/fooVault/foo.md"
+      );
     });
 
     describe("AND note contains `gitNoLink` property", () => {
@@ -50,9 +63,26 @@ describe(`GIVEN GitUtils`, () => {
         fname,
       });
 
-      test(`THEN canShowGitLink should be false`, () => {
+      test("THEN canShowGitLink should be false", () => {
         expect(GitUtils.canShowGitLink({ config, note })).toBeFalsy();
       });
     });
+  });
+
+  test("THEN `git2Github` conversion", () => {
+    expect(
+      GitUtils.git2Github("git@github.com:kevinslin/dendron-vault.git")
+    ).toEqual("https://github.com/kevinslin/dendron-vault");
+  });
+
+  test("THEN `getGithubAccessTokenUrl` conversion", () => {
+    expect(
+      GitUtils.getGithubAccessTokenUrl({
+        remotePath: "https://github.com/kevinslin/dendron-11ty-test",
+        accessToken: "abc",
+      })
+    ).toEqual(
+      "https://abc:x-oauth-basic@github.com/kevinslin/dendron-11ty-test"
+    );
   });
 });

--- a/packages/engine-test-utils/src/__tests__/common-all/git.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/git.spec.ts
@@ -1,0 +1,58 @@
+import {
+  GitUtils,
+  ConfigUtils,
+  NoteUtils,
+  DVault,
+  GithubEditViewModeEnum,
+} from "@dendronhq/common-all";
+
+const fname = "foo";
+const vault: DVault = {
+  name: "fooVault",
+  fsPath: "fooVault",
+};
+
+describe(`GIVEN GitUtils`, () => {
+  describe(`WHEN config is default`, () => {
+    const config = ConfigUtils.genDefaultConfig();
+    const note = NoteUtils.create({
+      vault,
+      fname,
+    });
+
+    test(`THEN canShowGitLink should be false`, () => {
+      expect(GitUtils.canShowGitLink({ config, note })).toBeFalsy();
+    });
+  });
+  describe(`WHEN config contains github properties`, () => {
+    const config = ConfigUtils.genDefaultConfig();
+
+    config.publishing.github = {
+      enableEditLink: true,
+      editLinkText: "Edit this page on Github",
+      editRepository: "https://github.com/kevinslin/dendron-11ty-test",
+      editBranch: "main",
+      editViewMode: GithubEditViewModeEnum.edit,
+    };
+
+    test(`THEN canShowGitLink should be true`, () => {
+      const note = NoteUtils.create({
+        vault,
+        fname,
+      });
+      expect(GitUtils.canShowGitLink({ config, note })).toBeTruthy();
+    });
+
+    describe("AND note contains `gitNoLink` property", () => {
+      const note = NoteUtils.create({
+        custom: { gitNoLink: true },
+        vault,
+        fname,
+      });
+
+      test(`THEN canShowGitLink should be false`, () => {
+        expect(GitUtils.canShowGitLink({ config, note })).toBeFalsy();
+      });
+    });
+  });
+});

--- a/packages/nextjs-template/components/DendronNoteFooter.tsx
+++ b/packages/nextjs-template/components/DendronNoteFooter.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable */
-import {
-  ConfigUtils,
-  DendronConfig,
-  NoteProps,
-  RESERVED_KEYS,
-  Time,
-  VaultUtils,
-} from "@dendronhq/common-all";
+import { ConfigUtils, Time, GitUtils } from "@dendronhq/common-all";
 import { Row, Col, Typography } from "antd";
 import _ from "lodash";
-import path from "path";
 import React from "react";
 import { useEngineAppSelector } from "../features/engine/hooks";
 import { useDendronRouter, useNoteActive } from "../utils/hooks";
@@ -20,94 +12,6 @@ const ms2ShortDate = (ts: number) => {
   const dt = Time.DateTime.fromMillis(ts);
   return dt.toLocaleString(Time.DateTime.DATE_SHORT);
 };
-
-const formatString = (opts: { txt: string; note: NoteProps }) => {
-  const { txt, note } = opts;
-  _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
-  const noteHierarchy = note.fname.replace(/\./g, "/");
-  return _.template(txt)({ noteHierarchy });
-};
-
-class GitUtils {
-  static canShowGitLink = (opts: {
-    config: DendronConfig;
-    note: NoteProps;
-  }) => {
-    const { config, note } = opts;
-    if (
-      _.isBoolean((note.custom || {})[RESERVED_KEYS.GIT_NO_LINK]) &&
-      note.custom[RESERVED_KEYS.GIT_NO_LINK]
-    ) {
-      return false;
-    }
-    const githubConfig = ConfigUtils.getGithubConfig(config);
-    return githubConfig
-      ? _.every([
-          githubConfig.enableEditLink,
-          githubConfig.editLinkText,
-          githubConfig.editRepository,
-          githubConfig.editBranch,
-          githubConfig.editViewMode,
-        ])
-      : false;
-  };
-
-  static githubUrl = (opts: { note: NoteProps; config: DendronConfig }) => {
-    const url = GitUtils.getGithubEditUrl(opts);
-    return url;
-  };
-
-  static getGithubEditUrl(opts: { note: NoteProps; config: DendronConfig }) {
-    const { note, config } = opts;
-    const vault = note.vault;
-    const vaults = ConfigUtils.getVaults(config);
-    const mvault = VaultUtils.matchVaultV2({ vault, vaults });
-    const vaultUrl = _.get(mvault, "remote.url", false);
-    const githubConfig = ConfigUtils.getGithubConfig(config);
-    const gitRepoUrl = githubConfig?.editRepository;
-    // if we have a vault, we don't need to include the vault name as an offset
-    if (mvault && vaultUrl) {
-      return _.join(
-        [
-          this.git2Github(vaultUrl),
-          githubConfig?.editViewMode,
-          githubConfig?.editBranch,
-          note.fname + ".md",
-        ],
-        "/"
-      );
-    }
-
-    let gitNotePath = _.join(
-      [VaultUtils.getRelPath(vault), note.fname + ".md"],
-      "/"
-    );
-    if (_.has(note?.custom, RESERVED_KEYS.GIT_NOTE_PATH)) {
-      gitNotePath = formatString({
-        txt: note.custom[RESERVED_KEYS.GIT_NOTE_PATH],
-        note,
-      });
-    }
-    // this assumes we have a workspace url
-    return _.join(
-      [
-        gitRepoUrl,
-        githubConfig?.editViewMode,
-        githubConfig?.editBranch,
-        gitNotePath,
-      ],
-      "/"
-    );
-  }
-
-  static git2Github(gitUrl: string) {
-    // 'git@github.com:kevinslin/dendron-vault.git'
-    // @ts-ignore
-    const [_, userAndRepo] = gitUrl.split(":");
-    const [user, repo] = userAndRepo.split("/");
-    return `https://github.com/${user}/${path.basename(repo, ".git")}`;
-  }
-}
 
 export function FooterText() {
   const dendronRouter = useDendronRouter();


### PR DESCRIPTION
The aim of this PR is to consolidate spread out common git utils `common-all`.
git utils inside `common-all` are re-exported in git utils `common-server` thereby nothing changes for the rest of the code. Its also practicall to have `common-all` git utils included in `common-server`.

# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
