### PR TITLE
chore(internal): Implement ConfigService

### DIFF
--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -38,6 +38,7 @@ export * from "./sidebar";
 export * from "./parse";
 export * from "./BacklinkUtils";
 export * from "./DLinkUtils";
+export * from "./service";
 export * as YamlUtils from "./yaml";
 export * as GitUtils from "./git";
 

--- a/packages/common-all/src/service/ConfigService.ts
+++ b/packages/common-all/src/service/ConfigService.ts
@@ -87,7 +87,7 @@ export class ConfigService {
    * @returns DendronConfig
    */
   readConfig(opts?: ConfigReadOpts) {
-    const { applyOverride } = _.defaults(opts, { applyOverride: false });
+    const { applyOverride } = _.defaults(opts, { applyOverride: true });
     if (!applyOverride) {
       return this.readWithDefaults();
     } else {

--- a/packages/common-all/src/service/ConfigService.ts
+++ b/packages/common-all/src/service/ConfigService.ts
@@ -1,0 +1,138 @@
+import _ from "lodash";
+import { URI } from "vscode-uri";
+import { ConfigReadOpts, ConfigStore, IFileStore } from "../store";
+import { okAsync } from "neverthrow";
+import { DendronConfig, DendronConfigValue, DVault } from "../types";
+import { DeepPartial } from "../utils";
+import { DendronError } from "../error";
+
+export type ConfigServiceOpts = {
+  wsRoot: URI;
+  // the home directory.
+  // do not pass in home directory if the file store implementation has no concept of home directory.
+  // i.e. only pass it in for NodeJSFileStore
+  homeDir: URI | undefined;
+  fileStore: IFileStore;
+};
+
+export class ConfigService {
+  static _singleton: undefined | ConfigService;
+  public wsRoot;
+  public homeDir;
+  private _configStore: ConfigStore;
+  private _fileStore: IFileStore;
+
+  get path(): URI {
+    return this._configStore.path;
+  }
+
+  /** static */
+
+  static instance(opts?: ConfigServiceOpts) {
+    if (_.isUndefined(this._singleton)) {
+      if (ConfigService.isConfigServiceOpts(opts)) {
+        this._singleton = new ConfigService(opts);
+      } else {
+        throw new DendronError({
+          message: "Unable to retrieve or create config service instance.",
+        });
+      }
+    }
+    return this._singleton;
+  }
+
+  static isConfigServiceOpts(
+    opts?: ConfigServiceOpts
+  ): opts is ConfigServiceOpts {
+    if (opts === undefined) return false;
+    if (opts.wsRoot === undefined || opts.fileStore === undefined) return false;
+    return true;
+  }
+
+  constructor(opts: ConfigServiceOpts) {
+    this.wsRoot = opts.wsRoot;
+    this.homeDir = opts.homeDir;
+    this._fileStore = opts.fileStore;
+    this._configStore = new ConfigStore(
+      this._fileStore,
+      this.wsRoot,
+      this.homeDir
+    );
+  }
+
+  /** public */
+
+  createConfig(defaults?: DeepPartial<DendronConfig>) {
+    return this._configStore.createConfig(defaults);
+  }
+
+  readRaw() {
+    return this._configStore.readRaw();
+  }
+
+  read(opts?: ConfigReadOpts) {
+    return this._configStore.read(opts);
+  }
+
+  write(payload: DendronConfig) {
+    return this.cleanWritePayload(payload).andThen(this._configStore.write);
+  }
+
+  get(key: string, opts?: ConfigReadOpts) {
+    return this._configStore.get(key, opts);
+  }
+
+  update(key: string, value: DendronConfigValue) {
+    return this._configStore.update(key, value);
+  }
+
+  delete(key: string) {
+    return this._configStore.delete(key);
+  }
+
+  /** helpers */
+
+  /**
+   * Given a write payload,
+   * if override is found, filter out the configs present in override
+   * otherwise, pass through
+   * @param payload write payload
+   * @returns cleaned payload
+   */
+  private cleanWritePayload(payload: DendronConfig) {
+    return this._configStore
+      .searchOverride()
+      .andThen((overrideConfig) => {
+        return this.excludeOverrideVaults(payload, overrideConfig);
+      })
+      .orElse(() => okAsync(payload));
+  }
+
+  /**
+   * Given a config and an override config,
+   * return the difference (config - override)
+   *
+   * Note that this is currently only used to filter out `workspace.vaults`
+   * @param payload original payload
+   * @param override override payload
+   * @returns
+   */
+  private excludeOverrideVaults(
+    payload: DendronConfig,
+    override: DeepPartial<DendronConfig>
+  ) {
+    const vaultsFromOverride = override.workspace?.vaults as DVault[];
+    const payloadDifference: DendronConfig = {
+      ...payload,
+      workspace: {
+        ...payload.workspace,
+        vaults: _.differenceWith(
+          payload.workspace.vaults,
+          vaultsFromOverride,
+          _.isEqual
+        ),
+      },
+    };
+    return okAsync(payloadDifference);
+  }
+}

--- a/packages/common-all/src/service/index.ts
+++ b/packages/common-all/src/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConfigService";

--- a/packages/common-all/src/store/ConfigStore.ts
+++ b/packages/common-all/src/store/ConfigStore.ts
@@ -1,13 +1,12 @@
-import { errAsync, okAsync } from "neverthrow";
+import { errAsync } from "neverthrow";
 import { DendronError } from "../error";
 import { URI, Utils } from "vscode-uri";
-import { ConfigReadOpts, IConfigStore } from "./IConfigStore";
+import { IConfigStore } from "./IConfigStore";
 import { IFileStore } from "./IFileStore";
 import { CONSTANTS } from "../constants";
 import { ConfigUtils, DeepPartial } from "../utils";
-import { DendronConfig, DendronConfigValue } from "../types";
+import { DendronConfig } from "../types";
 import * as YamlUtils from "../yaml";
-import { DConfigLegacy } from "../oneoff/ConfigCompat";
 import _ from "lodash";
 import { ResultUtils } from "../ResultUtils";
 
@@ -16,7 +15,7 @@ export class ConfigStore implements IConfigStore {
   private _wsRoot: URI;
   private _homeDir: URI | undefined;
 
-  get path(): URI {
+  get configPath(): URI {
     return Utils.joinPath(this._wsRoot, CONSTANTS.DENDRON_CONFIG_FILE);
   }
 
@@ -30,77 +29,45 @@ export class ConfigStore implements IConfigStore {
     const config: DendronConfig = ConfigUtils.genLatestConfig(defaults);
 
     return YamlUtils.toStr(config)
-      .asyncAndThen((configDump) => this.writeToFS(this.path, configDump))
+      .asyncAndThen((configDump) => this.writeToFS(this.configPath, configDump))
       .map(() => config);
   }
 
-  readRaw() {
-    return this.readFromFS(this.path)
+  readConfig() {
+    return this.readFromFS(this.configPath)
       .andThen(YamlUtils.fromStr)
       .andThen(ConfigUtils.parsePartial);
   }
 
-  read(opts?: ConfigReadOpts) {
-    const { applyOverride } = _.defaults(opts, {
-      applyOverride: false,
-    });
-    if (!applyOverride) {
-      return this.readWithDefaults();
+  readOverride(mode: "workspace" | "global") {
+    const doRead = (path: URI) => {
+      const readPath = Utils.joinPath(
+        path,
+        CONSTANTS.DENDRON_LOCAL_CONFIG_FILE
+      );
+      return this.readFromFS(readPath);
+    };
+
+    if (mode === "workspace") {
+      return doRead(this._wsRoot);
+    } else if (this._homeDir) {
+      return doRead(this._homeDir);
     } else {
-      return this.searchOverride()
-        .orElse(() => this.readWithDefaults())
-        .andThen(ConfigUtils.validateLocalConfig)
-        .andThen((override) =>
-          this.readWithDefaults().map((config) =>
-            ConfigUtils.mergeConfig(config, override)
-          )
-        );
+      return errAsync(
+        new DendronError({
+          message: "global override not supported with current file store.",
+        })
+      );
     }
   }
 
-  private readWithDefaults() {
-    return this.readRaw().andThen((rawConfig) => {
-      const cleanConfig = DConfigLegacy.configIsV4(rawConfig)
-        ? DConfigLegacy.v4ToV5(rawConfig)
-        : _.defaultsDeep(rawConfig, ConfigUtils.genDefaultConfig());
-      return ConfigUtils.parse(cleanConfig);
-    });
-  }
-
-  private readOverride(path: URI) {
-    return this.readFromFS(path);
-  }
-
-  searchOverride() {
-    const workspaceOverridePath = Utils.joinPath(
-      this._wsRoot,
-      CONSTANTS.DENDRON_LOCAL_CONFIG_FILE
-    );
-
-    return this.readOverride(workspaceOverridePath)
-      .orElse(() => {
-        if (this._homeDir) {
-          // try finding it globally
-          const globalOverridePath = Utils.joinPath(
-            this._homeDir,
-            CONSTANTS.DENDRON_LOCAL_CONFIG_FILE
-          );
-          return this.readOverride(globalOverridePath).orElse(() =>
-            okAsync("")
-          );
-        } else {
-          return okAsync("");
-        }
-      })
-      .andThen(YamlUtils.fromStr)
-      .andThen(ConfigUtils.parsePartial);
-  }
-
-  write(payload: DendronConfig) {
+  writeConfig(payload: DendronConfig) {
     return YamlUtils.toStr(payload)
-      .asyncAndThen((endPayload) => this.writeToFS(this.path, endPayload))
+      .asyncAndThen((endPayload) => this.writeToFS(this.configPath, endPayload))
       .map(() => payload);
   }
+
+  /** helpers */
 
   private writeToFS(uri: URI, content: string) {
     return ResultUtils.PromiseRespV3ToResultAsync(
@@ -110,28 +77,5 @@ export class ConfigStore implements IConfigStore {
 
   private readFromFS(uri: URI) {
     return ResultUtils.PromiseRespV3ToResultAsync(this._fileStore.read(uri));
-  }
-
-  get(key: string, opts?: ConfigReadOpts) {
-    return this.read(opts).map((config) => _.get(config, key));
-  }
-
-  update(key: string, value: DendronConfigValue) {
-    return this.read().andThen((config) => {
-      const prevValue = _.get(config, key);
-      const updatedConfig = _.set(config, key, value);
-      return this.write(updatedConfig).map(() => prevValue);
-    });
-  }
-
-  delete(key: string) {
-    return this.read().andThen((config) => {
-      const prevValue = _.get(config, key);
-      if (prevValue === undefined) {
-        return errAsync(new DendronError({ message: `${key} does not exist` }));
-      }
-      _.unset(config, key);
-      return this.write(config).map(() => prevValue);
-    });
   }
 }

--- a/packages/common-all/src/store/IConfigStore.ts
+++ b/packages/common-all/src/store/IConfigStore.ts
@@ -21,43 +21,52 @@ export interface IConfigStore {
   /**
    * Read the entire dendron config as is
    */
-  readRaw(): ResultAsync<DeepPartial<DendronConfig>, IDendronError>;
+  readConfig(): ResultAsync<DeepPartial<DendronConfig>, IDendronError>;
 
   /**
    * Read the entire dendron config with defaults filled.
    * If opts.applyOverride, attempt to look for dendronrc.yml and merge it with the read content of dendron.yml
    */
-  read(opts?: ConfigReadOpts): ResultAsync<DendronConfig, IDendronError>;
+  // read(opts?: ConfigReadOpts): ResultAsync<DendronConfig, IDendronError>;
 
   /**
    * Given a dendron config, update the persistent dendron config with the given payload
    * If dendronrc.yml is found, content that is present in dendronrc.yml will be filtered out before writing
    */
-  write(payload: DendronConfig): ResultAsync<DendronConfig, IDendronError>;
+  writeConfig(
+    payload: DendronConfig
+  ): ResultAsync<DendronConfig, IDendronError>;
+
+  /**
+   * Given mode (workspace or global), read override config
+   */
+  readOverride(
+    mode: "workspace" | "global"
+  ): ResultAsync<string, IDendronError>;
 
   /**
    * Given a property path, retrieve the config entry value in the persistent dendron config
    * e.g.) get("commands.lookup.note") will get the note lookup config object
    */
-  get(
-    key: string,
-    opts?: ConfigReadOpts
-  ): ResultAsync<DendronConfigValue, IDendronError>;
+  // get(
+  //   key: string,
+  //   opts?: ConfigReadOpts
+  // ): ResultAsync<DendronConfigValue, IDendronError>;
 
   /**
    * Given a property path, update the config entry value with given value in the persistent dendron config
    * e.g.) update("commands.lookup.note.fuzzThreshold", 1) will update the fuzzThreshold to 1
    * returns previous value, or undefined if it was not set before
    */
-  update(
-    key: string,
-    value: DendronConfigValue
-  ): ResultAsync<DendronConfigValue, IDendronError>;
+  // update(
+  //   key: string,
+  //   value: DendronConfigValue
+  // ): ResultAsync<DendronConfigValue, IDendronError>;
 
   /**
    * Given a property path, delete the config entry in the persistent dendron config
    * e.g.) delete("commands.lookup.note.fuzzThreshold") will unset the property fuzzThreshold
    * returns previous value, or errors if it is not set.
    */
-  delete(key: string): ResultAsync<DendronConfigValue, IDendronError>;
+  // delete(key: string): ResultAsync<DendronConfigValue, IDendronError>;
 }

--- a/packages/common-all/src/store/IConfigStore.ts
+++ b/packages/common-all/src/store/IConfigStore.ts
@@ -24,12 +24,6 @@ export interface IConfigStore {
   readConfig(): ResultAsync<DeepPartial<DendronConfig>, IDendronError>;
 
   /**
-   * Read the entire dendron config with defaults filled.
-   * If opts.applyOverride, attempt to look for dendronrc.yml and merge it with the read content of dendron.yml
-   */
-  // read(opts?: ConfigReadOpts): ResultAsync<DendronConfig, IDendronError>;
-
-  /**
    * Given a dendron config, update the persistent dendron config with the given payload
    * If dendronrc.yml is found, content that is present in dendronrc.yml will be filtered out before writing
    */
@@ -43,30 +37,4 @@ export interface IConfigStore {
   readOverride(
     mode: "workspace" | "global"
   ): ResultAsync<string, IDendronError>;
-
-  /**
-   * Given a property path, retrieve the config entry value in the persistent dendron config
-   * e.g.) get("commands.lookup.note") will get the note lookup config object
-   */
-  // get(
-  //   key: string,
-  //   opts?: ConfigReadOpts
-  // ): ResultAsync<DendronConfigValue, IDendronError>;
-
-  /**
-   * Given a property path, update the config entry value with given value in the persistent dendron config
-   * e.g.) update("commands.lookup.note.fuzzThreshold", 1) will update the fuzzThreshold to 1
-   * returns previous value, or undefined if it was not set before
-   */
-  // update(
-  //   key: string,
-  //   value: DendronConfigValue
-  // ): ResultAsync<DendronConfigValue, IDendronError>;
-
-  /**
-   * Given a property path, delete the config entry in the persistent dendron config
-   * e.g.) delete("commands.lookup.note.fuzzThreshold") will unset the property fuzzThreshold
-   * returns previous value, or errors if it is not set.
-   */
-  // delete(key: string): ResultAsync<DendronConfigValue, IDendronError>;
 }

--- a/packages/common-all/src/store/IConfigStore.ts
+++ b/packages/common-all/src/store/IConfigStore.ts
@@ -1,6 +1,6 @@
 import { ResultAsync } from "neverthrow";
 import { IDendronError } from "../error";
-import { DendronConfig, DendronConfigValue } from "../types";
+import { DendronConfig } from "../types";
 import { DeepPartial } from "../utils";
 
 export type ConfigValue = string | number | object;

--- a/packages/engine-test-utils/src/__tests__/engine-server/ConfigService.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/ConfigService.spec.ts
@@ -1,0 +1,311 @@
+import {
+  ConfigService,
+  ConfigUtils,
+  CONSTANTS,
+  DeepPartial,
+  DendronConfig,
+  DendronError,
+  URI,
+} from "@dendronhq/common-all";
+import { tmpDir, writeYAML } from "@dendronhq/common-server";
+import { NodeJSFileStore } from "@dendronhq/engine-server";
+import { existsSync, ensureFileSync, unlinkSync } from "fs-extra";
+import _ from "lodash";
+import path from "path";
+
+const writeGlobalOverride = (homeDir: string) => {
+  writeOverride(homeDir, {
+    workspace: {
+      vaults: [
+        {
+          fsPath: "foo",
+          name: "foo",
+        },
+      ],
+    },
+  });
+};
+
+const writeWorkspaceOverride = (wsRoot: string) => {
+  writeOverride(wsRoot, {
+    workspace: {
+      vaults: [
+        {
+          fsPath: "bar",
+          name: "foo",
+        },
+      ],
+    },
+  });
+};
+
+const writeOverride = (oPath: string, payload: DeepPartial<DendronConfig>) => {
+  writeYAML(path.join(oPath, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE), payload);
+};
+
+const deleteOverride = (oPath: string) => {
+  unlinkSync(path.join(oPath, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE));
+};
+
+describe("GIVEN ConfigService", () => {
+  describe("WHEN instance never created", () => {
+    test("THEN a bare .instance() call throws", async () => {
+      let cs: ConfigService | undefined;
+      try {
+        ConfigService.instance();
+      } catch (error: any) {
+        expect((error as unknown as DendronError).message).toEqual(
+          "Unable to retrieve or create config service instance."
+        );
+      }
+      expect(cs).toEqual(undefined);
+    });
+    test("THEN .instance() call creates and returns created instance", async () => {
+      const wsRoot = tmpDir().name;
+      const homeDir = tmpDir().name;
+      const cs = ConfigService.instance({
+        wsRoot: URI.file(wsRoot),
+        homeDir: URI.file(homeDir),
+        fileStore: new NodeJSFileStore(),
+      });
+      expect(cs).toBeTruthy();
+      ConfigService._singleton = undefined;
+    });
+  });
+
+  describe("WHEN instance already exists", () => {
+    let wsRoot: string;
+    let homeDir: string;
+    let instance: ConfigService;
+    beforeAll(() => {
+      wsRoot = tmpDir().name;
+      homeDir = tmpDir().name;
+      instance = ConfigService.instance({
+        wsRoot: URI.file(wsRoot),
+        homeDir: URI.file(homeDir),
+        fileStore: new NodeJSFileStore(),
+      });
+    });
+    describe("WHEN configPath getter called", () => {
+      test("THEN correct path of dendron.yml is returned", async () => {
+        expect(instance.configPath).toEqual(
+          URI.file(path.join(wsRoot, CONSTANTS.DENDRON_CONFIG_FILE))
+        );
+      });
+    });
+
+    describe("WHEN createConfig is called", () => {
+      test("THEN new config is created", async () => {
+        const createResult = await instance.createConfig();
+        expect(createResult.isOk()).toBeTruthy();
+        expect(createResult._unsafeUnwrap()).toMatchSnapshot();
+        expect(
+          existsSync(path.join(wsRoot, CONSTANTS.DENDRON_CONFIG_FILE))
+        ).toBeTruthy();
+      });
+    });
+
+    describe("WHEN readRaw is called", () => {
+      test("THEN config in fs is returned as-is", async () => {
+        let initialConfig: DeepPartial<DendronConfig> =
+          ConfigUtils.genDefaultConfig();
+        initialConfig = {
+          ...initialConfig,
+          preview: {},
+        };
+
+        const configPath = path.join(wsRoot, "dendron.yml");
+        ensureFileSync(configPath);
+        writeYAML(configPath, initialConfig);
+
+        const readRawResult = await instance.readRaw();
+        expect(readRawResult.isOk()).toBeTruthy();
+        expect(readRawResult._unsafeUnwrap()).toEqual(initialConfig);
+      });
+    });
+
+    describe("WHEN readConfig", () => {
+      describe("AND applyOverride", () => {
+        describe("AND override exists", () => {
+          test("THEN read config, apply defaults, and merged with override", async () => {
+            writeWorkspaceOverride(wsRoot);
+            writeGlobalOverride(homeDir);
+
+            const readResult1 = await instance.readConfig({
+              applyOverride: true,
+            });
+            expect(readResult1.isOk()).toBeTruthy();
+            expect(
+              readResult1._unsafeUnwrap().workspace.vaults[0].fsPath
+            ).toEqual("bar");
+
+            deleteOverride(wsRoot);
+
+            const readResult2 = await instance.readConfig({
+              applyOverride: true,
+            });
+            expect(readResult2.isOk()).toBeTruthy();
+            expect(
+              readResult2._unsafeUnwrap().workspace.vaults[0].fsPath
+            ).toEqual("foo");
+
+            deleteOverride(homeDir);
+          });
+        });
+        describe("AND override does not exist", () => {
+          test("THEN read config, apply defaults", async () => {
+            const readResult = await instance.readConfig({
+              applyOverride: true,
+            });
+            expect(readResult.isOk()).toBeTruthy();
+            expect(readResult._unsafeUnwrap().workspace.vaults).toEqual([]);
+          });
+        });
+      });
+      describe("AND not applyOverride", () => {
+        test("THEN read config, apply defaults", async () => {
+          const readResult = await instance.readConfig({
+            applyOverride: false,
+          });
+          expect(readResult.isOk()).toBeTruthy();
+          expect(readResult._unsafeUnwrap().workspace.vaults).toEqual([]);
+        });
+      });
+    });
+
+    describe("WHEN writeConfig", () => {
+      describe("AND override exists", () => {
+        beforeAll(() => {
+          writeGlobalOverride(homeDir);
+        });
+        afterAll(() => {
+          deleteOverride(homeDir);
+        });
+        describe("AND payload contains content from override", () => {
+          test("THEN difference of payload and override is written", async () => {
+            const readResult = await instance.readConfig({
+              applyOverride: true,
+            });
+            const configWithOverride = readResult._unsafeUnwrap();
+
+            configWithOverride.commands.lookup.note.leaveTrace = true;
+
+            const writeResult = await instance.writeConfig(configWithOverride);
+
+            expect(writeResult.isOk()).toBeTruthy();
+            expect(
+              writeResult._unsafeUnwrap().commands.lookup.note.leaveTrace
+            ).toEqual(true);
+            expect(writeResult._unsafeUnwrap().workspace.vaults).toEqual([]);
+          });
+        });
+        describe("AND payload does not contain content from override", () => {
+          test("THEN payload is written", async () => {
+            const readResult = await instance.readConfig({
+              applyOverride: false,
+            });
+            const config = readResult._unsafeUnwrap();
+
+            config.commands.lookup.note.leaveTrace = false;
+
+            const writeResult = await instance.writeConfig(config);
+
+            expect(writeResult.isOk()).toBeTruthy();
+            expect(
+              writeResult._unsafeUnwrap().commands.lookup.note.leaveTrace
+            ).toEqual(false);
+            expect(writeResult._unsafeUnwrap().workspace.vaults).toEqual([]);
+          });
+        });
+      });
+      describe("AND override does not exist", () => {
+        test("THEN payload is written", async () => {
+          const readResult = await instance.readConfig({
+            applyOverride: false,
+          });
+          const config = readResult._unsafeUnwrap();
+
+          config.commands.lookup.note.leaveTrace = true;
+
+          const writeResult = await instance.writeConfig(config);
+
+          expect(writeResult.isOk()).toBeTruthy();
+          expect(
+            writeResult._unsafeUnwrap().commands.lookup.note.leaveTrace
+          ).toEqual(true);
+          expect(writeResult._unsafeUnwrap().workspace.vaults).toEqual([]);
+        });
+      });
+    });
+
+    describe("WHEN getConfig", () => {
+      describe("AND applyOverride", () => {
+        describe("AND override exists", () => {
+          test("THEN get value of key after merging config with override", async () => {
+            writeGlobalOverride(homeDir);
+            const getResult = await instance.getConfig("workspace.vaults", {
+              applyOverride: true,
+            });
+            expect(getResult.isOk()).toBeTruthy();
+            expect(getResult._unsafeUnwrap()[0].fsPath).toEqual("foo");
+            deleteOverride(homeDir);
+          });
+        });
+        describe("AND override does not exist", () => {
+          test("THEN get value of key from config after applying defaults", async () => {
+            const getResult = await instance.getConfig("workspace.vaults", {
+              applyOverride: true,
+            });
+            expect(getResult.isOk()).toBeTruthy();
+            expect(getResult._unsafeUnwrap()).toEqual([]);
+          });
+        });
+      });
+      describe("AND not applyOverride", () => {
+        test("THEN get value of key from config", async () => {
+          writeGlobalOverride(homeDir);
+          const getResult = await instance.getConfig("workspace.vaults", {
+            applyOverride: false,
+          });
+          expect(getResult.isOk()).toBeTruthy();
+          expect(getResult._unsafeUnwrap()).toEqual([]);
+          deleteOverride(homeDir);
+        });
+      });
+    });
+
+    describe("WHEN updateConfig", () => {
+      test("THEN update key with value", async () => {
+        const updateResult = await instance.updateConfig(
+          "commands.lookup.note.leaveTrace",
+          false
+        );
+
+        expect(updateResult.isOk()).toBeTruthy();
+        expect(updateResult._unsafeUnwrap()).toEqual(true);
+      });
+    });
+
+    describe("WHEN deleteConfig", () => {
+      describe("AND value exists for key", () => {
+        test("THEN unset key", async () => {
+          const deleteResult = await instance.deleteConfig(
+            "commands.lookup.note.leaveTrace"
+          );
+          expect(deleteResult.isOk()).toBeTruthy();
+          expect(deleteResult._unsafeUnwrap()).toEqual(false);
+          const postDeleteRaw = (await instance.readRaw())._unsafeUnwrap();
+          expect(
+            postDeleteRaw.commands?.lookup?.note?.leaveTrace
+          ).toBeUndefined();
+        });
+      });
+      describe("AND value does not exist", () => {
+        test("THEN return error", async () => {
+          const deleteResult = await instance.deleteConfig("foo");
+          expect(deleteResult.isErr()).toBeTruthy();
+        });
+      });
+    });
+  });
+});

--- a/packages/engine-test-utils/src/__tests__/engine-server/ConfigService.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/ConfigService.spec.ts
@@ -32,7 +32,7 @@ const writeWorkspaceOverride = (wsRoot: string) => {
       vaults: [
         {
           fsPath: "bar",
-          name: "foo",
+          name: "bar",
         },
       ],
     },

--- a/packages/engine-test-utils/src/__tests__/engine-server/ConfigStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/ConfigStore.spec.ts
@@ -5,12 +5,11 @@ import {
   DeepPartial,
   DendronConfig,
   IFileStore,
-  LookupConfig,
   URI,
 } from "@dendronhq/common-all";
 import { tmpDir, writeYAML } from "@dendronhq/common-server";
 import { NodeJSFileStore } from "@dendronhq/engine-server";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync } from "fs";
 import { ensureFileSync } from "fs-extra";
 import _ from "lodash";
 import path from "path";
@@ -41,423 +40,400 @@ describe("ConfigStore", () => {
       expect(isConfigPersisted).toBeTruthy();
     });
 
+    test("WHEN readConfig, then read config as-is", async () => {
+      const homeDir = tmpDir().name;
+      const wsRoot = tmpDir().name;
+
+      // remove some configs initially
+      let initialConfig: DeepPartial<DendronConfig> =
+        ConfigUtils.genDefaultConfig();
+      initialConfig = {
+        ...initialConfig,
+        preview: {},
+      };
+
+      const configPath = path.join(wsRoot, "dendron.yml");
+      ensureFileSync(configPath);
+      writeYAML(configPath, initialConfig);
+
+      const configStore = new ConfigStore(
+        fileStore,
+        URI.file(wsRoot),
+        URI.file(homeDir)
+      );
+
+      const readConfigResult = await configStore.readConfig();
+      if (readConfigResult.isErr()) {
+        throw readConfigResult.error;
+      }
+      expect(readConfigResult.isOk()).toBeTruthy();
+      const config = readConfigResult._unsafeUnwrap();
+      expect(config).toEqual(initialConfig);
+    });
+
     describe("AND partial DendronConfig", () => {
-      test("WHEN readRaw, then retrieve config as is", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
+      test("WHEN readRaw, then retrieve config as is", async () => {});
 
-        // remove some configs initially
-        let initialConfig: DeepPartial<DendronConfig> =
-          ConfigUtils.genDefaultConfig();
-        initialConfig = {
-          ...initialConfig,
-          preview: {},
-        };
+      // test("WHEN read with default, then retrieve config with missing defaults filled", async () => {
+      //   const homeDir = tmpDir().name;
+      //   const wsRoot = tmpDir().name;
 
-        const configPath = path.join(wsRoot, "dendron.yml");
-        ensureFileSync(configPath);
-        writeYAML(configPath, initialConfig);
+      //   // remove some configs initially
+      //   let initialConfig: DeepPartial<DendronConfig> =
+      //     ConfigUtils.genDefaultConfig();
+      //   initialConfig = {
+      //     ...initialConfig,
+      //     preview: {},
+      //   };
 
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
+      //   const configPath = path.join(wsRoot, "dendron.yml");
+      //   ensureFileSync(configPath);
+      //   writeYAML(configPath, initialConfig);
 
-        const readRawResult = await configStore.readRaw();
-        if (readRawResult.isErr()) {
-          throw readRawResult.error;
-        }
-        expect(readRawResult.isOk()).toBeTruthy();
-        const rawConfig = readRawResult._unsafeUnwrap();
-        expect(rawConfig).toEqual(initialConfig);
-      });
+      //   const configStore = new ConfigStore(
+      //     fileStore,
+      //     URI.file(wsRoot),
+      //     URI.file(homeDir)
+      //   );
 
-      test("WHEN read with default, then retrieve config with missing defaults filled", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
+      //   const readWithDefaultResult = await configStore.read();
 
-        // remove some configs initially
-        let initialConfig: DeepPartial<DendronConfig> =
-          ConfigUtils.genDefaultConfig();
-        initialConfig = {
-          ...initialConfig,
-          preview: {},
-        };
+      //   if (readWithDefaultResult.isErr()) {
+      //     throw readWithDefaultResult.error;
+      //   }
+      //   expect(readWithDefaultResult.isOk()).toBeTruthy();
+      //   const config = readWithDefaultResult._unsafeUnwrap();
+      //   expect(config).toEqual(ConfigUtils.genDefaultConfig());
+      // });
 
-        const configPath = path.join(wsRoot, "dendron.yml");
-        ensureFileSync(configPath);
-        writeYAML(configPath, initialConfig);
+      // test("WHEN read with override, then retrieve config with override applied", async () => {
+      //   const homeDir = tmpDir().name;
+      //   const wsRoot = tmpDir().name;
 
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
+      //   // move some configs to wsRoot/dendronrc.yml and homeDir/dendronrc.yml
+      //   const initialConfig = ConfigUtils.genDefaultConfig();
+      //   const globalOverridePayload = {
+      //     workspace: {
+      //       vaults: [
+      //         {
+      //           fsPath: "foo",
+      //           name: "foo",
+      //         },
+      //       ],
+      //     },
+      //   };
+      //   const workspaceOverridePayload = {
+      //     workspace: {
+      //       vaults: [
+      //         {
+      //           fsPath: "bar",
+      //           name: "bar",
+      //         },
+      //       ],
+      //     },
+      //   };
 
-        const readWithDefaultResult = await configStore.read();
+      //   writeYAML(
+      //     path.join(homeDir, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+      //     globalOverridePayload
+      //   );
+      //   writeYAML(
+      //     path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+      //     workspaceOverridePayload
+      //   );
 
-        if (readWithDefaultResult.isErr()) {
-          throw readWithDefaultResult.error;
-        }
-        expect(readWithDefaultResult.isOk()).toBeTruthy();
-        const config = readWithDefaultResult._unsafeUnwrap();
-        expect(config).toEqual(ConfigUtils.genDefaultConfig());
-      });
+      //   const vaultExcludedInitialConfig = {
+      //     ...initialConfig,
+      //     workspace: _.omit(initialConfig.workspace, "vaults"),
+      //   } as DeepPartial<DendronConfig>;
 
-      test("WHEN read with override, then retrieve config with override applied", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
+      //   const configPath = path.join(wsRoot, "dendron.yml");
+      //   ensureFileSync(configPath);
+      //   writeYAML(configPath, vaultExcludedInitialConfig);
 
-        // move some configs to wsRoot/dendronrc.yml and homeDir/dendronrc.yml
-        const initialConfig = ConfigUtils.genDefaultConfig();
-        const globalOverridePayload = {
-          workspace: {
-            vaults: [
-              {
-                fsPath: "foo",
-                name: "foo",
-              },
-            ],
-          },
-        };
-        const workspaceOverridePayload = {
-          workspace: {
-            vaults: [
-              {
-                fsPath: "bar",
-                name: "bar",
-              },
-            ],
-          },
-        };
+      //   const configStore = new ConfigStore(
+      //     fileStore,
+      //     URI.file(wsRoot),
+      //     URI.file(homeDir)
+      //   );
 
-        writeYAML(
-          path.join(homeDir, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-          globalOverridePayload
-        );
-        writeYAML(
-          path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-          workspaceOverridePayload
-        );
+      //   // readRaw returns config with no vaults
+      //   const readRawResult = await configStore.readRaw();
+      //   if (readRawResult.isErr()) {
+      //     throw readRawResult.error;
+      //   }
+      //   expect(
+      //     readRawResult.isOk() &&
+      //       readRawResult._unsafeUnwrap().workspace?.vaults === undefined
+      //   ).toBeTruthy();
 
-        const vaultExcludedInitialConfig = {
-          ...initialConfig,
-          workspace: _.omit(initialConfig.workspace, "vaults"),
-        } as DeepPartial<DendronConfig>;
+      //   // read with override from workspace override if both exists
+      //   const readOverrideResult1 = await configStore.read({
+      //     applyOverride: true,
+      //   });
+      //   if (readOverrideResult1.isErr()) {
+      //     throw readOverrideResult1.error;
+      //   }
+      //   expect(readOverrideResult1.isOk()).toBeTruthy();
+      //   const overrideConfig1 = readOverrideResult1._unsafeUnwrap();
+      //   expect(overrideConfig1.workspace.vaults).toEqual([
+      //     {
+      //       fsPath: "bar",
+      //       name: "bar",
+      //     },
+      //   ]);
 
-        const configPath = path.join(wsRoot, "dendron.yml");
-        ensureFileSync(configPath);
-        writeYAML(configPath, vaultExcludedInitialConfig);
-
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
-
-        // readRaw returns config with no vaults
-        const readRawResult = await configStore.readRaw();
-        if (readRawResult.isErr()) {
-          throw readRawResult.error;
-        }
-        expect(
-          readRawResult.isOk() &&
-            readRawResult._unsafeUnwrap().workspace?.vaults === undefined
-        ).toBeTruthy();
-
-        // read with override from workspace override if both exists
-        const readOverrideResult1 = await configStore.read({
-          applyOverride: true,
-        });
-        if (readOverrideResult1.isErr()) {
-          throw readOverrideResult1.error;
-        }
-        expect(readOverrideResult1.isOk()).toBeTruthy();
-        const overrideConfig1 = readOverrideResult1._unsafeUnwrap();
-        expect(overrideConfig1.workspace.vaults).toEqual([
-          {
-            fsPath: "bar",
-            name: "bar",
-          },
-        ]);
-
-        // read with override from home directory if not found in workspace
-        unlinkSync(path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE));
-        const readOverrideResult2 = await configStore.read({
-          applyOverride: true,
-        });
-        if (readOverrideResult2.isErr()) {
-          throw readOverrideResult2.error;
-        }
-        expect(readOverrideResult2.isOk()).toBeTruthy();
-        const overrideConfig2 = readOverrideResult2._unsafeUnwrap();
-        expect(overrideConfig2.workspace.vaults).toEqual([
-          {
-            fsPath: "foo",
-            name: "foo",
-          },
-        ]);
-      });
+      //   // read with override from home directory if not found in workspace
+      //   unlinkSync(path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE));
+      //   const readOverrideResult2 = await configStore.read({
+      //     applyOverride: true,
+      //   });
+      //   if (readOverrideResult2.isErr()) {
+      //     throw readOverrideResult2.error;
+      //   }
+      //   expect(readOverrideResult2.isOk()).toBeTruthy();
+      //   const overrideConfig2 = readOverrideResult2._unsafeUnwrap();
+      //   expect(overrideConfig2.workspace.vaults).toEqual([
+      //     {
+      //       fsPath: "foo",
+      //       name: "foo",
+      //     },
+      //   ]);
+      // });
     });
 
     describe("AND write", () => {
-      test("WHEN no override exists, then write given config and persist", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
-
-        await configStore.createConfig();
-
-        const defaultConfig = ConfigUtils.genDefaultConfig();
-        const diff: LookupConfig = {
-          note: {
-            ...defaultConfig.commands.lookup.note,
-            selectionMode: "link",
-            fuzzThreshold: 1,
-          },
-        };
-        const writePayload: DendronConfig = {
-          ...defaultConfig,
-          commands: {
-            ...defaultConfig.commands,
-            lookup: diff,
-          },
-        };
-
-        // make sure we start with a default config
-        const readResult = await configStore.read();
-        if (readResult.isErr()) {
-          throw readResult.error;
-        }
-        expect(
-          readResult.isOk() && readResult._unsafeUnwrap() === defaultConfig
-        );
-
-        // write result contains payload
-        const writeResult = await configStore.write(writePayload);
-        if (writeResult.isErr()) {
-          throw writeResult.error;
-        }
-        expect(writeResult.isOk()).toBeTruthy();
-        expect(writeResult._unsafeUnwrap().commands.lookup).toEqual(diff);
-
-        // read again and verify
-        const readResult2 = await configStore.read();
-        if (readResult2.isErr()) {
-          throw readResult2.error;
-        }
-        expect(
-          readResult2.isOk() &&
-            readResult2._unsafeUnwrap().commands.lookup === diff
-        );
-      });
-
-      test("WHEN override exists, then filter out override vaults before writing", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
-
-        // move some configs to wsRoot/dendronrc.yml
-        const initialConfig = ConfigUtils.genDefaultConfig();
-        const workspaceOverridePayload = {
-          workspace: {
-            vaults: [
-              {
-                fsPath: "bar",
-                name: "bar",
-              },
-            ],
-          },
-        };
-
-        writeYAML(
-          path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-          workspaceOverridePayload
-        );
-
-        const vaultExcludedInitialConfig = {
-          ...initialConfig,
-          workspace: {
-            ...initialConfig.workspace,
-            vaults: [
-              {
-                fsPath: "foo",
-                name: "foo",
-              },
-            ],
-          },
-        } as DeepPartial<DendronConfig>;
-
-        const configPath = path.join(wsRoot, "dendron.yml");
-        ensureFileSync(configPath);
-        writeYAML(configPath, vaultExcludedInitialConfig);
-
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
-
-        // read in config with override
-        const configWithOverride = (
-          await configStore.read({ applyOverride: true })
-        )._unsafeUnwrap();
-
-        // change some things
-        ConfigUtils.setCommandsProp(configWithOverride, "lookup", {
-          note: {
-            ...configWithOverride.commands.lookup.note,
-            selectionMode: "none",
-          },
-        });
-
-        // write, and make sure the changes are there,
-        await configStore.write(configWithOverride);
-
-        const postWriteReadResult = await configStore.readRaw();
-        if (postWriteReadResult.isErr()) {
-          throw postWriteReadResult.error;
-        }
-        expect(postWriteReadResult.isOk()).toBeTruthy();
-        expect(
-          postWriteReadResult._unsafeUnwrap().commands?.lookup?.note
-            ?.selectionMode
-        ).toEqual("none");
-
-        // and override is filtered out
-        expect(postWriteReadResult._unsafeUnwrap().workspace?.vaults).toEqual([
-          {
-            fsPath: "foo",
-            name: "foo",
-          },
-        ]);
-      });
+      // test("WHEN no override exists, then write given config and persist", async () => {
+      //   const homeDir = tmpDir().name;
+      //   const wsRoot = tmpDir().name;
+      //   const configStore = new ConfigStore(
+      //     fileStore,
+      //     URI.file(wsRoot),
+      //     URI.file(homeDir)
+      //   );
+      //   await configStore.createConfig();
+      //   const defaultConfig = ConfigUtils.genDefaultConfig();
+      //   const diff: LookupConfig = {
+      //     note: {
+      //       ...defaultConfig.commands.lookup.note,
+      //       selectionMode: "link",
+      //       fuzzThreshold: 1,
+      //     },
+      //   };
+      //   const writePayload: DendronConfig = {
+      //     ...defaultConfig,
+      //     commands: {
+      //       ...defaultConfig.commands,
+      //       lookup: diff,
+      //     },
+      //   };
+      //   // make sure we start with a default config
+      //   const readResult = await configStore.read();
+      //   if (readResult.isErr()) {
+      //     throw readResult.error;
+      //   }
+      //   expect(
+      //     readResult.isOk() && readResult._unsafeUnwrap() === defaultConfig
+      //   );
+      //   // write result contains payload
+      //   const writeResult = await configStore.write(writePayload);
+      //   if (writeResult.isErr()) {
+      //     throw writeResult.error;
+      //   }
+      //   expect(writeResult.isOk()).toBeTruthy();
+      //   expect(writeResult._unsafeUnwrap().commands.lookup).toEqual(diff);
+      //   // read again and verify
+      //   const readResult2 = await configStore.read();
+      //   if (readResult2.isErr()) {
+      //     throw readResult2.error;
+      //   }
+      //   expect(
+      //     readResult2.isOk() &&
+      //       readResult2._unsafeUnwrap().commands.lookup === diff
+      //   );
+      // });
+      // todo: move to config service tests
+      //   test("WHEN override exists, then filter out override vaults before writing", async () => {
+      //     const homeDir = tmpDir().name;
+      //     const wsRoot = tmpDir().name;
+      //     // move some configs to wsRoot/dendronrc.yml
+      //     const initialConfig = ConfigUtils.genDefaultConfig();
+      //     const workspaceOverridePayload = {
+      //       workspace: {
+      //         vaults: [
+      //           {
+      //             fsPath: "bar",
+      //             name: "bar",
+      //           },
+      //         ],
+      //       },
+      //     };
+      //     writeYAML(
+      //       path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+      //       workspaceOverridePayload
+      //     );
+      //     const vaultExcludedInitialConfig = {
+      //       ...initialConfig,
+      //       workspace: {
+      //         ...initialConfig.workspace,
+      //         vaults: [
+      //           {
+      //             fsPath: "foo",
+      //             name: "foo",
+      //           },
+      //         ],
+      //       },
+      //     } as DeepPartial<DendronConfig>;
+      //     const configPath = path.join(wsRoot, "dendron.yml");
+      //     ensureFileSync(configPath);
+      //     writeYAML(configPath, vaultExcludedInitialConfig);
+      //     const configStore = new ConfigStore(
+      //       fileStore,
+      //       URI.file(wsRoot),
+      //       URI.file(homeDir)
+      //     );
+      //     // read in config with override
+      //     const configWithOverride = (
+      //       await configStore.read({ applyOverride: true })
+      //     )._unsafeUnwrap();
+      //     // change some things
+      //     ConfigUtils.setCommandsProp(configWithOverride, "lookup", {
+      //       note: {
+      //         ...configWithOverride.commands.lookup.note,
+      //         selectionMode: "none",
+      //       },
+      //     });
+      //     // write, and make sure the changes are there,
+      //     await configStore.write(configWithOverride);
+      //     const postWriteReadResult = await configStore.readRaw();
+      //     if (postWriteReadResult.isErr()) {
+      //       throw postWriteReadResult.error;
+      //     }
+      //     expect(postWriteReadResult.isOk()).toBeTruthy();
+      //     expect(
+      //       postWriteReadResult._unsafeUnwrap().commands?.lookup?.note
+      //         ?.selectionMode
+      //     ).toEqual("none");
+      //     // and override is filtered out
+      //     expect(postWriteReadResult._unsafeUnwrap().workspace?.vaults).toEqual([
+      //       {
+      //         fsPath: "foo",
+      //         name: "foo",
+      //       },
+      //     ]);
+      //   });
     });
 
     describe("AND get", () => {
-      test("WHEN default mode, then retrieve value of config", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
-
-        const createResult = await configStore.createConfig();
-
-        const defaultConfig = createResult._unsafeUnwrap();
-
-        const getResult = await configStore.get("commands");
-        if (getResult.isErr()) {
-          throw getResult.error;
-        }
-        expect(getResult.isOk()).toBeTruthy();
-        expect(getResult._unsafeUnwrap()).toEqual(defaultConfig.commands);
-      });
-
-      test("WHEN override mode, then retrieve value of config after override", async () => {
-        const homeDir = tmpDir().name;
-        const wsRoot = tmpDir().name;
-        const configStore = new ConfigStore(
-          fileStore,
-          URI.file(wsRoot),
-          URI.file(homeDir)
-        );
-
-        await configStore.createConfig();
-
-        const workspaceOverridePayload = {
-          workspace: {
-            vaults: [
-              {
-                fsPath: "bar",
-                name: "bar",
-              },
-            ],
-          },
-        };
-
-        writeYAML(
-          path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-          workspaceOverridePayload
-        );
-
-        const getResult = await configStore.get("workspace.vaults", {
-          applyOverride: true,
-        });
-
-        if (getResult.isErr()) {
-          throw getResult.error;
-        }
-
-        expect(getResult.isOk()).toBeTruthy();
-        expect(getResult._unsafeUnwrap()).toEqual([
-          {
-            fsPath: "bar",
-            name: "bar",
-          },
-        ]);
-      });
+      // test("WHEN default mode, then retrieve value of config", async () => {
+      //   const homeDir = tmpDir().name;
+      //   const wsRoot = tmpDir().name;
+      //   const configStore = new ConfigStore(
+      //     fileStore,
+      //     URI.file(wsRoot),
+      //     URI.file(homeDir)
+      //   );
+      //   const createResult = await configStore.createConfig();
+      //   const defaultConfig = createResult._unsafeUnwrap();
+      //   const getResult = await configStore.get("commands");
+      //   if (getResult.isErr()) {
+      //     throw getResult.error;
+      //   }
+      //   expect(getResult.isOk()).toBeTruthy();
+      //   expect(getResult._unsafeUnwrap()).toEqual(defaultConfig.commands);
+      // });
+      // test("WHEN override mode, then retrieve value of config after override", async () => {
+      //   const homeDir = tmpDir().name;
+      //   const wsRoot = tmpDir().name;
+      //   const configStore = new ConfigStore(
+      //     fileStore,
+      //     URI.file(wsRoot),
+      //     URI.file(homeDir)
+      //   );
+      //   await configStore.createConfig();
+      //   const workspaceOverridePayload = {
+      //     workspace: {
+      //       vaults: [
+      //         {
+      //           fsPath: "bar",
+      //           name: "bar",
+      //         },
+      //       ],
+      //     },
+      //   };
+      //   writeYAML(
+      //     path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+      //     workspaceOverridePayload
+      //   );
+      //   const getResult = await configStore.get("workspace.vaults", {
+      //     applyOverride: true,
+      //   });
+      //   if (getResult.isErr()) {
+      //     throw getResult.error;
+      //   }
+      //   expect(getResult.isOk()).toBeTruthy();
+      //   expect(getResult._unsafeUnwrap()).toEqual([
+      //     {
+      //       fsPath: "bar",
+      //       name: "bar",
+      //     },
+      //   ]);
+      // });
     });
 
-    test("WHEN update, update key with value, then persist change", async () => {
-      const homeDir = tmpDir().name;
-      const wsRoot = tmpDir().name;
-      const configStore = new ConfigStore(
-        fileStore,
-        URI.file(wsRoot),
-        URI.file(homeDir)
-      );
+    // test("WHEN update, update key with value, then persist change", async () => {
+    //   const homeDir = tmpDir().name;
+    //   const wsRoot = tmpDir().name;
+    //   const configStore = new ConfigStore(
+    //     fileStore,
+    //     URI.file(wsRoot),
+    //     URI.file(homeDir)
+    //   );
 
-      await configStore.createConfig();
+    //   await configStore.createConfig();
 
-      const updateResult = await configStore.update(
-        "commands.lookup.note.fuzzThreshold",
-        100
-      );
+    //   const updateResult = await configStore.update(
+    //     "commands.lookup.note.fuzzThreshold",
+    //     100
+    //   );
 
-      if (updateResult.isErr()) {
-        throw updateResult.error;
-      }
-      expect(updateResult.isOk()).toBeTruthy();
-      expect(updateResult._unsafeUnwrap()).toEqual(0.2);
+    //   if (updateResult.isErr()) {
+    //     throw updateResult.error;
+    //   }
+    //   expect(updateResult.isOk()).toBeTruthy();
+    //   expect(updateResult._unsafeUnwrap()).toEqual(0.2);
 
-      const readResult = await configStore.readRaw();
-      expect(
-        readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
-      ).toEqual(100);
-    });
+    //   const readResult = await configStore.readRaw();
+    //   expect(
+    //     readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
+    //   ).toEqual(100);
+    // });
 
-    test("WHEN delete, delete key, then persist", async () => {
-      const homeDir = tmpDir().name;
-      const wsRoot = tmpDir().name;
-      const configStore = new ConfigStore(
-        fileStore,
-        URI.file(wsRoot),
-        URI.file(homeDir)
-      );
+    // test("WHEN delete, delete key, then persist", async () => {
+    //   const homeDir = tmpDir().name;
+    //   const wsRoot = tmpDir().name;
+    //   const configStore = new ConfigStore(
+    //     fileStore,
+    //     URI.file(wsRoot),
+    //     URI.file(homeDir)
+    //   );
 
-      await configStore.createConfig();
+    //   await configStore.createConfig();
 
-      const deleteResult = await configStore.delete(
-        "commands.lookup.note.fuzzThreshold"
-      );
+    //   const deleteResult = await configStore.delete(
+    //     "commands.lookup.note.fuzzThreshold"
+    //   );
 
-      if (deleteResult.isErr()) {
-        throw deleteResult.error;
-      }
-      expect(deleteResult.isOk()).toBeTruthy();
-      expect(deleteResult._unsafeUnwrap()).toEqual(0.2);
+    //   if (deleteResult.isErr()) {
+    //     throw deleteResult.error;
+    //   }
+    //   expect(deleteResult.isOk()).toBeTruthy();
+    //   expect(deleteResult._unsafeUnwrap()).toEqual(0.2);
 
-      const readResult = await configStore.readRaw();
-      expect(
-        readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
-      ).toBeUndefined();
-    });
+    //   const readResult = await configStore.readRaw();
+    //   expect(
+    //     readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
+    //   ).toBeUndefined();
+    // });
   });
 });

--- a/packages/engine-test-utils/src/__tests__/engine-server/ConfigStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/ConfigStore.spec.ts
@@ -9,10 +9,10 @@ import {
 } from "@dendronhq/common-all";
 import { tmpDir, writeYAML } from "@dendronhq/common-server";
 import { NodeJSFileStore } from "@dendronhq/engine-server";
-import { existsSync } from "fs";
-import { ensureFileSync } from "fs-extra";
+import { existsSync, ensureFileSync } from "fs-extra";
 import _ from "lodash";
 import path from "path";
+import * as YAML from "js-yaml";
 
 describe("ConfigStore", () => {
   let fileStore: IFileStore;
@@ -71,369 +71,107 @@ describe("ConfigStore", () => {
       expect(config).toEqual(initialConfig);
     });
 
-    describe("AND partial DendronConfig", () => {
-      test("WHEN readRaw, then retrieve config as is", async () => {});
+    describe("WHEN readOverride", () => {
+      const homeDir = tmpDir().name;
+      const wsRoot = tmpDir().name;
+      const globalOverridePayload = {
+        workspace: {
+          vaults: [
+            {
+              fsPath: "foo",
+              name: "foo",
+            },
+          ],
+        },
+      };
+      const workspaceOverridePayload = {
+        workspace: {
+          vaults: [
+            {
+              fsPath: "bar",
+              name: "bar",
+            },
+          ],
+        },
+      };
 
-      // test("WHEN read with default, then retrieve config with missing defaults filled", async () => {
-      //   const homeDir = tmpDir().name;
-      //   const wsRoot = tmpDir().name;
+      writeYAML(
+        path.join(homeDir, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+        globalOverridePayload
+      );
+      writeYAML(
+        path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
+        workspaceOverridePayload
+      );
+      test("AND workspace mode, then read override from workspace root", async () => {
+        const configStore = new ConfigStore(
+          fileStore,
+          URI.file(wsRoot),
+          URI.file(homeDir)
+        );
 
-      //   // remove some configs initially
-      //   let initialConfig: DeepPartial<DendronConfig> =
-      //     ConfigUtils.genDefaultConfig();
-      //   initialConfig = {
-      //     ...initialConfig,
-      //     preview: {},
-      //   };
+        const readOverrideResult = await configStore.readOverride("workspace");
+        expect(readOverrideResult.isOk()).toBeTruthy();
+        expect(readOverrideResult._unsafeUnwrap()).toEqual(
+          YAML.dump(workspaceOverridePayload, {
+            indent: 4,
+            schema: YAML.JSON_SCHEMA,
+          })
+        );
+      });
+      test("AND global mode, then read override from homeDir", async () => {
+        const configStore = new ConfigStore(
+          fileStore,
+          URI.file(wsRoot),
+          URI.file(homeDir)
+        );
 
-      //   const configPath = path.join(wsRoot, "dendron.yml");
-      //   ensureFileSync(configPath);
-      //   writeYAML(configPath, initialConfig);
-
-      //   const configStore = new ConfigStore(
-      //     fileStore,
-      //     URI.file(wsRoot),
-      //     URI.file(homeDir)
-      //   );
-
-      //   const readWithDefaultResult = await configStore.read();
-
-      //   if (readWithDefaultResult.isErr()) {
-      //     throw readWithDefaultResult.error;
-      //   }
-      //   expect(readWithDefaultResult.isOk()).toBeTruthy();
-      //   const config = readWithDefaultResult._unsafeUnwrap();
-      //   expect(config).toEqual(ConfigUtils.genDefaultConfig());
-      // });
-
-      // test("WHEN read with override, then retrieve config with override applied", async () => {
-      //   const homeDir = tmpDir().name;
-      //   const wsRoot = tmpDir().name;
-
-      //   // move some configs to wsRoot/dendronrc.yml and homeDir/dendronrc.yml
-      //   const initialConfig = ConfigUtils.genDefaultConfig();
-      //   const globalOverridePayload = {
-      //     workspace: {
-      //       vaults: [
-      //         {
-      //           fsPath: "foo",
-      //           name: "foo",
-      //         },
-      //       ],
-      //     },
-      //   };
-      //   const workspaceOverridePayload = {
-      //     workspace: {
-      //       vaults: [
-      //         {
-      //           fsPath: "bar",
-      //           name: "bar",
-      //         },
-      //       ],
-      //     },
-      //   };
-
-      //   writeYAML(
-      //     path.join(homeDir, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-      //     globalOverridePayload
-      //   );
-      //   writeYAML(
-      //     path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-      //     workspaceOverridePayload
-      //   );
-
-      //   const vaultExcludedInitialConfig = {
-      //     ...initialConfig,
-      //     workspace: _.omit(initialConfig.workspace, "vaults"),
-      //   } as DeepPartial<DendronConfig>;
-
-      //   const configPath = path.join(wsRoot, "dendron.yml");
-      //   ensureFileSync(configPath);
-      //   writeYAML(configPath, vaultExcludedInitialConfig);
-
-      //   const configStore = new ConfigStore(
-      //     fileStore,
-      //     URI.file(wsRoot),
-      //     URI.file(homeDir)
-      //   );
-
-      //   // readRaw returns config with no vaults
-      //   const readRawResult = await configStore.readRaw();
-      //   if (readRawResult.isErr()) {
-      //     throw readRawResult.error;
-      //   }
-      //   expect(
-      //     readRawResult.isOk() &&
-      //       readRawResult._unsafeUnwrap().workspace?.vaults === undefined
-      //   ).toBeTruthy();
-
-      //   // read with override from workspace override if both exists
-      //   const readOverrideResult1 = await configStore.read({
-      //     applyOverride: true,
-      //   });
-      //   if (readOverrideResult1.isErr()) {
-      //     throw readOverrideResult1.error;
-      //   }
-      //   expect(readOverrideResult1.isOk()).toBeTruthy();
-      //   const overrideConfig1 = readOverrideResult1._unsafeUnwrap();
-      //   expect(overrideConfig1.workspace.vaults).toEqual([
-      //     {
-      //       fsPath: "bar",
-      //       name: "bar",
-      //     },
-      //   ]);
-
-      //   // read with override from home directory if not found in workspace
-      //   unlinkSync(path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE));
-      //   const readOverrideResult2 = await configStore.read({
-      //     applyOverride: true,
-      //   });
-      //   if (readOverrideResult2.isErr()) {
-      //     throw readOverrideResult2.error;
-      //   }
-      //   expect(readOverrideResult2.isOk()).toBeTruthy();
-      //   const overrideConfig2 = readOverrideResult2._unsafeUnwrap();
-      //   expect(overrideConfig2.workspace.vaults).toEqual([
-      //     {
-      //       fsPath: "foo",
-      //       name: "foo",
-      //     },
-      //   ]);
-      // });
+        const readOverrideResult = await configStore.readOverride("global");
+        expect(readOverrideResult.isOk()).toBeTruthy();
+        expect(readOverrideResult._unsafeUnwrap()).toEqual(
+          YAML.dump(globalOverridePayload, {
+            indent: 4,
+            schema: YAML.JSON_SCHEMA,
+          })
+        );
+      });
     });
 
-    describe("AND write", () => {
-      // test("WHEN no override exists, then write given config and persist", async () => {
-      //   const homeDir = tmpDir().name;
-      //   const wsRoot = tmpDir().name;
-      //   const configStore = new ConfigStore(
-      //     fileStore,
-      //     URI.file(wsRoot),
-      //     URI.file(homeDir)
-      //   );
-      //   await configStore.createConfig();
-      //   const defaultConfig = ConfigUtils.genDefaultConfig();
-      //   const diff: LookupConfig = {
-      //     note: {
-      //       ...defaultConfig.commands.lookup.note,
-      //       selectionMode: "link",
-      //       fuzzThreshold: 1,
-      //     },
-      //   };
-      //   const writePayload: DendronConfig = {
-      //     ...defaultConfig,
-      //     commands: {
-      //       ...defaultConfig.commands,
-      //       lookup: diff,
-      //     },
-      //   };
-      //   // make sure we start with a default config
-      //   const readResult = await configStore.read();
-      //   if (readResult.isErr()) {
-      //     throw readResult.error;
-      //   }
-      //   expect(
-      //     readResult.isOk() && readResult._unsafeUnwrap() === defaultConfig
-      //   );
-      //   // write result contains payload
-      //   const writeResult = await configStore.write(writePayload);
-      //   if (writeResult.isErr()) {
-      //     throw writeResult.error;
-      //   }
-      //   expect(writeResult.isOk()).toBeTruthy();
-      //   expect(writeResult._unsafeUnwrap().commands.lookup).toEqual(diff);
-      //   // read again and verify
-      //   const readResult2 = await configStore.read();
-      //   if (readResult2.isErr()) {
-      //     throw readResult2.error;
-      //   }
-      //   expect(
-      //     readResult2.isOk() &&
-      //       readResult2._unsafeUnwrap().commands.lookup === diff
-      //   );
-      // });
-      // todo: move to config service tests
-      //   test("WHEN override exists, then filter out override vaults before writing", async () => {
-      //     const homeDir = tmpDir().name;
-      //     const wsRoot = tmpDir().name;
-      //     // move some configs to wsRoot/dendronrc.yml
-      //     const initialConfig = ConfigUtils.genDefaultConfig();
-      //     const workspaceOverridePayload = {
-      //       workspace: {
-      //         vaults: [
-      //           {
-      //             fsPath: "bar",
-      //             name: "bar",
-      //           },
-      //         ],
-      //       },
-      //     };
-      //     writeYAML(
-      //       path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-      //       workspaceOverridePayload
-      //     );
-      //     const vaultExcludedInitialConfig = {
-      //       ...initialConfig,
-      //       workspace: {
-      //         ...initialConfig.workspace,
-      //         vaults: [
-      //           {
-      //             fsPath: "foo",
-      //             name: "foo",
-      //           },
-      //         ],
-      //       },
-      //     } as DeepPartial<DendronConfig>;
-      //     const configPath = path.join(wsRoot, "dendron.yml");
-      //     ensureFileSync(configPath);
-      //     writeYAML(configPath, vaultExcludedInitialConfig);
-      //     const configStore = new ConfigStore(
-      //       fileStore,
-      //       URI.file(wsRoot),
-      //       URI.file(homeDir)
-      //     );
-      //     // read in config with override
-      //     const configWithOverride = (
-      //       await configStore.read({ applyOverride: true })
-      //     )._unsafeUnwrap();
-      //     // change some things
-      //     ConfigUtils.setCommandsProp(configWithOverride, "lookup", {
-      //       note: {
-      //         ...configWithOverride.commands.lookup.note,
-      //         selectionMode: "none",
-      //       },
-      //     });
-      //     // write, and make sure the changes are there,
-      //     await configStore.write(configWithOverride);
-      //     const postWriteReadResult = await configStore.readRaw();
-      //     if (postWriteReadResult.isErr()) {
-      //       throw postWriteReadResult.error;
-      //     }
-      //     expect(postWriteReadResult.isOk()).toBeTruthy();
-      //     expect(
-      //       postWriteReadResult._unsafeUnwrap().commands?.lookup?.note
-      //         ?.selectionMode
-      //     ).toEqual("none");
-      //     // and override is filtered out
-      //     expect(postWriteReadResult._unsafeUnwrap().workspace?.vaults).toEqual([
-      //       {
-      //         fsPath: "foo",
-      //         name: "foo",
-      //       },
-      //     ]);
-      //   });
+    test("WHEN writeConfig, then write given config and persist", async () => {
+      const homeDir = tmpDir().name;
+      const wsRoot = tmpDir().name;
+      const configStore = new ConfigStore(
+        fileStore,
+        URI.file(wsRoot),
+        URI.file(homeDir)
+      );
+
+      const defaultConfig = ConfigUtils.genDefaultConfig();
+      const payload: DendronConfig = {
+        ...defaultConfig,
+        commands: {
+          ...defaultConfig.commands,
+          lookup: {
+            note: {
+              ...defaultConfig.commands.lookup.note,
+              leaveTrace: true,
+            },
+          },
+        },
+      };
+
+      const writeResult = await configStore.writeConfig(payload);
+      expect(writeResult.isOk()).toBeTruthy();
+      const config = writeResult._unsafeUnwrap();
+      expect(config).toMatchSnapshot();
+      expect(config.commands.lookup.note.leaveTrace).toEqual(true);
+      expect(_.omit(config, "commands.lookup.note.leaveTrace")).toEqual(
+        _.omit(defaultConfig, "commands.lookup.note.leaveTrace")
+      );
+      const isConfigPersisted = existsSync(
+        path.join(wsRoot, CONSTANTS.DENDRON_CONFIG_FILE)
+      );
+      expect(isConfigPersisted).toBeTruthy();
     });
-
-    describe("AND get", () => {
-      // test("WHEN default mode, then retrieve value of config", async () => {
-      //   const homeDir = tmpDir().name;
-      //   const wsRoot = tmpDir().name;
-      //   const configStore = new ConfigStore(
-      //     fileStore,
-      //     URI.file(wsRoot),
-      //     URI.file(homeDir)
-      //   );
-      //   const createResult = await configStore.createConfig();
-      //   const defaultConfig = createResult._unsafeUnwrap();
-      //   const getResult = await configStore.get("commands");
-      //   if (getResult.isErr()) {
-      //     throw getResult.error;
-      //   }
-      //   expect(getResult.isOk()).toBeTruthy();
-      //   expect(getResult._unsafeUnwrap()).toEqual(defaultConfig.commands);
-      // });
-      // test("WHEN override mode, then retrieve value of config after override", async () => {
-      //   const homeDir = tmpDir().name;
-      //   const wsRoot = tmpDir().name;
-      //   const configStore = new ConfigStore(
-      //     fileStore,
-      //     URI.file(wsRoot),
-      //     URI.file(homeDir)
-      //   );
-      //   await configStore.createConfig();
-      //   const workspaceOverridePayload = {
-      //     workspace: {
-      //       vaults: [
-      //         {
-      //           fsPath: "bar",
-      //           name: "bar",
-      //         },
-      //       ],
-      //     },
-      //   };
-      //   writeYAML(
-      //     path.join(wsRoot, CONSTANTS.DENDRON_LOCAL_CONFIG_FILE),
-      //     workspaceOverridePayload
-      //   );
-      //   const getResult = await configStore.get("workspace.vaults", {
-      //     applyOverride: true,
-      //   });
-      //   if (getResult.isErr()) {
-      //     throw getResult.error;
-      //   }
-      //   expect(getResult.isOk()).toBeTruthy();
-      //   expect(getResult._unsafeUnwrap()).toEqual([
-      //     {
-      //       fsPath: "bar",
-      //       name: "bar",
-      //     },
-      //   ]);
-      // });
-    });
-
-    // test("WHEN update, update key with value, then persist change", async () => {
-    //   const homeDir = tmpDir().name;
-    //   const wsRoot = tmpDir().name;
-    //   const configStore = new ConfigStore(
-    //     fileStore,
-    //     URI.file(wsRoot),
-    //     URI.file(homeDir)
-    //   );
-
-    //   await configStore.createConfig();
-
-    //   const updateResult = await configStore.update(
-    //     "commands.lookup.note.fuzzThreshold",
-    //     100
-    //   );
-
-    //   if (updateResult.isErr()) {
-    //     throw updateResult.error;
-    //   }
-    //   expect(updateResult.isOk()).toBeTruthy();
-    //   expect(updateResult._unsafeUnwrap()).toEqual(0.2);
-
-    //   const readResult = await configStore.readRaw();
-    //   expect(
-    //     readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
-    //   ).toEqual(100);
-    // });
-
-    // test("WHEN delete, delete key, then persist", async () => {
-    //   const homeDir = tmpDir().name;
-    //   const wsRoot = tmpDir().name;
-    //   const configStore = new ConfigStore(
-    //     fileStore,
-    //     URI.file(wsRoot),
-    //     URI.file(homeDir)
-    //   );
-
-    //   await configStore.createConfig();
-
-    //   const deleteResult = await configStore.delete(
-    //     "commands.lookup.note.fuzzThreshold"
-    //   );
-
-    //   if (deleteResult.isErr()) {
-    //     throw deleteResult.error;
-    //   }
-    //   expect(deleteResult.isOk()).toBeTruthy();
-    //   expect(deleteResult._unsafeUnwrap()).toEqual(0.2);
-
-    //   const readResult = await configStore.readRaw();
-    //   expect(
-    //     readResult._unsafeUnwrap().commands?.lookup?.note?.fuzzThreshold
-    //   ).toBeUndefined();
-    // });
   });
 });

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/ConfigService.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/ConfigService.spec.ts.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GIVEN ConfigService WHEN instance already exists WHEN createConfig is called THEN new config is created 1`] = `
+Object {
+  "commands": Object {
+    "copyNoteLink": Object {
+      "aliasMode": "title",
+    },
+    "insertNoteIndex": Object {
+      "enableMarker": false,
+    },
+    "insertNoteLink": Object {
+      "aliasMode": "none",
+      "enableMultiSelect": false,
+    },
+    "lookup": Object {
+      "note": Object {
+        "bubbleUpCreateNew": true,
+        "confirmVaultOnCreate": true,
+        "fuzzThreshold": 0.2,
+        "leaveTrace": false,
+        "selectionMode": "extract",
+        "vaultSelectionModeOnCreate": "smart",
+      },
+    },
+    "randomNote": Object {},
+    "templateHierarchy": "template",
+  },
+  "dev": Object {
+    "enablePreviewV2": true,
+  },
+  "preview": Object {
+    "automaticallyShowPreview": false,
+    "enableFMTitle": true,
+    "enableFrontmatterTags": true,
+    "enableHashesForFMTags": false,
+    "enableKatex": true,
+    "enableNoteTitleForLink": true,
+    "enablePrettyRefs": true,
+  },
+  "publishing": Object {
+    "copyAssets": true,
+    "enableFMTitle": true,
+    "enableFrontmatterTags": true,
+    "enableHashesForFMTags": false,
+    "enableKatex": true,
+    "enableNoteTitleForLink": true,
+    "enablePrettyLinks": true,
+    "enablePrettyRefs": true,
+    "enableRandomlyColoredTags": true,
+    "enableSiteLastModified": true,
+    "enableTaskNotes": true,
+    "github": Object {
+      "editBranch": "main",
+      "editLinkText": "Edit this page on GitHub",
+      "editViewMode": "tree",
+      "enableEditLink": true,
+    },
+    "searchMode": "search",
+    "seo": Object {
+      "description": "Personal Knowledge Space",
+      "title": "Dendron",
+    },
+    "siteHierarchies": Array [
+      "root",
+    ],
+    "siteRootDir": "docs",
+    "writeStubs": false,
+  },
+  "version": 5,
+  "workspace": Object {
+    "enableAutoCreateOnDefinition": false,
+    "enableAutoFoldFrontmatter": false,
+    "enableEditorDecorations": true,
+    "enableFullHierarchyNoteTitle": false,
+    "enableHashTags": true,
+    "enableRemoteVaultInit": true,
+    "enableUserTags": true,
+    "enableXVaultWikiLink": false,
+    "graph": Object {
+      "createStub": false,
+      "zoomSpeed": 1,
+    },
+    "journal": Object {
+      "addBehavior": "childOfDomain",
+      "dailyDomain": "daily",
+      "dateFormat": "y.MM.dd",
+      "name": "journal",
+    },
+    "maxNoteLength": 204800,
+    "maxPreviewsCached": 10,
+    "scratch": Object {
+      "addBehavior": "asOwnDomain",
+      "dateFormat": "y.MM.dd.HHmmss",
+      "name": "scratch",
+    },
+    "task": Object {
+      "addBehavior": "asOwnDomain",
+      "createTaskSelectionType": "selection2link",
+      "dateFormat": "y.MM.dd",
+      "name": "task",
+      "prioritySymbols": Object {
+        "H": "high",
+        "L": "low",
+        "M": "medium",
+      },
+      "statusSymbols": Object {
+        "": " ",
+        "assigned": "a",
+        "blocked": "b",
+        "delegated": "l",
+        "done": "x",
+        "dropped": "d",
+        "moved": "m",
+        "pending": "y",
+        "wip": "w",
+      },
+      "taskCompleteStatus": Array [
+        "done",
+        "x",
+      ],
+      "todoIntegration": false,
+    },
+    "vaults": Array [],
+    "workspaceVaultSyncMode": "noCommit",
+  },
+}
+`;

--- a/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/ConfigStore.spec.ts.snap
+++ b/packages/engine-test-utils/src/__tests__/engine-server/__snapshots__/ConfigStore.spec.ts.snap
@@ -126,3 +126,130 @@ Object {
   },
 }
 `;
+
+exports[`ConfigStore GIVEN NodeJSFileStore WHEN writeConfig, then write given config and persist 1`] = `
+Object {
+  "commands": Object {
+    "copyNoteLink": Object {
+      "aliasMode": "title",
+    },
+    "insertNoteIndex": Object {
+      "enableMarker": false,
+    },
+    "insertNoteLink": Object {
+      "aliasMode": "none",
+      "enableMultiSelect": false,
+    },
+    "lookup": Object {
+      "note": Object {
+        "bubbleUpCreateNew": true,
+        "confirmVaultOnCreate": true,
+        "fuzzThreshold": 0.2,
+        "leaveTrace": true,
+        "selectionMode": "extract",
+        "vaultSelectionModeOnCreate": "smart",
+      },
+    },
+    "randomNote": Object {},
+    "templateHierarchy": "template",
+  },
+  "dev": Object {
+    "enablePreviewV2": true,
+  },
+  "preview": Object {
+    "automaticallyShowPreview": false,
+    "enableFMTitle": true,
+    "enableFrontmatterTags": true,
+    "enableHashesForFMTags": false,
+    "enableKatex": true,
+    "enableNoteTitleForLink": true,
+    "enablePrettyRefs": true,
+  },
+  "publishing": Object {
+    "copyAssets": true,
+    "enableFMTitle": true,
+    "enableFrontmatterTags": true,
+    "enableHashesForFMTags": false,
+    "enableKatex": true,
+    "enableNoteTitleForLink": true,
+    "enablePrettyLinks": true,
+    "enablePrettyRefs": true,
+    "enableRandomlyColoredTags": true,
+    "enableSiteLastModified": true,
+    "enableTaskNotes": true,
+    "github": Object {
+      "editBranch": "main",
+      "editLinkText": "Edit this page on GitHub",
+      "editViewMode": "tree",
+      "enableEditLink": true,
+    },
+    "searchMode": "lookup",
+    "seo": Object {
+      "description": "Personal Knowledge Space",
+      "title": "Dendron",
+    },
+    "siteHierarchies": Array [
+      "root",
+    ],
+    "siteRootDir": "docs",
+    "writeStubs": false,
+  },
+  "version": 5,
+  "workspace": Object {
+    "enableAutoCreateOnDefinition": false,
+    "enableAutoFoldFrontmatter": false,
+    "enableEditorDecorations": true,
+    "enableFullHierarchyNoteTitle": false,
+    "enableHashTags": true,
+    "enableRemoteVaultInit": true,
+    "enableUserTags": true,
+    "enableXVaultWikiLink": false,
+    "graph": Object {
+      "createStub": false,
+      "zoomSpeed": 1,
+    },
+    "journal": Object {
+      "addBehavior": "childOfDomain",
+      "dailyDomain": "daily",
+      "dateFormat": "y.MM.dd",
+      "name": "journal",
+    },
+    "maxNoteLength": 204800,
+    "maxPreviewsCached": 10,
+    "scratch": Object {
+      "addBehavior": "asOwnDomain",
+      "dateFormat": "y.MM.dd.HHmmss",
+      "name": "scratch",
+    },
+    "task": Object {
+      "addBehavior": "asOwnDomain",
+      "createTaskSelectionType": "selection2link",
+      "dateFormat": "y.MM.dd",
+      "name": "task",
+      "prioritySymbols": Object {
+        "H": "high",
+        "L": "low",
+        "M": "medium",
+      },
+      "statusSymbols": Object {
+        "": " ",
+        "assigned": "a",
+        "blocked": "b",
+        "delegated": "l",
+        "done": "x",
+        "dropped": "d",
+        "moved": "m",
+        "pending": "y",
+        "wip": "w",
+      },
+      "taskCompleteStatus": Array [
+        "done",
+        "x",
+      ],
+      "todoIntegration": false,
+    },
+    "vaults": Array [],
+    "workspaceVaultSyncMode": "noCommit",
+  },
+}
+`;


### PR DESCRIPTION
# chore(internal): Implement ConfigService

This PR:
- adds a `ConfigService` that can be consumed by the engine and the client separately.
- `ConfigStore` now only holds primitive store-level operations regarding the configs, and the rest of the higher level logic is moved to `ConfigService`.
  - As a result, the interface for `ConfigStore` has slight changes.

## Next (in order of priority)
- Swap out `DConfig` with `ConfigService`
  - This will resolve various local override vault issues (before engine v3 rollout)
- Deprecate `DConfig`
- Refactor `ConfigUtils` to be part of the service
- Make `ConfigService` an `@injectable` (after wider tsyringe adoption)
- Implement `ConfigEventEmitter` to enable real time config updates and remove the need for reload

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)