### PR TITLE
enhance(views): remove stub icon from tree view

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -172,7 +172,12 @@
       },
       {
         "command": "dendron.treeView.expandStub",
-        "title": "Dendron:Dev: Expand Stub"
+        "title": "Dendron: Dev: Expand Stub"
+      },
+      {
+        "command": "dendron.treeView.gotoNote",
+        "title": "Create Note",
+        "icon": "$(gist-new)"
       },
       {
         "command": "dendron.graph-panel.increaseDepth",
@@ -629,7 +634,15 @@
           "when": "dendron:devMode"
         },
         {
+          "command": "dendron.treeView.createNote",
+          "when": "false"
+        },
+        {
           "command": "dendron.treeView.expandStub",
+          "when": "false"
+        },
+        {
+          "command": "dendron.treeView.gotoNote",
           "when": "false"
         },
         {
@@ -1164,6 +1177,11 @@
         {
           "command": "dendron.createNote",
           "when": "view == dendron.treeView && shellExecutionSupported"
+        },
+        {
+          "command": "dendron.treeView.gotoNote",
+          "when": "view == dendron.treeView && viewItem == stub && shellExecutionSupported",
+          "group": "inline"
         }
       ]
     },

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -171,6 +171,10 @@
         "icon": "$(new-file)"
       },
       {
+        "command": "dendron.treeView.expandStub",
+        "title": "Dendron:Dev: Expand Stub"
+      },
+      {
         "command": "dendron.graph-panel.increaseDepth",
         "title": "Increase Depth",
         "icon": "$(arrow-up)"
@@ -623,6 +627,10 @@
         {
           "command": "dendron.treeView.expandAll",
           "when": "dendron:devMode"
+        },
+        {
+          "command": "dendron.treeView.expandStub",
+          "when": "false"
         },
         {
           "command": "dendron.browseNote",

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -77,6 +77,7 @@ import { WSUtils } from "./WSUtils";
 import { CreateScratchNoteKeybindingTip } from "./showcase/CreateScratchNoteKeybindingTip";
 import semver from "semver";
 import _ from "lodash";
+import { GotoNoteCommand } from "./commands/GotoNote";
 
 const MARKDOWN_WORD_PATTERN = new RegExp("([\\w\\.]+)");
 // === Main
@@ -711,6 +712,21 @@ async function _setupCommands({
             await new ConfigureWithUICommand(
               ConfigureUIPanelFactory.create(ext)
             ).run();
+          })
+        )
+      );
+    }
+    if (!existingCommands.includes(DENDRON_COMMANDS.TREEVIEW_GOTO_NOTE.key)) {
+      context.subscriptions.push(
+        vscode.commands.registerCommand(
+          DENDRON_COMMANDS.TREEVIEW_GOTO_NOTE.key,
+          sentryReportingCallback(async (id: string) => {
+            const resp = await ext.getEngine().getNoteMeta(id);
+            const { data } = resp;
+            await new GotoNoteCommand(ext).run({
+              qs: data?.fname,
+              vault: data?.vault,
+            });
           })
         )
       );

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -172,7 +172,6 @@ type CommandEntry = {
 
 const CMD_PREFIX = "Dendron:";
 export const ICONS = {
-  STUB: "gist-new",
   LINK_CANDIDATE: "debug-disconnect",
   WIKILINK: "link",
 };
@@ -400,6 +399,11 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.treeView.createNote",
     title: "Create Note",
     icon: "$(new-file)",
+  },
+  TREEVIEW_EXPAND_STUB: {
+    key: "dendron.treeView.expandStub",
+    title: `${CMD_PREFIX}Dev: Expand Stub`,
+    when: "false",
   },
   // graph panel buttons
   GRAPH_PANEL_INCREASE_DEPTH: {

--- a/packages/plugin-core/src/constants.ts
+++ b/packages/plugin-core/src/constants.ts
@@ -174,6 +174,7 @@ const CMD_PREFIX = "Dendron:";
 export const ICONS = {
   LINK_CANDIDATE: "debug-disconnect",
   WIKILINK: "link",
+  SCHEMA: "repo",
 };
 export const DENDRON_WORKSPACE_FILE = "dendron.code-workspace";
 
@@ -352,6 +353,11 @@ export const DENDRON_MENUS = {
       command: "dendron.createNote",
       when: "view == dendron.treeView && shellExecutionSupported",
     },
+    {
+      command: "dendron.treeView.gotoNote",
+      when: "view == dendron.treeView && viewItem == stub && shellExecutionSupported",
+      group: "inline",
+    },
   ],
 };
 
