### PR TITLE
chore: workflow tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,12 @@ on:
   push:
     branches:
       - master
-      - dev
-      - integ-publish
       - release/*
-      - prerelease/*
-      - kevin-*/*
   pull_request:
     branches:
       - "*"
       - "*/*"
+  workflow_dispatch:
 
 env:
   BINARY_CACHE_INDEX: 23 # Rev this if we need a new node cache

--- a/.github/workflows/create-early-seed-branch.yml
+++ b/.github/workflows/create-early-seed-branch.yml
@@ -2,10 +2,12 @@
 name: Create Early Seed Branch
 
 # See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
-# Scheduled to run at 7 PM UTC on Wednesday every other week
+# Scheduled to run at 7 PM UTC on Wednesday every week. Intended to run
+# every-other-week, but POSIX syntax has limited support for that. We can just
+# have the job fail every other week because the branch already exists.
 on:
   schedule:
-    - cron: "0 19 8-14,22-28 * 3"
+    - cron: "0 19 * * 3"
 
 jobs:
   build:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,11 +1,14 @@
 # Creates a release branch off of master every Thursday, 7 PM UTC
 name: Create Release Branch
 
-# See documentation on POSIX cron syntax here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
-# Scheduled to run at 7 PM UTC on Wednesday every other week
+# See documentation on POSIX cron syntax here:
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
+# Scheduled to run at 7 PM UTC on Wednesday every week. Intended to run
+# every-other-week, but POSIX syntax has limited support for that. We can just
+# have the job fail every other week because the branch already exists.
 on:
   schedule:
-    - cron: "0 19 1-7,15-21,29-31 * 3"
+    - cron: "0 19 * * 3"
 
 jobs:
   build:


### PR DESCRIPTION
## chore: workflow tweaks

- Makes the create branch workflows run every Wednesday. For Github Actions, the attempted syntax of '0 19 8-14,22-28 * 3' will actually run as a OR union instead of an AND, resulting in the job running every day 8-14, 22-28 of the month.  If we just run the job every week, we'll get our intended effect, as the alternating weeks will result in the job failing b/c the branch already exists.
- Makes ci.yml be able to be triggered manually; a few times here and there ci.yml doesn't trigger automatically for some reason.