### PR TITLE
fix(publish): runtime error on undefined dendron config

### DIFF
--- a/packages/nextjs-template/hooks/useDendronConfig.ts
+++ b/packages/nextjs-template/hooks/useDendronConfig.ts
@@ -1,10 +1,6 @@
-import { assertUnreachable } from "@dendronhq/common-all";
 import { useEngineAppSelector } from "../features/engine/hooks";
 
 export const useDendronConfig = () => {
   const { config } = useEngineAppSelector((state) => state.engine);
-  if (!config) {
-    assertUnreachable(undefined as never);
-  }
   return config;
 };

--- a/packages/nextjs-template/utils/useFuse.ts
+++ b/packages/nextjs-template/utils/useFuse.ts
@@ -5,6 +5,7 @@ import {
   FuseNoteIndex,
   NotePropsByIdDict,
   ConfigUtils,
+  genDefaultLookupConfig,
 } from "@dendronhq/common-all";
 import { fetchFuseIndex } from "./fetchers";
 import { useEffect, useState } from "react";
@@ -28,7 +29,11 @@ function useFuse(
   const [loading, setLoading] = useState<boolean>(false);
   const [fuse, setFuse] = useState<FuseNote>();
   const dendronConfig = useDendronConfig();
-  const fuzzThreshold = ConfigUtils.getLookup(dendronConfig).note.fuzzThreshold;
+  const fuzzThreshold = (
+    dendronConfig
+      ? ConfigUtils.getLookup(dendronConfig)
+      : genDefaultLookupConfig()
+  ).note.fuzzThreshold;
 
   useEffect(() => {
     if (_.isUndefined(fuse)) {


### PR DESCRIPTION
The aim of this PR is to fix a regression that came in from https://github.com/dendronhq/dendron/pull/3684.
In that PR I had a false assumption, which was that the dendron config will have been loaded initially to the redux store and therefore thought its safe to add the `assertUnreachable` throw. I made the mistake and did not check for runtime errors locally.

This was not caught inside our CI because we currently do not check for runtime errors.

This PR fixes that by removing it.

NOTE: In the newer 8.x version of `react-redux` there exists a new prop for the `Provider`. [`serverState`](https://react-redux.js.org/api/provider#props) is its name and we could use that to provide the initial dendron config in `packages/nextjs-template/pages/_app.tsx:61:1`. This way we can work based on the assumption that a dendron config will always be available and can remove all the conditional checks. I think this would simplify our nextjs-template code  and make it easier to work with.



# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
