### PR TITLE
fix(refactor): correctly handle reference updates after move selection to

### DIFF
--- a/packages/common-all/src/util/compat.ts
+++ b/packages/common-all/src/util/compat.ts
@@ -46,6 +46,30 @@ export function getTextRange(text: string, range: VSRange): string {
   return lines.join("\n");
 }
 
+/**
+ * Similar to doing a `delete` on an `editor.edit()`, except it works with strings.
+ */
+export function deleteTextRange(text: string, range: VSRange): string {
+  const { start, end } = range;
+  const lines = text.split("\n");
+  const processed = lines
+    .map((line, index) => {
+      if (index === start.line) {
+        return line.substring(0, start.character);
+      } else if (index > start.line && index < end.line) {
+        return undefined;
+      } else if (index === end.line) {
+        return line.substring(end.character);
+      } else {
+        return line;
+      }
+    })
+    .filter((maybeLine): maybeLine is string => {
+      return maybeLine !== undefined;
+    });
+  return processed.join("\n");
+}
+
 export function newRange(
   startLine: number,
   startCharacter: number,

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -775,15 +775,18 @@ export class LookupControllerV3 implements ILookupControllerV3 {
             config,
           })
             .filter((link) => {
-              return (
-                link.to?.fname?.toLowerCase() ===
-                  sourceNote.fname.toLowerCase() &&
-                link.to?.anchorHeader &&
-                anchorNamesToUpdate.includes(link.to.anchorHeader)
-              );
+              const fnameMatch =
+                link.to?.fname?.toLocaleLowerCase() ===
+                sourceNote.fname.toLowerCase();
+              if (!fnameMatch) return false;
+
+              if (!link.to?.anchorHeader) return false;
+              const anchorHeader = link.to.anchorHeader.startsWith("^")
+                ? link.to.anchorHeader.substring(1)
+                : link.to.anchorHeader;
+              return anchorNamesToUpdate.includes(anchorHeader);
             })
             .map((link) => LinkUtils.dlink2DNoteLink(link));
-
           const resp = await LinkUtils.updateLinksInNote({
             linksToUpdate,
             note: noteToUpdate,

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -15,6 +15,8 @@ import {
   NoteQuickInput,
   NoteUtils,
   TaskNoteUtils,
+  VSRange,
+  deleteTextRange,
 } from "@dendronhq/common-all";
 import { HistoryService, WorkspaceUtils } from "@dendronhq/engine-server";
 import { LinkUtils } from "@dendronhq/unified";
@@ -26,7 +28,11 @@ import { DendronClientUtilsV2 } from "../../clientUtils";
 import { ExtensionProvider } from "../../ExtensionProvider";
 import { Logger } from "../../logger";
 import { clipboard } from "../../utils";
-import { findReferences, hasAnchorsToUpdate } from "../../utils/md";
+import {
+  findReferences,
+  getOneIndexedFrontmatterEndingLineNumber,
+  hasAnchorsToUpdate,
+} from "../../utils/md";
 import { VersionProvider } from "../../versionProvider";
 import { LookupPanelView } from "../../views/LookupPanelView";
 import { VSCodeUtils } from "../../vsCodeUtils";
@@ -770,6 +776,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
               vault,
             })
           )[0];
+
           const linksToUpdate = LinkUtils.findLinksFromBody({
             note: noteToUpdate,
             config,
@@ -851,14 +858,36 @@ export class LookupControllerV3 implements ILookupControllerV3 {
               ),
               alias: { mode: "title" },
             });
+            // TODO: editor.edit API is prone to race conditions in our case
+            // because we also change files directly through the engine.
+            // remove the use of `editor.edit` and switch to processing the text
+            // and doing an `engine.writeNote()` call instead.
             await editor?.edit((builder) => {
               if (!_.isUndefined(selection) && !selection.isEmpty) {
                 builder.replace(selection, `!${link}`);
               }
             });
