### PR TITLE
chore(internal): fix regression in preview background

### DIFF
--- a/packages/plugin-core/.eslintrc.json
+++ b/packages/plugin-core/.eslintrc.json
@@ -5,16 +5,14 @@
     "ecmaVersion": 6,
     "sourceType": "module"
   },
-  "plugins": [
-    "@typescript-eslint"
-  ],
+  "plugins": ["@typescript-eslint"],
   "env": {
     "mocha": true
   },
   "rules": {
     // 1. allow anonymous functions inside of mocha tests
     "prefer-arrow-callback": 0,
-    "func-names": "off",
+    "func-names": "off"
     // 1. end
   }
 }

--- a/packages/plugin-core/src/vsCodeUtils.ts
+++ b/packages/plugin-core/src/vsCodeUtils.ts
@@ -217,6 +217,9 @@ export class VSCodeUtils {
         storagePath: tmpDir().name,
         globalStoragePath: tmpDir().name,
         asAbsolutePath: {} as any, //vscode.Uri.file(wsPath)
+        extension: {
+          id: "dummy",
+        },
       } as unknown as vscode.ExtensionContext;
     }
     return _MOCK_CONTEXT;

--- a/packages/plugin-core/src/web/views/preview/WebViewUtils.ts
+++ b/packages/plugin-core/src/web/views/preview/WebViewUtils.ts
@@ -7,7 +7,6 @@ import {
   DUtils,
   getStage,
   getWebTreeViewEntry,
-  ThemeType,
 } from "@dendronhq/common-all";
 import { inject, injectable } from "tsyringe";
 import * as vscode from "vscode";
@@ -146,14 +145,6 @@ export class WebViewUtils {
         )
         .toString();
     });
-
-    const vscodeColorTheme = vscode.window.activeColorTheme.kind;
-    const defaultInitialTheme =
-      vscodeColorTheme === vscode.ColorThemeKind.Dark ||
-      vscodeColorTheme === vscode.ColorThemeKind.HighContrast
-        ? ThemeType.DARK
-        : ThemeType.LIGHT;
-
     const out = this.genVSCodeHTMLIndex({
       jsSrc: panel.webview.asWebviewUri(jsSrc).toString(),
       cssSrc: panel.webview.asWebviewUri(cssSrc).toString(),
@@ -174,7 +165,7 @@ export class WebViewUtils {
       // and hand it out to any other functions that need to use it.
       acquireVsCodeApi: `const vscode = acquireVsCodeApi(); window.vscode = vscode;`,
       themeMap: themeMap as WebViewThemeMap,
-      initialTheme: initialTheme ?? defaultInitialTheme,
+      initialTheme,
       name,
     });
     return out;
@@ -375,7 +366,7 @@ export class WebViewUtils {
             list-style-type: disc;
           }
   
-          body {
+          body, .ant-layout {
             background-color: var(--vscode-editor-background);
           }
   


### PR DESCRIPTION
This PR aims to 
- fix a regression with preview background CSS introduced with preview code consolidation(#3777). 
Updated WebviewUtils files to be in-sync with `src/views/utils.ts`
Fix for: https://discordapp.com/channels/717965437182410783/1046957933340143626/1047067244301127730
- fix plugin test cases regression after enterprise build #3804 
- removes trailing comma from packages/plugin-core/.eslintrc.json to fix commit hook