### PR TITLE
fix(sync): next js export pod fix on engine v3

### DIFF
--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -33,6 +33,9 @@ const router = Router();
 router.get(
   "/get",
   asyncHandler(async (req: Request, res: Response<GetNoteResp>) => {
+    // TODO: All of these 'as unknown as foo' calls are problematic - we can
+    // never guarantee that the correct parameters get passed over to the API.
+    // We need more robust input checking at this API layer.
     const { id, ws } = req.query as unknown as EngineGetNoteRequest;
     const engine = await getWSEngine({ ws: ws || "" });
     ExpressUtils.setResponse(res, await engine.getNote(id));
@@ -200,7 +203,7 @@ router.post(
  * case, convert the object back to an array
  */
 function convertToArrayIfObject(payload: any): Array<any> {
-  if (!Array.isArray(payload)) {
+  if (payload && !Array.isArray(payload)) {
     return Object.values(payload);
   }
   return payload;

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -79,6 +79,12 @@ export abstract class EngineV3Base implements ReducedDEngine {
    * See {@link DEngine.bulkGetNotes}
    */
   async bulkGetNotes(ids: string[]): Promise<BulkGetNoteResp> {
+    if (!ids || ids.length === 0) {
+      return {
+        data: [],
+      };
+    }
+
     const bulkResponses = await this.noteStore.bulkGet(ids);
 
     const errors = bulkResponses
@@ -97,6 +103,12 @@ export abstract class EngineV3Base implements ReducedDEngine {
    * See {@link DEngine.bulkGetNotesMeta}
    */
   async bulkGetNotesMeta(ids: string[]): Promise<BulkGetNoteMetaResp> {
+    if (!ids || ids.length === 0) {
+      return {
+        data: [],
+      };
+    }
+
     const bulkResponses = await this.noteStore.bulkGetMetadata(ids);
 
     const errors = bulkResponses

--- a/packages/engine-server/src/topics/site.ts
+++ b/packages/engine-server/src/topics/site.ts
@@ -602,12 +602,22 @@ export class SiteUtils {
     const domainId = domainNote.id;
     // merge children
     domainNote.children = getUniqueChildrenIds(noteCandidates);
-    // update children's parent field
-    const children = (await engine.bulkGetNotes(domainNote.children)).data;
-    children.map((note) => {
-      note.parent = domainId;
-    });
-    await engine.bulkWriteNotes({ notes: children, opts: { metaOnly: true } });
+
+    if (domainNote.children) {
+      // update children's parent field
+      const children = (await engine.bulkGetNotes(domainNote.children)).data;
+
+      if (children && children.length > 0) {
+        children.map((note) => {
+          note.parent = domainId;
+        });
+        await engine.bulkWriteNotes({
+          notes: children,
+          opts: { metaOnly: true },
+        });
+      }
+    }
+
     const logger = createLogger(LOGGER_NAME);
     logger.info({
       ctx: "filterByHierarchy",


### PR DESCRIPTION
## fix(sync): next js export pod fix on engine v3

For Engine V3, there's an issue during Next JS Export when exporting a domain that has no children.  This change fixes it at several layers (even though only one is necessary to unblock the scenario):
- in NextJS, don't call bulkGet with an empty ID list as an argument (unnecessary network call)
- On Engine side, do some _slightly_ better input validation.

In general, we need more robust input validation in api-server or we'll keep hitting issues like this. We do a lot of 'as unknown as foo' casting which is problematic.