### PR TITLE
Chore/nightly build tweaks

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,38 +1,17 @@
-# This workflow will build the plugin vsix every week night at 12:00 AM PST and
-# publish it to the VS Code Marketplace under the 'nightly' extension target.
-# This will NOT publish any packages to NPM.
+# Builds and publishes the release. This will publish packages to npm and
+# publish the release extension to the VS Code and Open VSX Marketplaces. This
+# is manually triggered once the release build is smoke-tested and ready for
+# release.
 name: Proto
 
-# See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
-# Scheduled to run every weekday at 12:00 AM PST, which is 7:00 AM UTC Tuesday-Saturday
-on:
-  workflow_dispatch:
-  # schedule:
-  #   - cron: "0 7 * * 1-6"
-
+on: workflow_dispatch
 jobs:
   build:
-    # Don't run this job outside of the Dendronhq organization https://github.com/prisma/prisma/issues/3539#issuecomment-690260573
-    if: github.repository_owner == 'dendronhq'
-    timeout-minutes: 60
-    environment: plugin-production
-
+    environment: plugin-development
     strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: win32
-            arch: x64
-          - platform: win32
-            arch: ia32
-          - platform: linux
-            arch: x64
-          - platform: linux
-            arch: arm64
-          - platform: darwin
-            arch: x64
-          - platform: darwin
-            arch: arm64
+      fail-fast: true
+
+    timeout-minutes: 30
 
     runs-on: ubuntu-latest
 
@@ -54,22 +33,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 14.x
 
       - name: Yarn Setup
         run: yarn setup
-
-      - name: Download SQLite Binary
-        run: |
-          if [ ${{ matrix.platform }} == linux ]; then
-            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
-            else
-            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
-          fi
-        working-directory: ./packages/plugin-core
-
-      - name: Update schema file
-        run: yarn gen:data
 
       - name: Set Up Yarn Local Registry
         run: yarn config set registry http://localhost:4873
@@ -79,23 +46,22 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`-nightly" >> $GITHUB_ENV
+          echo "DENDRON_RELEASE_VERSION=`cat ./packages/plugin-core/package.json | jq ".version" -r | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
-          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build the VSIX
         run: |
