### PR TITLE
chore: mark all real notes with stub=undefined

### DIFF
--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -887,7 +887,6 @@ export class NoteUtils {
     // Separate custom and builtin props
     const builtinProps = _.pick(propsWithTrait, [
       ...Object.values(DNodeExplicitPropsEnum),
-      "stub",
     ]);
 
     const { custom: customProps } = cleanProps;
@@ -895,12 +894,9 @@ export class NoteUtils {
     return meta;
   }
 
-  static serialize(props: NoteProps, opts?: { excludeStub?: boolean }): string {
+  static serialize(props: NoteProps): string {
     const body = props.body;
-    const blacklist = ["parent", "children"];
-    if (opts?.excludeStub) {
-      blacklist.push("stub");
-    }
+    const blacklist = ["parent", "children", "stub"];
     const meta = _.omit(NoteUtils.serializeExplicitProps(props), blacklist);
     // Make sure title and ID are always strings
     meta.title = _.toString(meta.title);

--- a/packages/common-all/src/drivers/string2Note.ts
+++ b/packages/common-all/src/drivers/string2Note.ts
@@ -48,8 +48,7 @@ export function string2Note({
   });
 
   // Any note parsed from a real string cannot be a stub - stubs are only
-  // virtual notes to fill in hierarchy gaps.
-  // TODO Sqlite - add this back and fix test snapshots.
-  // note.stub = false;
-  return note;
+  // virtual notes to fill in hierarchy gaps. Just omit the property - the value
+  // defaults to 'false'
+  return _.omit(note, "stub");
 }

--- a/packages/common-all/src/store/NoteStore.ts
+++ b/packages/common-all/src/store/NoteStore.ts
@@ -153,7 +153,7 @@ export class NoteStore implements INoteStore<string> {
   async write(opts: WriteNoteOpts<string>): Promise<RespV3<string>> {
     const { key, note } = opts;
     const notePropsMeta: NotePropsMeta = _.omit(note, ["body"]);
-    const content = NoteUtils.serialize(note, { excludeStub: true });
+    const content = NoteUtils.serialize(note);
     const noteMeta = {
       ...notePropsMeta,
       contentHash: genHash(content),

--- a/packages/common-server/src/filesv2.ts
+++ b/packages/common-server/src/filesv2.ts
@@ -322,7 +322,7 @@ export async function note2File({
 }) {
   const { fname } = note;
   const ext = ".md";
-  const payload = NoteUtils.serialize(note, { excludeStub: true });
+  const payload = NoteUtils.serialize(note);
   const vpath = vault2Path({ vault, wsRoot });
   await fs.writeFile(path.join(vpath, fname + ext), payload);
   return genHash(payload);

--- a/packages/plugin-core/src/web/utils/note2File.ts
+++ b/packages/plugin-core/src/web/utils/note2File.ts
@@ -21,7 +21,7 @@ export async function note2File({
 }) {
   const { fname } = note;
   const ext = ".md";
-  const payload = NoteUtils.serialize(note, { excludeStub: true });
+  const payload = NoteUtils.serialize(note);
   const vaultPath = vault2Path({ vault, wsRoot });
   await vscode.workspace.fs.writeFile(
     Utils.joinPath(vaultPath, fname + ext),


### PR DESCRIPTION
## chore: mark all real notes with stub=undefined

When extracting NoteProps from a string/physical file via `string2note`, omit the stub property from NoteProps even if it's set to true - a real file should never be marked as a stub.  Only non-existing nodes that are used to form a complete hierarchy should have stub=true. This is necessary for the sqlite db logic to work properly.