### PR TITLE
fix: correctly add quickpick label highlight functionality

### DIFF
--- a/packages/common-all/src/abTests.ts
+++ b/packages/common-all/src/abTests.ts
@@ -90,26 +90,6 @@ export const _2022_09_VIDEO_TUTORIAL_TEST = new ABTest(
 );
 
 /**
- * Experiment to test highlights in quickpick labels
- */
-export enum CreateNewWithTemplateQuickPickLabelHighlightTestGroups {
-  "none" = "none",
-  "label" = "label",
-}
-
-export const _2022_09_CREATE_NEW_WITH_TEMPLATE_QUICKPICK_LABEL_HIGHLIGHT_TEST =
-  new ABTest("2022-09-CreateNewWithTemplateQuickPickLabelHighlightTest", [
-    {
-      name: CreateNewWithTemplateQuickPickLabelHighlightTestGroups.none,
-      weight: 1,
-    },
-    {
-      name: CreateNewWithTemplateQuickPickLabelHighlightTestGroups.label,
-      weight: 1,
-    },
-  ]);
-
-/**
  * Tutorial type of our ever-running / up to date main tutorial.
  * This should never change.
  *

--- a/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/NotePickerUtils.ts
@@ -7,14 +7,9 @@ import {
   NoteLookupUtils,
   NoteProps,
   NoteQuickInput,
-  CreateNewWithTemplateQuickPickLabelHighlightTestGroups,
   TransformedQueryString,
-  _2022_09_CREATE_NEW_WITH_TEMPLATE_QUICKPICK_LABEL_HIGHLIGHT_TEST,
 } from "@dendronhq/common-all";
-import {
-  getDurationMilliseconds,
-  SegmentClient,
-} from "@dendronhq/common-server";
+import { getDurationMilliseconds } from "@dendronhq/common-server";
 import { LinkUtils } from "@dendronhq/unified";
 import _ from "lodash";
 import path from "path";
@@ -111,27 +106,15 @@ export class NotePickerUtils {
       // @ts-ignore
       vault: {},
     });
-    const ABUserGroup =
-      _2022_09_CREATE_NEW_WITH_TEMPLATE_QUICKPICK_LABEL_HIGHLIGHT_TEST.getUserGroup(
-        SegmentClient.instance().anonymousId
-      );
 
-    let label: string;
-    if (
-      ABUserGroup ===
-      CreateNewWithTemplateQuickPickLabelHighlightTestGroups.label
-    ) {
-      label = LabelUtils.createLabelWithHighlight({
-        value: CREATE_NEW_WITH_TEMPLATE_LABEL,
-        highlight: {
-          value: "$(beaker) [New] ",
-          location: "prefix",
-          expirationDate: new Date("2022-11-01"),
-        },
-      });
-    } else {
-      label = CREATE_NEW_WITH_TEMPLATE_LABEL;
-    }
+    const label = LabelUtils.createLabelWithHighlight({
+      value: CREATE_NEW_WITH_TEMPLATE_LABEL,
+      highlight: {
+        value: "$(beaker) [New] ",
+        location: "prefix",
+        expirationDate: new Date("2022-11-15"),
+      },
+    });
 
     return {
       ...props,


### PR DESCRIPTION
# fix: correctly add quickpick label highlight functionality
This PR:
- removes ab test defined to test effectiveness of quickpick label highlight
- this also correctly adds the quickpick label highlight

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [~] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [~] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)