### PR TITLE
chore: clean-up / continuation of `neverthrow-exploration`

### DIFF
--- a/packages/common-all/src/store/IConfigStore.ts
+++ b/packages/common-all/src/store/IConfigStore.ts
@@ -1,14 +1,12 @@
-import { Result, ResultAsync } from "neverthrow";
+import { ResultAsync } from "neverthrow";
 import { IDendronError } from "../error";
 import { DendronConfig, DendronConfigValue } from "../types";
 import { DeepPartial } from "../utils";
 
 export type ConfigValue = string | number | object;
 
-export type ConfigReadMode = "override" | "default";
 export type ConfigReadOpts = {
-  mode: ConfigReadMode;
-  useCache?: boolean;
+  applyOverride?: boolean;
 };
 
 export interface IConfigStore {
@@ -20,12 +18,12 @@ export interface IConfigStore {
    */
   createConfig(
     defaults?: DeepPartial<DendronConfig>
-  ): Promise<Result<DendronConfig, IDendronError>>;
+  ): ResultAsync<DendronConfig, IDendronError>;
   /**
    * Read the entire dendron config
    */
-  readRaw(): Promise<Result<DeepPartial<DendronConfig>, IDendronError>>;
-  read(opts: ConfigReadOpts): Promise<Result<DendronConfig, IDendronError>>;
+  readRaw(): ResultAsync<DeepPartial<DendronConfig>, IDendronError>;
+  read(opts?: ConfigReadOpts): ResultAsync<DendronConfig, IDendronError>;
   /**
    * Given a dendron config, update the persistent dendron config with the given payload
    */
@@ -38,8 +36,8 @@ export interface IConfigStore {
    */
   get(
     key: string,
-    opts: ConfigReadOpts
-  ): Promise<Result<DendronConfigValue, IDendronError>>;
+    opts?: ConfigReadOpts
+  ): ResultAsync<DendronConfigValue, IDendronError>;
   /**
    * Given a property path, update the config entry value with given value in the persistent dendron config
    * e.g.) update("commands.lookup.note.fuzzThreshold", 1) will update the fuzzThreshold to 1
@@ -48,11 +46,11 @@ export interface IConfigStore {
   update(
     key: string,
     value: DendronConfigValue
-  ): Promise<Result<DendronConfigValue, IDendronError>>;
+  ): ResultAsync<DendronConfigValue, IDendronError>;
   /**
    * Given a property path, delete the config entry in the persistent dendron config
    * e.g.) delete("commands.lookup.note.fuzzThreshold") will unset the property fuzzThreshold
    * returns previous value
    */
-  delete(key: string): Promise<Result<DendronConfigValue, IDendronError>>;
+  delete(key: string): ResultAsync<DendronConfigValue, IDendronError>;
 }

--- a/packages/common-all/src/utils/index.ts
+++ b/packages/common-all/src/utils/index.ts
@@ -1221,7 +1221,7 @@ export class ConfigUtils {
   static parsePartial(
     input: unknown
   ): Result<DeepPartial<DendronConfig>, DendronError> {
-    const schema = getDendronConfigSchema();
+    const schema = getDendronConfigSchema().deepPartial();
     return parse(schema, input, "Invalid partial Dendron config");
   }
 


### PR DESCRIPTION
cleanup of #3744.
Creating a separate PR on top of #3744 to avoid being blocked with the merge.

- Make rest of the signatures `ResultAsync<T, E>`
- Handle some edge cases
- fix `ConfigUtils.parsePartial`
- Remove config caching