### PR TITLE
fix(workspace): Correctly read and apply local override config in engine v3

### DIFF
--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -137,7 +137,11 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
 
   static create({ wsRoot, logger }: { logger?: DLogger; wsRoot: string }) {
     const LOGGER = logger || createLogger();
-    const config = DConfig.readConfigSync(wsRoot);
+    const { error, data: config } =
+      DConfig.readConfigAndApplyLocalOverrideSync(wsRoot);
+    if (error) {
+      LOGGER.error(stringifyError(error));
+    }
 
     const fileStore = new NodeJSFileStore();
     const fuseEngine = new FuseEngine({
@@ -167,7 +171,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
    * Does not throw error but returns it
    */
   async init(): Promise<DEngineInitResp> {
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     const defaultResp = {
       notes: {},
       schemas: {},
@@ -307,7 +313,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
       note: NoteUtils.toLogObj(note),
     });
 
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     // Update links/anchors based on note body
     await EngineUtils.refreshNoteLinksAndAnchors({
       note,
@@ -621,7 +629,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     const linkNotesResp = await this._noteStore.bulkGet(notesReferencingOld);
 
     // update note body of all notes that have changed
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
     const notesToUpdate = linkNotesResp
       .map((resp) => {
         if (resp.error) {
@@ -904,7 +914,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           }),
         };
       }
-      const config = DConfig.readConfigSync(this.wsRoot);
+      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+        this.wsRoot
+      );
       const blocks = await RemarkUtils.extractBlocks({
         note,
         config,
@@ -948,7 +960,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           ),
         };
       });
-      const config = DConfig.readConfigSync(this.wsRoot);
+      const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+        this.wsRoot
+      );
       const {
         allDecorations: decorations,
         allDiagnostics: diagnostics,
@@ -1477,7 +1491,9 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
     dest: DendronASTDest;
   }): Promise<string> {
     let proc: ReturnType<typeof MDUtilsV5["procRehypeFull"]>;
-    const config = DConfig.readConfigSync(this.wsRoot);
+    const { data: config } = DConfig.readConfigAndApplyLocalOverrideSync(
+      this.wsRoot
+    );
 
     const noteCacheForRenderDict = await getParsingDependencyDicts(
       note,

--- a/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/noteStore.spec.ts
@@ -14,7 +14,6 @@ import _ from "lodash";
 import { runEngineTestV5 } from "../../../engine";
 import { ENGINE_HOOKS } from "../../../presets";
 import fs from "fs-extra";
-import path from "path";
 
 describe("GIVEN NoteStore", () => {
   test("WHEN workspace contains notes, THEN find and findMetadata should return correct notes", async () => {
@@ -646,7 +645,7 @@ describe("GIVEN NoteStore", () => {
     );
   });
 
-  describe.only("AND absolute vault path", () => {
+  describe("AND absolute vault path", () => {
     const wsRoot = tmpDir().name;
     // giving absolute fsPath for vault
     // to simulate the case where we try to .get() a note


### PR DESCRIPTION
# fix(workspace): Correctly read and apply local override config in engine v3

This PR:
- correctly reads and applies local override in engine v3
  - I've commented in https://github.com/dendronhq/dendron/pull/3687 that using `DConfig.readConfigAndApplyLocalOverrideSync` would not be safe yet but that turns out to be an unfounded worry. Not doing so caused a regression with engine v3 where local vaults are not properly loaded. Apologies @tma66 
  - adding them back fixes the issue.
- I've also found an issue with note path resolution where if the override specifies a vault with absolute path (which works in engine v2 and there are users doing this)
  - I've added a crude resolution in `NoteStore` for this issue.

## Note
- Ultimately these should all be resolved with the migration from `DConfig` to `ConfigService`, but with our timeline for rolling out engine v3, it seems very unlikely that `ConfigService` will be ready and thoroughly tested in time (https://github.com/dendronhq/dendron/pull/3776). I deferred fixing this until after that happens, but in favor of iteration I'm going with a temporary solution rather than try to rush the switch to `ConfigService`.
- I believe this should resolve the last bit of discrepancy engine v2 and v3 has that you mentioned @kevinslin. I've tested cross vault operations between overridden vaults / normal vaults and it works as expected.

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [ ] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)