### PR TITLE
chore(workspace): load schemas in windows when engineV3 is enabled

### DIFF
--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -996,7 +996,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           const vpath = vault2Path({ vault, wsRoot: this.wsRoot });
           // Get list of files from filesystem
           const maybeFiles = await this._fileStore.readDir({
-            root: URI.parse(vpath),
+            root: URI.file(vpath),
             include: ["*.schema.yml"],
           });
           if (maybeFiles.error || maybeFiles.data.length === 0) {


### PR DESCRIPTION
with enginev3 flag enabled, schemas are not loaded on init and Dendron throws the below-specified error. This is because, in windows URI.parse does not have the correct file scheme and appends `C:/` drive to the wsRoot.

`
Multiple errors: - Unable to get schemas for vault archive - Unable to get schemas for vault dendron.community - Unable to get schemas for vault incubator - Unable to get schemas for vault dendron.docs - Unable to get schemas for vault users - Unable to get schemas for vault dendron.blog - Unable to get schemas for vault dendron.dendron-site - Unable to get schemas for vault dendron.handbook - Unable to get schemas for vault private - Unable to get schemas for vault dev
`