### PR TITLE
chore(workspace): Bug and test fixes for Engine v3

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -14,6 +14,7 @@ import {
   RespV3,
   FindNoteOpts,
   APIRequest,
+  FindNotesMetaResp,
 } from "@dendronhq/common-all";
 import { ExpressUtils } from "@dendronhq/common-server";
 import { Request, Response, Router } from "express";
@@ -78,6 +79,18 @@ router.post(
     const out = await engine.findNotes(opts);
     ExpressUtils.setResponse(res, { data: out });
   })
+);
+
+router.post(
+  "/findMeta",
+  asyncHandler(
+    async (req: Request, res: Response<RespV3<FindNotesMetaResp>>) => {
+      const { ws, ...opts } = req.body as APIRequest<FindNoteOpts>;
+      const engine = await getWSEngine({ ws: ws || "" });
+      const out = await engine.findNotesMeta(opts);
+      ExpressUtils.setResponse(res, { data: out });
+    }
+  )
 );
 
 router.post(

--- a/packages/api-server/src/store/memoryStore.ts
+++ b/packages/api-server/src/store/memoryStore.ts
@@ -1,5 +1,4 @@
-import { DendronError } from "@dendronhq/common-all";
-import { DendronEngineV2 } from "@dendronhq/engine-server";
+import { DendronError, DEngine } from "@dendronhq/common-all";
 import _ from "lodash";
 
 const STORE: any = {};
@@ -22,7 +21,7 @@ export class MemoryStore {
     STORE[key] = value;
   }
 
-  getEngine(): DendronEngineV2 {
+  getEngine(): DEngine {
     const out = _.values(STORE)[0];
     if (!out) {
       throw new DendronError({ message: "STORE is empty" });

--- a/packages/api-server/src/utils.ts
+++ b/packages/api-server/src/utils.ts
@@ -6,7 +6,6 @@ import {
   stringifyError,
 } from "@dendronhq/common-all";
 import { createLogger } from "@dendronhq/common-server";
-import { DendronEngineV2 } from "@dendronhq/engine-server";
 import execa, { ExecaChildProcess } from "execa";
 import _ from "lodash";
 import path from "path";
@@ -17,13 +16,7 @@ export function getWSKey(uri: string) {
   return _.trimEnd(uri, "/").toLowerCase();
 }
 
-export async function putWS({
-  ws,
-  engine,
-}: {
-  ws: string;
-  engine: DendronEngineV2;
-}) {
+export async function putWS({ ws, engine }: { ws: string; engine: DEngine }) {
   MemoryStore.instance().put(`ws:${getWSKey(ws)}`, engine);
 }
 

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -7,6 +7,7 @@ import {
   EngineDeleteOpts,
   EngineInfoResp,
   EngineWriteOptsV2,
+  FindNotesMetaResp,
   RenameNoteOpts,
   SchemaModuleProps,
   WriteNoteResp,
@@ -377,6 +378,16 @@ export class DendronAPI extends API {
   noteFind(req: APIRequest<FindNoteOpts>): Promise<RespV3<FindNotesResp>> {
     return this._makeRequest({
       path: "note/find",
+      method: "post",
+      body: req,
+    });
+  }
+
+  noteFindMeta(
+    req: APIRequest<FindNoteOpts>
+  ): Promise<RespV3<FindNotesMetaResp>> {
+    return this._makeRequest({
+      path: "note/findMeta",
       method: "post",
       body: req,
     });

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -218,13 +218,21 @@ export class DNodeUtils {
     const { vault } = opts;
     const dirname = DNodeUtils.dirName(fpath);
     if (dirname === "") {
-      const _node = NoteDictsUtils.findByFname("root", noteDicts, vault)[0];
+      const _node = NoteDictsUtils.findByFname({
+        fname: "root",
+        noteDicts,
+        vault,
+      })[0];
       if (_.isUndefined(_node)) {
         throw new DendronError({ message: `no root found for ${fpath}` });
       }
       return _node;
     }
-    const maybeNode = NoteDictsUtils.findByFname(dirname, noteDicts, vault)[0];
+    const maybeNode = NoteDictsUtils.findByFname({
+      fname: dirname,
+      noteDicts,
+      vault,
+    })[0];
     if (
       (maybeNode && !opts?.noStubs) ||
       (maybeNode && opts?.noStubs && !maybeNode.stub && !maybeNode.schemaStub)
@@ -350,11 +358,11 @@ export class NoteUtils {
       return changed;
     }
     const parentPath = DNodeUtils.dirName(note.fname).toLowerCase();
-    const parent = NoteDictsUtils.findByFname(
-      parentPath,
+    const parent = NoteDictsUtils.findByFname({
+      fname: parentPath,
       noteDicts,
-      note.vault
-    )[0];
+      vault: note.vault,
+    })[0];
 
     if (parent) {
       const prevParentState = { ...parent };

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -417,24 +417,18 @@ export abstract class EngineV3Base implements ReducedDEngine {
             vaults: this.vaults,
           })
         : undefined;
-      const notes = await this.noteStore.findMetaData({
+      const notes = await this.noteStore.find({
         fname: link.to.fname,
         vault: maybeVault,
       });
       if (notes.data) {
         return Promise.all(
           notes.data.map(async (note) => {
-            const prevNote = _.merge(_.cloneDeep(note), {
-              body: "",
-            });
+            const prevNote = _.cloneDeep(note);
             BacklinkUtils.addBacklinkInPlace({ note, backlink: maybeBacklink });
-            // Temp solution to get around current restrictions where NoteChangeEntry needs a NoteProp
-            const updatedNote = _.merge(note, {
-              body: "",
-            });
             return {
               prevNote,
-              note: updatedNote,
+              note,
               status: "update",
             };
           })
@@ -462,27 +456,21 @@ export abstract class EngineV3Base implements ReducedDEngine {
             vaults: this.vaults,
           })
         : undefined;
-      const notes = await this.noteStore.findMetaData({
+      const notes = await this.noteStore.find({
         fname: link.to.fname,
         vault: maybeVault,
       });
       if (notes.data) {
         return Promise.all(
           notes.data.map(async (note) => {
-            const prevNote = _.merge(_.cloneDeep(note), {
-              body: "",
-            });
+            const prevNote = _.cloneDeep(note);
             BacklinkUtils.removeBacklinkInPlace({
               note,
               backlink: maybeBacklink,
             });
-            // Temp solution to get around current restrictions where NoteChangeEntry needs a NoteProp
-            const updatedNote = _.merge(note, {
-              body: "",
-            });
             return {
               prevNote,
-              note: updatedNote,
+              note,
               status: "update",
             };
           })

--- a/packages/common-all/src/noteDictsUtils.ts
+++ b/packages/common-all/src/noteDictsUtils.ts
@@ -49,13 +49,21 @@ export class NoteDictsUtils {
    * @param fname
    * @param noteDicts
    * @param vault If provided, use to filter results
+   * @param skipCloneDeep If true, do not clone notes and return same reference in noteDicts.
+   * This means that any changes to the returned notes will affect the same note in noteDicts
    * @returns Array of NoteProps matching opts
    */
-  static findByFname(
-    fname: string,
-    noteDicts: NoteDicts,
-    vault?: DVault
-  ): NoteProps[] {
+  static findByFname({
+    fname,
+    noteDicts,
+    vault,
+    skipCloneDeep,
+  }: {
+    fname: string;
+    noteDicts: NoteDicts;
+    vault?: DVault;
+    skipCloneDeep?: boolean;
+  }): NoteProps[] {
     const { notesById, notesByFname } = noteDicts;
     const cleanedFname = cleanName(fname);
     const ids: string[] | undefined = notesByFname[cleanedFname];
@@ -65,6 +73,10 @@ export class NoteDictsUtils {
     let notes = ids.map((id) => notesById[id]).filter(isNotUndefined);
     if (vault) {
       notes = notes.filter((note) => VaultUtils.isEqualV2(note.vault, vault));
+    }
+
+    if (skipCloneDeep) {
+      return notes;
     }
     return _.cloneDeep(notes);
   }

--- a/packages/common-all/src/store/IDataStore.ts
+++ b/packages/common-all/src/store/IDataStore.ts
@@ -1,10 +1,10 @@
-import { RespV3 } from "../types";
+import { Disposable, RespV3 } from "../types";
 
 /**
  * Interface responsible for interacting with data store
  */
 
-export interface IDataStore<K, V> {
+export interface IDataStore<K, V> extends Disposable {
   /**
    * Get data by key
    * If key is not found, return error.

--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -1,4 +1,5 @@
 import {
+  Disposable,
   DNoteLoc,
   NoteProps,
   NotePropsMeta,
@@ -11,7 +12,7 @@ import { FindNoteOpts } from "../types/FindNoteOpts";
 /**
  * Interface responsible for interacting with NoteProps storage layer
  */
-export interface INoteStore<K> {
+export interface INoteStore<K> extends Disposable {
   /**
    * Get NoteProps by key
    * If key is not found, return error.

--- a/packages/common-all/src/store/ISchemaStore.ts
+++ b/packages/common-all/src/store/ISchemaStore.ts
@@ -1,9 +1,14 @@
-import { SchemaModuleProps, RespV3, WriteSchemaOpts } from "../types";
+import {
+  SchemaModuleProps,
+  RespV3,
+  WriteSchemaOpts,
+  Disposable,
+} from "../types";
 
 /**
  * Interface responsible for interacting with SchemaModuleProps storage layer
  */
-export interface ISchemaStore<K> {
+export interface ISchemaStore<K> extends Disposable {
   /**
    * Get SchemaModuleProps metadata by key.
    * Unlike {@link ISchemaStore.get}, this retrieves SchemaModuleProps from the metadata store.

--- a/packages/common-all/src/store/NoteMetadataStore.ts
+++ b/packages/common-all/src/store/NoteMetadataStore.ts
@@ -23,6 +23,11 @@ export class NoteMetadataStore implements INoteMetadataStore {
     this._noteIdsByFname = {};
   }
 
+  dispose() {
+    this._noteMetadataById = {};
+    this._noteIdsByFname = {};
+  }
+
   /**
    * See {@link IDataStore.get}
    */

--- a/packages/common-all/src/store/SchemaMetadataStore.ts
+++ b/packages/common-all/src/store/SchemaMetadataStore.ts
@@ -16,6 +16,10 @@ export class SchemaMetadataStore
     this._schemaMetadataById = {};
   }
 
+  dispose() {
+    this._schemaMetadataById = {};
+  }
+
   /**
    * See {@link IDataStore.get}
    */

--- a/packages/common-all/src/store/SchemaStore.ts
+++ b/packages/common-all/src/store/SchemaStore.ts
@@ -2,18 +2,13 @@ import { URI, Utils } from "vscode-uri";
 import { ERROR_SEVERITY, ERROR_STATUS } from "../constants";
 import { SchemaUtils } from "../dnode";
 import { DendronError } from "../error";
-import {
-  Disposable,
-  RespV3,
-  SchemaModuleProps,
-  WriteSchemaOpts,
-} from "../types";
+import { RespV3, SchemaModuleProps, WriteSchemaOpts } from "../types";
 import { VaultUtils } from "../vault";
 import { IDataStore } from "./IDataStore";
 import { IFileStore } from "./IFileStore";
 import { ISchemaStore } from "./ISchemaStore";
 
-export class SchemaStore implements Disposable, ISchemaStore<string> {
+export class SchemaStore implements ISchemaStore<string> {
   private _fileStore: IFileStore;
   private _metadataStore: IDataStore<string, SchemaModuleProps>;
   private _wsRoot: URI;
@@ -28,7 +23,9 @@ export class SchemaStore implements Disposable, ISchemaStore<string> {
     this._wsRoot = wsRoot;
   }
 
-  dispose() {}
+  dispose() {
+    this._metadataStore.dispose();
+  }
 
   /**
    * See {@link ISchemaStore.getMetadata}

--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -235,7 +235,7 @@ export type NoteProps = DNodeProps<any, any>;
 /**
  * Dendron note metadata
  */
-export type NotePropsMeta = Omit<NoteProps, "body" | "contentHash">;
+export type NotePropsMeta = Omit<NoteProps, "body">;
 
 /**
  * Dendron note with optional custom props

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -246,6 +246,7 @@ export type EngineWriteOptsV2 = {
   runHooks?: boolean;
   /**
    * If true, overwrite existing note with same fname and vault, even if note has a different id
+   * Commonly used if needed to override a note id
    */
   overrideExisting?: boolean;
   /**

--- a/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
+++ b/packages/dendron-plugin-views/src/hooks/useGraphElements.tsx
@@ -412,14 +412,14 @@ function getOutwardLinkedConnections({
       }
 
       const fname = fnameArray[fnameArray.length - 1];
-      const to = NoteDictsUtils.findByFname(
+      const to = NoteDictsUtils.findByFname({
         fname,
-        {
+        noteDicts: {
           notesById: notes,
           notesByFname: fNameDict,
         },
-        toVault
-      )[0];
+        vault: toVault,
+      })[0];
 
       if (!to) {
         logger.warn(
@@ -565,14 +565,14 @@ const getFullNoteGraphElements = ({
         }
 
         const fname = fnameArray[fnameArray.length - 1];
-        let to = NoteDictsUtils.findByFname(
+        let to = NoteDictsUtils.findByFname({
           fname,
-          {
+          noteDicts: {
             notesById: notes,
             notesByFname: fNameDict,
           },
-          toVault
-        )[0];
+          vault: toVault,
+        })[0];
 
         if (!to) {
           logger.debug(

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -139,11 +139,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
 
   static create({ wsRoot, logger }: { logger?: DLogger; wsRoot: string }) {
     const LOGGER = logger || createLogger();
-    const { error, data: config } =
-      DConfig.readConfigAndApplyLocalOverrideSync(wsRoot);
-    if (error) {
-      LOGGER.error(stringifyError(error));
-    }
+    const config = DConfig.readConfigSync(wsRoot);
 
     const queryStore = new FuseQueryStore();
     const fileStore = new NodeJSFileStore();
@@ -172,9 +168,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
    * Does not throw error but returns it
    */
   async init(): Promise<DEngineInitResp> {
-    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-      this.wsRoot
-    );
+    const config = DConfig.readConfigSync(this.wsRoot);
     const defaultResp = {
       notes: {},
       schemas: {},
@@ -315,9 +309,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       note: NoteUtils.toLogObj(note),
     });
 
-    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-      this.wsRoot
-    );
+    const config = DConfig.readConfigSync(this.wsRoot);
     // Update links/anchors based on note body
     await EngineUtils.refreshNoteLinksAndAnchors({
       note,
@@ -632,9 +624,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
 
     // update note body of all notes that have changed
-    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-      this.wsRoot
-    );
+    const config = DConfig.readConfigSync(this.wsRoot);
     const notesToUpdate = linkNotesResp
       .map((resp) => {
         if (resp.error) {
@@ -930,9 +920,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           }),
         };
       }
-      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-        this.wsRoot
-      );
+      const config = DConfig.readConfigSync(this.wsRoot);
       const blocks = await RemarkUtils.extractBlocks({
         note,
         config,
@@ -976,9 +964,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           ),
         };
       });
-      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-        this.wsRoot
-      );
+      const config = DConfig.readConfigSync(this.wsRoot);
       const {
         allDecorations: decorations,
         allDiagnostics: diagnostics,
@@ -1507,9 +1493,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     dest: DendronASTDest;
   }): Promise<string> {
     let proc: ReturnType<typeof MDUtilsV5["procRehypeFull"]>;
-    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
-      this.wsRoot
-    );
+    const config = DConfig.readConfigSync(this.wsRoot);
 
     const noteCacheForRenderDict = await getParsingDependencyDicts(
       note,

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -172,12 +172,15 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
    * Does not throw error but returns it
    */
   async init(): Promise<DEngineInitResp> {
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     const defaultResp = {
       notes: {},
       schemas: {},
       wsRoot: this.wsRoot,
       vaults: this.vaults,
-      config: ConfigUtils.genDefaultConfig(),
+      config,
     };
     try {
       const { data: schemas, error: schemaErrors } = await this.initSchema();
@@ -201,12 +204,14 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       const bulkWriteSchemaOpts = schemas.map((schema) => {
         return { key: schema.root.id, schema };
       });
+      this._schemaStore.dispose();
       this._schemaStore.bulkWriteMetadata(bulkWriteSchemaOpts);
 
-      const { data: notes, error: noteErrors } = await this.initNotes(
+      const { data: noteDicts, error: noteErrors } = await this.initNotes(
         schemaDict
       );
-      if (_.isUndefined(notes)) {
+      const { notesById } = noteDicts;
+      if (_.isUndefined(notesById)) {
         return {
           data: defaultResp,
           error: DendronError.createFromStatus({
@@ -217,13 +222,26 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
         };
       }
 
-      await this.queryStore.replaceNotesIndex(notes);
+      // Backlink candidates have to be done after notes are initialized because it depends on the engine already having notes in it
+      if (config.dev?.enableLinkCandidates) {
+        const ctx = "_addLinkCandidates";
+        const start = process.hrtime();
+        this.logger.info({ ctx, msg: "pre:addLinkCandidates" });
+        // Mutates existing note objects so we don't need to reset the notes
+        const maxNoteLength = ConfigUtils.getWorkspace(config).maxNoteLength;
+        this.updateNotesWithLinkCandidates(noteDicts, maxNoteLength, config);
+        const duration = getDurationMilliseconds(start);
+        this.logger.info({ ctx, duration });
+      }
+
+      await this.queryStore.replaceNotesIndex(notesById);
       await this.queryStore.replaceSchemasIndex(schemaDict);
-      const bulkWriteOpts = _.values(notes).map((note) => {
-        const noteMeta: NotePropsMeta = _.omit(note, ["body", "contentHash"]);
+      const bulkWriteOpts = _.values(notesById).map((note) => {
+        const noteMeta: NotePropsMeta = _.omit(note, ["body"]);
 
         return { key: note.id, noteMeta };
       });
+      this._noteStore.dispose();
       this._noteStore.bulkWriteMetadata(bulkWriteOpts);
 
       const hookErrors: IDendronError[] = [];
@@ -261,10 +279,10 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       return {
         error,
         data: {
-          notes,
+          notes: notesById,
           wsRoot: this.wsRoot,
           vaults: this.vaults,
-          config: DConfig.readConfigSync(this.wsRoot),
+          config,
         },
       };
     } catch (error: any) {
@@ -297,11 +315,14 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       note: NoteUtils.toLogObj(note),
     });
 
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     // Update links/anchors based on note body
     await EngineUtils.refreshNoteLinksAndAnchors({
       note,
       engine: this,
-      config: DConfig.readConfigSync(this.wsRoot),
+      config,
     });
 
     // Apply hooks
@@ -611,7 +632,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
 
     // update note body of all notes that have changed
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     const notesToUpdate = linkNotesResp
       .map((resp) => {
         if (resp.error) {
@@ -907,9 +930,12 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           }),
         };
       }
+      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+        this.wsRoot
+      );
       const blocks = await RemarkUtils.extractBlocks({
         note,
-        config: DConfig.readConfigSync(this.wsRoot, true),
+        config,
       });
       if (opts.filterByAnchorType) {
         _.remove(
@@ -950,7 +976,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           ),
         };
       });
-      const config = DConfig.readConfigSync(this.wsRoot, true);
+      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+        this.wsRoot
+      );
       const {
         allDecorations: decorations,
         allDiagnostics: diagnostics,
@@ -1043,7 +1071,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
    */
   private async initNotes(
     schemas: SchemaModuleDict
-  ): Promise<RespWithOptError<NotePropsByIdDict>> {
+  ): Promise<RespWithOptError<NoteDicts>> {
     const ctx = "DEngine:initNotes";
     this.logger.info({ ctx, msg: "enter" });
     let errors: IDendronError[] = [];
@@ -1081,16 +1109,14 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           logger: this.logger,
         });
 
-        const { data: notesDict, error } = await new NoteParserV2({
+        const { noteDicts, errors: parseErrors } = await new NoteParserV2({
           cache: notesCache,
           engine: this,
           logger: this.logger,
         }).parseFiles(maybeFiles.data, vault, schemas);
-        if (error) {
-          errors = errors.concat(error);
-        }
-        if (notesDict) {
-          const { notesById, notesByFname } = notesDict;
+        errors = errors.concat(parseErrors);
+        if (noteDicts) {
+          const { notesById, notesByFname } = noteDicts;
           notesFname = NoteFnameDictUtils.merge(notesFname, notesByFname);
 
           this.logger.info({
@@ -1117,8 +1143,12 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     this.logger.info({ ctx, msg: `time to init notes: "${duration}" ms` });
 
     return {
-      data: allNotes,
-      error: new DendronCompositeError(errors),
+      data: {
+        notesById: allNotes,
+        notesByFname: notesFname,
+      },
+      error:
+        errors.length === 0 ? undefined : new DendronCompositeError(errors),
     };
   }
 
@@ -1159,17 +1189,17 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
         noteFrom.links.forEach((link) => {
           const maybeBacklink = BacklinkUtils.createFromDLink(link);
           if (maybeBacklink) {
-            const notes = NoteDictsUtils.findByFname(
-              link.to!.fname!,
-              noteDicts
-            );
+            const notes = NoteDictsUtils.findByFname({
+              fname: link.to!.fname!,
+              noteDicts,
+              skipCloneDeep: true,
+            });
 
             notes.forEach((noteTo: NoteProps) => {
               BacklinkUtils.addBacklinkInPlace({
                 note: noteTo,
                 backlink: maybeBacklink,
               });
-              NoteDictsUtils.add(noteTo, noteDicts);
             });
           }
         });
@@ -1477,7 +1507,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     dest: DendronASTDest;
   }): Promise<string> {
     let proc: ReturnType<typeof MDUtilsV5["procRehypeFull"]>;
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
 
     const noteCacheForRenderDict = await getParsingDependencyDicts(
       note,
@@ -1517,6 +1549,36 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const payload = await proc.process(NoteUtils.serialize(note));
     const renderedNote = payload.toString();
     return renderedNote;
+  }
+
+  private updateNotesWithLinkCandidates(
+    noteDicts: NoteDicts,
+    maxNoteLength: number,
+    config: DendronConfig
+  ) {
+    return _.map(noteDicts.notesById, (noteFrom: NoteProps) => {
+      try {
+        if (
+          noteFrom.body.length <
+          (maxNoteLength || CONSTANTS.DENDRON_DEFAULT_MAX_NOTE_LENGTH)
+        ) {
+          const linkCandidates = LinkUtils.findLinkCandidatesSync({
+            note: noteFrom,
+            noteDicts,
+            config,
+          });
+          noteFrom.links = noteFrom.links.concat(linkCandidates);
+        }
+      } catch (err: any) {
+        const error = error2PlainObject(err);
+        this.logger.error({
+          error,
+          noteFrom,
+          message: "issue with link candidates",
+        });
+        return;
+      }
+    });
   }
 }
 

--- a/packages/engine-server/src/backfillV2/service.ts
+++ b/packages/engine-server/src/backfillV2/service.ts
@@ -39,7 +39,7 @@ export class BackfillService {
           return n;
         })
     );
-    await engine.bulkWriteNotes({ notes });
+    await engine.bulkWriteNotes({ notes, opts: { overrideExisting: true } });
     return {};
   }
 }

--- a/packages/engine-server/src/doctor/service.ts
+++ b/packages/engine-server/src/doctor/service.ts
@@ -115,11 +115,11 @@ export class DoctorService implements Disposable {
         if (!vault) return false;
       }
       const isMultiVault = vaults.length > 1;
-      const noteExists: NoteProps | undefined = NoteDictsUtils.findByFname(
-        link.to!.fname as string,
+      const noteExists: NoteProps | undefined = NoteDictsUtils.findByFname({
+        fname: link.to!.fname as string,
         noteDicts,
-        hasVaultPrefix ? vault! : note.vault
-      )[0];
+        vault: hasVaultPrefix ? vault! : note.vault,
+      })[0];
       if (hasVaultPrefix) {
         // true: link w/ vault prefix that points to nothing. (candidate for sure)
         // false: link w/ vault prefix that points to a note. (valid link)
@@ -408,6 +408,7 @@ export class DoctorService implements Disposable {
           note.id = genUUID();
           await engine.writeNote(note, {
             runHooks: false,
+            overrideExisting: true,
           });
           numChanges += 1;
         };
@@ -714,8 +715,11 @@ export class DoctorService implements Disposable {
           fname,
         });
         const canRename =
-          NoteDictsUtils.findByFname(cleanedFname, noteDicts, note.vault)
-            .length === 0;
+          NoteDictsUtils.findByFname({
+            fname: cleanedFname,
+            noteDicts,
+            vault: note.vault,
+          }).length === 0;
         return {
           ...item,
           cleanedFname,

--- a/packages/engine-server/src/drivers/SQLiteMetadataStore.ts
+++ b/packages/engine-server/src/drivers/SQLiteMetadataStore.ts
@@ -68,6 +68,8 @@ export class SQLiteMetadataStore implements IDataStore<string, NotePropsMeta> {
     });
   }
 
+  dispose() {}
+
   async get(id: string) {
     const note = await getPrismaClient().note.findUnique({ where: { id } });
     if (_.isNull(note)) {

--- a/packages/engine-server/src/drivers/file/NoteParserV2.ts
+++ b/packages/engine-server/src/drivers/file/NoteParserV2.ts
@@ -20,7 +20,6 @@ import {
   NoteChangeEntry,
   genHash,
   RespV2,
-  cleanName,
   SchemaUtils,
   string2Note,
   globMatch,

--- a/packages/engine-server/src/drivers/file/NoteParserV2.ts
+++ b/packages/engine-server/src/drivers/file/NoteParserV2.ts
@@ -21,12 +21,10 @@ import {
   genHash,
   RespV2,
   cleanName,
-  DendronCompositeError,
   SchemaUtils,
   string2Note,
   globMatch,
   DendronConfig,
-  RespWithOptError,
   asyncLoopOneAtATime,
   SchemaModuleDict,
 } from "@dendronhq/common-all";
@@ -94,7 +92,7 @@ export class NoteParserV2 {
     allPaths: string[],
     vault: DVault,
     schemas: SchemaModuleDict
-  ): Promise<RespWithOptError<NoteDicts>> {
+  ): Promise<{ noteDicts: NoteDicts; errors: IDendronError[] }> {
     const ctx = "parseFiles";
     const fileMetaDict: FileMetaDict = getFileMeta(allPaths);
     const maxLvl = _.max(_.keys(fileMetaDict).map((e) => _.toInteger(e))) || 2;
@@ -114,19 +112,23 @@ export class NoteParserV2 {
     // get root note
     if (_.isUndefined(fileMetaDict[1])) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootFile = fileMetaDict[1].find((n) => n.fpath === "root.md");
     if (!rootFile) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootProps = await this.parseNoteProps({
@@ -140,10 +142,12 @@ export class NoteParserV2 {
     }
     if (!rootProps.data || rootProps.data.length === 0) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootNote = rootProps.data[0].note;
@@ -282,8 +286,8 @@ export class NoteParserV2 {
 
     this.logger.info({ ctx, msg: "post:matchSchemas" });
     return {
-      data: noteDicts,
-      error: errors.length > 0 ? new DendronCompositeError(errors) : undefined,
+      noteDicts,
+      errors,
     };
   }
 
@@ -402,7 +406,7 @@ export class NoteParserV2 {
       }
     }
     // If hash is different, then we update all links and anchors ^link-anchor
-    note = string2Note({ content, fname: cleanName(name), vault });
+    note = string2Note({ content, fname: name, vault });
     note.contentHash = sig;
     // Link/anchor errors should be logged but not interfere with rest of parsing
     let error: IDendronError | null = null;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -232,11 +232,11 @@ export class FileStorage implements DStore {
     let notes: NoteProps[];
 
     if (fname) {
-      notes = NoteDictsUtils.findByFname(
+      notes = NoteDictsUtils.findByFname({
         fname,
-        { notesById: this.notes, notesByFname: this.noteFnames },
-        vault
-      );
+        noteDicts: { notesById: this.notes, notesByFname: this.noteFnames },
+        vault,
+      });
     } else if (vault) {
       notes = _.values(this.notes).filter((note) =>
         VaultUtils.isEqualV2(note.vault, vault)
@@ -1300,11 +1300,11 @@ export class FileStorage implements DStore {
       note: NoteUtils.toLogObj(note),
     });
     // check if note might already exist
-    const maybeNote = NoteDictsUtils.findByFname(
-      note.fname,
-      { notesById: this.notes, notesByFname: this.noteFnames },
-      note.vault
-    )[0];
+    const maybeNote = NoteDictsUtils.findByFname({
+      fname: note.fname,
+      noteDicts: { notesById: this.notes, notesByFname: this.noteFnames },
+      vault: note.vault,
+    })[0];
     this.logger.info({
       ctx,
       msg: "check:existing",
@@ -1499,19 +1499,16 @@ export class FileStorage implements DStore {
             vaults: this.vaults,
           })
         : undefined;
-      const notes = NoteDictsUtils.findByFname(
-        link.to.fname,
-        { notesById: this.notes, notesByFname: this.noteFnames },
-        maybeVault
-      );
+      const notes = NoteDictsUtils.findByFname({
+        fname: link.to.fname,
+        noteDicts: { notesById: this.notes, notesByFname: this.noteFnames },
+        vault: maybeVault,
+        skipCloneDeep: true,
+      });
       return Promise.all(
         notes.map(async (note) => {
           const prevNote = _.cloneDeep(note);
           BacklinkUtils.addBacklinkInPlace({ note, backlink: maybeBacklink });
-          NoteDictsUtils.add(note, {
-            notesById: this.notes,
-            notesByFname: this.noteFnames,
-          });
           return {
             prevNote,
             note,
@@ -1541,21 +1538,18 @@ export class FileStorage implements DStore {
             vaults: this.vaults,
           })
         : undefined;
-      const notes = NoteDictsUtils.findByFname(
-        link.to.fname,
-        { notesById: this.notes, notesByFname: this.noteFnames },
-        maybeVault
-      );
+      const notes = NoteDictsUtils.findByFname({
+        fname: link.to.fname,
+        noteDicts: { notesById: this.notes, notesByFname: this.noteFnames },
+        vault: maybeVault,
+        skipCloneDeep: true,
+      });
       return Promise.all(
         notes.map(async (note) => {
           const prevNote = _.cloneDeep(note);
           BacklinkUtils.removeBacklinkInPlace({
             note,
             backlink: maybeBacklink,
-          });
-          NoteDictsUtils.add(note, {
-            notesById: this.notes,
-            notesByFname: this.noteFnames,
           });
           return {
             prevNote,

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -234,10 +234,10 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
 
   /**
    * See {@link DStore.findNotesMeta}
-   * TODO: fix logic after engine refactor
    */
   async findNotesMeta(opts: FindNoteOpts): Promise<NotePropsMeta[]> {
-    return this.findNotes(opts);
+    const resp = await this.api.noteFindMeta({ ...opts, ws: this.ws });
+    return resp.data!;
   }
 
   async bulkWriteNotes(opts: BulkWriteNotesOpts) {

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -611,11 +611,11 @@ export class DendronEngineV2 implements DEngine {
             })
           : undefined;
 
-        return NoteDictsUtils.findByFname(
-          pointTo.fname!,
+        return NoteDictsUtils.findByFname({
+          fname: pointTo.fname!,
           noteDicts,
-          maybeVault
-        )[0];
+          vault: maybeVault,
+        })[0];
       })
       // Filter out broken links (pointing to non existent files)
       .filter((refNote) => refNote !== undefined);

--- a/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
@@ -84,7 +84,6 @@ describe("api/note/render tests", () => {
             // Modify the value of foo
             await api.engineWrite({
               ws: wsRoot,
-              opts: { metaOnly: true },
               node: {
                 ...fooNote,
                 updated: fooNote.updated + 1,
@@ -182,7 +181,6 @@ describe("api/note/render tests", () => {
         // Modify the value of foo-two
         await api.engineWrite({
           ws: wsRoot,
-          opts: { metaOnly: true },
           node: {
             ...fooTwo,
             updated: 2,

--- a/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
@@ -175,8 +175,7 @@ describe("GIVEN NoteStore", () => {
         note = await noteStore.get(newNote.id);
         expect(note.data!.fname).toEqual(newNote.fname);
         expect(note.data!.body.trim()).toEqual(newNote.body.trim());
-        expect(note.data!.contentHash).toBeFalsy();
-        expect(newNote.data!.contentHash).toBeFalsy();
+        expect(note.data!.contentHash).toBeTruthy();
 
         // Test NoteStore.getMetadata
         const noteMetadata = await noteStore.getMetadata(newNote.id);
@@ -380,7 +379,7 @@ describe("GIVEN NoteStore", () => {
           noWrite: true,
         });
 
-        let noteMeta: NotePropsMeta = _.omit(newNote, ["body", "contentHash"]);
+        let noteMeta: NotePropsMeta = _.omit(newNote, ["body"]);
         let writeResp = await noteStore.writeMetadata({
           key: newNote.id,
           noteMeta,
@@ -395,7 +394,7 @@ describe("GIVEN NoteStore", () => {
         expect(metadata.data!.fname).toEqual(newNote.fname);
 
         // Write same note
-        noteMeta = _.omit(newNote, ["body", "contentHash"]);
+        noteMeta = _.omit(newNote, ["body"]);
         writeResp = await noteStore.writeMetadata({
           key: newNote.id,
           noteMeta,
@@ -406,7 +405,7 @@ describe("GIVEN NoteStore", () => {
 
         // Update note metadata and write
         newNote.color = "new color";
-        noteMeta = _.omit(newNote, ["body", "contentHash"]);
+        noteMeta = _.omit(newNote, ["body"]);
         writeResp = await noteStore.writeMetadata({
           key: newNote.id,
           noteMeta,
@@ -448,14 +447,8 @@ describe("GIVEN NoteStore", () => {
           noWrite: true,
         });
 
-        const newNoteMeta: NotePropsMeta = _.omit(newNote, [
-          "body",
-          "contentHash",
-        ]);
-        const anotherNoteMeta: NotePropsMeta = _.omit(anotherNote, [
-          "body",
-          "contentHash",
-        ]);
+        const newNoteMeta: NotePropsMeta = _.omit(newNote, ["body"]);
+        const anotherNoteMeta: NotePropsMeta = _.omit(anotherNote, ["body"]);
         const writeResp = await noteStore.bulkWriteMetadata([
           {
             key: newNoteMeta.id,

--- a/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
@@ -174,6 +174,7 @@ describe("engine, cache", () => {
         ).toEqual([newVault]);
       },
       {
+        createEngine,
         expect,
         preSetupHook: async ({ wsRoot, vaults }) => {
           await NoteTestUtilsV4.createNote({

--- a/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/GithubIssuePod.spec.ts
@@ -175,7 +175,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
       desc: "",
       links: [],
       anchors: {},
-      fname: "foo",
+      fname: "publish",
       updated: 1627283357535,
       created: 1627283357535,
       parent: null,
@@ -229,7 +229,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",
@@ -271,7 +271,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",
@@ -319,7 +319,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",
@@ -365,7 +365,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",
@@ -410,7 +410,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",
@@ -456,7 +456,7 @@ describe("GIVEN: Github publish pod is run for a note", () => {
             vaults,
             wsRoot,
             config: {
-              fname: "foo",
+              fname: "publish",
               vaultName,
               dest: "stdout",
               token: "asjska",

--- a/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/v2/MarkdownExportPodV2.spec.ts
@@ -77,6 +77,7 @@ function verifyWikiLink(resp: MarkdownExportReturnType, match: string) {
 
 function addVaultSiteUrlOverride(engine: DEngineClient) {
   engine.vaults[0].siteUrl = SITE_URL_VAULT;
+  engine.init();
 }
 
 const NOTE_REG = "parent";

--- a/packages/engine-test-utils/src/presets/engine-server/note-refs.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/note-refs.ts
@@ -1,8 +1,6 @@
-import { vault2Path } from "@dendronhq/common-server";
 import {
   TestPresetEntryV4,
   AssertUtils,
-  FileTestUtils,
   NoteTestUtilsV4,
 } from "@dendronhq/common-test-utils";
 
@@ -22,25 +20,30 @@ const WILDCARD_LINK_V4 = new TestPresetEntryV4(
       return [{ actual: out, expected: true }];
     },
     preSetupHook: async ({ wsRoot, vaults }) => {
-      const vpath = vault2Path({ wsRoot, vault: vaults[0] });
-      await FileTestUtils.createFiles(vpath, [
-        {
-          path: "journal.2020.07.01.md",
-          body: "journal0",
-        },
-        {
-          path: "journal.2020.08.01.md",
-          body: "journal1",
-        },
-        {
-          path: "journal.2020.08.03.md",
-          body: "journal3",
-        },
-        {
-          path: "journal.2020.08.02.md",
-          body: "journal2",
-        },
-      ]);
+      await NoteTestUtilsV4.createNote({
+        vault: vaults[0],
+        wsRoot,
+        body: "journal0",
+        fname: "journal.2020.07.01",
+      });
+      await NoteTestUtilsV4.createNote({
+        vault: vaults[0],
+        wsRoot,
+        body: "journal1",
+        fname: "journal.2020.08.01",
+      });
+      await NoteTestUtilsV4.createNote({
+        vault: vaults[0],
+        wsRoot,
+        body: "journal2",
+        fname: "journal.2020.08.02",
+      });
+      await NoteTestUtilsV4.createNote({
+        vault: vaults[0],
+        wsRoot,
+        body: "journal3",
+        fname: "journal.2020.08.03",
+      });
       const note = await NoteTestUtilsV4.createNote({
         vault: vaults[0],
         wsRoot,

--- a/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveNoteCommand.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEngine,
   DNodeUtils,
   NoteProps,
   VaultUtils,
@@ -13,7 +14,6 @@ import {
   runJestHarnessV2,
   TestPresetEntryV4,
 } from "@dendronhq/common-test-utils";
-import { DendronEngineV2 } from "@dendronhq/engine-server";
 import {
   ENGINE_HOOKS,
   ENGINE_HOOKS_MULTI,
@@ -32,10 +32,7 @@ import { createEngineFactory, describeMultiWS } from "../testUtilsV3";
 
 const createEngine = createEngineFactory({
   renameNote: (opts: WorkspaceOpts) => {
-    const rename: DendronEngineV2["renameNote"] = async ({
-      oldLoc,
-      newLoc,
-    }) => {
+    const rename: DEngine["renameNote"] = async ({ oldLoc, newLoc }) => {
       const extension = ExtensionProvider.getExtension();
       const cmd = new MoveNoteCommand(extension);
       const vpathOld = vault2Path({
@@ -69,16 +66,13 @@ const createEngine = createEngineFactory({
     return rename;
   },
   findNotes: () => {
-    const findNotes: DendronEngineV2["findNotes"] = async ({
-      fname,
-      vault,
-    }) => {
+    const findNotes: DEngine["findNotes"] = async ({ fname, vault }) => {
       return ExtensionProvider.getEngine().findNotes({ fname, vault });
     };
     return findNotes;
   },
   findNotesMeta: () => {
-    const findNotesMeta: DendronEngineV2["findNotesMeta"] = async ({
+    const findNotesMeta: DEngine["findNotesMeta"] = async ({
       fname,
       vault,
     }) => {
@@ -87,13 +81,13 @@ const createEngine = createEngineFactory({
     return findNotesMeta;
   },
   getNote: () => {
-    const getNote: DendronEngineV2["getNote"] = async (id) => {
+    const getNote: DEngine["getNote"] = async (id) => {
       return ExtensionProvider.getEngine().getNote(id);
     };
     return getNote;
   },
   getNoteMeta: () => {
-    const getNoteMeta: DendronEngineV2["getNoteMeta"] = async (id) => {
+    const getNoteMeta: DEngine["getNoteMeta"] = async (id) => {
       return ExtensionProvider.getEngine().getNoteMeta(id);
     };
     return getNoteMeta;
@@ -371,7 +365,7 @@ suite("MoveNoteCommand", function () {
                 vaultName: VaultUtils.getName(vaultFrom),
               },
               newLoc: {
-                fname: "bar",
+                fname: "newFoo",
                 vaultName: VaultUtils.getName(vaultTo),
               },
             },
@@ -379,7 +373,7 @@ suite("MoveNoteCommand", function () {
         });
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.fileName.endsWith(
-            path.join("vault1", "bar.md")
+            path.join("vault1", "newFoo.md")
           )
         ).toBeTruthy();
         // note not in old vault
@@ -387,17 +381,19 @@ suite("MoveNoteCommand", function () {
           await EngineTestUtilsV4.checkVault({
             wsRoot,
             vault: vaultFrom,
-            match: ["bar.md"],
+            match: ["newFoo.md"],
             nomatch: ["foo.md"],
           })
         ).toBeTruthy();
         // note foo is now a stub
         const fooNoteAfter = (await engine.findNotes({ fname: "foo" }))[0];
         expect(!_.isUndefined(fooNoteAfter) && fooNoteAfter.stub).toBeTruthy();
-        // bar isn't in the first vault
+        // newFoo is in the first vault
         expect(
           _.isUndefined(
-            (await engine.findNotesMeta({ fname: "bar", vault: vaultFrom }))[0]
+            (
+              await engine.findNotesMeta({ fname: "newFoo", vault: vaultFrom })
+            )[0]
           )
         ).toBeFalsy();
       });
@@ -436,7 +432,7 @@ suite("MoveNoteCommand", function () {
                 vaultName: VaultUtils.getName(vault1),
               },
               newLoc: {
-                fname: "bar",
+                fname: "newScratch",
                 vaultName: VaultUtils.getName(vault2),
               },
             },
@@ -444,7 +440,7 @@ suite("MoveNoteCommand", function () {
         });
         expect(
           VSCodeUtils.getActiveTextEditor()?.document.fileName.endsWith(
-            path.join("vault1", "bar.md")
+            path.join("vault1", "newScratch.md")
           )
         ).toBeTruthy();
         const note = await engine.getNote(fname);

--- a/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/pods/AirtableExportPodCommand.test.ts
@@ -72,7 +72,7 @@ suite("AirtableExportCommand", function () {
         test("THEN new airtable id should be appended in the note frontmatter", async () => {
           const extension = ExtensionProvider.getExtension();
           const cmd = new AirtableExportPodCommand(extension);
-          const { engine } = ExtensionProvider.getDWorkspace();
+          const { engine, vaults } = ExtensionProvider.getDWorkspace();
           const { config } = await setUpPod();
           const note = getNoteFromTextEditor();
           note.custom = {
@@ -82,6 +82,7 @@ suite("AirtableExportCommand", function () {
               },
             },
           };
+          note.vault = vaults[0];
           await engine.writeNote(note);
           const payload = await cmd.enrichInputs(config);
           const airtableId = "airtable-proj.beta";

--- a/packages/plugin-core/src/test/testUtilsV3.ts
+++ b/packages/plugin-core/src/test/testUtilsV3.ts
@@ -1,6 +1,7 @@
 import {
   ConfigUtils,
   DENDRON_VSCODE_CONFIG_KEYS,
+  DEngine,
   DEngineClient,
   Disposable,
   DVault,
@@ -34,7 +35,6 @@ import {
 } from "@dendronhq/common-test-utils";
 import {
   DendronEngineClient,
-  DendronEngineV2,
   Git,
   HistoryService,
   WorkspaceUtils,
@@ -428,7 +428,7 @@ export function stubSetupWorkspace({ wsRoot }: { wsRoot: string }) {
 class FakeEngine {}
 
 type EngineOverride = {
-  [P in keyof DendronEngineV2]: (opts: WorkspaceOpts) => DendronEngineV2[P];
+  [P in keyof DEngine]: (opts: WorkspaceOpts) => DEngine[P];
 };
 
 export const createEngineFactory = (
@@ -438,7 +438,7 @@ export const createEngineFactory = (
     opts: WorkspaceOpts
   ): DEngineClient => {
     const engine = new FakeEngine() as DEngineClient;
-    _.map(overrides || {}, (method, key: keyof DendronEngineV2) => {
+    _.map(overrides || {}, (method, key: keyof DEngine) => {
       // @ts-ignore
       engine[key] = method(opts);
     });

--- a/packages/plugin-core/src/web/engine/NoteParserV2.ts
+++ b/packages/plugin-core/src/web/engine/NoteParserV2.ts
@@ -311,7 +311,7 @@ export class NoteParserV2 {
 
     const note = string2Note({
       content,
-      fname: cleanName(name),
+      fname: name,
       vault,
     });
     note.contentHash = sig;

--- a/packages/plugin-core/src/web/engine/NoteParserV2.ts
+++ b/packages/plugin-core/src/web/engine/NoteParserV2.ts
@@ -1,6 +1,5 @@
 import {
   cleanName,
-  DendronCompositeError,
   DendronError,
   DNodeUtils,
   DuplicateNoteError,
@@ -20,7 +19,6 @@ import {
   NotePropsByIdDict,
   NoteUtils,
   RespV2,
-  RespWithOptError,
   string2Note,
   stringifyError,
   VaultUtils,
@@ -69,7 +67,7 @@ export class NoteParserV2 {
   async parseFiles(
     allPaths: string[],
     vault: DVault
-  ): Promise<RespWithOptError<NoteDicts>> {
+  ): Promise<{ noteDicts: NoteDicts; errors: IDendronError[] }> {
     const fileMetaDict: FileMetaDict = getFileMeta(allPaths);
     const maxLvl = _.max(_.keys(fileMetaDict).map((e) => _.toInteger(e))) || 2;
     // In-memory representation of NoteProps dictionary
@@ -84,19 +82,23 @@ export class NoteParserV2 {
     // get root note
     if (_.isUndefined(fileMetaDict[1])) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootFile = fileMetaDict[1].find((n) => n.fpath === "root.md");
     if (!rootFile) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootProps = await this.parseNoteProps({
@@ -109,10 +111,12 @@ export class NoteParserV2 {
     }
     if (!rootProps.data || rootProps.data.length === 0) {
       return {
-        data: noteDicts,
-        error: DendronError.createFromStatus({
-          status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
-        }),
+        noteDicts,
+        errors: [
+          DendronError.createFromStatus({
+            status: ERROR_STATUS.NO_ROOT_NOTE_FOUND,
+          }),
+        ],
       };
     }
     const rootNote = rootProps.data[0].note;
@@ -219,8 +223,8 @@ export class NoteParserV2 {
       await Promise.all(anotherOp);
     }
     return {
-      data: noteDicts,
-      error: errors.length > 0 ? new DendronCompositeError(errors) : undefined,
+      noteDicts,
+      errors,
     };
   }
 

--- a/packages/pods-core/src/builtin/GraphvizPod.ts
+++ b/packages/pods-core/src/builtin/GraphvizPod.ts
@@ -97,11 +97,11 @@ export class GraphvizExportPod extends ExportPod<GraphvizExportConfig> {
       note.links.forEach((link: DLink) => {
         if (link.to) {
           const destinationNote: NoteProps | undefined =
-            NoteDictsUtils.findByFname(
-              link.to!.fname as string,
+            NoteDictsUtils.findByFname({
+              fname: link.to!.fname as string,
               noteDicts,
-              note.vault
-            )[0];
+              vault: note.vault,
+            })[0];
 
           if (!_.isUndefined(destinationNote)) {
             if (

--- a/packages/unified/src/SiteUtils.ts
+++ b/packages/unified/src/SiteUtils.ts
@@ -528,7 +528,11 @@ export class SiteUtils {
           vaults,
         });
 
-        const maybeNote = NoteDictsUtils.findByFname(fname, noteDict, vault)[0];
+        const maybeNote = NoteDictsUtils.findByFname({
+          fname,
+          noteDicts: noteDict,
+          vault,
+        })[0];
         if (
           maybeNote &&
           this.canPublish({

--- a/packages/unified/src/remark/backlinks.ts
+++ b/packages/unified/src/remark/backlinks.ts
@@ -69,11 +69,11 @@ const plugin: Plugin = function (this: Unified.Processor) {
         return false;
       }
 
-      const note = NoteDictsUtils.findByFname(
-        backlink.from.fname!,
-        noteCacheForRenderDict,
-        vault
-      )[0];
+      const note = NoteDictsUtils.findByFname({
+        fname: backlink.from.fname!,
+        noteDicts: noteCacheForRenderDict,
+        vault,
+      })[0];
 
       // if note doesn't exist, don't include in backlinks
       if (!note) {
@@ -100,14 +100,14 @@ const plugin: Plugin = function (this: Unified.Processor) {
           backlinksToPublish.map((mdLink) => {
             let alias;
 
-            const notes = NoteDictsUtils.findByFname(
-              mdLink.from.fname!,
-              noteCacheForRenderDict!,
-              VaultUtils.getVaultByName({
+            const notes = NoteDictsUtils.findByFname({
+              fname: mdLink.from.fname!,
+              noteDicts: noteCacheForRenderDict!,
+              vault: VaultUtils.getVaultByName({
                 vaults,
                 vname: mdLink.from.vaultName!,
-              })
-            );
+              }),
+            });
 
             const note = notes[0];
 

--- a/packages/unified/src/remark/dendronPub.ts
+++ b/packages/unified/src/remark/dendronPub.ts
@@ -288,11 +288,11 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         let note: NoteProps | undefined;
         if (mode !== ProcMode.IMPORT) {
           if (noteCacheForRenderDict) {
-            note = NoteDictsUtils.findByFname(
-              valueOrig,
-              noteCacheForRenderDict,
-              vault
-            )[0];
+            note = NoteDictsUtils.findByFname({
+              fname: valueOrig,
+              noteDicts: noteCacheForRenderDict,
+              vault,
+            })[0];
           }
 
           if (!note) {
@@ -381,11 +381,11 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
               ? VaultUtils.getVaultByName({ vname: data.vaultName, vaults })
               : undefined;
 
-            const target = NoteDictsUtils.findByFname(
-              valueOrig,
-              noteCacheForRenderDict,
-              targetVault
-            )[0];
+            const target = NoteDictsUtils.findByFname({
+              fname: valueOrig,
+              noteDicts: noteCacheForRenderDict,
+              vault: targetVault,
+            })[0];
 
             if (target) {
               title = target.title;

--- a/packages/unified/src/remark/noteRefsV2.ts
+++ b/packages/unified/src/remark/noteRefsV2.ts
@@ -440,7 +440,10 @@ export function convertNoteRefToHAST(
 
     let data;
     if (noteCacheForRenderDict) {
-      data = NoteDictsUtils.findByFname(fname, noteCacheForRenderDict);
+      data = NoteDictsUtils.findByFname({
+        fname,
+        noteDicts: noteCacheForRenderDict,
+      });
       // data = NoteDictsUtils.findByFname(fname, noteCacheForRenderDict, vault);
     }
     if (!data || data.length === 0) {

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -402,11 +402,11 @@ const getLinkCandidatesSync = ({
     const value = textNode.value as string;
 
     value.split(/\s+/).map((word) => {
-      const possibleCandidates = NoteDictsUtils.findByFname(
-        word,
+      const possibleCandidates = NoteDictsUtils.findByFname({
+        fname: word,
         noteDicts,
-        note.vault
-      )
+        vault: note.vault,
+      })
         // await engine.findNotesMeta({ fname: word, vault: note.vault })
         .filter((note) => note.stub !== true);
 

--- a/packages/unified/src/remark/wikiLinks.ts
+++ b/packages/unified/src/remark/wikiLinks.ts
@@ -112,11 +112,11 @@ function attachCompiler(proc: Unified.Processor, opts?: CompilerOpts) {
             ? VaultUtils.getVaultByName({ vname: data.vaultName, vaults })
             : undefined;
 
-          const target = NoteDictsUtils.findByFname(
-            value,
-            noteCacheForRenderDict,
-            targetVault
-          )[0];
+          const target = NoteDictsUtils.findByFname({
+            fname: value,
+            noteDicts: noteCacheForRenderDict,
+            vault: targetVault,
+          })[0];
 
           if (target) {
             alias = target.title;
@@ -150,7 +150,10 @@ function attachCompiler(proc: Unified.Processor, opts?: CompilerOpts) {
         // TODO: Consolidate logic.
         if (noteCacheForRenderDict) {
           // TODO: Add vault filter
-          notes = NoteDictsUtils.findByFname(alias, noteCacheForRenderDict);
+          notes = NoteDictsUtils.findByFname({
+            fname: alias,
+            noteDicts: noteCacheForRenderDict,
+          });
         } else {
           return "error - no note cache provided";
         }


### PR DESCRIPTION
This is the first portion of the changes to move to engine v3. While making the switch, it uncovered several test and engine bugs that this pr will fix. The next pr will move to engine v3 under a feature flag.

**Changes**
1. Add missing candidate links feature to engine v3
2. Improve init speed of v3
3. Include `contentHash` as part of `NotePropsMeta`
4. Extend NoteStore and DataStore to be `Disposable`. This will allow the engine to refresh from clean state everytime init is called