### PR TITLE
chore: workflow update for 2 week release cycle and cleanup

### DIFF
--- a/.github/workflows/ci-windows-test.yml
+++ b/.github/workflows/ci-windows-test.yml
@@ -37,7 +37,7 @@ jobs:
           yarn --version
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -45,7 +45,7 @@ jobs:
 
       - name: Restore Node modules cache for Windows
         if: runner.os == 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: node-modules-cache-windows
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
           yarn --version
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "${{ matrix.node-version }}"
           cache: "yarn"
@@ -77,7 +77,7 @@ jobs:
           git config --global user.email ci@dendron.so
 
       - name: Restore typescript lib cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: ts-cache
         with:
           path: |
@@ -110,16 +110,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
       - name: Restore typescript lib cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: ts-cache
         with:
           path: |
@@ -151,16 +151,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
       - name: Restore typescript lib cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: ts-cache
         with:
           path: |

--- a/.github/workflows/create-early-seed-branch.yml
+++ b/.github/workflows/create-early-seed-branch.yml
@@ -1,11 +1,11 @@
-# Creates a release branch off of master every Thursday, 7 PM UTC
-name: Create Release Branch
+# Creates an early seed branch off of master every other Wednesday, 7 PM UTC
+name: Create Early Seed Branch
 
 # See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
 # Scheduled to run at 7 PM UTC on Wednesday every other week
 on:
   schedule:
-    - cron: "0 19 1-7,15-21,29-31 * 3"
+    - cron: "0 19 8-14,22-28 * 3"
 
 jobs:
   build:
@@ -32,7 +32,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           version=`cat ./packages/plugin-core/package.json | jq ".version" -r |  awk -F. -v OFS=. 'NF>1{$(NF-1)=sprintf("%0*d", length($(NF-1)), ($(NF-1)+1)); $NF=0; print}'`
-          branchName="release/${version}" 
+          branchName="early-seed/${version}" 
           echo $branchName
           git checkout -b $branchName
           git push origin $branchName

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -2,10 +2,10 @@
 name: Create Release Branch
 
 # See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
-# Scheduled to run at 7 PM UTC on Thursdays
+# Scheduled to run at 7 PM UTC on Wednesday every other week (1-7,15-21 corresponds to first and third weeks of the month)
 on:
   schedule:
-    - cron: "0 19 * * 4"
+    - cron: "0 19 1-7,15-21 * 3"
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
     # inifinte loops of workflows
     steps:
       - name: Checkout and Create Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           ssh-key: "${{ secrets.COMMIT_KEY }}"

--- a/.github/workflows/create-release-image-patch.yml
+++ b/.github/workflows/create-release-image-patch.yml
@@ -28,10 +28,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -75,16 +75,3 @@ jobs:
           name: vsix
           path: ${{ env.VSIX_RELATIVE_PATH }}
           if-no-files-found: error
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.DENDRON_BOT_S3_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DENDRON_BOT_S3_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Publish VSIX to S3
-        run: |
-          BUCKET=org-dendron-public-assets
-          aws s3 cp --acl public-read ${{ env.VSIX_RELATIVE_PATH }} s3://$BUCKET/publish/${{ env.VSIX_FILE_NAME }}
-          echo https://$BUCKET.s3.amazonaws.com/publish/${{ env.VSIX_FILE_NAME }}

--- a/.github/workflows/create-release-image.yml
+++ b/.github/workflows/create-release-image.yml
@@ -31,10 +31,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -78,16 +78,3 @@ jobs:
           name: vsix
           path: ${{ env.VSIX_RELATIVE_PATH }}
           if-no-files-found: error
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.DENDRON_BOT_S3_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DENDRON_BOT_S3_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Publish VSIX to S3
-        run: |
-          BUCKET=org-dendron-public-assets
-          aws s3 cp --acl public-read ${{ env.VSIX_RELATIVE_PATH }} s3://$BUCKET/publish/${{ env.VSIX_FILE_NAME }}
-          echo https://$BUCKET.s3.amazonaws.com/publish/${{ env.VSIX_FILE_NAME }}

--- a/.github/workflows/create-release-image.yml
+++ b/.github/workflows/create-release-image.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - release/*
+      - early-seed/*
 
 jobs:
   build:

--- a/.github/workflows/hackathon-create-test-image.yml
+++ b/.github/workflows/hackathon-create-test-image.yml
@@ -30,10 +30,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -77,16 +77,3 @@ jobs:
           name: vsix
           path: ${{ env.VSIX_RELATIVE_PATH }}
           if-no-files-found: error
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.DENDRON_BOT_S3_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DENDRON_BOT_S3_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Publish VSIX to S3
-        run: |
-          BUCKET=org-dendron-public-assets
-          aws s3 cp --acl public-read ${{ env.VSIX_RELATIVE_PATH }} s3://$BUCKET/publish/${{ env.VSIX_FILE_NAME }}
-          echo https://$BUCKET.s3.amazonaws.com/publish/${{ env.VSIX_FILE_NAME }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -28,10 +28,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 

--- a/.github/workflows/publish-extension-dendron-minor.yml
+++ b/.github/workflows/publish-extension-dendron-minor.yml
@@ -29,10 +29,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 

--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -29,10 +29,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 

--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -72,10 +72,10 @@ jobs:
           git config --global user.email github-actions@github.com
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 


### PR DESCRIPTION
## chore: workflow update for 2 week release cycle and cleanup

A few updates to our github workflows:
- Create Release Branch now runs on Wednesdays 7pm UTC every other week
- Removing AWS upload steps which were failing from an auth issue
- Updating actions to use v3 to get rid of node 12 warnings, which are getting deprecated in Github Actions.