### PR TITLE
fix(workspace): duplicate note entries in lookup bar

### DIFF
--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -837,11 +837,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     // If provided, we render the given note entirely. Otherwise find the note in workspace.
     if (!note) {
       note = (await this.getNote(id)).data;
-    } else {
-      // `procRehype` needs the note to be in the engine, so we have to add it in case it's a dummy note
-      await this.writeNote(note, { metaOnly: true });
     }
-
     // If note was not provided and we couldn't find it, we can't render.
     if (!note) {
       return {

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -320,7 +320,9 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
         originalQS,
       });
     }
-    let noteProps = noteIndexProps.map((ent) => this.notes[ent.id]);
+    let noteProps = noteIndexProps
+      .map((ent) => this.notes[ent.id])
+      .filter((note) => !note.id.startsWith(NoteUtils.FAKE_ID_PREFIX));
     // TODO: hack
     if (!_.isUndefined(vault)) {
       noteProps = noteProps.filter((ent) =>

--- a/packages/engine-server/src/engineClient.ts
+++ b/packages/engine-server/src/engineClient.ts
@@ -320,9 +320,7 @@ export class DendronEngineClient implements DEngineClient, EngineEventEmitter {
         originalQS,
       });
     }
-    let noteProps = noteIndexProps
-      .map((ent) => this.notes[ent.id])
-      .filter((note) => !note.id.startsWith(NoteUtils.FAKE_ID_PREFIX));
+    let noteProps = noteIndexProps.map((ent) => this.notes[ent.id]);
     // TODO: hack
     if (!_.isUndefined(vault)) {
       noteProps = noteProps.filter((ent) =>

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -469,9 +469,6 @@ export class DendronEngineV2 implements DEngine {
     // If provided, we render the given note entirely. Otherwise find the note in workspace.
     if (!note) {
       note = this.notes[id];
-    } else {
-      // `procRehype` needs the note to be in the engine, so we have to add it in case it's a dummy note
-      this.store.updateNote(note);
     }
 
     // If note was not provided and we couldn't find it, we can't render.


### PR DESCRIPTION
This PR aims to fix the issue with duplicate note entries in lookup bar by filtering out the note ids that starts with prefix fake.
- Bug: https://discordapp.com/channels/717965437182410783/802578902429597726/1031927164645421116
- Debug: all the three entries are of same note
![image](https://user-images.githubusercontent.com/84971366/198097441-405f8522-d944-4cd6-a471-28d9fe0e22ff.png)
