### PR TITLE
fix: autocomplete properly fills out value if user manually selected an item

### DIFF
--- a/packages/plugin-core/src/utils/autoCompleter.ts
+++ b/packages/plugin-core/src/utils/autoCompleter.ts
@@ -157,7 +157,7 @@ export class AutoCompleter {
       // Even if the user has not selected an item with arrow keys the focus
       // of the drop down will be on the first item hence we only want to switch
       // the active item if we detect that arrow key selection has happened.
-      if (_.isEmpty(fnames) || candidate !== fnames[0]) {
+      if (!_.isEqual(_quickPick.activeItems[0], _quickPick.items[0])) {
         activeItemValue = candidate;
       }
     }


### PR DESCRIPTION
## fix: autocomplete properly fills out value if user manually selected an item

Related to https://github.com/dendronhq/dendron/issues/3784.

If a user manually selects an item from the quickpick drop down list and hits tab for autocomplete, the desired behavior is to have the quickpick value be populated with the selected item - but we had an issue where that wasn't happening (I think a regression was maybe introduced after some ordering of the 'Create New' items was changed around.