### PR TITLE
fix(workspace): rename note breaks noteref for user hierarchy

### DIFF
--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -1318,7 +1318,7 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           alias = undefined;
         }
         // for user tag links, we'll have to regenerate the alias
-        if (newLoc.fname.startsWith(USERS_HIERARCHY)) {
+        if (link.type !== "ref" && newLoc.fname.startsWith(USERS_HIERARCHY)) {
           const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
           alias = `@${fnameWithoutTag}`;
         } else if (oldLink.from.fname.startsWith(USERS_HIERARCHY)) {

--- a/packages/engine-server/src/DendronEngineV3.ts
+++ b/packages/engine-server/src/DendronEngineV3.ts
@@ -1317,7 +1317,8 @@ export class DendronEngineV3 extends EngineV3Base implements DEngine {
           // And if this used to be a frontmatter tag, the alias being undefined will force it to be removed because a frontmatter tag can't point to something outside of tags hierarchy.
           alias = undefined;
         }
-        // for user tag links, we'll have to regenerate the alias
+        // for user tag links, we'll have to regenerate the alias.
+        // added link.type !==ref check because syntax like !@john doesn't work as a note ref
         if (link.type !== "ref" && newLoc.fname.startsWith(USERS_HIERARCHY)) {
           const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
           alias = `@${fnameWithoutTag}`;

--- a/packages/engine-server/src/drivers/file/storev2.ts
+++ b/packages/engine-server/src/drivers/file/storev2.ts
@@ -900,7 +900,7 @@ export class FileStorage implements DStore {
           alias = undefined;
         }
         // for user tag links, we'll have to regenerate the alias
-        if (newLoc.fname.startsWith(USERS_HIERARCHY)) {
+        if (link.type !== "ref" && newLoc.fname.startsWith(USERS_HIERARCHY)) {
           const fnameWithoutTag = newLoc.fname.slice(USERS_HIERARCHY.length);
           alias = `@${fnameWithoutTag}`;
         } else if (oldLink.from.fname.startsWith(USERS_HIERARCHY)) {

--- a/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/RenameNoteCommand.test.ts
@@ -66,4 +66,61 @@ suite("RenameNoteCommand", function () {
       expect(updatedSomeNote.body).toEqual("[[foo]]");
     });
   });
+  describeMultiWS("GIVEN a note with reference to user note", {}, () => {
+    test("WHEN renamed THEN note ref should not break", async () => {
+      const extension = ExtensionProvider.getExtension();
+      const { vaults, wsRoot } = extension.getDWorkspace();
+      const engine = extension.getEngine();
+      const oldNote = await NoteTestUtilsV4.createNoteWithEngine({
+        fname: "user.one",
+        body: "note body",
+        vault: vaults[0],
+        engine,
+        wsRoot,
+      });
+
+      await NoteTestUtilsV4.createNoteWithEngine({
+        fname: "some-note",
+        body: "![[user.one]]",
+        vault: vaults[0],
+        wsRoot,
+        engine,
+      });
+      await extension.wsUtils.openNote(oldNote);
+      const cmd = new RenameNoteCommand(extension);
+      const vaultName = VaultUtils.getName(vaults[0]);
+      await cmd.execute({
+        moves: [
+          {
+            oldLoc: {
+              fname: oldNote.fname,
+              vaultName,
+            },
+            newLoc: {
+              fname: "user.two",
+              vaultName,
+            },
+          },
+        ],
+        nonInteractive: true,
+        initialValue: "user.two",
+      });
+      // note `user.one` is renamed to `user.two`, `some-note`'s reference to `![[user.one]]` is updated to `![[user.two]]`
+      const newNote = (
+        await engine.findNotes({
+          vault: vaults[0],
+          fname: "user.two",
+        })
+      )[0];
+      expect(newNote).toBeTruthy();
+
+      const updatedSomeNote = (
+        await engine.findNotes({
+          vault: vaults[0],
+          fname: "some-note",
+        })
+      )[0];
+      expect(updatedSomeNote.body).toEqual("![[user.two]]");
+    });
+  });
 });


### PR DESCRIPTION
Related issue: https://github.com/dendronhq/dendron/issues/3780

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
## Instrumentation

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [ ] 1-2 Edge cases tested
- [~] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

