### PR TITLE
enhance(workspace): Support queryNotesMeta and migrate NoteQuickInput to NoteQuickInputV2

### DIFF
--- a/packages/api-server/src/modules/notes/index.ts
+++ b/packages/api-server/src/modules/notes/index.ts
@@ -3,6 +3,7 @@ import {
   EngineInfoResp,
   EngineRenameNoteRequest,
   NoteQueryRequest,
+  QueryNotesMetaResp,
   QueryNotesResp,
   RenameNoteResp,
   RenderNoteOpts,
@@ -37,6 +38,16 @@ export class NoteController {
       ? await getWSEngine({ ws })
       : MemoryStore.instance().getEngine();
     return engine.queryNotes(opts.opts);
+  }
+
+  async queryMeta({
+    ws,
+    ...opts
+  }: NoteQueryRequest): Promise<QueryNotesMetaResp> {
+    const engine = ws
+      ? await getWSEngine({ ws })
+      : MemoryStore.instance().getEngine();
+    return engine.queryNotesMeta(opts.opts);
   }
 
   async info(): Promise<EngineInfoResp> {

--- a/packages/api-server/src/routes/note.ts
+++ b/packages/api-server/src/routes/note.ts
@@ -128,6 +128,16 @@ router.get(
   })
 );
 
