### PR TITLE
chore(internal): make zod validation message more readably

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -52,7 +52,8 @@
     "spark-md5": "^3.0.2",
     "title": "^3.4.4",
     "vscode-uri": "^3.0.3",
-    "zod": "3.19.1"
+    "zod": "3.19.1",
+    "zod-validation-error": "^0.2.1"
   },
   "devDependencies": {
     "@types/fast-levenshtein": "^0.0.2",
@@ -62,8 +63,8 @@
     "@types/luxon": "^1.25.0",
     "@types/minimatch": "^3.0.5",
     "@types/nanoid-dictionary": "^4.2.0",
-    "@types/normalize-path": "^3.0.0",
     "@types/node": "13.11.0",
+    "@types/normalize-path": "^3.0.0",
     "@types/semver": "^7.3.4",
     "@types/title": "^3.4.1",
     "@types/unist": "^2.0.3",

--- a/packages/common-all/src/parse.ts
+++ b/packages/common-all/src/parse.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
 import type { ZodType } from "zod";
 import { ok, err } from "./utils";
 import type { Result } from "neverthrow";
@@ -36,8 +37,7 @@ export const parse = <T extends z.ZodTypeAny>(
     return err(
       new DendronError({
         message: [
-          ...(msg ? [msg] : []),
-          JSON.stringify(parsed.error.issues, null, 2),
+          fromZodError(parsed.error, { prefix: msg }).message,
           ...(schema.description ? [`Schema:${schema.description}`] : []),
         ].join("\n"),
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,6 +3823,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@swc/helpers@^0.4.11":
+  version "0.4.12"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.12.tgz#203243e78cff3c87c081c97ae548ab33e2503573"
+  integrity sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==
+  dependencies:
+    tslib "^2.4.0"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -27246,6 +27253,13 @@ zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zod-validation-error@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.2.1.tgz#d855c8bba835f43692756670d407453424a7ba5b"
+  integrity sha512-zGg6P5EHi5V0dvyEeC8HBZd2pzp7QDKTngkSWgWunljrY+0SHkHyjI519D+u8/37BHkGHAFseWgnZ2Uq8LNFKg==
+  dependencies:
+    "@swc/helpers" "^0.4.11"
 
 zod@3.19.1:
   version "3.19.1"


### PR DESCRIPTION
The aim of this PR is to make zod validation more readable.
This uses `zod-validation-error` library to return a more readably validation message.

from 

```sh
DendronError: Invalid Dendron Config
[
  {
    "code": "invalid_type",
    "expected": "boolean",
    "received": "string",
    "path": [
      "publishing",
      "copyAssets"
    ],
    "message": "Expected boolean, received string"
  }
]
```

to 

```sh
DendronError: Invalid Dendron Config: Expected boolean, received string at "publishing.copyAssets"
```


# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.