### PR TITLE
fix(workspace): decoration does not display correct custom color for hashtags

### DIFF
--- a/packages/unified/src/decorations/frontmatter.ts
+++ b/packages/unified/src/decorations/frontmatter.ts
@@ -24,7 +24,7 @@ export const decorateFrontmatter: Decorator<
   FrontmatterContent,
   DecorationsForDecorateFrontmatter
 > = async (opts) => {
-  const { node: frontmatter, config, engine, note } = opts;
+  const { node: frontmatter, config, engine } = opts;
   const { value: contents, position } = frontmatter;
   // Decorate the timestamps
 
@@ -71,7 +71,6 @@ export const decorateFrontmatter: Decorator<
         lineOffset,
         config,
         engine,
-        note,
       });
       tagDecorations.push(...decorations);
       errors.push(...errors);

--- a/packages/unified/src/decorations/hashTags.ts
+++ b/packages/unified/src/decorations/hashTags.ts
@@ -1,7 +1,6 @@
 import {
   ConfigUtils,
   DendronConfig,
-  NoteProps,
   NoteUtils,
   Position,
   position2VSCodeRange,
@@ -24,14 +23,13 @@ export function isDecorationHashTag(
 export const decorateHashTag: Decorator<HashTag, DecorationHashTag> = (
   opts
 ) => {
-  const { node: hashtag, engine, config, note } = opts;
+  const { node: hashtag, engine, config } = opts;
   const { position } = hashtag;
   return decorateTag({
     fname: hashtag.fname,
     engine,
     position,
     config,
-    note,
   });
 };
 
@@ -41,20 +39,18 @@ export async function decorateTag({
   position,
   lineOffset,
   config,
-  note,
 }: {
   fname: string;
   engine: ReducedDEngine;
   position: Position;
   lineOffset?: number;
   config: DendronConfig;
-  note?: NoteProps;
 }) {
   let color: string | undefined;
+  const hashtag = (await engine.findNotesMeta({ fname }))[0];
   const { color: foundColor, type: colorType } = NoteUtils.color({
     fname,
-    note,
-    // engine,
+    note: hashtag,
   });
   const enableRandomlyColoredTags =
     ConfigUtils.getPublishing(config).enableRandomlyColoredTags;

--- a/packages/unified/src/remark/dendronPub.ts
+++ b/packages/unified/src/remark/dendronPub.ts
@@ -308,7 +308,7 @@ function plugin(this: Unified.Processor, opts?: PluginOpts): Transformer {
         if (mode !== ProcMode.IMPORT && value.startsWith(TAGS_HIERARCHY)) {
           const { color: maybeColor, type: colorType } = NoteUtils.color({
             fname: value,
-            note: noteToRender,
+            note,
             vault,
           });
           const enableRandomlyColoredTagsConfig =


### PR DESCRIPTION
This PR aims to address the following issue: https://github.com/dendronhq/dendron/issues/3605#issuecomment-1297023998

Note this PR does not fix the one 'intended regression' which is that colors don't observe the hierarchy anymore (i.e. if #foo is red, then #foo.bar used to be red too, but now it'll be something else).