### PR TITLE
fix(workspace): remove duplicate entries in prompt to select vault with go to note command

### DIFF
--- a/packages/plugin-core/src/commands/GotoNote.ts
+++ b/packages/plugin-core/src/commands/GotoNote.ts
@@ -116,7 +116,9 @@ export class GotoNoteCommand extends BasicCommand<
 
   private async maybeSetOptsFromExistingNote(opts: GoToNoteCommandOpts) {
     const engine = this.extension.getEngine();
-    const notes = await engine.findNotesMeta({ fname: opts.qs });
+    const notes = (await engine.findNotesMeta({ fname: opts.qs })).filter(
+      (note) => !note.id.startsWith(NoteUtils.FAKE_ID_PREFIX)
+    );
     if (notes.length === 1) {
       // There's just one note, so that's the one we'll go with.
       opts.vault = notes[0].vault;

--- a/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/GotoNote.test.ts
@@ -113,6 +113,29 @@ suite("GotoNote", function () {
     );
 
     describeMultiWS(
+      "WHEN goto existing note via wikilink",
+      {
+        preSetupHook: GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.preSetupHook,
+        timeout: 5e3,
+      },
+      () => {
+        test("THEN user is not prompted to select vault", async () => {
+          const ext = ExtensionProvider.getExtension();
+          await GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.beforeTestResults({
+            ext,
+          });
+          const promptVaultSpy = sinon.spy(PickerUtilsV2, "promptVault");
+          const cmd = createGoToNoteCmd();
+          await cmd.run();
+          expect(promptVaultSpy.called).toBeFalsy();
+          await runMochaHarness(
+            GOTO_NOTE_PRESETS.LINK_TO_NOTE_IN_SAME_VAULT.results
+          );
+        });
+      }
+    );
+
+    describeMultiWS(
       "WHEN goto new note with invalid filename",
       {
         preSetupHook,


### PR DESCRIPTION
This PR aims to fix the duplicate entries in vault prompt while running `Go To Note` command. The Reference Hover provider creates a new note with same name but id with prefix fake- to render hover. This PR aims to filter those references in gotonote command

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [ ] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [ ] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [ ] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [ ] display is correct for following dimensions
    - [ ] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [ ] lg: screen ≥ 992px
    - [ ] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [ ] display is correct for following browsers (across the various dimensions)
    - [ ] safari
    - [ ] firefox
    - [ ] chrome

## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)