### PR TITLE
fix(workspace): completionProvider and other bulk operations for engine v3

### DIFF
--- a/packages/api-server/src/Server.ts
+++ b/packages/api-server/src/Server.ts
@@ -17,6 +17,7 @@ import asyncHandler from "express-async-handler";
 import fs from "fs-extra";
 import morgan from "morgan";
 import path from "path";
+import qs from "qs";
 import querystring from "querystring";
 import { getLogger } from "./core";
 import { GoogleAuthController } from "./modules/oauth";
@@ -47,6 +48,14 @@ export function appModule({
   const ctx = "appModule:start";
   const logger = getLogger();
   const app = express();
+
+  // Increase the size limit of arrays being parsed from query parameters. If
+  // the number of items in the query string exceed 'arrayLimit', it gets
+  // converted to an object instead of an array automatically.
+  app.set("query parser", (str: any) => {
+    return qs.parse(str, { arrayLimit: 1000 });
+  });
+
   app.use(cors());
   app.use(express.json({ limit: "500mb" }));
   app.use(express.urlencoded({ extended: true }));

--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -53,13 +53,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response<BulkGetNoteResp>) => {
     const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
 
-    // Express will convert the ids array into an object if it exceeds the
-    // 'arrayLimit' value set in the query parser (see {@link appModule}). In
-    // that case, convert the object back to an array
-    let processedIdPayload = ids;
-    if (!Array.isArray(processedIdPayload)) {
-      processedIdPayload = Object.values(processedIdPayload);
-    }
+    const processedIdPayload = convertToArrayIfObject(ids);
 
     const engine = await getWSEngine({ ws: ws || "" });
     ExpressUtils.setResponse(
@@ -74,10 +68,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response<BulkGetNoteMetaResp>) => {
     const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
 
-    let processedIdPayload = ids;
-    if (!Array.isArray(processedIdPayload)) {
-      processedIdPayload = Object.values(processedIdPayload);
-    }
+    const processedIdPayload = convertToArrayIfObject(ids);
 
     const engine = await getWSEngine({ ws: ws || "" });
     ExpressUtils.setResponse(
@@ -202,5 +193,17 @@ router.post(
     ExpressUtils.setResponse(res, await engine.getDecorations(opts));
   })
 );
+
+/**
+ * Express will convert the ids array into an object if it exceeds the
+ * 'arrayLimit' value set in the query parser (see {@link appModule}). In that
+ * case, convert the object back to an array
+ */
+function convertToArrayIfObject(payload: any): Array<any> {
+  if (!Array.isArray(payload)) {
+    return Object.values(payload);
+  }
+  return payload;
+}
 
 export { router as noteRouter };

--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -52,8 +52,20 @@ router.get(
   "/bulkGet",
   asyncHandler(async (req: Request, res: Response<BulkGetNoteResp>) => {
     const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
+
+    // Express will convert the ids array into an object if it exceeds the
+    // 'arrayLimit' value set in the query parser (see {@link appModule}). In
+    // that case, convert the object back to an array
+    let processedIdPayload = ids;
+    if (!Array.isArray(processedIdPayload)) {
+      processedIdPayload = Object.values(processedIdPayload);
+    }
+
     const engine = await getWSEngine({ ws: ws || "" });
-    ExpressUtils.setResponse(res, await engine.bulkGetNotes(ids));
+    ExpressUtils.setResponse(
+      res,
+      await engine.bulkGetNotes(processedIdPayload)
+    );
   })
 );
 
@@ -61,8 +73,17 @@ router.get(
   "/bulkGetMeta",
   asyncHandler(async (req: Request, res: Response<BulkGetNoteMetaResp>) => {
     const { ids, ws } = req.query as unknown as EngineBulkGetNoteRequest;
+
+    let processedIdPayload = ids;
+    if (!Array.isArray(processedIdPayload)) {
+      processedIdPayload = Object.values(processedIdPayload);
+    }
+
     const engine = await getWSEngine({ ws: ws || "" });
-    ExpressUtils.setResponse(res, await engine.bulkGetNotesMeta(ids));
+    ExpressUtils.setResponse(
+      res,
+      await engine.bulkGetNotesMeta(processedIdPayload)
+    );
   })
 );
 
@@ -149,6 +170,11 @@ router.post(
   "/bulkAdd",
   asyncHandler(async (req: Request, res: Response<BulkWriteNotesResp>) => {
     const { ws, opts } = req.body as EngineBulkAddRequest;
+
+    if (!Array.isArray(opts.notes)) {
+      opts.notes = Object.values(opts.notes);
+    }
+
     const engine = await getWSEngine({ ws: ws || "" });
     const out = await engine.bulkWriteNotes(opts);
     ExpressUtils.setResponse(res, out);

--- a/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/api-server/notes.spec.ts
@@ -319,4 +319,6 @@ describe("api/note/getMeta tests", () => {
       expect(resp.error?.message).toContain("NoteProps not found");
     });
   });
+
+  // TODO: Add bulk get tests
 });


### PR DESCRIPTION
## fix(workspace): completionProvider and other bulk operations for engine v3

There's an issue with bulk operations (or any operations passing in an array as a query parameter) where an array param exceeding 20 items will get converted to an object. This may cause engine side logic to fail. See https://github.com/expressjs/express/issues/2661

This was causing an issue with the wikilink completion provider not providing results for bigger workspaces while on v3, and potentially other issues as well that call `bulkGet`, `bulkGetMeta`, `bulkAdd`