### PR TITLE
chore: fix `dendron-plugin-views` build

### DIFF
--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -53,7 +53,8 @@
     "title": "^3.4.4",
     "vscode-uri": "^3.0.3",
     "zod": "3.19.1",
-    "zod-validation-error": "^0.2.1"
+    "zod-validation-error": "^0.1.1",
+    "@swc/helpers": "^0.3.2"
   },
   "devDependencies": {
     "@types/fast-levenshtein": "^0.0.2",

--- a/packages/dendron-plugin-views/config/webpack.config.js
+++ b/packages/dendron-plugin-views/config/webpack.config.js
@@ -429,7 +429,6 @@ module.exports = function (webpackEnv) {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve("babel-loader"),
-              type: "javascript/auto",
               options: {
                 babelrc: false,
                 configFile: false,

--- a/packages/dendron-plugin-views/config/webpack.config.js
+++ b/packages/dendron-plugin-views/config/webpack.config.js
@@ -298,8 +298,6 @@ module.exports = function (webpackEnv) {
       ],
     },
     resolve: {
-      // Prefer `main` over `module`
-      mainFields: ["main", "module"],
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"
       // if there are any conflicts. This matches Node resolution mechanism.
@@ -431,6 +429,7 @@ module.exports = function (webpackEnv) {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve("babel-loader"),
+              type: "javascript/auto",
               options: {
                 babelrc: false,
                 configFile: false,

--- a/packages/dendron-plugin-views/config/webpack.config.js
+++ b/packages/dendron-plugin-views/config/webpack.config.js
@@ -429,6 +429,7 @@ module.exports = function (webpackEnv) {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve("babel-loader"),
+              type: "javascript/auto",
               options: {
                 babelrc: false,
                 configFile: false,

--- a/packages/dendron-plugin-views/config/webpack.config.js
+++ b/packages/dendron-plugin-views/config/webpack.config.js
@@ -298,6 +298,8 @@ module.exports = function (webpackEnv) {
       ],
     },
     resolve: {
+      // Prefer `main` over `module`
+      mainFields: ["main", "module"],
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"
       // if there are any conflicts. This matches Node resolution mechanism.
@@ -429,7 +431,6 @@ module.exports = function (webpackEnv) {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve("babel-loader"),
-              type: "javascript/auto",
               options: {
                 babelrc: false,
                 configFile: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,10 +3823,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@swc/helpers@^0.4.11":
-  version "0.4.12"
-  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.12.tgz#203243e78cff3c87c081c97ae548ab33e2503573"
-  integrity sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==
+"@swc/helpers@^0.3.2":
+  version "0.3.17"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz#7c1b91f43c77e2bba99492162a498d465ef253d5"
+  integrity sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==
   dependencies:
     tslib "^2.4.0"
 
@@ -27254,12 +27254,10 @@ zen-observable@^0.8.0:
   resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zod-validation-error@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.2.1.tgz#d855c8bba835f43692756670d407453424a7ba5b"
-  integrity sha512-zGg6P5EHi5V0dvyEeC8HBZd2pzp7QDKTngkSWgWunljrY+0SHkHyjI519D+u8/37BHkGHAFseWgnZ2Uq8LNFKg==
-  dependencies:
-    "@swc/helpers" "^0.4.11"
+zod-validation-error@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.1.1.tgz#9d231d934c3c23f2fa66c067edcb520ab78decfc"
+  integrity sha512-uRXWNeI6XyZtO2pr6D/gk+ths0WCrV+OImIk1YikwwztOQvO5jbFzbnY642iRmLSCFaOIsFF4u7YQIub7CFh2Q==
 
 zod@3.19.1:
   version "3.19.1"


### PR DESCRIPTION
This aim of this PR is to fix the build task within `dendron-plugin-views` package which currently results into the following error:

```
/home/nam/code/dendronhq/dendron/node_modules/zod-validation-error/node_modules/@swc/helpers/src/index.mjs
Can't reexport the named export '__decorate' from non EcmaScript module (only default export is available)
```

The commit 419dec79d880228e5677b005f89b52db724b4dc1 (PR: https://github.com/dendronhq/dendron/pull/3762) is responsible for this by adding a dependency
which conflicts with the webpack build in `dendron-plugin-views`. That
dependency uses withing its cjs build files `@swc/helpers` which
conflicts with the import type from webpack.
`@swc/helpers` provides a `module` entry https://github.com/swc-project/swc/blob/main/packages/swc-helpers/package.json#L6-L7 which has named reexports which gets flagged as an [error](https://github.com/webpack/webpack/blob/v4.44.2/lib/dependencies/HarmonyExportImportedSpecifierDependency.js#L372). 

Update: Found a solution which works by pinning `zod-validation-error` to an other version: https://github.com/dendronhq/dendron/pull/3775/commits/5e406cc229c9bdf559686a8febb8a1c0b63a05bc

---

Update: I tried another solution to tell webpack to prefer main entry field instead of `module´. But since that would disable webpacks tree-shaking capabilities since this requries static module structure I reverted that change.

---

The solution is to use explicitly set [`Rule.type`](https://webpack.js.org/configuration/module/#ruletype) property which was introduced in [webpack 4.0](https://github.com/webpack/webpack/releases/tag/v4.0.0):

> javascript/auto: (The default one in webpack 3) Javascript module with all module systems enabled: CommonJS, AMD, ESM
> javascript/esm handles ESM more strictly compared to javascript/auto:
>  Imported names need to exist on imported module
>  Dynamic modules (non-esm, i. e. CommonJs) can only imported via default import, everything else (including namespace import) emit errors
> In .mjs modules are javascript/esm by default

In my understanding setting the value `javascript/auto` tells webpack that it allows for `mjs` files to be not ESM strict.

This is a kind of hack and curcumvents the issue. In a proper setup `mjs` should only be handled as esm modules and nothing else.
So instead of changing how webpack sees `mjs` file we might want to
revert the change that introduced this issue.





# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.