-          yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
+          yarn build:patch:local:ci
 
       - name: Check for VSIX
         run: |
           vsixCount=`ls ./packages/plugin-core/*.vsix | wc -l | awk '{print $1}'`
           if [ $vsixCount = 1 ]; then
             vsix=$(ls ./packages/plugin-core/*.vsix | tail -1)
-            echo "found a single .vsix file named $vsix" 
+            echo "found a single .vsix file named $vsix"
             echo "VSIX_FILE_NAME=$(basename $vsix)" >> $GITHUB_ENV
             echo "VSIX_RELATIVE_PATH=$vsix" >> $GITHUB_ENV
             else
@@ -110,14 +76,15 @@ jobs:
           path: ${{ env.VSIX_RELATIVE_PATH }}
           if-no-files-found: error
 
-      - name: Publish to VS Code Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
-        working-directory: ./packages/plugin-core
-        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DENDRON_BOT_S3_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DENDRON_BOT_S3_ACCESS_KEY }}
+          aws-region: us-east-1
 
-      - name: Publish to Open VSX Marketplace
-        env:
-          OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
-        working-directory: ./packages/plugin-core
-        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}
+      - name: Publish VSIX to S3
+        run: |
+          BUCKET=org-dendron-public-assets
+          aws s3 cp --acl public-read ${{ env.VSIX_RELATIVE_PATH }} s3://$BUCKET/publish/${{ env.VSIX_FILE_NAME }}
+          echo https://$BUCKET.s3.amazonaws.com/publish/${{ env.VSIX_FILE_NAME }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Download SQLite Binary
         run: |
-          if [ ${{ matrix.platform }} == 'linux']; then
+          if [ ${{ matrix.platform }} == linux ]; then
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
             else
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Download SQLite Binary
         run: |
           if [ ${{ matrix.platform }} = linux]; then
-            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }}
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
             else
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
           fi

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -62,7 +62,12 @@ jobs:
         run: yarn setup
 
       - name: Download SQLite Binary
-        run: yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }}
+        run: |
+          if [ ${{ matrix.platform }} = linux]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }}
+            else
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          fi
         working-directory: ./packages/plugin-core
 
       - name: Update schema file
@@ -85,7 +90,7 @@ jobs:
 
       - name: Build the VSIX
         run: |
-          yarn build:patch:local:ci:nightly
+          yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
 
       - name: Check for VSIX
         run: |
@@ -111,10 +116,10 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
         working-directory: ./packages/plugin-core
-        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}
+        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }}
 
       - name: Publish to Open VSX Marketplace
         env:
           OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
         working-directory: ./packages/plugin-core
-        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}
+        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,17 +1,40 @@
-# Builds and publishes the release. This will publish packages to npm and
-# publish the release extension to the VS Code and Open VSX Marketplaces. This
-# is manually triggered once the release build is smoke-tested and ready for
-# release.
+# This workflow will build the plugin vsix every week night at 12:00 AM PST and
+# publish it to the VS Code Marketplace under the 'nightly' extension target.
+# This will NOT publish any packages to NPM.
 name: Proto
 
-on: workflow_dispatch
+# See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
+# Scheduled to run every weekday at 12:00 AM PST, which is 7:00 AM UTC Tuesday-Saturday
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 7 * * 1-6"
+
 jobs:
   build:
-    environment: plugin-development
-    strategy:
-      fail-fast: true
+    # Don't run this job outside of the Dendronhq organization https://github.com/prisma/prisma/issues/3539#issuecomment-690260573
+    if: github.repository_owner == 'dendronhq'
+    timeout-minutes: 60
+    environment: plugin-production
 
-    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: win32
+            arch: x64
+          - platform: win32
+            arch: ia32
+          - platform: win32
+            arch: arm64
+          - platform: linux
+            arch: x64
+          - platform: linux
+            arch: arm64
+          - platform: darwin
+            arch: x64
+          - platform: darwin
+            arch: arm64
 
     runs-on: ubuntu-latest
 
@@ -33,10 +56,17 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Yarn Setup
         run: yarn setup
+
+      - name: Download SQLite Binary
+        run: yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }}
+        working-directory: ./packages/plugin-core
+
+      - name: Update schema file
+        run: yarn gen:data
 
       - name: Set Up Yarn Local Registry
         run: yarn config set registry http://localhost:4873
@@ -46,22 +76,23 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "DENDRON_RELEASE_VERSION=`cat ./packages/plugin-core/package.json | jq ".version" -r | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`" >> $GITHUB_ENV
+          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`-nightly" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build the VSIX
         run: |
-          yarn build:patch:local:ci
+          yarn build:patch:local:ci:nightly
 
       - name: Check for VSIX
         run: |
           vsixCount=`ls ./packages/plugin-core/*.vsix | wc -l | awk '{print $1}'`
           if [ $vsixCount = 1 ]; then
             vsix=$(ls ./packages/plugin-core/*.vsix | tail -1)
-            echo "found a single .vsix file named $vsix"
+            echo "found a single .vsix file named $vsix" 
             echo "VSIX_FILE_NAME=$(basename $vsix)" >> $GITHUB_ENV
             echo "VSIX_RELATIVE_PATH=$vsix" >> $GITHUB_ENV
             else
@@ -76,15 +107,14 @@ jobs:
           path: ${{ env.VSIX_RELATIVE_PATH }}
           if-no-files-found: error
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.DENDRON_BOT_S3_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DENDRON_BOT_S3_ACCESS_KEY }}
-          aws-region: us-east-1
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
+        working-directory: ./packages/plugin-core
+        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}
 
-      - name: Publish VSIX to S3
-        run: |
-          BUCKET=org-dendron-public-assets
-          aws s3 cp --acl public-read ${{ env.VSIX_RELATIVE_PATH }} s3://$BUCKET/publish/${{ env.VSIX_FILE_NAME }}
-          echo https://$BUCKET.s3.amazonaws.com/publish/${{ env.VSIX_FILE_NAME }}
+      - name: Publish to Open VSX Marketplace
+        env:
+          OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
+        working-directory: ./packages/plugin-core
+        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -25,8 +25,6 @@ jobs:
             arch: x64
           - platform: win32
             arch: ia32
-          - platform: win32
-            arch: arm64
           - platform: linux
             arch: x64
           - platform: linux
@@ -63,7 +61,7 @@ jobs:
 
       - name: Download SQLite Binary
         run: |
-          if [ ${{ matrix.platform }} = linux]; then
+          if [ ${{ matrix.platform }} == 'linux']; then
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
             else
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown

--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -21,32 +21,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
-            platform: win32
+          - platform: win32
             arch: x64
-          - os: windows-latest
-            platform: win32
+          - platform: win32
             arch: ia32
-          - os: windows-latest
-            platform: win32
+          - platform: linux
+            arch: x64
+          - platform: linux
             arch: arm64
-          - os: ubuntu-latest
-            platform: linux
+          - platform: darwin
             arch: x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: arm64
-          - os: ubuntu-latest
-            platform: alpine
-            arch: x64
-          - os: macos-latest
-            platform: darwin
-            arch: x64
-          - os: macos-latest
-            platform: darwin
+          - platform: darwin
             arch: arm64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Gather environment data
@@ -72,7 +60,12 @@ jobs:
         run: yarn setup
 
       - name: Download SQLite Binary
-        run: yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
+        run: |
+          if [ ${{ matrix.platform }} == linux ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
+            else
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          fi
         working-directory: ./packages/plugin-core
 
       - name: Update schema file
@@ -91,11 +84,11 @@ jobs:
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
-          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build the VSIX
         run: |
-          yarn build:patch:local:ci:nightly
+          yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
 
       - name: Check for VSIX
         run: |
@@ -121,10 +114,10 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
         working-directory: ./packages/plugin-core
-        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}
+        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }}
 
       - name: Publish to Open VSX Marketplace
         env:
           OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
         working-directory: ./packages/plugin-core
-        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }} --target ${{ env.PUBLISHING_TARGET }}
+        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}

--- a/bootstrap/scripts/buildNightly.sh
+++ b/bootstrap/scripts/buildNightly.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Build plugin for CI and release
+# TODO: `buildPatch.sh` is a bad name - it should just be `buildPlugin`
+
+echo "starting verdaccio with in-memory cache to speed up build time"
+verdaccio -c ./bootstrap/data/verdaccio/config.yaml > verdaccio.log 2>&1 &
+FOO_PID=$!
+echo "$FOO_PID"
+sleep 10
+
+SCRIPT_BUILD_ENV=${BUILD_ENV:-local}
+SCRIPT_EXT_TYPE=${EXT_TYPE:-dendron}
+echo "building... upgrade: patch, endpoint: local build environment: $SCRIPT_BUILD_ENV"
+
+DENDRON_CLI=./packages/dendron-cli/lib/bin/dendron-cli.js
+
+LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType patch --publishEndpoint local --extensionType nightly --extensionTarget $1
+
+echo "closing verdaccio - killing "
+kill $FOO_PID
+

--- a/bootstrap/scripts/buildNightly.sh
+++ b/bootstrap/scripts/buildNightly.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Build plugin for CI and release
-# TODO: `buildPatch.sh` is a bad name - it should just be `buildPlugin`
+# Build script specific for Nightly
 
 echo "starting verdaccio with in-memory cache to speed up build time"
 verdaccio -c ./bootstrap/data/verdaccio/config.yaml > verdaccio.log 2>&1 &

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build:prerelease:remote:ci": "cross-env UPGRADE_TYPE=prerelease PUBLISH_ENDPOINT=remote BUILD_ENV=ci ./bootstrap/scripts/buildPatch.sh",
     "build:patch:local": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=local USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
     "build:patch:local:ci": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
-    "build:patch:local:ci:nightly": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 EXT_TARGET=nightly ./bootstrap/scripts/buildPatch.sh",
+    "build:patch:local:ci:nightly": "./bootstrap/scripts/buildNightly.sh",
     "build:patch:remote": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote ./bootstrap/scripts/buildPatch.sh",
     "build:patch:remote:ci": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote BUILD_ENV=ci ./bootstrap/scripts/buildPatch.sh",
     "build:minor:local": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local ./bootstrap/scripts/buildPatch.sh",

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -29,7 +29,7 @@ import yargs from "yargs";
 import { CLIAnalyticsUtils, setupEngine } from "..";
 import {
   BuildUtils,
-  ExtensionTarget,
+  ExtensionType,
   LernaUtils,
   PublishEndpoint,
   SemverVersion,
@@ -69,7 +69,8 @@ type CommandOutput = Partial<{ error: DendronError; data: any }>;
 type BuildCmdOpts = {
   publishEndpoint: PublishEndpoint;
   fast?: boolean;
-  extensionTarget: ExtensionTarget;
+  extensionType: ExtensionType;
+  extensionTarget?: string;
   skipSentry?: boolean;
 } & BumpVersionOpts &
   PrepPluginOpts;
@@ -87,7 +88,7 @@ type BumpVersionOpts = {
 } & CommandCLIOpts;
 
 type PrepPluginOpts = {
-  extensionTarget: ExtensionTarget;
+  extensionType: ExtensionType;
 } & CommandCLIOpts;
 
 type RunMigrationOpts = {
@@ -144,9 +145,15 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       describe: "where to publish",
       choices: Object.values(PublishEndpoint),
     });
+    args.option("extensionType", {
+      describe:
+        "extension name to publish in the marketplace (Dendron / Nightly)",
+      choices: Object.values(ExtensionType),
+    });
     args.option("extensionTarget", {
-      describe: "extension name to publish in the marketplace",
-      choices: Object.values(ExtensionTarget),
+      describe:
+        "extension target to pass to vsce to specify platform and architecture",
+      choices: Object.values(ExtensionType),
     });
     args.option("fast", {
       describe: "skip some checks",
@@ -347,7 +354,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
             };
           }
 
-          await BuildUtils.prepPluginPkg(opts.extensionTarget);
+          await BuildUtils.prepPluginPkg(opts.extensionType);
           return { error: null };
         }
         case DevCommands.PACKAGE_PLUGIN: {
@@ -450,7 +457,7 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     await this.syncAssets(opts);
 
     this.print("prep repo...");
-    await BuildUtils.prepPluginPkg(opts.extensionTarget);
+    await BuildUtils.prepPluginPkg(opts.extensionType);
 
     if (!shouldPublishLocal) {
       this.print(
@@ -581,8 +588,8 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
   }
 
   validatePrepPluginArgs(opts: CommandOpts): opts is PrepPluginOpts {
-    if (opts.extensionTarget) {
-      return Object.values(ExtensionTarget).includes(opts.extensionTarget);
+    if (opts.extensionType) {
+      return Object.values(ExtensionType).includes(opts.extensionType);
     }
     return true;
   }

--- a/packages/dendron-cli/src/commands/devCLICommand.ts
+++ b/packages/dendron-cli/src/commands/devCLICommand.ts
@@ -153,7 +153,6 @@ export class DevCLICommand extends CLICommand<CommandOpts, CommandOutput> {
     args.option("extensionTarget", {
       describe:
         "extension target to pass to vsce to specify platform and architecture",
-      choices: Object.values(ExtensionType),
     });
     args.option("fast", {
       describe: "skip some checks",


### PR DESCRIPTION
## chore/nightly build tweaks

Some fixes for the nightly build:
- vsce publish doesn't support using both the --target and --packagePath arguments at the same time for some reason, so we need to specify --target at package time.
- Fixed issues with linux build logic
- Removed windows arm, which isn't available right now for sqlite3.