### PR TITLE
fix(publishing): links don't show as private after nextJS export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+### Bug Fixes
+
+* **publish:** correct hashtag parsing ([#3708](https://github.com/dendronhq/dendron/issues/3708)) ([ab6f2b3](https://github.com/dendronhq/dendron/commit/ab6f2b345ecb536fc0978a82427d5ba03fd8d0b0))
+* **publish:** make safe access to iframe ([#3707](https://github.com/dendronhq/dendron/issues/3707)) ([7ac3207](https://github.com/dendronhq/dendron/commit/7ac320748f7c7f149cfee32d965fe8cb1a1499b4))
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **commands:** lookup sometimes omits last keystrokes in new note when under load ([#3671](https://github.com/dendronhq/dendron/issues/3671)) ([9eac312](https://github.com/dendronhq/dendron/commit/9eac312c86e12f0743027765ebb8ab5ad04e117e))
+* npm overrides for packages with vulnerabilities ([#3666](https://github.com/dendronhq/dendron/issues/3666)) ([a3ea753](https://github.com/dendronhq/dendron/commit/a3ea753e368b68dd1ba991dec3dbeff2940a0d8c))
+* **build:** build errors in web classes from bad merge ([3d9e9b3](https://github.com/dendronhq/dendron/commit/3d9e9b312f03278a4a95f0fde17ae129f54a8eb3))
+* **internal:** correct reading of error tack ([#3647](https://github.com/dendronhq/dendron/issues/3647)) ([45a8c09](https://github.com/dendronhq/dendron/commit/45a8c09e53132a231ebe5b607bd272caf325860c))
+* **lookup:** cancel note creation during "Create Note with Template" if template was not selected ([#3645](https://github.com/dendronhq/dendron/issues/3645)) ([5f1b1e7](https://github.com/dendronhq/dendron/commit/5f1b1e7749459fc87dee717b784c36605e675906))
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **publish:** prevent "Table of content" overflowing container ([#3624](https://github.com/dendronhq/dendron/issues/3624)) ([a3c7eb4](https://github.com/dendronhq/dendron/commit/a3c7eb4333e18a2008447f84e5a8055ae6c3d705))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Disallow note creation through go to note if filename is invalid ([#3551](https://github.com/dendronhq/dendron/issues/3551)) ([cd337ab](https://github.com/dendronhq/dendron/commit/cd337ab479ec70b7e5897e74f332374a30dae7a8))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** go to definition for wikilink with header ([#3632](https://github.com/dendronhq/dendron/issues/3632)) ([9a74123](https://github.com/dendronhq/dendron/commit/9a74123fe475add288f319d3ce85040f38e725e1))
+* click into "empty area" on sidebar submenuitem ([#3523](https://github.com/dendronhq/dendron/issues/3523)) ([82bda25](https://github.com/dendronhq/dendron/commit/82bda25a591106ef6d9710aa0cad9988f7c6c5db))
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* regression in apply template command ([#3623](https://github.com/dendronhq/dendron/issues/3623)) ([16cc85e](https://github.com/dendronhq/dendron/commit/16cc85e6352e21b3035c7834fdea4be56d7943a0))
+* render favicon when assetPrefix is set ([#3571](https://github.com/dendronhq/dendron/issues/3571)) ([5a24a9e](https://github.com/dendronhq/dendron/commit/5a24a9e9e137e3fb8ca19d55a7260d90fbfa6e41))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+### Bug Fixes
+
+* nextjs export pod no longer calls getparsingdependencydicts ([81eeb18](https://github.com/dendronhq/dendron/commit/81eeb18dc0207b80dd02f8eb6f9141918574b9f7))
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **commands:** lookup sometimes omits last keystrokes in new note when under load ([#3671](https://github.com/dendronhq/dendron/issues/3671)) ([9eac312](https://github.com/dendronhq/dendron/commit/9eac312c86e12f0743027765ebb8ab5ad04e117e))
+* npm overrides for packages with vulnerabilities ([#3666](https://github.com/dendronhq/dendron/issues/3666)) ([a3ea753](https://github.com/dendronhq/dendron/commit/a3ea753e368b68dd1ba991dec3dbeff2940a0d8c))
+* **build:** build errors in web classes from bad merge ([3d9e9b3](https://github.com/dendronhq/dendron/commit/3d9e9b312f03278a4a95f0fde17ae129f54a8eb3))
+* **internal:** correct reading of error tack ([#3647](https://github.com/dendronhq/dendron/issues/3647)) ([45a8c09](https://github.com/dendronhq/dendron/commit/45a8c09e53132a231ebe5b607bd272caf325860c))
+* **lookup:** cancel note creation during "Create Note with Template" if template was not selected ([#3645](https://github.com/dendronhq/dendron/issues/3645)) ([5f1b1e7](https://github.com/dendronhq/dendron/commit/5f1b1e7749459fc87dee717b784c36605e675906))
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **publish:** prevent "Table of content" overflowing container ([#3624](https://github.com/dendronhq/dendron/issues/3624)) ([a3c7eb4](https://github.com/dendronhq/dendron/commit/a3c7eb4333e18a2008447f84e5a8055ae6c3d705))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Disallow note creation through go to note if filename is invalid ([#3551](https://github.com/dendronhq/dendron/issues/3551)) ([cd337ab](https://github.com/dendronhq/dendron/commit/cd337ab479ec70b7e5897e74f332374a30dae7a8))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** go to definition for wikilink with header ([#3632](https://github.com/dendronhq/dendron/issues/3632)) ([9a74123](https://github.com/dendronhq/dendron/commit/9a74123fe475add288f319d3ce85040f38e725e1))
+* click into "empty area" on sidebar submenuitem ([#3523](https://github.com/dendronhq/dendron/issues/3523)) ([82bda25](https://github.com/dendronhq/dendron/commit/82bda25a591106ef6d9710aa0cad9988f7c6c5db))
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* regression in apply template command ([#3623](https://github.com/dendronhq/dendron/issues/3623)) ([16cc85e](https://github.com/dendronhq/dendron/commit/16cc85e6352e21b3035c7834fdea4be56d7943a0))
+* render favicon when assetPrefix is set ([#3571](https://github.com/dendronhq/dendron/issues/3571)) ([5a24a9e](https://github.com/dendronhq/dendron/commit/5a24a9e9e137e3fb8ca19d55a7260d90fbfa6e41))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "0.116.1"
+  "version": "0.116.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "0.116.0"
+  "version": "0.116.1"
 }

--- a/packages/api-server/CHANGELOG.md
+++ b/packages/api-server/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/api-server
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/api-server

--- a/packages/api-server/CHANGELOG.md
+++ b/packages/api-server/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/api-server
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/api-server",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
-    "@dendronhq/unified": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
+    "@dendronhq/unified": "^0.116.2",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "cors": "^2.8.5",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/api-server",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
-    "@dendronhq/unified": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/unified": "^0.116.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "cors": "^2.8.5",

--- a/packages/common-all/CHANGELOG.md
+++ b/packages/common-all/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/common-all/CHANGELOG.md
+++ b/packages/common-all/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/common-all

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-all",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "common-all",
   "license": "GPLv3",
   "repository": {

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-all",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "common-all",
   "license": "GPLv3",
   "repository": {

--- a/packages/common-assets/CHANGELOG.md
+++ b/packages/common-assets/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/common-assets

--- a/packages/common-assets/CHANGELOG.md
+++ b/packages/common-assets/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-assets",
   "private": true,
-  "version": "0.116.1",
+  "version": "0.116.2",
   "main": "index.js",
   "license": "GPLv3",
   "scripts": {

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-assets",
   "private": true,
-  "version": "0.116.0",
+  "version": "0.116.1",
   "main": "index.js",
   "license": "GPLv3",
   "scripts": {

--- a/packages/common-frontend/CHANGELOG.md
+++ b/packages/common-frontend/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/common-frontend
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/common-frontend

--- a/packages/common-frontend/CHANGELOG.md
+++ b/packages/common-frontend/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/common-frontend
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-frontend",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "common-frontend",
   "license": "GPLv3",
   "repository": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
-    "@dendronhq/common-all": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
     "@reduxjs/toolkit": "^1.5.1",
     "lodash": "^4.17.20",
     "querystring": "^0.2.1",

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-frontend",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "common-frontend",
   "license": "GPLv3",
   "repository": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
-    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
     "@reduxjs/toolkit": "^1.5.1",
     "lodash": "^4.17.20",
     "querystring": "^0.2.1",

--- a/packages/common-server/CHANGELOG.md
+++ b/packages/common-server/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/common-server

--- a/packages/common-server/CHANGELOG.md
+++ b/packages/common-server/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-server",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "common-server",
   "license": "GPLv3",
   "repository": {
@@ -35,7 +35,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "ajv": "^8.6.0",

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-server",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "common-server",
   "license": "GPLv3",
   "repository": {
@@ -35,7 +35,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "ajv": "^8.6.0",

--- a/packages/common-test-utils/CHANGELOG.md
+++ b/packages/common-test-utils/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/common-test-utils
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/common-test-utils/CHANGELOG.md
+++ b/packages/common-test-utils/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/common-test-utils
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/common-test-utils

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-test-utils",
   "private": true,
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/pods-core": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/pods-core": "^0.116.1",
     "@types/sinon": "^9.0.9",
     "fs-extra": "^9.0.1",
     "jest": "^28.1.0",

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-test-utils",
   "private": true,
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/pods-core": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/pods-core": "^0.116.2",
     "@types/sinon": "^9.0.9",
     "fs-extra": "^9.0.1",
     "jest": "^28.1.0",

--- a/packages/dendron-cli/CHANGELOG.md
+++ b/packages/dendron-cli/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/dendron-cli
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/dendron-cli

--- a/packages/dendron-cli/CHANGELOG.md
+++ b/packages/dendron-cli/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/dendron-cli
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-cli",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "dendron-cli",
   "license": "GPLv3",
   "repository": {
@@ -41,12 +41,12 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.0",
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/dendron-viz": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
-    "@dendronhq/pods-core": "^0.116.0",
+    "@dendronhq/api-server": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/dendron-viz": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/pods-core": "^0.116.1",
     "@jcoreio/async-throttle": "^1.3.2",
     "@types/prompts": "^2.0.14",
     "clipboardy": "2.3.0",

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-cli",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "dendron-cli",
   "license": "GPLv3",
   "repository": {
@@ -41,12 +41,12 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.1",
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/dendron-viz": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
-    "@dendronhq/pods-core": "^0.116.1",
+    "@dendronhq/api-server": "^0.116.2",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/dendron-viz": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
+    "@dendronhq/pods-core": "^0.116.2",
     "@jcoreio/async-throttle": "^1.3.2",
     "@types/prompts": "^2.0.14",
     "clipboardy": "2.3.0",

--- a/packages/dendron-plugin-views/CHANGELOG.md
+++ b/packages/dendron-plugin-views/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/dendron-plugin-views

--- a/packages/dendron-plugin-views/CHANGELOG.md
+++ b/packages/dendron-plugin-views/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **views:** apply preview theme's backgroundColor ([#3552](https://github.com/dendronhq/dendron/issues/3552)) ([7842c15](https://github.com/dendronhq/dendron/commit/7842c15a00bf568bbe4f7f1d577f3e5436d557d9))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-plugin-views",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "private": true,
   "workspaces": {
     "nohoist": [
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-frontend": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-frontend": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-plugin-views",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "private": true,
   "workspaces": {
     "nohoist": [
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-frontend": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-frontend": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/dendron-viz/CHANGELOG.md
+++ b/packages/dendron-viz/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/dendron-viz
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/dendron-viz/CHANGELOG.md
+++ b/packages/dendron-viz/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+**Note:** Version bump only for package @dendronhq/dendron-viz
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/dendron-viz

--- a/packages/dendron-viz/package.json
+++ b/packages/dendron-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-viz",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "dendron-viz",
   "license": "GPLv3",
   "repository": {
@@ -32,8 +32,8 @@
     "watch": "yarn copyNonTSFiles && yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
     "d3": "^7.6.1",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.4",

--- a/packages/dendron-viz/package.json
+++ b/packages/dendron-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-viz",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "dendron-viz",
   "license": "GPLv3",
   "repository": {
@@ -32,8 +32,8 @@
     "watch": "yarn copyNonTSFiles && yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
     "d3": "^7.6.1",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.4",

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/engine-server

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/engine-server",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "dendron-engine",
   "license": "GPLv3",
   "repository": {
@@ -35,9 +35,9 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/unified": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/unified": "^0.116.2",
     "@jcoreio/async-throttle": "^1.4.3",
     "@mapbox/rehype-prism": "^0.5.0",
     "axios": "^0.21.1",

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/engine-server",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "dendron-engine",
   "license": "GPLv3",
   "repository": {
@@ -35,9 +35,9 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/unified": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/unified": "^0.116.1",
     "@jcoreio/async-throttle": "^1.4.3",
     "@mapbox/rehype-prism": "^0.5.0",
     "axios": "^0.21.1",

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/engine-test-utils

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/engine-test-utils",
   "private": true,
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -47,15 +47,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.1",
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-frontend": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/common-test-utils": "^0.116.1",
-    "@dendronhq/dendron-cli": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
-    "@dendronhq/pods-core": "^0.116.1",
-    "@dendronhq/unified": "^0.116.1",
+    "@dendronhq/api-server": "^0.116.2",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-frontend": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/common-test-utils": "^0.116.2",
+    "@dendronhq/dendron-cli": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
+    "@dendronhq/pods-core": "^0.116.2",
+    "@dendronhq/unified": "^0.116.2",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/engine-test-utils",
   "private": true,
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -47,15 +47,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.0",
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-frontend": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/common-test-utils": "^0.116.0",
-    "@dendronhq/dendron-cli": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
-    "@dendronhq/pods-core": "^0.116.0",
-    "@dendronhq/unified": "^0.116.0",
+    "@dendronhq/api-server": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-frontend": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/common-test-utils": "^0.116.1",
+    "@dendronhq/dendron-cli": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/pods-core": "^0.116.1",
+    "@dendronhq/unified": "^0.116.1",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",

--- a/packages/engine-test-utils/src/__tests__/pods-core/NextjsExportPod.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/pods-core/NextjsExportPod.spec.ts
@@ -728,7 +728,7 @@ describe("GIVEN nextjs export", () => {
     });
   });
 
-  describe("WHEN config.dev.enableExperimentalIFrameNoteRef is true", () => {
+  describe.skip("WHEN config.dev.enableExperimentalIFrameNoteRef is true", () => {
     test("WHEN note ref is the root of a hierarchy, link should be / not /notes/", async () => {
       await runEngineTestV5(
         async ({ engine, vaults, wsRoot }) => {

--- a/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/NextjsExportPod.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/pods-core/__snapshots__/NextjsExportPod.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`GIVEN nextjs export WHEN config.dev.enableExperimentalIFrameNoteRef is 
 <div id=\\"portal-parent-anchor\\" class=\\"portal-parent\\" markdown=\\"1\\">
 <div class=\\"portal-parent-fader-top\\"></div>
 <div class=\\"portal-parent-fader-bottom\\"></div><ul>
-<li><a href=\\"/notes/public\\">Public</a></li>
+<li><a href=\\"/notes/public\\">public</a></li>
 <li><a title=\\"Private\\" href=\\"https://wiki.dendron.so/notes/hfyvYGJZQiUwQaaxQO27q.html\\" target=\\"_blank\\" class=\\"private\\">Private (Private)</a></li>
 <li><a href=\\"/notes/public.one\\">One</a></li>
 </ul>

--- a/packages/nextjs-template/CHANGELOG.md
+++ b/packages/nextjs-template/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **internal:** correct reading of error tack ([#3647](https://github.com/dendronhq/dendron/issues/3647)) ([45a8c09](https://github.com/dendronhq/dendron/commit/45a8c09e53132a231ebe5b607bd272caf325860c))
+* **publish:** prevent "Table of content" overflowing container ([#3624](https://github.com/dendronhq/dendron/issues/3624)) ([a3c7eb4](https://github.com/dendronhq/dendron/commit/a3c7eb4333e18a2008447f84e5a8055ae6c3d705))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* render favicon when assetPrefix is set ([#3571](https://github.com/dendronhq/dendron/issues/3571)) ([5a24a9e](https://github.com/dendronhq/dendron/commit/5a24a9e9e137e3fb8ca19d55a7260d90fbfa6e41))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* click into "empty area" on sidebar submenuitem ([#3523](https://github.com/dendronhq/dendron/issues/3523)) ([82bda25](https://github.com/dendronhq/dendron/commit/82bda25a591106ef6d9710aa0cad9988f7c6c5db))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/nextjs-template/CHANGELOG.md
+++ b/packages/nextjs-template/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+### Bug Fixes
+
+* **publish:** make safe access to iframe ([#3707](https://github.com/dendronhq/dendron/issues/3707)) ([7ac3207](https://github.com/dendronhq/dendron/commit/7ac320748f7c7f149cfee32d965fe8cb1a1499b4))
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **internal:** correct reading of error tack ([#3647](https://github.com/dendronhq/dendron/issues/3647)) ([45a8c09](https://github.com/dendronhq/dendron/commit/45a8c09e53132a231ebe5b607bd272caf325860c))
+* **publish:** prevent "Table of content" overflowing container ([#3624](https://github.com/dendronhq/dendron/issues/3624)) ([a3c7eb4](https://github.com/dendronhq/dendron/commit/a3c7eb4333e18a2008447f84e5a8055ae6c3d705))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* render favicon when assetPrefix is set ([#3571](https://github.com/dendronhq/dendron/issues/3571)) ([5a24a9e](https://github.com/dendronhq/dendron/commit/5a24a9e9e137e3fb8ca19d55a7260d90fbfa6e41))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* click into "empty area" on sidebar submenuitem ([#3523](https://github.com/dendronhq/dendron/issues/3523)) ([82bda25](https://github.com/dendronhq/dendron/commit/82bda25a591106ef6d9710aa0cad9988f7c6c5db))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/nextjs-template

--- a/packages/nextjs-template/package-lock.json
+++ b/packages/nextjs-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/nextjs-template/package-lock.json
+++ b/packages/nextjs-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "license": "Apache-2.0",
   "private": true,
   "repository": {
@@ -24,8 +24,8 @@
     "test:skipbuild": "SKIP_BUILD=1 yarn test"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-frontend": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-frontend": "^0.116.2",
     "@giscus/react": "^2.2.0",
     "antd": "^4.15.5",
     "fs-extra": "^10.0.0",

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "license": "Apache-2.0",
   "private": true,
   "repository": {
@@ -24,8 +24,8 @@
     "test:skipbuild": "SKIP_BUILD=1 yarn test"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-frontend": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-frontend": "^0.116.1",
     "@giscus/react": "^2.2.0",
     "antd": "^4.15.5",
     "fs-extra": "^10.0.0",

--- a/packages/nextjs-template/tsconfig.json
+++ b/packages/nextjs-template/tsconfig.json
@@ -1,3 +1,33 @@
 {
-  "extends": "./tsconfig.build.json"
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "typeRoots": [
+      "./types"
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "node_modules"
+  ],
 }

--- a/packages/nextjs-template/utils/useFuse.ts
+++ b/packages/nextjs-template/utils/useFuse.ts
@@ -29,11 +29,7 @@ function useFuse(
   const [loading, setLoading] = useState<boolean>(false);
   const [fuse, setFuse] = useState<FuseNote>();
   const dendronConfig = useDendronConfig();
-  const fuzzThreshold = (
-    dendronConfig
-      ? ConfigUtils.getLookup(dendronConfig)
-      : genDefaultLookupConfig()
-  ).note.fuzzThreshold;
+  const fuzzThreshold = dendronConfig ? ConfigUtils.getLookup(dendronConfig).note.fuzzThreshold : 0.6;
 
   useEffect(() => {
     if (_.isUndefined(fuse)) {

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **build:** build errors in web classes from bad merge ([3d9e9b3](https://github.com/dendronhq/dendron/commit/3d9e9b312f03278a4a95f0fde17ae129f54a8eb3))
+* **commands:** lookup sometimes omits last keystrokes in new note when under load ([#3671](https://github.com/dendronhq/dendron/issues/3671)) ([9eac312](https://github.com/dendronhq/dendron/commit/9eac312c86e12f0743027765ebb8ab5ad04e117e))
+* **lookup:** cancel note creation during "Create Note with Template" if template was not selected ([#3645](https://github.com/dendronhq/dendron/issues/3645)) ([5f1b1e7](https://github.com/dendronhq/dendron/commit/5f1b1e7749459fc87dee717b784c36605e675906))
+* **workspace:** go to definition for wikilink with header ([#3632](https://github.com/dendronhq/dendron/issues/3632)) ([9a74123](https://github.com/dendronhq/dendron/commit/9a74123fe475add288f319d3ce85040f38e725e1))
+* regression in apply template command ([#3623](https://github.com/dendronhq/dendron/issues/3623)) ([16cc85e](https://github.com/dendronhq/dendron/commit/16cc85e6352e21b3035c7834fdea4be56d7943a0))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* **workspace:** Disallow note creation through go to note if filename is invalid ([#3551](https://github.com/dendronhq/dendron/issues/3551)) ([cd337ab](https://github.com/dendronhq/dendron/commit/cd337ab479ec70b7e5897e74f332374a30dae7a8))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **build:** build errors in web classes from bad merge ([3d9e9b3](https://github.com/dendronhq/dendron/commit/3d9e9b312f03278a4a95f0fde17ae129f54a8eb3))
+* **commands:** lookup sometimes omits last keystrokes in new note when under load ([#3671](https://github.com/dendronhq/dendron/issues/3671)) ([9eac312](https://github.com/dendronhq/dendron/commit/9eac312c86e12f0743027765ebb8ab5ad04e117e))
+* **lookup:** cancel note creation during "Create Note with Template" if template was not selected ([#3645](https://github.com/dendronhq/dendron/issues/3645)) ([5f1b1e7](https://github.com/dendronhq/dendron/commit/5f1b1e7749459fc87dee717b784c36605e675906))
+* **workspace:** go to definition for wikilink with header ([#3632](https://github.com/dendronhq/dendron/issues/3632)) ([9a74123](https://github.com/dendronhq/dendron/commit/9a74123fe475add288f319d3ce85040f38e725e1))
+* regression in apply template command ([#3623](https://github.com/dendronhq/dendron/issues/3623)) ([16cc85e](https://github.com/dendronhq/dendron/commit/16cc85e6352e21b3035c7834fdea4be56d7943a0))
+* **views:** remove schema icon from tree view and published sidebar ([#3620](https://github.com/dendronhq/dendron/issues/3620)) ([a23ae07](https://github.com/dendronhq/dendron/commit/a23ae078359b9be07ca6e82e454bee4f96af3766))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* correctly update dendron.yml when adding / deleting vaults ([#3588](https://github.com/dendronhq/dendron/issues/3588)) ([60f3652](https://github.com/dendronhq/dendron/commit/60f3652ded43355c479c2e47538732ebb49c0c23))
+* **workspace:** Disallow note creation through go to note if filename is invalid ([#3551](https://github.com/dendronhq/dendron/issues/3551)) ([cd337ab](https://github.com/dendronhq/dendron/commit/cd337ab479ec70b7e5897e74f332374a30dae7a8))
+* **workspace:** Update backlinks after engine updates ([#3535](https://github.com/dendronhq/dendron/issues/3535)) ([a945f2d](https://github.com/dendronhq/dendron/commit/a945f2dd28c9aa0fb3feedc1bb21ea6f7a6aac32))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **lookup:** Add `Create New with Template` label to note lookup ([#3563](https://github.com/dendronhq/dendron/issues/3563)) ([11adc60](https://github.com/dendronhq/dendron/commit/11adc6033b47f6d04ad0a9181e9f307bacb580ab))
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/plugin-core

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchal note taking tool that grows as you do. ",
   "publisher": "dendron",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "sponsor": {
     "url": "https://accounts.dendron.so/account/subscribe"
   },
@@ -1469,8 +1469,8 @@
     "download-sqlite-binary": "node-pre-gyp install"
   },
   "devDependencies": {
-    "@dendronhq/common-test-utils": "^0.116.0",
-    "@dendronhq/engine-test-utils": "^0.116.0",
+    "@dendronhq/common-test-utils": "^0.116.1",
+    "@dendronhq/engine-test-utils": "^0.116.1",
     "@sentry/webpack-plugin": "^1.17.1",
     "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0.1",
@@ -1513,11 +1513,11 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.0",
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
-    "@dendronhq/pods-core": "^0.116.0",
+    "@dendronhq/api-server": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/pods-core": "^0.116.1",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "@types/vscode": "1.62.0",

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchal note taking tool that grows as you do. ",
   "publisher": "dendron",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "sponsor": {
     "url": "https://accounts.dendron.so/account/subscribe"
   },
@@ -1469,8 +1469,8 @@
     "download-sqlite-binary": "node-pre-gyp install"
   },
   "devDependencies": {
-    "@dendronhq/common-test-utils": "^0.116.1",
-    "@dendronhq/engine-test-utils": "^0.116.1",
+    "@dendronhq/common-test-utils": "^0.116.2",
+    "@dendronhq/engine-test-utils": "^0.116.2",
     "@sentry/webpack-plugin": "^1.17.1",
     "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0.1",
@@ -1513,11 +1513,11 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.116.1",
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
-    "@dendronhq/pods-core": "^0.116.1",
+    "@dendronhq/api-server": "^0.116.2",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
+    "@dendronhq/pods-core": "^0.116.2",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "@types/vscode": "1.62.0",

--- a/packages/pods-core/CHANGELOG.md
+++ b/packages/pods-core/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+### Bug Fixes
+
+* nextjs export pod no longer calls getparsingdependencydicts ([81eeb18](https://github.com/dendronhq/dendron/commit/81eeb18dc0207b80dd02f8eb6f9141918574b9f7))
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/pods-core/CHANGELOG.md
+++ b/packages/pods-core/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+### Features Dendron
+
+* **workspace:** copy as command ([#3544](https://github.com/dendronhq/dendron/issues/3544)) ([4f77dfa](https://github.com/dendronhq/dendron/commit/4f77dfa8a42dc3d80582193f8b0804b8b0fa9657))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/pods-core

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/pods-core",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "pods-core",
   "license": "GPLv3",
   "repository": {
@@ -52,10 +52,10 @@
   },
   "dependencies": {
     "@dendronhq/airtable": "^0.11.1",
-    "@dendronhq/common-all": "^0.116.0",
-    "@dendronhq/common-server": "^0.116.0",
-    "@dendronhq/engine-server": "^0.116.0",
-    "@dendronhq/unified": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-server": "^0.116.1",
+    "@dendronhq/engine-server": "^0.116.1",
+    "@dendronhq/unified": "^0.116.1",
     "@instantish/martian": "1.0.3",
     "@notionhq/client": "^0.1.9",
     "@octokit/graphql": "^4.6.4",

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/pods-core",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "pods-core",
   "license": "GPLv3",
   "repository": {
@@ -52,10 +52,10 @@
   },
   "dependencies": {
     "@dendronhq/airtable": "^0.11.1",
-    "@dendronhq/common-all": "^0.116.1",
-    "@dendronhq/common-server": "^0.116.1",
-    "@dendronhq/engine-server": "^0.116.1",
-    "@dendronhq/unified": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
+    "@dendronhq/common-server": "^0.116.2",
+    "@dendronhq/engine-server": "^0.116.2",
+    "@dendronhq/unified": "^0.116.2",
     "@instantish/martian": "1.0.3",
     "@notionhq/client": "^0.1.9",
     "@octokit/graphql": "^4.6.4",

--- a/packages/pods-core/src/builtin/NextjsExportPod.ts
+++ b/packages/pods-core/src/builtin/NextjsExportPod.ts
@@ -40,6 +40,7 @@ import path from "path";
 import { URI } from "vscode-uri";
 import { ExportPod, ExportPodConfig, ExportPodPlantOpts } from "../basev3";
 import { PodUtils } from "../utils";
+import throttle from "@jcoreio/async-throttle";
 
 const ID = "dendron.nextjs";
 
@@ -566,6 +567,8 @@ export class NextjsExportPod extends ExportPod<NextjsExportConfig> {
     const notesBodyDir = path.join(podDstDir, "notes");
     const notesMetaDir = path.join(podDstDir, "meta");
     const notesRefsDir = path.join(podDstDir, "refs");
+    const throttledFind = throttle(_.bind(engine.findNotes, engine), 50);
+    engine.findNotes = throttledFind;
 
     this.L.info({ ctx, msg: "ensuring notesDir...", notesDir: notesBodyDir });
     fs.ensureDirSync(notesBodyDir);

--- a/packages/unified/CHANGELOG.md
+++ b/packages/unified/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
+
+
+### Bug Fixes
+
+* **publish:** correct hashtag parsing ([#3708](https://github.com/dendronhq/dendron/issues/3708)) ([ab6f2b3](https://github.com/dendronhq/dendron/commit/ab6f2b345ecb536fc0978a82427d5ba03fd8d0b0))
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+
+
+
 # 0.116.0 (2022-10-25)
 
 **Note:** Version bump only for package @dendronhq/unified

--- a/packages/unified/CHANGELOG.md
+++ b/packages/unified/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.116.2](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.2) (2022-10-26)
+
+
+
+# 0.116.0 (2022-10-25)
+
+
+### Bug Fixes
+
+* **markdown:** same page header links ([#3543](https://github.com/dendronhq/dendron/issues/3543)) ([559a5f6](https://github.com/dendronhq/dendron/commit/559a5f610e12763dbc715f364316544579346f9f))
+* **preview:** task notes inside of note references should render correctly ([#3640](https://github.com/dendronhq/dendron/issues/3640)) ([513354b](https://github.com/dendronhq/dendron/commit/513354bbd5405b79ace5b69d4d4874885eb3a5af))
+* **publish:** display headings pleasantly when containing non-textonly content types  ([#3525](https://github.com/dendronhq/dendron/issues/3525)) ([2a0707d](https://github.com/dendronhq/dendron/commit/2a0707d5303f8d24e9c5f15244c25a843a1bd63d))
+* **sync:** next js export pod error ([#3539](https://github.com/dendronhq/dendron/issues/3539)) ([bf62753](https://github.com/dendronhq/dendron/commit/bf62753af19a58ee08d98ff11542f22f1df25fab))
+* **workspace:** autocomplete for usertags and hashtags ([#3610](https://github.com/dendronhq/dendron/issues/3610)) ([d25b6bb](https://github.com/dendronhq/dendron/commit/d25b6bb15d58b042365567c2f9f9668a1f4a242e))
+* **workspace:** custom color decoration for hashtags ([#3637](https://github.com/dendronhq/dendron/issues/3637)) ([1d41270](https://github.com/dendronhq/dendron/commit/1d412701791b4d5018f41c5dabdee759a968649c))
+* **workspace:** engine init with note candidates enabled ([#3585](https://github.com/dendronhq/dendron/issues/3585)) ([59597b4](https://github.com/dendronhq/dendron/commit/59597b476fd4b46d5b1c9a5d950af2c8e2dc15b1))
+* **workspace:** wikilinks appear broken + pod fixes ([#3532](https://github.com/dendronhq/dendron/issues/3532)) ([74f91e2](https://github.com/dendronhq/dendron/commit/74f91e26f5f9bad25059cf160ac54bbb2f816eca))
+
+
+
+
+
 ## [0.116.1](https://github.com/dendronhq/dendron/compare/v0.112.1...v0.116.1) (2022-10-25)
 
 

--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/unified",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "Unified parser utilities for Dendron",
   "license": "GPLv3",
   "repository": {
@@ -31,7 +31,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.0",
+    "@dendronhq/common-all": "^0.116.1",
     "@dendronhq/remark-mermaid": "^0.4.0",
     "hast-util-parse-selector": "^2.2.4",
     "hast-util-select": "^4.0.0",

--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/unified",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "Unified parser utilities for Dendron",
   "license": "GPLv3",
   "repository": {
@@ -31,7 +31,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.116.1",
+    "@dendronhq/common-all": "^0.116.2",
     "@dendronhq/remark-mermaid": "^0.4.0",
     "hast-util-parse-selector": "^2.2.4",
     "hast-util-select": "^4.0.0",

--- a/packages/unified/src/utilities/getParsingDependencyDicts.ts
+++ b/packages/unified/src/utilities/getParsingDependencyDicts.ts
@@ -123,13 +123,13 @@ function getNoteDependencies(ast: Node<Data>): DNodeCompositeKey[] {
 
   visit(ast, [DendronASTTypes.HASHTAG], (hashtag: HashTag, _index) => {
     renderDependencies.push({
-      fname: hashtag.value,
+      fname: hashtag.fname,
     });
   });
 
   visit(ast, [DendronASTTypes.USERTAG], (noteRef: UserTag, _index) => {
     renderDependencies.push({
-      fname: noteRef.value,
+      fname: noteRef.fname,
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24590,7 +24590,7 @@ trim-trailing-lines@^1.0.0:
 
 trim@0.0.1, trim@0.0.3:
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  resolved "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
   integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -24590,7 +24590,7 @@ trim-trailing-lines@^1.0.0:
 
 trim@0.0.1, trim@0.0.3:
   version "0.0.3"
-  resolved "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
   integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:


### PR DESCRIPTION
## fix(publishing): links don't show as private after nextJS export

This changes how we do the note rendering during NextJS Export Pod - instead of calling `getParsingDependencyDicts()` on each individual note, we just use the full set of engine notes as the dependency Dictionary. This gets rid of a performance issue of calling `getParsingDependencyDicts()` too many times during export as well as an issue where notes were getting marked as 'private' in published sites due to them not being in the dependency dictionary.