### PR TITLE
fix(workspace): correctly populate backlink when creating new note using go to note

### DIFF
--- a/packages/plugin-core/src/commands/GoToNoteInterface.ts
+++ b/packages/plugin-core/src/commands/GoToNoteInterface.ts
@@ -19,6 +19,7 @@ export type GoToNoteCommandOpts = {
   column?: ViewColumn;
   /** added for contextual UI analytics. */
   source?: string;
+  originNote?: NoteProps;
 };
 export { GoToNoteCommandOpts as GotoNoteCommandOpts };
 

--- a/packages/plugin-core/src/commands/GoToNoteInterface.ts
+++ b/packages/plugin-core/src/commands/GoToNoteInterface.ts
@@ -19,6 +19,11 @@ export type GoToNoteCommandOpts = {
   column?: ViewColumn;
   /** added for contextual UI analytics. */
   source?: string;
+  /**
+   * the note which go to originates from.
+   * this is populated in the process of running the command
+   * and should not be passed in outside of tests.
+   */
   originNote?: NoteProps;
 };
 export { GoToNoteCommandOpts as GotoNoteCommandOpts };


### PR DESCRIPTION
# fix(workspace): correctly populate backlink when creating new note using go to note

This PR:
- fixes an issue with go to note, where newly created notes using go to note (originating from a wikilink) was not getting backlinks populated.
- this happens in both engine v2 and v3 (not an engine v3 regression)
- Ideally, the client probably shouldn't be concerned with this detail. I was considering adding this logic to the engine (like the rest is done in https://github.com/dendronhq/dendron/pull/3535), but the case where we need to populate backlinks of a newly created note is very limited (pretty much only this case I can think of so far), and for a generic real-time backlink updating in the engine we would have to a O(nk) pass of all existing notes and all their links, just to find one backlink to update. So I left the logic here in the command for the time being. Maybe we can consider moving this concern to the engine when we are more confident about the perf (sqlite?).

# Pull Request Checklist
## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)