### PR TITLE
chore: cancel redundant ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
       - "*/*"
   workflow_dispatch:
 
+# If multiple pushes occur in close succession, cancel all CI jobs except the
+# last one to save resources
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BINARY_CACHE_INDEX: 23 # Rev this if we need a new node cache
 


### PR DESCRIPTION
## chore: cancel redundant ci jobs

If you make multiple pushes in close succession, we'll kick off a CI job for every push, which can take up our github actions resources.  Turns out there's a github actions syntax that can auto-cancel all jobs except for the last one. 

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency