### PR TITLE
enhance(workspace): Move engineClient to v3

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -15,6 +15,12 @@ import {
   FindNoteOpts,
   APIRequest,
   FindNotesMetaResp,
+  GetNoteResp,
+  EngineGetNoteRequest,
+  GetNoteMetaResp,
+  BulkGetNoteResp,
+  EngineBulkGetNoteRequest,
+  BulkGetNoteMetaResp,
 } from "@dendronhq/common-all";
 import { ExpressUtils } from "@dendronhq/common-server";
 import { Request, Response, Router } from "express";
@@ -23,6 +29,42 @@ import { NoteController } from "../modules/notes";
 import { getWSEngine } from "../utils";
 
 const router = Router();
+
+router.get(
+  "/get",
+  asyncHandler(async (req: Request, res: Response<GetNoteResp>) => {
+    const { id, ws } = req.query as unknown as EngineGetNoteRequest;
+    const engine = await getWSEngine({ ws: ws || "" });
+    ExpressUtils.setResponse(res, await engine.getNote(id));
+  })
+);
+
+router.get(
+  "/getMeta",
+  asyncHandler(async (req: Request, res: Response<GetNoteMetaResp>) => {
+    const { id, ws } = req.query as unknown as EngineGetNoteRequest;
+    const engine = await getWSEngine({ ws: ws || "" });
+    ExpressUtils.setResponse(res, await engine.getNoteMeta(id));
+  })
+);
+
+router.get(
+  "/bulkGet",
+  asyncHandler(async (req: Request, res: Response<BulkGetNoteResp>) => {
+    const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
+    const engine = await getWSEngine({ ws: ws || "" });
+    ExpressUtils.setResponse(res, await engine.bulkGetNotes(ids));
+  })
+);
+
+router.get(
+  "/bulkGetMeta",
+  asyncHandler(async (req: Request, res: Response<BulkGetNoteMetaResp>) => {
+    const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
+    const engine = await getWSEngine({ ws: ws || "" });
+    ExpressUtils.setResponse(res, await engine.bulkGetNotesMeta(ids));
+  })
+);
 
 router.post(
   "/delete",

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -2,12 +2,16 @@ import axios, { AxiosInstance } from "axios";
 import _ from "lodash";
 import * as querystring from "qs";
 import {
+  BulkGetNoteMetaResp,
+  BulkGetNoteResp,
   BulkWriteNotesOpts,
   DNodeProps,
   EngineDeleteOpts,
   EngineInfoResp,
   EngineWriteOptsV2,
   FindNotesMetaResp,
+  GetNoteMetaResp,
+  GetNoteResp,
   RenameNoteOpts,
   SchemaModuleProps,
   WriteNoteResp,
@@ -105,6 +109,14 @@ export type WorkspaceInitRequest = {
 export type WorkspaceSyncRequest = WorkspaceRequest;
 
 export type WorkspaceRequest = { ws: string };
+
+export type EngineGetNoteRequest = {
+  id: string;
+} & WorkspaceRequest;
+
+export type EngineBulkGetNoteRequest = {
+  ids: string[];
+} & WorkspaceRequest;
 
 export type EngineRenameNoteRequest = RenameNoteOpts & { ws: string };
 export type EngineWriteRequest = {
@@ -372,6 +384,38 @@ export class DendronAPI extends API {
       path: "note/write",
       method: "post",
       body: req,
+    });
+  }
+
+  noteGet(req: EngineGetNoteRequest): Promise<GetNoteResp> {
+    return this._makeRequest({
+      path: "note/get",
+      method: "get",
+      qs: req,
+    });
+  }
+
+  noteGetMeta(req: EngineGetNoteRequest): Promise<GetNoteMetaResp> {
+    return this._makeRequest({
+      path: "note/getMeta",
+      method: "get",
+      qs: req,
+    });
+  }
+
+  noteBulkGet(req: EngineBulkGetNoteRequest): Promise<BulkGetNoteResp> {
+    return this._makeRequest({
+      path: "note/bulkGet",
+      method: "get",
+      qs: req,
+    });
+  }
+
+  noteBulkGetMeta(req: EngineBulkGetNoteRequest): Promise<BulkGetNoteMetaResp> {
+    return this._makeRequest({
+      path: "note/bulkGetMeta",
+      method: "get",
+      qs: req,
     });
   }
 

--- a/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
@@ -2,6 +2,8 @@ import {
   APIUtils,
   DendronAPI,
   DVault,
+  GetNoteMetaResp,
+  GetNoteResp,
   NotePropsMeta,
   RenderNoteResp,
 } from "@dendronhq/common-all";
@@ -206,6 +208,115 @@ describe("api/note/render tests", () => {
       it(`THEN rendered foo to contain newly modified value from foo.two.`, () => {
         expect(rendered.data?.includes("modified-val")).toBeTruthy();
       });
+    });
+  });
+});
+
+describe("api/note/get tests", () => {
+  describe(`WHEN calling /get on existent note`, () => {
+    let resp: GetNoteResp;
+
+    beforeAll(async () => {
+      await runEngineTestV5(
+        async ({ wsRoot, vaults }) => {
+          const api = await getApiWithInitializedWS(wsRoot, vaults);
+
+          resp = await api.noteGet({
+            ws: wsRoot,
+            id: "foo",
+          });
+        },
+        { expect, preSetupHook: ENGINE_HOOKS.setupBasic }
+      );
+    });
+
+    it(`THEN data in payload is expected note`, () => {
+      expect(resp.data?.id).toEqual("foo");
+      expect(resp.data?.body).toEqual("foo body");
+    });
+
+    it(`THEN error to be undefined`, () => {
+      expect(resp.error).toBeUndefined();
+    });
+  });
+
+  describe(`WHEN calling /get on nonexistent note`, () => {
+    let resp: GetNoteResp;
+
+    beforeAll(async () => {
+      await runEngineTestV5(
+        async ({ wsRoot, vaults }) => {
+          const api = await getApiWithInitializedWS(wsRoot, vaults);
+
+          resp = await api.noteGet({
+            ws: wsRoot,
+            id: "foobasdf",
+          });
+        },
+        { expect, preSetupHook: ENGINE_HOOKS.setupBasic }
+      );
+    });
+
+    it(`THEN data in payload is undefined`, () => {
+      expect(resp.data).toBeUndefined();
+    });
+
+    it(`THEN error contains missing note error`, () => {
+      expect(resp.error?.message).toContain("NoteProps not found");
+    });
+  });
+});
+
+describe("api/note/getMeta tests", () => {
+  describe(`WHEN calling /getMeta on existent note`, () => {
+    let resp: GetNoteMetaResp;
+
+    beforeAll(async () => {
+      await runEngineTestV5(
+        async ({ wsRoot, vaults }) => {
+          const api = await getApiWithInitializedWS(wsRoot, vaults);
+
+          resp = await api.noteGetMeta({
+            ws: wsRoot,
+            id: "foo",
+          });
+        },
+        { expect, preSetupHook: ENGINE_HOOKS.setupBasic }
+      );
+    });
+
+    it(`THEN data in payload is expected note`, () => {
+      expect(resp.data?.id).toEqual("foo");
+    });
+
+    it(`THEN error to be undefined`, () => {
+      expect(resp.error).toBeUndefined();
+    });
+  });
+
+  describe(`WHEN calling /getMeta on nonexistent note`, () => {
+    let resp: GetNoteMetaResp;
+
+    beforeAll(async () => {
+      await runEngineTestV5(
+        async ({ wsRoot, vaults }) => {
+          const api = await getApiWithInitializedWS(wsRoot, vaults);
+
+          resp = await api.noteGetMeta({
+            ws: wsRoot,
+            id: "foobasdf",
+          });
+        },
+        { expect, preSetupHook: ENGINE_HOOKS.setupBasic }
+      );
+    });
+
+    it(`THEN data in payload is undefined`, () => {
+      expect(resp.data).toBeUndefined();
+    });
+
+    it(`THEN error contains missing note error`, () => {
+      expect(resp.error?.message).toContain("NoteProps not found");
     });
   });
 });


### PR DESCRIPTION
This change moves engineClient to v3 for the following methods
- getNote
- getNoteMeta
- bulkGetNotes
- bulkGetNotesMeta

Similar to the backend, this will be under a dev flag `enableEngineV3`