### PR TITLE
chore(internal): Add config store to engine v3

### DIFF
--- a/packages/api-server/src/modules/workspace/index.ts
+++ b/packages/api-server/src/modules/workspace/index.ts
@@ -29,7 +29,7 @@ export class WorkspaceController {
     const config = DConfig.readConfigSync(uri);
     let engine;
     if (config.dev?.enableEngineV3) {
-      engine = DendronEngineV3.create({
+      engine = await DendronEngineV3.create({
         wsRoot: uri,
         logger,
       });

--- a/packages/dendron-cli/src/commands/utils.ts
+++ b/packages/dendron-cli/src/commands/utils.ts
@@ -79,7 +79,7 @@ export async function setupEngine(
   // in memory
   if (useLocalEngine) {
     const engine = newEngine
-      ? DendronEngineV3.create({ wsRoot, logger })
+      ? await DendronEngineV3.create({ wsRoot, logger })
       : DendronEngineV2.create({ wsRoot, logger });
     const out = await engine.init();
     if (out.error) {

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -1,6 +1,7 @@
 import {
   BacklinkUtils,
   Cache,
+  ConfigStore,
   ConfigUtils,
   CONSTANTS,
   DeleteSchemaResp,
@@ -32,6 +33,7 @@ import {
   GetNoteBlocksOpts,
   GetNoteBlocksResp,
   GetSchemaResp,
+  IConfigStore,
   IDendronError,
   IFileStore,
   INoteStore,
@@ -77,7 +79,6 @@ import {
 } from "@dendronhq/common-all";
 import {
   createLogger,
-  DConfig,
   DLogger,
   getDurationMilliseconds,
   NodeJSUtils,
@@ -91,6 +92,7 @@ import {
   runAllDecorators,
 } from "@dendronhq/unified";
 import _ from "lodash";
+import { homedir } from "os";
 import path from "path";
 import { NotesFileSystemCache } from "./cache/notesFileSystemCache";
 import { NoteParserV2 } from "./drivers/file/NoteParserV2";
@@ -106,6 +108,7 @@ type DendronEngineOptsV3 = {
   noteStore: INoteStore<string>;
   queryStore: IQueryStore;
   schemaStore: ISchemaStore<string>;
+  configStore: IConfigStore;
   logger: DLogger;
   config: DendronConfig;
 };
@@ -122,6 +125,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
   private _fileStore: IFileStore;
   private _noteStore: INoteStore<string>;
   private _schemaStore: ISchemaStore<string>;
+  private _configStore: IConfigStore;
   private _renderedCache: Cache<string, CachedPreview>;
 
   constructor(props: DendronEngineOptsV3) {
@@ -135,14 +139,32 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     this._fileStore = props.fileStore;
     this._noteStore = props.noteStore;
     this._schemaStore = props.schemaStore;
+    this._configStore = props.configStore;
   }
 
-  static create({ wsRoot, logger }: { logger?: DLogger; wsRoot: string }) {
+  static async create({
+    wsRoot,
+    logger,
+  }: {
+    logger?: DLogger;
+    wsRoot: string;
+  }) {
     const LOGGER = logger || createLogger();
-    const config = DConfig.readConfigSync(wsRoot);
 
     const queryStore = new FuseQueryStore();
     const fileStore = new NodeJSFileStore();
+    const configStore = new ConfigStore(
+      fileStore,
+      URI.parse(wsRoot),
+      URI.parse(homedir())
+    );
+
+    const configReadResult = await configStore.read();
+    if (configReadResult.isErr()) {
+      throw configReadResult.error;
+    }
+
+    const config = configReadResult.value;
 
     return new DendronEngineV3({
       wsRoot,
@@ -159,6 +181,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
         URI.parse(wsRoot)
       ),
       fileStore,
+      configStore,
       logger: LOGGER,
       config,
     });
@@ -168,14 +191,27 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
    * Does not throw error but returns it
    */
   async init(): Promise<DEngineInitResp> {
-    const config = DConfig.readConfigSync(this.wsRoot);
-    const defaultResp = {
+    let defaultResp = {
       notes: {},
       schemas: {},
       wsRoot: this.wsRoot,
       vaults: this.vaults,
-      config,
+      config: ConfigUtils.genDefaultConfig(),
     };
+    const readConfigResult = await this._configStore.read();
+    if (readConfigResult.isOk()) {
+      defaultResp = {
+        ...defaultResp,
+        config: readConfigResult.value,
+      };
+    } else {
+      return {
+        data: defaultResp,
+        error: readConfigResult.error,
+      };
+    }
+    const config = readConfigResult.value;
+
     try {
       const { data: schemas, error: schemaErrors } = await this.initSchema();
       if (_.isUndefined(schemas)) {
@@ -309,7 +345,14 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       note: NoteUtils.toLogObj(note),
     });
 
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const configReadResult = await this._configStore.read();
+    if (configReadResult.isErr()) {
+      return {
+        error: configReadResult.error,
+      };
+    }
+
+    const config = configReadResult.value;
     // Update links/anchors based on note body
     await EngineUtils.refreshNoteLinksAndAnchors({
       note,
@@ -624,7 +667,13 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
 
     // update note body of all notes that have changed
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const configReadResult = await this._configStore.read();
+    if (configReadResult.isErr()) {
+      return {
+        error: configReadResult.error,
+      };
+    }
+    const config = configReadResult.value;
     const notesToUpdate = linkNotesResp
       .map((resp) => {
         if (resp.error) {
@@ -916,7 +965,13 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           }),
         };
       }
-      const config = DConfig.readConfigSync(this.wsRoot);
+      const configReadResult = await this._configStore.read();
+      if (configReadResult.isErr()) {
+        return {
+          error: configReadResult.error,
+        };
+      }
+      const config = configReadResult.value;
       const blocks = await RemarkUtils.extractBlocks({
         note,
         config,
@@ -960,7 +1015,15 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           ),
         };
       });
-      const config = DConfig.readConfigSync(this.wsRoot);
+      const configReadResult = await this._configStore.read();
+      if (configReadResult.isErr()) {
+        return {
+          error: configReadResult.error,
+          data: {},
+        };
+      }
+
+      const config = configReadResult.value;
       const {
         allDecorations: decorations,
         allDiagnostics: diagnostics,
@@ -1489,7 +1552,11 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     dest: DendronASTDest;
   }): Promise<string> {
     let proc: ReturnType<typeof MDUtilsV5["procRehypeFull"]>;
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const configReadResult = await this._configStore.read();
+    if (configReadResult.isErr()) {
+      throw configReadResult.error;
+    }
+    const config = configReadResult.value;
 
     const noteCacheForRenderDict = await getParsingDependencyDicts(
       note,
@@ -1564,5 +1631,5 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
 
 export const createEngineV3 = ({ wsRoot }: WorkspaceOpts) => {
   const engine = DendronEngineV3.create({ wsRoot });
-  return engine as DEngineClient;
+  return engine as Promise<DEngineClient>;
 };

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -155,8 +155,8 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const fileStore = new NodeJSFileStore();
     const configStore = new ConfigStore(
       fileStore,
-      URI.parse(wsRoot),
-      URI.parse(homedir())
+      URI.file(wsRoot),
+      URI.file(homedir())
     );
 
     const configReadResult = await configStore.read();

--- a/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/DendronEngineV3.spec.ts
@@ -187,3 +187,25 @@ describe("engine, cache", () => {
     );
   });
 });
+
+describe("engine, config", () => {
+  describe("WHEN engine is created", () => {
+    test("THEN config store is properly initialized", async () => {
+      await runEngineTestV5(
+        async ({ engine }) => {
+          const initResp = await engine.init();
+          expect(initResp.error).toBeUndefined();
+          expect(initResp.data).toBeTruthy();
+          expect(initResp.data.config).toBeTruthy();
+        },
+        {
+          createEngine,
+          expect,
+          preSetupHook: async (opts) => {
+            await ENGINE_HOOKS.setupBasic(opts);
+          },
+        }
+      );
+    });
+  });
+});

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -299,7 +299,6 @@ export async function runEngineTestV5(
     await preSetupHook({ wsRoot, vaults });
     const resp = await createEngine({ wsRoot, vaults });
     const engine = resp.engine;
-    console.log({ engine: JSON.stringify(engine, null, 2) });
     server = resp.server;
     const start = process.hrtime();
     const initResp = await engine.init();

--- a/packages/engine-test-utils/src/engine.ts
+++ b/packages/engine-test-utils/src/engine.ts
@@ -84,7 +84,7 @@ export async function createEngineFromEngine(opts: WorkspaceOpts) {
  */
 export async function createEngineV3FromEngine(opts: WorkspaceOpts) {
   return {
-    engine: createEngineV3(opts) as DEngineClient,
+    engine: (await createEngineV3(opts)) as DEngineClient,
     port: undefined,
     server: undefined,
   };
@@ -299,6 +299,7 @@ export async function runEngineTestV5(
     await preSetupHook({ wsRoot, vaults });
     const resp = await createEngine({ wsRoot, vaults });
     const engine = resp.engine;
+    console.log({ engine: JSON.stringify(engine, null, 2) });
     server = resp.server;
     const start = process.hrtime();
     const initResp = await engine.init();


### PR DESCRIPTION
# chore(internal): Add config store to engine v3

This PR:
- adds `ConfigStore` to `DendronEngineV3`

## Note
- This PR only adds `ConfigStore` to the engine. It does not add endpoints that the engine client can call. All places where the config needs to be accessed still directly uses `DConfig` methods.
- Swapping out the usage of `DConfig` completely will take some time and most likely happen after we fully switch to engine v3 because
  - Adding new endpoints for the config creates a bit of complication because engine v2 and v3 shares a common interface.
  - configs are accessed in a lot of places; of those places, a lot don't have direct access to the engine and currently needs quite a bit of refactoring in every corner of our code base.

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [~] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)