@@ -399,10 +405,17 @@ export const DENDRON_COMMANDS: { [key: string]: CommandEntry } = {
     key: "dendron.treeView.createNote",
     title: "Create Note",
     icon: "$(new-file)",
+    when: "false",
   },
   TREEVIEW_EXPAND_STUB: {
     key: "dendron.treeView.expandStub",
-    title: `${CMD_PREFIX}Dev: Expand Stub`,
+    title: `${CMD_PREFIX} Dev: Expand Stub`,
+    when: "false",
+  },
+  TREEVIEW_GOTO_NOTE: {
+    key: "dendron.treeView.gotoNote",
+    title: `Create Note`, // will appear in the tooltip
+    icon: "$(gist-new)",
     when: "false",
   },
   // graph panel buttons

--- a/packages/plugin-core/src/views/common/treeview/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/common/treeview/EngineNoteProvider.ts
@@ -13,13 +13,11 @@ import {
   Event,
   EventEmitter,
   ProviderResult,
-  ThemeIcon,
   TreeDataProvider,
   TreeItem,
   TreeItemCollapsibleState,
 } from "vscode";
 import { URI } from "vscode-uri";
-import { ICONS } from "../../../constants";
 import { type ITreeViewConfig } from "./ITreeViewConfig";
 import { TreeNote } from "./TreeNote";
 
@@ -255,9 +253,6 @@ export class EngineNoteProvider
       collapsibleState,
       labelType: this._treeViewConfig.LabelTypeSetting,
     });
-    if (note.stub) {
-      tn.iconPath = new ThemeIcon(ICONS.STUB);
-    }
 
     this._tree[note.id] = tn;
 

--- a/packages/plugin-core/src/views/common/treeview/EngineNoteProvider.ts
+++ b/packages/plugin-core/src/views/common/treeview/EngineNoteProvider.ts
@@ -13,11 +13,13 @@ import {
   Event,
   EventEmitter,
   ProviderResult,
+  ThemeIcon,
   TreeDataProvider,
   TreeItem,
   TreeItemCollapsibleState,
 } from "vscode";
 import { URI } from "vscode-uri";
+import { ICONS } from "../../../constants";
 import { type ITreeViewConfig } from "./ITreeViewConfig";
 import { TreeNote } from "./TreeNote";
 
@@ -255,6 +257,9 @@ export class EngineNoteProvider
     });
 
     this._tree[note.id] = tn;
+    if (note.schema) {
+      tn.iconPath = new ThemeIcon(ICONS.SCHEMA);
+    }
 
     return tn;
   }

--- a/packages/plugin-core/src/views/common/treeview/NativeTreeView.ts
+++ b/packages/plugin-core/src/views/common/treeview/NativeTreeView.ts
@@ -92,6 +92,16 @@ export class NativeTreeView implements Disposable {
     }
   }
 
+  public async expandTreeItem(id: string) {
+    if (this.treeView) {
+      await this.treeView?.reveal(id, {
+        expand: true,
+        focus: false,
+        select: false,
+      });
+    }
+  }
+
   /**
    * Whenever a new note is opened, we move the tree view focus to the newly
    * opened note.

--- a/packages/plugin-core/src/views/common/treeview/TreeNote.ts
+++ b/packages/plugin-core/src/views/common/treeview/TreeNote.ts
@@ -8,6 +8,7 @@ import {
 import _ from "lodash";
 import vscode, { Uri } from "vscode";
 import { URI, Utils } from "vscode-uri";
+import { DENDRON_COMMANDS } from "../../../constants";
 
 /**
  * Contains {@link NoteProps} representing a single Tree Item inside the
@@ -67,10 +68,18 @@ export class TreeNote extends vscode.TreeItem {
     // TODO: Need to replace with go-to note if we want parity with local ext.
     // This will not create a new note right now if you click on a 'stub' but
     // will show an error page
-    this.command = {
-      command: "vscode.open",
-      title: "",
-      arguments: [this.uri],
-    };
+    if (note.stub) {
+      this.command = {
+        command: DENDRON_COMMANDS.TREEVIEW_EXPAND_STUB.key,
+        title: "",
+        arguments: [this.note.id],
+      };
+    } else {
+      this.command = {
+        command: "vscode.open",
+        title: "",
+        arguments: [this.uri],
+      };
+    }
   }
 }

--- a/packages/plugin-core/src/web/extension.ts
+++ b/packages/plugin-core/src/web/extension.ts
@@ -99,6 +99,20 @@ async function setupCommands(context: vscode.ExtensionContext) {
       )
     );
   }
+  /**
+   * go to note is not yet supported in dendron-web.
+   * for now, we open lookup bar when user clicks on the view action(+) for stubs
+   */
+  if (!existingCommands.includes(DENDRON_COMMANDS.TREEVIEW_GOTO_NOTE.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        DENDRON_COMMANDS.TREEVIEW_GOTO_NOTE.key,
+        async (_args: any) => {
+          await container.resolve(NoteLookupCmd).run();
+        }
+      )
+    );
+  }
 }
 
 async function setupViews(context: vscode.ExtensionContext) {
@@ -112,17 +126,29 @@ async function setupTreeView(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(treeView);
 
-  vscode.commands.registerCommand("dendron.treeView.labelByTitle", () => {
-    treeView.updateLabelType({
-      labelType: TreeViewItemLabelTypeEnum.title,
-    });
-  });
+  vscode.commands.registerCommand(
+    DENDRON_COMMANDS.TREEVIEW_LABEL_BY_TITLE.key,
+    () => {
+      treeView.updateLabelType({
+        labelType: TreeViewItemLabelTypeEnum.title,
+      });
+    }
+  );
 
-  vscode.commands.registerCommand("dendron.treeView.labelByFilename", () => {
-    treeView.updateLabelType({
-      labelType: TreeViewItemLabelTypeEnum.filename,
-    });
-  });
+  vscode.commands.registerCommand(
+    DENDRON_COMMANDS.TREEVIEW_LABEL_BY_FILENAME.key,
+    () => {
+      treeView.updateLabelType({
+        labelType: TreeViewItemLabelTypeEnum.filename,
+      });
+    }
+  );
+  vscode.commands.registerCommand(
+    DENDRON_COMMANDS.TREEVIEW_EXPAND_STUB.key,
+    async (id: string) => {
+      await treeView.expandTreeItem(id);
+    }
+  );
 }
 
 async function reportActivationTelemetry() {

--- a/packages/plugin-core/src/workspace/workspaceActivator.ts
+++ b/packages/plugin-core/src/workspace/workspaceActivator.ts
@@ -101,6 +101,15 @@ function _setupTreeViewCommands(
       })
     );
   }
+
+  if (!existingCommands.includes(DENDRON_COMMANDS.TREEVIEW_EXPAND_STUB.key)) {
+    vscode.commands.registerCommand(
+      DENDRON_COMMANDS.TREEVIEW_EXPAND_STUB.key,
+      sentryReportingCallback(async (id) => {
+        await treeView.expandTreeItem(id);
+      })
+    );
+  }
 }
 
 export function trackTopLevelRepoFound(opts: { wsService: WorkspaceService }) {


### PR DESCRIPTION
This PR aims to 
- resolve the issue of accidentally creating a stub note when clicking a tree-item. It expands the tree item in case of click on a stub.
- remove the + icon from the tree view.
- add back the book icon for schema in tree view
- adds a view action item for stubs to automatically create note when clicked on the action icon(+)

![tree-view-stub](https://user-images.githubusercontent.com/84971366/196956609-ec25c0e1-ad5c-41ec-8d30-d8e6a2a2eee5.jpg)


# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [ ] code should follow [Code Conventions](dev.process.code)
- [ ] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [ ] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)


## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [x]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)