### PR TITLE
chore(internal): disable startup prompts

### DIFF
--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -588,13 +588,14 @@ async function showWelcomeOrWhatsNew({
       break;
   }
 
+  // NOTE: these two prompts are disabled for now. uncomment to renable when needed.
   // Show lapsed users (users who have installed Dendron but haven't initialied
   // a workspace) a reminder prompt to re-engage them.
-  StartupPrompts.showLapsedUserMessageIfNecessary({ assetUri });
+  // StartupPrompts.showLapsedUserMessageIfNecessary({ assetUri });
 
   // Show inactive users (users who were active on first week but have not used lookup in 2 weeks)
   // a reminder prompt to re-engage them.
-  StartupUtils.showInactiveUserMessageIfNecessary();
+  // StartupUtils.showInactiveUserMessageIfNecessary();
 }
 
 async function _setupCommands({

--- a/packages/plugin-core/src/_extension.ts
+++ b/packages/plugin-core/src/_extension.ts
@@ -66,7 +66,6 @@ import { Extensions } from "./settings";
 import { FeatureShowcaseToaster } from "./showcase/FeatureShowcaseToaster";
 import { AnalyticsUtils, sentryReportingCallback } from "./utils/analytics";
 import { ExtensionUtils } from "./utils/ExtensionUtils";
-import { StartupPrompts } from "./utils/StartupPrompts";
 import { StartupUtils } from "./utils/StartupUtils";
 import { VSCodeUtils } from "./vsCodeUtils";
 import { showWelcome } from "./WelcomeUtils";


### PR DESCRIPTION
# chore(internal): disable startup prompts

This PR:
- disables inactive user prompts and lapsed user prompts that asks users if they want to schedule onboarding and feedback sessions.