-            await editor?.document.save();
           } else {
-            await VSCodeUtils.deleteRange(document, range as vscode.Range);
+            const activeNote = await ext.wsUtils.getNoteFromDocument(document);
+            if (activeNote && range) {
+              const activeNoteBody = activeNote?.body;
+              const fmOffset =
+                getOneIndexedFrontmatterEndingLineNumber(document.getText()) ||
+                1;
+              const vsRange: VSRange = {
+                start: {
+                  line: range.start.line - fmOffset,
+                  character: range.start.character,
+                },
+                end: {
+                  line: range.end.line - fmOffset,
+                  character: range.end.character,
+                },
+              };
+              const processed = deleteTextRange(activeNoteBody, vsRange);
+              activeNote.body = processed;
+              await ext.getEngine().writeNote(activeNote);
+            }
           }
         }
         return note;

--- a/packages/plugin-core/src/test/suite-integ/MoveSelectionToCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/MoveSelectionToCommand.test.ts
@@ -18,14 +18,26 @@ suite("MoveSelectionToCommand", function () {
             fname: "active",
             vault: vaults[0],
             wsRoot,
-            body: ["## Stuff", "one", "two", "three"].join("\n"),
+            body: [
+              "## Stuff",
+              "one",
+              "two",
+              "three",
+              "",
+              "some text ^test",
+              "",
+              "same file [[#^test]]",
+            ].join("\n"),
             genRandomId: true,
           });
           await NoteTestUtilsV4.createNote({
             fname: "refnote",
             vault: vaults[0],
             wsRoot,
-            body: "[[stuff|active#stuff]]",
+            body: [
+              "[[stuff|active#stuff]]",
+              "[[link to anchor|active#^test]]",
+            ].join("\n"),
             genRandomId: true,
           });
         },
@@ -39,15 +51,22 @@ suite("MoveSelectionToCommand", function () {
           const cmd = new MoveSelectionToCommand(extension);
           editor!.selection = new vscode.Selection(
             new vscode.Position(7, 0),
-            new vscode.Position(11, 0)
+            new vscode.Position(13, 0)
           );
 
           await cmd.run({
             initialValue: "newNote",
             noConfirm: true,
           });
+          const originalNote = (
+            await extension.getEngine().findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
+          expect(originalNote.body.includes("## Stuff")).toBeFalsy();
+          expect(originalNote.body.includes("same file [[newNote#^test]]"));
 
-          expect(editor?.document.getText().includes("## Stuff")).toBeFalsy();
           const newNote = (
             await extension.getEngine().findNotes({
               fname: "newNote",
@@ -55,14 +74,18 @@ suite("MoveSelectionToCommand", function () {
             })
           )[0];
           expect(newNote).toBeTruthy();
-          expect(newNote.body.trim()).toEqual("## Stuff\none\ntwo\nthree");
+          expect(newNote.body.trim()).toEqual(
+            "## Stuff\none\ntwo\nthree\n\nsome text ^test"
+          );
           const postRunRefNote = (
             await extension.getEngine().findNotes({
               fname: "refnote",
               vault: vaults[0],
             })
           )[0];
-          expect(postRunRefNote.body).toEqual("[[stuff|newNote#stuff]]");
+          expect(postRunRefNote.body).toEqual(
+            "[[stuff|newNote#stuff]]\n[[link to anchor|newNote#^test]]"
+          );
         });
       }
     );
@@ -75,14 +98,26 @@ suite("MoveSelectionToCommand", function () {
             fname: "active",
             vault: vaults[0],
             wsRoot,
-            body: ["## Stuff", "one", "two", "three"].join("\n"),
+            body: [
+              "## Stuff",
+              "one",
+              "two",
+              "three",
+              "",
+              "some text ^test",
+              "",
+              "same file [[#^test]]",
+            ].join("\n"),
             genRandomId: true,
           });
           await NoteTestUtilsV4.createNote({
             fname: "refnote",
             vault: vaults[0],
             wsRoot,
-            body: "[[stuff|active#stuff]]",
+            body: [
+              "[[stuff|active#stuff]]",
+              "[[link to anchor|active#^test]]",
+            ].join("\n"),
             genRandomId: true,
           });
           await NoteTestUtilsV4.createNote({
@@ -103,7 +138,7 @@ suite("MoveSelectionToCommand", function () {
           const cmd = new MoveSelectionToCommand(extension);
           editor!.selection = new vscode.Selection(
             new vscode.Position(7, 0),
-            new vscode.Position(11, 0)
+            new vscode.Position(13, 0)
           );
 
           await cmd.run({
@@ -111,7 +146,14 @@ suite("MoveSelectionToCommand", function () {
             noConfirm: true,
           });
 
-          expect(editor?.document.getText().includes("## Stuff")).toBeFalsy();
+          const originalNote = (
+            await extension.getEngine().findNotes({
+              fname: "active",
+              vault: vaults[0],
+            })
+          )[0];
+          expect(originalNote.body.includes("## Stuff")).toBeFalsy();
+          expect(originalNote.body.includes("same file [[newNote#^test]]"));
           const anotherNote = (
             await extension.getEngine().findNotes({
               fname: "anotherNote",
@@ -119,7 +161,7 @@ suite("MoveSelectionToCommand", function () {
             })
           )[0];
           expect(anotherNote.body.trim()).toEqual(
-            "anotherNote\n\n## Stuff\none\ntwo\nthree"
+            "anotherNote\n\n## Stuff\none\ntwo\nthree\n\nsome text ^test"
           );
           const postRunRefNote = (
             await extension.getEngine().findNotes({
@@ -127,7 +169,9 @@ suite("MoveSelectionToCommand", function () {
               vault: vaults[0],
             })
           )[0];
-          expect(postRunRefNote.body).toEqual("[[stuff|anotherNote#stuff]]");
+          expect(postRunRefNote.body).toEqual(
+            "[[stuff|anotherNote#stuff]]\n[[link to anchor|anotherNote#^test]]"
+          );
         });
       }
     );

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -2077,8 +2077,13 @@ suite("NoteLookupCommand", function () {
           expect(newNote?.body.trim()).toEqual("foo body");
 
           // should remove selection
-          const changedText = fooNoteEditor.document.getText();
-          expect(changedText.includes("foo body")).toBeFalsy();
+          const originalNote = (
+            await engine.findNotes({
+              fname: "foo",
+              vault: vaults[0],
+            })
+          )[0];
+          expect(originalNote.body.includes("foo body")).toBeFalsy();
           cmd.cleanUp();
           done();
         },

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -713,6 +713,9 @@ export function hasAnchorsToUpdate(
 
     if (processed.includes("#")) {
       const [_fname, anchor] = processed.split("#");
+      if (anchor.startsWith("^")) {
+        return anchorNamesToUpdate.includes(anchor.substring(1));
+      }
       return anchorNamesToUpdate.includes(anchor);
     } else {
       return false;

--- a/packages/plugin-core/src/utils/md.ts
+++ b/packages/plugin-core/src/utils/md.ts
@@ -676,7 +676,7 @@ function getFrontmatterEndingOffsetPosition(input: string): number | undefined {
  * @param input
  * @returns
  */
-function getOneIndexedFrontmatterEndingLineNumber(
+export function getOneIndexedFrontmatterEndingLineNumber(
   input: string
 ): number | undefined {
   const offset = getFrontmatterEndingOffsetPosition(input);

--- a/packages/unified/src/remark/utils.ts
+++ b/packages/unified/src/remark/utils.ts
@@ -999,9 +999,12 @@ export class LinkUtils {
             vaultName: VaultUtils.getName(destNote.vault),
           },
           data: {
-            ...oldLink.data,
             // preserve the cross vault status or add it if necessary
             xvault: isXVault,
+            // if the link was originally a sameFile link,
+            // we need to flip this so the new link correctly
+            // renders as regular wikilink
+            sameFile: note.id === destNote.fname,
           },
         };
 


### PR DESCRIPTION
# fix(refactor): correctly handle reference updates after move selection to

This PR:
- fixes an issue where block references were not being updated after block anchor was moved with `Move Selection to`
- fixes an issue where same file links were not being updated after block anchor was moved with `Move Selection to`
- since `Move selection to` is a wrapper around note lookup with some special inputs, this was also happening with regular selection extracts in note lookup, and is fixed as well.
- fixes a race condition where the engine and VSCode both attempts a file system change asynchornously, which results in dirty file state during the reference update process

related to: https://github.com/dendronhq/dendron/issues/3644, https://github.com/dendronhq/dendron/issues/3728

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [~] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)