### PR TITLE
fix(publish): make safe access to iframe

### DIFF
--- a/packages/nextjs-template/hooks/useIFrameHeightAdjuster.tsx
+++ b/packages/nextjs-template/hooks/useIFrameHeightAdjuster.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 
+function canAccessIframe(iframe: HTMLIFrameElement) {
+  try {
+    return Boolean(iframe.contentWindow?.document);
+  } catch (e) {
+    return false;
+  }
+}
+
 const updateIFrameHeight = () => {
   const iframes = document.querySelectorAll("iframe");
   iframes.forEach((iframe) => {
-    if (iframe) {
+    if (iframe && canAccessIframe(iframe)) {
       const height = iframe!.contentWindow!.document.body.offsetHeight;
       iframe.style.height = `${height}px`;
     }


### PR DESCRIPTION
This PR aims to fix a same-origin error.
It was reported here: https://discord.com/channels/717965437182410783/735365126227493004/1033370857789210634

Sometimes browser extensions embed iframes. In this case `updateIFrameHeight`
is trying to access iframes which could possibly throw a same-origin policy (`SecurityError: Permission denied to access property "document" on cross-origin object`).

The solution is to add a check that makes sure the iframe accessible.


# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.