+router.get(
+  "/queryMeta",
+  asyncHandler(async (req: Request, res: Response) => {
+    const resp = await NoteController.instance().queryMeta(
+      req.query as unknown as NoteQueryRequest
+    );
+    ExpressUtils.setResponse(res, { data: resp });
+  })
+);
+
 router.post(
   "/find",
   asyncHandler(async (req: Request, res: Response<RespV3<FindNotesResp>>) => {

--- a/packages/common-all/src/api.ts
+++ b/packages/common-all/src/api.ts
@@ -12,6 +12,7 @@ import {
   FindNotesMetaResp,
   GetNoteMetaResp,
   GetNoteResp,
+  QueryNotesMetaResp,
   QueryNotesOpts,
   RenameNoteOpts,
   SchemaModuleProps,
@@ -440,6 +441,14 @@ export class DendronAPI extends API {
   noteQuery(req: NoteQueryRequest): Promise<RespV3<QueryNotesResp>> {
     return this._makeRequest({
       path: "note/query",
+      method: "get",
+      qs: req,
+    });
+  }
+
+  noteQueryMeta(req: NoteQueryRequest): Promise<RespV3<QueryNotesMetaResp>> {
+    return this._makeRequest({
+      path: "note/queryMeta",
       method: "get",
       qs: req,
     });

--- a/packages/common-all/src/dnode.ts
+++ b/packages/common-all/src/dnode.ts
@@ -185,7 +185,7 @@ export class DNodeUtils {
    * @returns
    */
   static enhancePropForQuickInputV4(opts: {
-    props: NoteProps;
+    props: NotePropsMeta;
     schema?: SchemaModuleProps;
     alwaysShow?: boolean;
   }): NoteQuickInputV2 {
@@ -285,7 +285,7 @@ export class DNodeUtils {
     return _.omit(props, blacklist);
   }
 
-  static getDepth(node: DNodeProps): number {
+  static getDepth(node: NotePropsMeta): number {
     return this.getFNameDepth(node.fname);
   }
 
@@ -407,7 +407,7 @@ export class NoteUtils {
   }
 
   static addSchema(opts: {
-    note: NoteProps;
+    note: NotePropsMeta;
     schemaModule: SchemaModuleProps;
     schema: SchemaProps;
   }) {
@@ -601,7 +601,10 @@ export class NoteUtils {
     });
   }
 
-  static genSchemaDesc(note: NoteProps, schemaMod?: SchemaModuleProps): string {
+  static genSchemaDesc(
+    note: NotePropsMeta,
+    schemaMod?: SchemaModuleProps
+  ): string {
     const prefixParts = [];
     if (note.title !== note.fname) {
       prefixParts.push(note.title);
@@ -1342,30 +1345,6 @@ export class SchemaUtils {
     };
   }
 
-  static enhanceForQuickInput({
-    props,
-    vaults,
-  }: {
-    props: SchemaModuleProps;
-    vaults: DVault[];
-  }): DNodePropsQuickInputV2 {
-    const vaultSuffix =
-      vaults.length > 1
-        ? ` (${path.basename(props.vault?.fsPath as string)})`
-        : "";
-    const label = DNodeUtils.isRoot(props.root) ? "root" : props.root.id;
-    const detail = props.root.desc;
-    const out = {
-      ...props.root,
-      fname: props.fname,
-      label,
-      detail,
-      description: vaultSuffix,
-      vault: props.vault,
-    };
-    return out;
-  }
-
   static getModuleRoot(
     module: SchemaModuleOpts | SchemaModuleProps
   ): SchemaProps {
@@ -1451,7 +1430,7 @@ export class SchemaUtils {
     note,
     engine,
   }: {
-    note: NoteProps;
+    note: NotePropsMeta;
     engine: DEngineClient;
   }) {
     if (note.schema) {

--- a/packages/common-all/src/engine/EngineV3Base.ts
+++ b/packages/common-all/src/engine/EngineV3Base.ts
@@ -21,6 +21,7 @@ import {
   NoteChangeEntry,
   NoteProps,
   NotePropsMeta,
+  QueryNotesMetaResp,
   QueryNotesOpts,
   QueryNotesResp,
   ReducedDEngine,
@@ -45,6 +46,8 @@ export abstract class EngineV3Base implements ReducedDEngine {
   protected logger;
   public vaults;
   public wsRoot;
+  // TODO: Make configurable
+  API_MAX_LIMIT = 100;
 
   constructor(opts: {
     noteStore: INoteStore<string>;
@@ -301,43 +304,43 @@ export abstract class EngineV3Base implements ReducedDEngine {
     };
   }
 
+  /**
+   * See {@link DEngine.queryNotes}
+   */
   async queryNotes(opts: QueryNotesOpts): Promise<QueryNotesResp> {
-    // const ctx = "Engine:queryNotes";
-    const { vault } = opts;
-    const MAX_LIMIT = 100;
-
-    // Need to ignore this because the engine stringifies this property, so the types are incorrect.
-    // @ts-ignore
-    if (vault?.selfContained === "true" || vault?.selfContained === "false")
-      vault.selfContained = vault.selfContained === "true";
-    const response = await this.noteStore.queryMetadata(opts);
+    const response = await this.noteStore.query(opts);
     if (response.isErr()) {
-      // TODO: need to return an error
-      return [];
-    }
-    let items = response.value;
-    if (items.length === 0) {
-      return [];
-    }
-
-    if (!_.isUndefined(vault)) {
-      items = items.filter((ent) => {
-        return VaultUtils.isEqual(vault, ent.vault, this.wsRoot);
+      throw new DendronError({
+        message: "Error querying for notes with opts: " + opts,
+        innerError: response.error,
       });
     }
 
-    // TODO: Support actual pagination if needed. For now, cap results
-    if (items.length > MAX_LIMIT) {
-      items = items.slice(0, MAX_LIMIT);
+    let items = response.value;
+    if (items.length > this.API_MAX_LIMIT) {
+      items = items.slice(0, this.API_MAX_LIMIT);
     }
+    return items;
+  }
 
-    const notes = await this.noteStore.bulkGet(items.map((ent) => ent.id));
-
-    const modifiedNotes = notes
-      .filter((ent) => _.isUndefined(ent.error))
-      .map((resp) => resp.data!);
-
-    return modifiedNotes;
+  /**
+   * See {@link DEngine.queryNotesMeta}
+   */
+  async queryNotesMeta(opts: QueryNotesOpts): Promise<QueryNotesMetaResp> {
+    const response = await this.noteStore.queryMetadata(opts);
+    if (response.isErr()) {
+      throw new DendronError({
+        message: "Error querying for notes with opts: " + opts,
+        innerError: response.error,
+      });
+    }
+    let items = response.value;
+    // We should cap number of results sent over through the api,
+    // otherwise it degrades performance
+    if (items.length > this.API_MAX_LIMIT) {
+      items = items.slice(0, this.API_MAX_LIMIT);
+    }
+    return items;
   }
 
   /**

--- a/packages/common-all/src/store/INoteStore.ts
+++ b/packages/common-all/src/store/INoteStore.ts
@@ -125,6 +125,15 @@ export interface INoteStore<K> extends Disposable {
   rename(oldLoc: DNoteLoc, newLoc: DNoteLoc): Promise<RespV3<K>>;
 
   /**
+   * Query NoteProps by criteria. Differs from find in that this supports full-text fuzzy search
+   * on note properties.
+   *
+   * @param opts: NoteProps criteria
+   * @return List of NoteProps that matches criteria
+   */
+  query(opts: QueryNotesOpts): ResultAsync<NoteProps[], IDendronError>;
+
+  /**
    * Query NoteProps metadata by criteria. Differs from find in that this supports full-text fuzzy search
    * on note properties.
    * TODO: consider replacing findMetadata altogether

--- a/packages/common-all/src/store/NoteStore.ts
+++ b/packages/common-all/src/store/NoteStore.ts
@@ -269,6 +269,24 @@ export class NoteStore implements INoteStore<string> {
   }
 
   /**
+   * See {@link INoteStore.query}
+   */
+  query(
+    opts: QueryNotesOpts
+  ): ResultAsync<NoteProps[], IDendronError<StatusCodes | undefined>> {
+    const result = this._metadataStore
+      .query(opts)
+      .map((items) => {
+        return this.bulkGet(items.map((ent) => ent.id));
+      })
+      .map((responses) =>
+        responses.map((resp) => resp.data).filter(isNotUndefined)
+      );
+
+    return result;
+  }
+
+  /**
    * See {@link INoteStore.queryMetadata}
    */
   queryMetadata(

--- a/packages/common-all/src/types/ReducedDEngine.ts
+++ b/packages/common-all/src/types/ReducedDEngine.ts
@@ -17,5 +17,6 @@ export type ReducedDEngine = Pick<
   | "writeNote"
   | "renameNote"
   | "queryNotes"
+  | "queryNotesMeta"
   | "renderNote"
 >;

--- a/packages/common-all/src/types/foundation.ts
+++ b/packages/common-all/src/types/foundation.ts
@@ -226,7 +226,7 @@ export type SchemaTemplate = {
   type: "snippet" | "note";
 };
 
-export type SchemaProps = DNodeProps<SchemaData>;
+export type SchemaProps = Omit<DNodeProps<SchemaData>, "body">;
 /**
  * Interface for a Dendron Note
  */

--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -87,7 +87,7 @@ export type SchemaRaw = Pick<SchemaProps, "id"> &
     Pick<DNodeProps, "children">
   >;
 
-export type SchemaOpts = Omit<DNodeOpts<SchemaData>, "type" | "id"> & {
+export type SchemaOpts = Omit<DNodeOpts<SchemaData>, "type" | "id" | "body"> & {
   id: string;
 };
 export type NoteOpts = Omit<DNodeOpts, "type">;
@@ -97,20 +97,12 @@ export type DNodePropsQuickInputV2<T = any> = DNodeProps<T> & {
   detail?: string;
   alwaysShow?: boolean;
 };
-export type NoteQuickInput = NoteProps & {
-  label: string;
-  detail?: string;
-  alwaysShow?: boolean;
-};
 
 /**
  * A reduced version of NoteQuickInput that only keeps the props necessary for
  * lookup quick pick items
  */
-export type NoteQuickInputV2 = Pick<
-  NoteProps,
-  "fname" | "vault" | "schema" | "stub"
-> & {
+export type NoteQuickInputV2 = NotePropsMeta & {
   label: string;
   detail?: string;
   alwaysShow?: boolean;
@@ -381,6 +373,7 @@ export type BulkWriteNotesResp = RespWithOptError<NoteChangeEntry[]>;
 export type UpdateNoteResp = RespV2<NoteChangeEntry[]>; // TODO: remove
 export type DeleteNoteResp = RespV3<NoteChangeEntry[]>;
 export type QueryNotesResp = NoteProps[];
+export type QueryNotesMetaResp = NotePropsMeta[];
 export type RenameNoteResp = RespV3<NoteChangeEntry[]>;
 export type EngineInfoResp = RespV3<{
   version: string;
@@ -509,9 +502,13 @@ export type DEngine = DCommonProps &
     getSchema: (id: string) => Promise<GetSchemaResp>;
     querySchema: (qs: string) => Promise<QuerySchemaResp>;
     /**
-     * Query for NoteProps from fuse engine
+     * Query for NoteProps
      */
     queryNotes: (opts: QueryNotesOpts) => Promise<QueryNotesResp>;
+    /**
+     * Query for NotePropsMeta
+     */
+    queryNotesMeta: (opts: QueryNotesOpts) => Promise<QueryNotesMetaResp>;
     /**
      * Rename note from old DNoteLoc to new DNoteLoc. New note keeps original id
      */

--- a/packages/common-all/src/utils/lookup.ts
+++ b/packages/common-all/src/utils/lookup.ts
@@ -4,6 +4,7 @@ import {
   FuseExtendedSearchConstants,
   NoteProps,
   NotePropsByIdDict,
+  NotePropsMeta,
   NoteUtils,
   ReducedDEngine,
 } from "..";
@@ -67,11 +68,10 @@ export class NoteLookupUtils {
   };
 
   static fetchRootResultsFromEngine = async (engine: ReducedDEngine) => {
-    // TODO: Support findNotesMeta
-    const roots = await engine.findNotes({ fname: "root" });
+    const roots = await engine.findNotesMeta({ fname: "root" });
 
     const childrenOfRoot = roots.flatMap((ent) => ent.children);
-    const childrenOfRootNotes = await engine.bulkGetNotes(childrenOfRoot);
+    const childrenOfRootNotes = await engine.bulkGetNotesMeta(childrenOfRoot);
     return roots.concat(childrenOfRootNotes.data);
   };
 
@@ -93,7 +93,7 @@ export class NoteLookupUtils {
     qsRaw: string;
     engine: DEngineClient;
     showDirectChildrenOnly?: boolean;
-  }): Promise<NoteProps[]> {
+  }): Promise<NotePropsMeta[]> {
     const qsClean = this.slashToDot(qsRaw);
 
     // special case: if query is empty, fetch top level notes
@@ -106,7 +106,7 @@ export class NoteLookupUtils {
       query: qsRaw,
       onlyDirectChildren: showDirectChildrenOnly,
     });
-    let nodes = await engine.queryNotes({
+    let nodes = await engine.queryNotesMeta({
       qs: transformedQuery.queryString,
       originalQS: qsRaw,
       onlyDirectChildren: showDirectChildrenOnly,

--- a/packages/dendron-cli/src/commands/notes.ts
+++ b/packages/dendron-cli/src/commands/notes.ts
@@ -234,7 +234,21 @@ export class NoteCLICommand extends CLICommand<CommandOpts, CommandOutput> {
       switch (cmd) {
         case NoteCommands.LOOKUP: {
           const query = checkQuery(opts);
-          const notes = await NoteLookupUtils.lookup({ qsRaw: query, engine });
+          const notePropsMeta = await NoteLookupUtils.lookup({
+            qsRaw: query,
+            engine,
+          });
+          const noteIds = notePropsMeta.map((note) => note.id);
+          const noteResp = await engine.bulkGetNotes(noteIds);
+          if (noteResp.error) {
+            return {
+              error: ErrorFactory.create404Error({
+                url: query,
+              }),
+              data: undefined,
+            };
+          }
+          const notes = noteResp.data;
           const resp = await formatNotes({
             output,
             notes,

--- a/packages/engine-server/src/enginev2.ts
+++ b/packages/engine-server/src/enginev2.ts
@@ -62,6 +62,7 @@ import {
   isNotUndefined,
   ConfigService,
   URI,
+  QueryNotesMetaResp,
 } from "@dendronhq/common-all";
 import {
   createLogger,
@@ -468,6 +469,10 @@ export class DendronEngineV2 implements DEngine {
       });
     }
     return notes;
+  }
+
+  async queryNotesMeta(opts: QueryNotesOpts): Promise<QueryNotesMetaResp> {
+    return this.queryNotes(opts);
   }
 
   async renderNote({

--- a/packages/engine-test-utils/src/presets/engine-server/query.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/query.ts
@@ -176,6 +176,39 @@ const NOTES = {
       preSetupHook: setupBasic,
     }
   ),
+  NOTE_META_QUERY: new TestPresetEntryV4(
+    async ({ vaults, engine }) => {
+      const vault = vaults[0];
+      const fname = NOTE_PRESETS_V4.NOTE_SIMPLE.fname;
+      const data = await engine.queryNotesMeta({
+        qs: fname,
+        originalQS: fname,
+        vault,
+      });
+      const expectedNote = (
+        await engine.findNotesMeta({
+          fname,
+          vault,
+        })
+      )[0];
+      return [
+        {
+          actual: data ? data[0] : undefined,
+          expected: expectedNote,
+        },
+        {
+          actual: data ? data[0].schema : undefined,
+          expected: {
+            moduleId: SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.fname,
+            schemaId: SCHEMA_PRESETS_V4.SCHEMA_SIMPLE.fname,
+          },
+        },
+      ];
+    },
+    {
+      preSetupHook: setupBasic,
+    }
+  ),
 };
 export const ENGINE_QUERY_PRESETS = {
   NOTES,

--- a/packages/engine-test-utils/src/presets/engine-server/write.ts
+++ b/packages/engine-test-utils/src/presets/engine-server/write.ts
@@ -860,9 +860,8 @@ const NOTES_MULTI = {
     ];
   }),
   NEW_DOMAIN_WITH_FULL_PATH_VAULT: new TestPresetEntryV4(
-    async ({ wsRoot, vaults, engine }) => {
+    async ({ vaults, engine }) => {
       const vault = { ...vaults[1] };
-      vault.fsPath = path.join(wsRoot, vault.fsPath);
       const noteNew = NoteUtils.create({
         id: "bar",
         fname: "bar",

--- a/packages/plugin-core/src/commands/ConvertLink.ts
+++ b/packages/plugin-core/src/commands/ConvertLink.ts
@@ -1,7 +1,7 @@
 import {
   assertUnreachable,
   DendronError,
-  NoteProps,
+  NotePropsMeta,
   NoteUtils,
   VaultUtils,
 } from "@dendronhq/common-all";
@@ -234,7 +234,7 @@ export class ConvertLinkCommand extends BasicCommand<
           break;
         }
         text = NoteUtils.createWikiLink({
-          note: resp?.selectedItems[0] as NoteProps,
+          note: resp?.selectedItems[0] as NotePropsMeta,
           alias: { mode: "title" },
         });
         break;

--- a/packages/plugin-core/src/commands/InsertNoteLink.ts
+++ b/packages/plugin-core/src/commands/InsertNoteLink.ts
@@ -2,7 +2,7 @@ import {
   ConfigUtils,
   InsertNoteLinkAliasMode,
   InsertNoteLinkAliasModeEnum,
-  NoteProps,
+  NotePropsMeta,
   NoteUtils,
 } from "@dendronhq/common-all";
 import { HistoryEvent } from "@dendronhq/engine-server";
@@ -25,7 +25,7 @@ type CommandInput = {
 };
 
 type CommandOpts = {
-  notes: readonly NoteProps[];
+  notes: readonly NotePropsMeta[];
 } & CommandInput;
 type CommandOutput = CommandOpts;
 
@@ -91,7 +91,7 @@ export class InsertNoteLinkCommand extends BasicCommand<
     });
   }
 
-  async promptForAlias(note: NoteProps) {
+  async promptForAlias(note: NotePropsMeta) {
     const value = await VSCodeUtils.showInputBox({
       prompt: `Alias for note link of ${note.fname}. Leave blank to skip aliasing.`,
       ignoreFocusOut: true,

--- a/packages/plugin-core/src/commands/MoveHeader.ts
+++ b/packages/plugin-core/src/commands/MoveHeader.ts
@@ -15,11 +15,11 @@ import {
   isNotUndefined,
   NoteChangeEntry,
   NoteProps,
-  NoteQuickInput,
   NoteUtils,
   VaultUtils,
   ConfigService,
   URI,
+  NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import { file2Note, vault2Path } from "@dendronhq/common-server";
 import { Heading, HistoryEvent, Node } from "@dendronhq/engine-server";
@@ -210,7 +210,7 @@ export class MoveHeaderCommand extends BasicCommand<
   async prepareDestination(opts: {
     engine: IEngineAPIService;
     quickpick: DendronQuickPickerV2;
-    selectedItems: readonly NoteQuickInput[];
+    selectedItems: readonly NoteQuickInputV2[];
   }) {
     const { engine, quickpick, selectedItems } = opts;
     const vault =
@@ -234,7 +234,12 @@ export class MoveHeaderCommand extends BasicCommand<
           dest = maybeNote;
         }
       } else {
-        dest = selected as NoteProps;
+        const resp = await engine.getNote(selected.id);
+        if (resp.error) {
+          this.L.error({ error: resp.error });
+          return;
+        }
+        dest = resp.data;
       }
     }
     return dest;

--- a/packages/plugin-core/src/commands/MoveNoteCommand.ts
+++ b/packages/plugin-core/src/commands/MoveNoteCommand.ts
@@ -215,10 +215,13 @@ export class MoveNoteCommand extends BasicCommand<CommandOpts, CommandOutput> {
         items = [];
       }
     } else {
-      const notes = data.selectedItems.map(
-        (item): NoteProps => _.omit(item, ["label", "detail", "alwaysShow"])
-      );
-      items = notes;
+      const noteIds = data.selectedItems.map((item) => item.id);
+      const resp = await engine.bulkGetNotes(noteIds);
+      if (resp.error) {
+        this.L.error({ ctx, error: resp.error });
+        return;
+      }
+      items = resp.data;
     }
 
     const basicStats = StatisticsUtils.getBasicStatsFromNotes(items);

--- a/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
+++ b/packages/plugin-core/src/commands/RefactorHierarchyV2.ts
@@ -1,10 +1,10 @@
 import {
   DEngineClient,
   DNodeProps,
-  DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
   extractNoteChangeEntryCounts,
+  NoteQuickInputV2,
   NoteUtils,
   RefactoringCommandUsedPayload,
   StatisticsUtils,
@@ -70,7 +70,7 @@ export class RefactorHierarchyCommandV2 extends BasicCommand<
     label: "Entire Workspace",
     detail: "Scope refactor to entire workspace",
     alwaysShow: true,
-  } as DNodePropsQuickInputV2;
+  } as NoteQuickInputV2;
 
   async promptScope(): Promise<NoteLookupProviderSuccessResp | undefined> {
     // see if we have a selection that contains wikilinks

--- a/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
+++ b/packages/plugin-core/src/components/lookup/LookupControllerV3.ts
@@ -12,12 +12,12 @@ import {
   LookupSelectionTypeEnum,
   NoteChangeEntry,
   NoteProps,
-  NoteQuickInput,
   NoteUtils,
   TaskNoteUtils,
   VSRange,
   deleteTextRange,
   ConfigService,
+  NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import { HistoryService, WorkspaceUtils } from "@dendronhq/engine-server";
 import { LinkUtils } from "@dendronhq/unified";
@@ -371,7 +371,7 @@ export class LookupControllerV3 implements ILookupControllerV3 {
           this.quickPick.showDirectChildrenOnly = newValue;
 
           if (newValue) {
-            this.quickPick.filterMiddleware = (items: NoteQuickInput[]) =>
+            this.quickPick.filterMiddleware = (items: NoteQuickInputV2[]) =>
               items;
           } else {
             this.quickPick.filterMiddleware = undefined;

--- a/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
+++ b/packages/plugin-core/src/components/lookup/LookupProviderV3Interface.ts
@@ -1,9 +1,8 @@
 import { DendronQuickPickerV2 } from "./types";
 import { CancellationToken, CancellationTokenSource } from "vscode";
 import {
-  DNodePropsQuickInputV2,
   InvalidFilenameReason,
-  NoteQuickInput,
+  NoteQuickInputV2,
   RespV2,
   SchemaQuickInput,
 } from "@dendronhq/common-all";
@@ -17,7 +16,7 @@ export type ILookupProviderV3 = {
     quickpick: DendronQuickPickerV2;
     cancellationToken: CancellationTokenSource;
   }): any;
-  shouldRejectItem?: (opts: { item: NoteQuickInput }) =>
+  shouldRejectItem?: (opts: { item: NoteQuickInputV2 }) =>
     | {
         shouldReject: true;
         reason: InvalidFilenameReason;
@@ -71,12 +70,12 @@ export type ILookupProviderOptsV3 = {
    * This will always be shown at the top
    * when (and only when) nothing is queried.
    */
-  extraItems?: DNodePropsQuickInputV2[];
-  preAcceptValidators?: ((selectedItems: NoteQuickInput[]) => boolean)[];
+  extraItems?: NoteQuickInputV2[];
+  preAcceptValidators?: ((selectedItems: NoteQuickInputV2[]) => boolean)[];
 };
 
 export type NoteLookupProviderSuccessResp<T = never> = {
-  selectedItems: readonly NoteQuickInput[];
+  selectedItems: readonly NoteQuickInputV2[];
   onAcceptHookResp: T[];
   cancel?: boolean;
 };
@@ -92,5 +91,5 @@ export type SchemaLookupProviderSuccessResp<T = never> = {
 
 export type OnAcceptHook = (opts: {
   quickpick: DendronQuickPickerV2;
-  selectedItems: NoteQuickInput[];
+  selectedItems: NoteQuickInputV2[];
 }) => Promise<RespV2<any>>;

--- a/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/NoteLookupProvider.ts
@@ -5,7 +5,7 @@ import {
   LookupEvents,
   NoteLookupUtils,
   NoteProps,
-  NoteQuickInput,
+  NoteQuickInputV2,
   NoteUtils,
   SchemaUtils,
   VSCodeEvents,
@@ -119,7 +119,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
     return;
   }
 
-  shouldRejectItem(opts: { item: NoteQuickInput }):
+  shouldRejectItem(opts: { item: NoteQuickInputV2 }):
     | {
         shouldReject: true;
         reason: InvalidFilenameReason;
@@ -334,7 +334,7 @@ export class NoteLookupProvider implements ILookupProviderV3 {
       }
 
       // initialize with current picker items without default items present
-      const items: NoteQuickInput[] = [...picker.items];
+      const items: NoteQuickInputV2[] = [...picker.items];
       let updatedItems = PickerUtilsV2.filterDefaultItems(items);
       if (token?.isCancellationRequested) {
         return;

--- a/packages/plugin-core/src/components/lookup/SchemaLookupProvider.ts
+++ b/packages/plugin-core/src/components/lookup/SchemaLookupProvider.ts
@@ -1,7 +1,7 @@
 import {
   DNodeUtils,
   NoteLookupUtils,
-  NoteQuickInput,
+  NoteQuickInputV2,
   NoteUtils,
   SchemaModuleProps,
   SchemaUtils,
@@ -205,13 +205,11 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
         );
         picker.items = await Promise.all(
           nodes.map(async (ent) => {
-            return DNodeUtils.enhancePropForQuickInputV3({
-              wsRoot: this._extension.getDWorkspace().wsRoot,
+            return DNodeUtils.enhancePropForQuickInputV4({
               props: ent,
               schema: ent.schema
                 ? (await engine.getSchema(ent.schema.moduleId)).data
                 : undefined,
-              vaults: await ws.vaults,
             });
           })
         );
@@ -219,7 +217,7 @@ export class SchemaLookupProvider implements ILookupProviderV3 {
       }
 
       // initialize with current picker items without default items present
-      const items: NoteQuickInput[] = [...picker.items];
+      const items: NoteQuickInputV2[] = [...picker.items];
       let updatedItems = PickerUtilsV2.filterDefaultItems(items);
       if (token?.isCancellationRequested) {
         return;

--- a/packages/plugin-core/src/components/lookup/SchemaPickerUtils.ts
+++ b/packages/plugin-core/src/components/lookup/SchemaPickerUtils.ts
@@ -13,21 +13,17 @@ export class SchemaPickerUtils {
   }: {
     picker: DendronQuickPickerV2;
   }) {
-    const ws = ExtensionProvider.getDWorkspace();
-    const { engine, wsRoot } = ws;
-    const vaults = await ws.vaults;
+    const { engine } = ExtensionProvider.getDWorkspace();
     const resp = await engine.querySchema(picker.value);
     if (resp.data && resp.data.length > 0) {
       const node = SchemaUtils.getModuleRoot(resp.data[0]);
       if (node.fname === picker.value) {
         return [
-          DNodeUtils.enhancePropForQuickInputV3({
-            wsRoot,
+          DNodeUtils.enhancePropForQuickInputV4({
             props: node,
             schema: node.schema
               ? (await engine.getSchema(node.schema.moduleId)).data
               : undefined,
-            vaults,
           }),
         ];
       }
@@ -47,9 +43,7 @@ export class SchemaPickerUtils {
     const ctx = "SchemaPickerUtils:fetchPickerResults";
     const start = process.hrtime();
     const { picker, qs } = opts;
-    const ws = ExtensionProvider.getDWorkspace();
-    const { engine, wsRoot } = ws;
-    const vaults = await ws.vaults;
+    const { engine } = ExtensionProvider.getDWorkspace();
     const resp = await engine.querySchema(qs);
     let nodes: SchemaProps[] = [];
     if (resp.data) {
@@ -66,15 +60,13 @@ export class SchemaPickerUtils {
     }
     const updatedItems = await Promise.all(
       nodes.map(async (ent) =>
-        DNodeUtils.enhancePropForQuickInputV3({
-          wsRoot,
+        DNodeUtils.enhancePropForQuickInputV4({
           props: ent,
           schema: ent.schema
             ? (
                 await engine.getSchema(ent.schema.moduleId)
               ).data
             : undefined,
-          vaults,
           alwaysShow: picker.alwaysShowAll,
         })
       )

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -3,14 +3,14 @@ import {
   DNodeProps,
   NoteProps,
   DVault,
-  NoteQuickInput,
+  NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import { QuickPick, QuickPickItem, TextEditor, Uri } from "vscode";
 import { DendronBtn } from "./ButtonTypes";
 
 export type FilterQuickPickFunction = (
-  items: NoteQuickInput[]
-) => NoteQuickInput[];
+  items: NoteQuickInputV2[]
+) => NoteQuickInputV2[];
 type ModifyPickerValueFunc = (value?: string) => {
   noteName: string;
   prefix: string;
@@ -32,7 +32,7 @@ export enum DendronQuickPickState {
   PENDING_NEXT_PICK = "PENDING_NEXT_PICK",
 }
 
-export type DendronQuickPickItemV2 = QuickPick<DNodePropsQuickInputV2>;
+export type DendronQuickPickItemV2 = QuickPick<NoteQuickInputV2>;
 export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   // --- Private State
   _justActivated?: boolean;
@@ -72,7 +72,7 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
   // pagiation
   offset?: number;
   moreResults?: boolean;
-  allResults?: DNodeProps[];
+  allResults?: Omit<DNodeProps, "body">[];
   /**
    * Should VSCode managing sorting of results?
    * Supported in VSCode but not added to the type definition files, see https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036

--- a/packages/plugin-core/src/features/completionProvider.ts
+++ b/packages/plugin-core/src/features/completionProvider.ts
@@ -10,7 +10,6 @@ import {
   LINK_NAME,
   LINK_NAME_NO_SPACES,
   NoteLookupUtils,
-  NoteProps,
   NotePropsMeta,
   TAGS_HIERARCHY,
   URI,
@@ -109,11 +108,11 @@ async function noteToCompletionItem({
   insertTextTransform,
   sortTextTransform,
 }: {
-  note: NoteProps;
+  note: NotePropsMeta;
   range: Range;
-  lblTransform?: (note: NoteProps) => string;
-  insertTextTransform?: (note: NoteProps) => Promise<string>;
-  sortTextTransform?: (note: NoteProps) => string | undefined;
+  lblTransform?: (note: NotePropsMeta) => string;
+  insertTextTransform?: (note: NotePropsMeta) => Promise<string>;
+  sortTextTransform?: (note: NotePropsMeta) => string | undefined;
 }): Promise<CompletionItem> {
   const label = lblTransform ? lblTransform(note) : note.fname;
   const insertText = insertTextTransform
@@ -275,7 +274,7 @@ export const provideCompletionItems = sentryReportingCallback(
       } else {
         qsRaw = "";
       }
-      const insertTextTransform = async (note: NoteProps) => {
+      const insertTextTransform = async (note: NotePropsMeta) => {
         let resp = note.fname;
         if (found?.groups?.noBracket !== undefined) {
           resp += "]]";

--- a/packages/plugin-core/src/services/EngineAPIService.ts
+++ b/packages/plugin-core/src/services/EngineAPIService.ts
@@ -30,6 +30,7 @@ import {
   NoteChangeEntry,
   NoteProps,
   NotePropsMeta,
+  QueryNotesMetaResp,
   QueryNotesOpts,
   QueryNotesResp,
   QuerySchemaResp,
@@ -252,6 +253,10 @@ export class EngineAPIService
 
   queryNotes(opts: QueryNotesOpts): Promise<QueryNotesResp> {
     return this._internalEngine.queryNotes(opts);
+  }
+
+  queryNotesMeta(opts: QueryNotesOpts): Promise<QueryNotesMetaResp> {
+    return this._internalEngine.queryNotesMeta(opts);
   }
 
   renameNote(opts: RenameNoteOpts): Promise<RenameNoteResp> {

--- a/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
+++ b/packages/plugin-core/src/services/EngineAPIServiceInterface.ts
@@ -22,6 +22,7 @@ import {
   GetNoteResp,
   GetSchemaResp,
   NoteProps,
+  QueryNotesMetaResp,
   QueryNotesOpts,
   QueryNotesResp,
   QuerySchemaResp,
@@ -94,6 +95,8 @@ export interface IEngineAPIService {
   querySchema(qs: string): Promise<QuerySchemaResp>;
 
   queryNotes(opts: QueryNotesOpts): Promise<QueryNotesResp>;
+
+  queryNotesMeta: (opts: QueryNotesOpts) => Promise<QueryNotesMetaResp>;
 
   renameNote(opts: RenameNoteOpts): Promise<RenameNoteResp>;
 

--- a/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts
@@ -1,6 +1,5 @@
 import {
   ConfigUtils,
-  DNodePropsQuickInputV2,
   DNodeUtils,
   DVault,
   DendronConfig,
@@ -8,13 +7,13 @@ import {
   LookupSelectionModeEnum,
   LookupSelectionTypeEnum,
   NoteProps,
-  NoteQuickInput,
   SchemaTemplate,
   SchemaUtils,
   Time,
   VaultUtils,
   ConfigService,
   URI,
+  NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import { tmpDir, vault2Path } from "@dendronhq/common-server";
 import {
@@ -63,7 +62,6 @@ import {
 } from "../../components/lookup/utils";
 import { CONFIG } from "../../constants";
 import { ExtensionProvider } from "../../ExtensionProvider";
-import { StateService } from "../../services/stateService";
 import { clipboard } from "../../utils";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { DendronExtension } from "../../workspace";
@@ -129,7 +127,7 @@ function expectCreateNew({
   item,
   fname,
 }: {
-  item: DNodePropsQuickInputV2;
+  item: NoteQuickInputV2;
   fname?: string;
 }) {
   if (item.label !== CREATE_NEW_LABEL) {
@@ -2620,7 +2618,7 @@ suite("NoteLookupCommand", function () {
               vaults,
             });
           })
-        )) as NoteQuickInput[];
+        )) as NoteQuickInputV2[];
 
         const runOpts = {
           multiSelect: true,
@@ -2832,8 +2830,7 @@ suite("NoteLookupCommand", function () {
 suite("stateService", function () {
   let homeDirStub: SinonStub;
   const ctx: vscode.ExtensionContext = setupBeforeAfter(this, {
-    beforeHook: async (ctx) => {
-      new StateService(ctx);
+    beforeHook: async () => {
       await resetCodeWorkspace();
       homeDirStub = TestEngineUtils.mockHomeDir();
     },

--- a/packages/plugin-core/src/test/suite-integ/autoCompleter.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/autoCompleter.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "mocha";
 import { expect } from "../expect";
 import { VSCodeUtils } from "../../vsCodeUtils";
 import { TestNoteFactory } from "@dendronhq/common-test-utils";
-import { DNodePropsQuickInputV2 } from "@dendronhq/common-all";
+import { NoteQuickInputV2 } from "@dendronhq/common-all";
 import { DendronQuickPickerV2 } from "../../components/lookup/types";
 
 const LANGUAGE_FNAMES = [
@@ -27,7 +27,7 @@ describe(`Auto Completer tests.`, () => {
     describe(`WHEN we are at the first value of dropdown`, () => {
       it("THEN we should do partial completion", async () => {
         const quickPick =
-          VSCodeUtils.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
+          VSCodeUtils.createQuickPick<NoteQuickInputV2>() as DendronQuickPickerV2;
         const items = await noteFactory.createNoteInputWithFNames(
           LANGUAGE_FNAMES
         );
@@ -51,7 +51,7 @@ describe(`Auto Completer tests.`, () => {
           "languages.with-data.make-sense",
         ];
         const quickPick =
-          VSCodeUtils.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
+          VSCodeUtils.createQuickPick<NoteQuickInputV2>() as DendronQuickPickerV2;
         const items = await noteFactory.createNoteInputWithFNames(fnames);
 
         quickPick.items = items;
@@ -67,7 +67,7 @@ describe(`Auto Completer tests.`, () => {
     describe(`WHEN we are at subsequent value of dropdown`, () => {
       it("THEN we should do full completion", async () => {
         const quickPick =
-          VSCodeUtils.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
+          VSCodeUtils.createQuickPick<NoteQuickInputV2>() as DendronQuickPickerV2;
         const items = await noteFactory.createNoteInputWithFNames(
           LANGUAGE_FNAMES
         );

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/LookupViewModel.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/LookupViewModel.test.ts
@@ -1,7 +1,7 @@
 import {
-  DNodePropsQuickInputV2,
   LookupNoteTypeEnum,
   LookupSelectionTypeEnum,
+  NoteQuickInputV2,
 } from "@dendronhq/common-all";
 import _ from "lodash";
 import { after, before, describe, it } from "mocha";
@@ -39,7 +39,7 @@ const isButtonPressed = function (type: ButtonType, buttons: DendronBtn[]) {
 
 describe(`GIVEN a LookupV3QuickPick`, () => {
   const qp =
-    vscode.window.createQuickPick<DNodePropsQuickInputV2>() as DendronQuickPickerV2;
+    vscode.window.createQuickPick<NoteQuickInputV2>() as DendronQuickPickerV2;
 
   qp.buttons = [
     VaultSelectButton.create({ pressed: false }),

--- a/packages/plugin-core/src/test/suite-integ/components/lookup/utils.test.ts
+++ b/packages/plugin-core/src/test/suite-integ/components/lookup/utils.test.ts
@@ -2,7 +2,7 @@ import { NoteTestUtilsV4 } from "@dendronhq/common-test-utils";
 import {
   DNodePropsQuickInputV2,
   NoteLookupUtils,
-  NoteProps,
+  NotePropsMeta,
   TransformedQueryString,
 } from "@dendronhq/common-all";
 import { filterPickerResults } from "../../../../components/lookup/utils";
@@ -167,7 +167,7 @@ describe(`filterPickerResults`, () => {
 
   pickerValue = "h1.v1";
   describe(`WHEN dot splitting is used by the query. pickerValue: '${pickerValue}'`, () => {
-    let results: NoteProps[];
+    let results: NotePropsMeta[];
 
     beforeEach(async () => {
       const inputs = [
@@ -211,7 +211,7 @@ describe(`filterPickerResults`, () => {
 
   pickerValue = "h1.v1 GG";
   describe(`WHEN dot splitting with additional tokens are used by the query. pickerValue: '${pickerValue}'`, () => {
-    let results: NoteProps[];
+    let results: NotePropsMeta[];
 
     beforeEach(async () => {
       const inputs = [

--- a/packages/plugin-core/src/test/testUtils.ts
+++ b/packages/plugin-core/src/test/testUtils.ts
@@ -1,4 +1,4 @@
-import { DNodePropsQuickInputV2 } from "@dendronhq/common-all";
+import { NoteQuickInputV2 } from "@dendronhq/common-all";
 import {
   HistoryEvent,
   HistoryEventAction,
@@ -39,7 +39,7 @@ export function createMockConfig(settings: any): vscode.WorkspaceConfiguration {
 
 type QuickPickOpts = Partial<{
   value: string;
-  selectedItems: DNodePropsQuickInputV2[];
+  selectedItems: NoteQuickInputV2[];
   canSelectMany: boolean;
   buttons: DendronBtn[];
 }>;
@@ -50,7 +50,7 @@ export function createMockQuickPick({
   canSelectMany,
   buttons,
 }: QuickPickOpts): DendronQuickPickerV2 {
-  const qp = vscode.window.createQuickPick<DNodePropsQuickInputV2>();
+  const qp = vscode.window.createQuickPick<NoteQuickInputV2>();
   if (value) {
     qp.value = value;
   }

--- a/packages/plugin-core/src/web/commands/lookup/NoteLookupProvider.ts
+++ b/packages/plugin-core/src/web/commands/lookup/NoteLookupProvider.ts
@@ -158,7 +158,7 @@ export class NoteLookupProvider implements ILookupProvider {
   }) {
     const { transformedQuery, originalQS } = opts;
 
-    const nodes = await this.engine.queryNotes({
+    const nodes = await this.engine.queryNotesMeta({
       qs: transformedQuery.queryString,
       onlyDirectChildren: transformedQuery.onlyDirectChildren,
       originalQS,

--- a/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
+++ b/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
@@ -76,7 +76,7 @@ export class VaultQuickPick {
 
     const domain = fname.split(".").slice(0, -1);
     const newQs = domain.join(".");
-    const queryResponse = await this._engine.queryNotes({
+    const queryResponse = await this._engine.queryNotesMeta({
       qs: newQs,
       originalQS: newQs,
     });

--- a/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
+++ b/packages/plugin-core/src/web/test/helpers/MockEngineAPIService.ts
@@ -22,6 +22,7 @@ import {
   FuseEngine,
   RenderNoteOpts,
   RenderNoteResp,
+  QueryNotesMetaResp,
 } from "@dendronhq/common-all";
 
 export class MockEngineAPIService implements ReducedDEngine {
@@ -123,11 +124,15 @@ export class MockEngineAPIService implements ReducedDEngine {
     throw new Error("Method not implemented.");
   }
   async queryNotes(_opts: QueryNotesOpts): Promise<QueryNotesResp> {
-    // throw new Error("Method not implemented.");
-
     const resp = await this.store.get("foo");
 
     const data = resp.data as NoteProps;
+    return Promise.resolve([data]);
+  }
+  async queryNotesMeta(_opts: QueryNotesOpts): Promise<QueryNotesMetaResp> {
+    const resp = await this.store.get("foo");
+
+    const data = resp.data as NotePropsMeta;
     return Promise.resolve([data]);
   }
   renderNote(_opts: RenderNoteOpts): Promise<RenderNoteResp> {

--- a/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
@@ -1,4 +1,8 @@
-import { DVault, NoteQuickInput, ReducedDEngine } from "@dendronhq/common-all";
+import {
+  DVault,
+  NoteQuickInputV2,
+  ReducedDEngine,
+} from "@dendronhq/common-all";
 import { stubInterface } from "ts-sinon";
 import { ILookupProvider } from "../../../commands/lookup/ILookupProvider";
 import { MoveNoteCmd } from "../../../commands/MoveNoteCmd";
@@ -34,13 +38,13 @@ suite("WHEN Move note command is run", () => {
     } as unknown as LookupController;
     const vaults = getVaults();
     const lookupReturn: LookupAcceptPayload = {
-      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInput],
+      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInputV2],
     };
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);
     sinon.replace(factory, "showLookup", showLookupFake);
     mockEngine.renameNote.resolves({ data: [] });
-    mockEngine.queryNotes.resolves([]);
+    mockEngine.queryNotesMeta.resolves([]);
     mockEngine.findNotesMeta.resolves([]);
     sinon.stub(window, "showQuickPick").resolves({ vault: vaults[1] } as any);
 
@@ -77,15 +81,15 @@ suite("WHEN Move note command is run", () => {
     const vaults = getVaults();
     const lookupReturn: LookupAcceptPayload = {
       items: [
-        { fname: "foo.one", vault: vaults[0] } as NoteQuickInput,
-        { fname: "foo.two", vault: vaults[0] } as NoteQuickInput,
+        { fname: "foo.one", vault: vaults[0] } as NoteQuickInputV2,
+        { fname: "foo.two", vault: vaults[0] } as NoteQuickInputV2,
       ],
     };
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);
     sinon.replace(factory, "showLookup", showLookupFake);
     mockEngine.renameNote.resolves({ data: [] });
-    mockEngine.queryNotes.resolves([]);
+    mockEngine.queryNotesMeta.resolves([]);
     mockEngine.findNotesMeta.resolves([]);
     sinon.stub(window, "showQuickPick").resolves({ vault: vaults[1] } as any);
 
@@ -128,7 +132,7 @@ suite("WHEN Move note command is run", () => {
     } as unknown as LookupController;
     const vaults = getVaults();
     const lookupReturn: LookupAcceptPayload = {
-      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInput],
+      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInputV2],
     };
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);
@@ -145,7 +149,7 @@ suite("WHEN Move note command is run", () => {
       wsRoot,
       noWrite: true,
     });
-    mockEngine.queryNotes.resolves([]);
+    mockEngine.queryNotesMeta.resolves([]);
     mockEngine.findNotesMeta.resolves([note1, note2]);
     const windowSpy = sinon.spy(window, "showErrorMessage");
     const moveNoteCmd = new MoveNoteCmd(

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -1,6 +1,6 @@
 import {
   DVault,
-  NoteQuickInput,
+  NoteQuickInputV2,
   type ReducedDEngine,
 } from "@dendronhq/common-all";
 import assert from "assert";
@@ -73,7 +73,7 @@ suite("GIVEN a NoteLookupCmd", () => {
       fsPath: "path",
     };
     const lookupReturn: LookupAcceptPayload = {
-      items: [{ fname: "foo", vault } as NoteQuickInput],
+      items: [{ fname: "foo", vault } as NoteQuickInputV2],
     };
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);
@@ -123,7 +123,7 @@ suite("GIVEN a NoteLookupCmd", () => {
       fsPath: "path",
     };
     const lookupReturn: LookupAcceptPayload = {
-      items: [{ fname: "foo", vault, label: "Create New" } as NoteQuickInput],
+      items: [{ fname: "foo", vault, label: "Create New" } as NoteQuickInputV2],
     };
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);

--- a/packages/unified/src/utilities/getParsingDependencyDicts.ts
+++ b/packages/unified/src/utilities/getParsingDependencyDicts.ts
@@ -172,7 +172,7 @@ async function getRecursiveNoteDependencies(
   // the all notes that match the wildcard pattern.
   await Promise.all(
     wildCards.map(async (data) => {
-      const resp = await engine.queryNotes({
+      const resp = await engine.queryNotesMeta({
         qs: data.fname,
         originalQS: data.fname,
         // vault: data.vaultName


### PR DESCRIPTION
**Background**
Lookup currently calls `queryNotes` which returns the entire NoteProps. With engineV3, this can cause some slow down b/c we're reading from disk to get the note body. Since lookup doesn't require the body, we will support `queryNotesMeta` to return `NotePropsMeta` instead

**Changes**
1. New api route for `queryNotesMeta`
2. Migrate users to use `queryNotesMeta` instead of `queryNotes`
3. Update `NoteQuickInputV2` to include `NotePropsMeta`. This is b/c many commands need to work with `NotePropsMeta` after selection is made
4. Migrate from `NoteQuickInput` to `NoteQuickInputV2`. Since lookup doesn't need the body anymore, the data type will change as well

**Testing**
Tested on `org-workspace`. Keeping the limit to 100 notes, the response should be under 100ms