### PR TITLE
feat(internal): web performance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: mcr.microsoft.com/playwright:v1.28.0-focal
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,11 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
+        env:
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
+          GITHUB_SHA: $GITHUB_SHA
+          GITHUB_REF: $GITHUB_REF
         run: yarn ci:test:template
 
       - name: Upload Playwright test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
         run: yarn ci:test:plugin-web
 
   test-playwright:
+    environment: plugin-development
+
     timeout-minutes: 15
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container:
+      image: mcr.microsoft.com/playwright:v1.28.0-focal
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,4 +213,3 @@ jobs:
         with:
           name: playwright-report
           path: ./packages/nextjs-template/playwright-report/
-          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,12 @@ jobs:
           AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
           GITHUB_SHA: $GITHUB_SHA
           GITHUB_REF: $GITHUB_REF
-        run: yarn ci:test:template
+        run: yarn ci:test:template --reporter=html
 
       - name: Upload Playwright test results
         uses: actions/upload-artifact@v3
+        if: always()
         with:
-          name: test-artifact
-          path: ./packages/nextjs-template/test-results/
+          name: playwright-report
+          path: ./packages/nextjs-template/playwright-report/
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ci:test:plugin-web": "npx lerna run compile-web --scope @dendronhq/plugin-core && npx lerna run test-in-browser --scope @dendronhq/plugin-core",
     "ci:test:plugin-perf": "npx lerna run perf-test --scope @dendronhq/plugin-core",
     "ci:test:template": "yarn --cwd packages/nextjs-template run test",
-    "ci:test:template:docker": "docker run -it --rm --ipc=host -v \"$(pwd):/test\" -u \"$(id -u ${USER}):$(id -g ${USER})\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /test; npx playwright install; yarn ci:test:template $([ \"$0\" = \"/bin/bash\" ] || ([ \"$#\" = 0 ] && echo \"$0\" || echo \"$0 $@\"))'",
+    "ci:test:template:docker": "docker run -it --rm --ipc=host -v \"$(pwd):/test\" -u \"$(id -u ${USER}):$(id -g ${USER})\" mcr.microsoft.com/playwright:v1.26.0-focal /bin/bash -c 'cd /test; npx playwright install; yarn ci:test:template $([ \"$0\" = \"/bin/bash\" ] || ([ \"$#\" = 0 ] && echo \"$0\" || echo \"$0 $@\"))'",
     "template:build": "yarn --cwd packages/nextjs-template run build",
     "template:export": "yarn --cwd packages/nextjs-template run export",
     "template:start": "yarn --cwd packages/nextjs-template run start",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ci:test:plugin-web": "npx lerna run compile-web --scope @dendronhq/plugin-core && npx lerna run test-in-browser --scope @dendronhq/plugin-core",
     "ci:test:plugin-perf": "npx lerna run perf-test --scope @dendronhq/plugin-core",
     "ci:test:template": "yarn --cwd packages/nextjs-template run test",
-    "ci:test:template:docker": "docker run -it --rm --ipc=host -v \"$(pwd):/test\" -u \"$(id -u ${USER}):$(id -g ${USER})\" mcr.microsoft.com/playwright:v1.26.0-focal /bin/bash -c 'cd /test; npx playwright install; yarn ci:test:template $([ \"$0\" = \"/bin/bash\" ] || ([ \"$#\" = 0 ] && echo \"$0\" || echo \"$0 $@\"))'",
+    "ci:test:template:docker": "docker run -it --rm --ipc=host -v \"$(pwd):/test\" -u \"$(id -u ${USER}):$(id -g ${USER})\" mcr.microsoft.com/playwright:v1.28.0-focal /bin/bash -c 'cd /test; npx playwright install; yarn ci:test:template $([ \"$0\" = \"/bin/bash\" ] || ([ \"$#\" = 0 ] && echo \"$0\" || echo \"$0 $@\"))'",
     "template:build": "yarn --cwd packages/nextjs-template run build",
     "template:export": "yarn --cwd packages/nextjs-template run export",
     "template:start": "yarn --cwd packages/nextjs-template run start",

--- a/packages/common-server/src/errorReporting.ts
+++ b/packages/common-server/src/errorReporting.ts
@@ -1,7 +1,7 @@
 import { DendronError, Stage } from "@dendronhq/common-all";
 import { RewriteFrames } from "@sentry/integrations";
 import * as Sentry from "@sentry/node";
-import { CaptureContext } from "@sentry/types";
+import { NodeOptions } from "@sentry/node/types";
 import _ from "lodash";
 
 // Extracted to make testing easy
@@ -58,7 +58,7 @@ export function initializeSentry({
   const dsn =
     "https://bc206b31a30a4595a2efb31e8cc0c04e@o949501.ingest.sentry.io/5898219";
 
-  const initialScope: CaptureContext = {};
+  const initialScope: NodeOptions["initialScope"] = {};
   if (sessionId) {
     initialScope.tags = { sessionId };
   }

--- a/packages/common-server/src/files.ts
+++ b/packages/common-server/src/files.ts
@@ -1,4 +1,4 @@
-import fs, { Dirent } from "fs-extra";
+import fs, { Dirent, Mode } from "fs-extra";
 import matter from "gray-matter";
 import YAML from "js-yaml";
 import _ from "lodash";
@@ -225,6 +225,29 @@ const readFileSync = fromThrowable(fs.readFileSync, (error) => {
 
 export function readString(path: string) {
   return readFileSync(path, "utf8") as Result<string, DendronError>;
+}
+
+export function mkDir(
+  path: fs.PathLike,
+  options: Mode | fs.MakeDirectoryOptions | null
+) {
+  return fromPromise(fs.mkdir(path, options), (error: unknown) => {
+    return new DendronError({
+      message: `Unable to create ${path}`,
+      severity: ERROR_SEVERITY.FATAL,
+      ...(error instanceof Error && { innerError: error }),
+    });
+  });
+}
+
+export function writeFile(file: fs.PathLike, data: any) {
+  return fromPromise(fs.writeFile(file, data), (error: unknown) => {
+    return new DendronError({
+      message: `Unable to write ${path}`,
+      severity: ERROR_SEVERITY.FATAL,
+      ...(error instanceof Error && { innerError: error }),
+    });
+  });
 }
 
 export function readJson(path: string) {

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -62,6 +62,7 @@
     "fs-extra": "^9.0.1",
     "jest": "^28.1.0",
     "jest-mock-extended": "^2.0.7",
+    "lighthouse": "^9.6.8",
     "lodash": "^4.17.20",
     "prompts": "^2.4.2",
     "react": "^17.0.2",

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -57,6 +57,9 @@
     "@dendronhq/pods-core": "^0.119.0",
     "@dendronhq/unified": "^0.119.0",
     "@reduxjs/toolkit": "^1.6.0",
+    "@size-limit/file": "^8.1.0",
+    "@size-limit/time": "^8.1.0",
+    "@size-limit/webpack": "^8.1.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",
     "fs-extra": "^9.0.1",
@@ -68,6 +71,7 @@
     "react": "^17.0.2",
     "react-redux": "^7.2.4",
     "react-test-renderer": "^17.0.2",
-    "sinon": "^9.2.1"
+    "sinon": "^9.2.1",
+    "size-limit": "^8.1.0"
   }
 }

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -212,22 +212,30 @@ function computeSizes(filePathsMap: FilePathsMap) {
     ).map(([result]) => {
       return {
         [name]: {
-          size: {
-            value: result.size,
-            unit: "byte",
-          },
-          time: {
-            value: result.time,
-            unit: "millisecond",
-          },
-          runTime: {
-            value: result.runTime,
-            unit: "millisecond",
-          },
-          loadTime: {
-            value: result.loadTime,
-            unit: "millisecond",
-          },
+          ...("size" in result && {
+            size: {
+              value: result.size,
+              unit: "byte",
+            },
+          }),
+          ...("time" in result && {
+            time: {
+              value: result.time,
+              unit: "second",
+            },
+          }),
+          ...("runTime" in result && {
+            runTime: {
+              value: result.runTime,
+              unit: "second",
+            },
+          }),
+          ...("loadTime" in result && {
+            loadTime: {
+              value: result.loadTime,
+              unit: "second",
+            },
+          }),
         },
       } as Audit["size"];
     });

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -1,0 +1,150 @@
+import fs from "fs-extra";
+// @ts-ignore
+import lighthouse from "lighthouse";
+// @ts-ignore
+import { computeMedianRun } from "lighthouse/lighthouse-core/lib/median-run";
+// @ts-ignore
+import lighthouseDesktopConfig from "lighthouse/lighthouse-core/config/lr-desktop-config";
+// @ts-ignore
+import lighthouseMobileConfig from "lighthouse/lighthouse-core/config/lr-mobile-config";
+// @ts-ignore
+import ReportGenerator from "lighthouse/report/generator/report-generator";
+import type { RunnerResult, Flags } from "lighthouse/types/externs";
+
+const metricFilter = [
+  // core web vitals
+  "cumulative-layout-shift",
+  "largest-contentful-paint",
+  "total-blocking-time", // proxy for First Input Delay (FID)
+  // others
+  "first-contentful-paint",
+  "speed-index",
+  "interactive",
+  "server-response-time",
+];
+
+const validTypes = ["csv", "html", "json"] as const;
+
+const defaultReports: Reports = {
+  formats: {
+    csv: false,
+    html: false,
+    json: false,
+  },
+  name: `lighthouse-${new Date().toISOString().replace(/:/g, "_")}`,
+  directory: `${process.cwd()}/lighthouse`,
+};
+
+type ValidTypes = typeof validTypes[number];
+
+type Reports = {
+  formats: {
+    [key in ValidTypes]?: boolean;
+  };
+  name: string;
+  directory: string;
+};
+
+type LighthouseResult = RunnerResult["lhr"];
+// type AuditResult = LighthouseResult['audits']['x']
+type AuditConfig = {
+  port: number;
+  url: string;
+  runs?: number;
+  options?: Flags;
+  config?: Record<string, any>;
+  reports?: Partial<Reports>;
+  formFactor: "desktop" | "mobile";
+  disableLogs?: boolean;
+};
+
+type AuditReport = {
+  vital: {
+    lhr: LighthouseResult;
+    medianOf: number;
+  };
+};
+
+async function getReport(
+  lhr: LighthouseResult,
+  dir: string,
+  name: string,
+  type: ValidTypes
+) {
+  name = name.substring(0, name.lastIndexOf(".")) || name;
+
+  if (validTypes.includes(type)) {
+    const reportBody = ReportGenerator.generateReport(lhr, type);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(`${dir}/${name}.${type}`, reportBody);
+  } else {
+    console.log(`Invalid report type specified: ${type} Skipping Reports...)`);
+  }
+}
+
+async function playAudit(auditConfig: AuditConfig): Promise<AuditReport> {
+  const log = auditConfig.disableLogs ? () => {} : console.log; // eslint-disable-line no-console
+
+  const url = auditConfig.url;
+  const port = auditConfig.port;
+  const runs = auditConfig.runs ?? 5;
+  const reports = { ...defaultReports, ...auditConfig.reports };
+  const results: Array<LighthouseResult> = [];
+
+  for (let index = 0; index < runs; index += 1) {
+    /* eslint-disable no-await-in-loop -- should run in serie */
+    const result = await lighthouse(
+      url,
+      {
+        port,
+        ...auditConfig.options,
+      },
+      {
+        ...(auditConfig.formFactor === "desktop"
+          ? lighthouseDesktopConfig
+          : lighthouseMobileConfig),
+        ...auditConfig.config,
+      }
+    );
+    results.push(result.lhr);
+  }
+
+  const median = computeMedianRun(results) as LighthouseResult;
+
+  Object.entries(reports.formats ?? {}).forEach(async ([key, value]) => {
+    if (value) {
+      await getReport(
+        median,
+        reports.directory,
+        reports.name,
+        key as ValidTypes
+      );
+    }
+  });
+
+  const result = {
+    vital: {
+      lhr: median,
+      medianOf: runs,
+    },
+  };
+
+  const audits = result.vital.lhr.audits;
+
+  const data = Object.entries(audits)
+    .filter(([key]) => metricFilter.includes(key))
+    .map(([_, value]) => {
+      return {
+        metric: value.title,
+        value: `${Math.round(value.numericValue as number)} ${
+          value.numericUnit
+        }`,
+      };
+    });
+
+  log(data);
+
+  return result;
+}
+
+export { playAudit };

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -81,7 +81,7 @@ type AuditConfig = {
   reports?: Partial<Reports>;
   formFactor: "desktop" | "mobile";
   disableLogs?: boolean;
-  filePath: string | FilePathsMap;
+  filePath?: string | FilePathsMap;
 };
 
 type Audit = {

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -94,14 +94,14 @@ type Audit = {
   githubRef: string | undefined;
   os: string;
   pkgPath: string;
-  vital: {
+  vitals: {
     [key in VitalsMetrics]?: {
       value: number | string;
       unit: string | undefined;
       description: string | undefined;
     };
   };
-  size: {
+  sizes: {
     [name: string]: {
       [key in SizeMetrics | TimeMetrics]?: {
         value: number | string;
@@ -335,10 +335,10 @@ export async function playAudit(auditConfig: AuditConfig) {
       return generateReports(medianLhr, reports).map(() => medianLhr);
     })
     .andThen((medianLhr) => {
-      return computeSizes(filePathsMap).map((size) => ({ size, medianLhr }));
+      return computeSizes(filePathsMap).map((sizes) => ({ sizes, medianLhr }));
     })
-    .map(({ size, medianLhr }) => {
-      const vital = Object.fromEntries(
+    .map(({ sizes, medianLhr }) => {
+      const vitals = Object.fromEntries(
         Object.entries(medianLhr.audits)
           .filter(([key]) => vitalsMetrics.includes(key as VitalsMetrics))
           .map(([key, value]) => {
@@ -359,8 +359,8 @@ export async function playAudit(auditConfig: AuditConfig) {
         githubRef: process.env.GITHUB_REF,
         os: os.platform(),
         pkgPath,
-        vital,
-        size,
+        vitals,
+        sizes,
       };
 
       if (process.env.AIRTABLE_API_KEY) {
@@ -368,13 +368,13 @@ export async function playAudit(auditConfig: AuditConfig) {
           Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`,
           "Content-Type": "application/json",
         };
-        const { vital, size, ...rest } = audit;
+        const { vitals, sizes, ...rest } = audit;
         const report = {
           records: [
             {
               fields: {
-                vital: JSON.stringify(vital, null, 2),
-                size: JSON.stringify(size, null, 2),
+                vitals: JSON.stringify(vitals, null, 2),
+                sizes: JSON.stringify(sizes, null, 2),
                 ...rest,
               },
             },

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -1,4 +1,5 @@
 import os from "os";
+import _ from "lodash";
 import {
   axios,
   Time,
@@ -10,7 +11,7 @@ import {
   okAsync,
   AxiosError,
 } from "@dendronhq/common-all";
-import { mkDir, writeFile } from "@dendronhq/common-server";
+import { mkDir, writeFile, GitUtils } from "@dendronhq/common-server";
 // @ts-ignore
 import sizeLimit from "size-limit";
 // @ts-ignore
@@ -88,6 +89,7 @@ type Audit = {
   commitHash: string | undefined;
   githubRef: string | undefined;
   os: string;
+  pkgPath: string;
   vital: {
     [key in VitalsMetrics]?: {
       value: number | string;
@@ -258,6 +260,7 @@ async function playAudit(auditConfig: AuditConfig) {
   const port = auditConfig.port;
   const runs = auditConfig.runs ?? 5;
   const reports = { ...defaultReports, ...auditConfig.reports };
+  const gitRootPath = await GitUtils.getGitRoot("");
   const filePathsMap =
     typeof auditConfig.filePath === "string"
       ? { [auditConfig.filePath]: [auditConfig.filePath] }
@@ -297,6 +300,7 @@ async function playAudit(auditConfig: AuditConfig) {
         commitHash: process.env.GITHUB_SHA,
         githubRef: process.env.GITHUB_REF,
         os: os.platform(),
+        pkgPath: process.cwd().replace(gitRootPath ?? "", ""),
         vital,
         size,
       };

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -56,7 +56,7 @@ const defaultReports: Reports = {
     html: false,
     json: true,
   },
-  name: `lighthouse-${new Date().toISOString().replace(/:/g, "_")}`,
+  name: new Date().toISOString().replace(/:/g, "_"),
   directory: `${process.cwd()}/.audit`,
 };
 

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -95,6 +95,7 @@ type Audit = {
     [key in VitalsMetrics]?: {
       value: number | string;
       unit: string | undefined;
+      description: string | undefined;
     };
   };
   size: {
@@ -102,6 +103,7 @@ type Audit = {
       [key in SizeMetrics]?: {
         value: number | string;
         unit: string | undefined;
+        description: string | undefined;
       };
     };
   };
@@ -216,24 +218,29 @@ function computeSizes(filePathsMap: FilePathsMap) {
             size: {
               value: result.size,
               unit: "byte",
+              description: "Gzipped",
             },
           }),
           ...("time" in result && {
             time: {
               value: result.time,
               unit: "second",
+              description: "run time + load time",
             },
           }),
           ...("runTime" in result && {
             runTime: {
               value: result.runTime,
               unit: "second",
+              description:
+                "Time which was spent for both event groups (scriptParseCompile and scriptEvaluation). See https://github.com/mbalabash/estimo#fields-description",
             },
           }),
           ...("loadTime" in result && {
             loadTime: {
               value: result.loadTime,
               unit: "second",
+              description: "Load time based on a slow 3g network",
             },
           }),
         },
@@ -327,6 +334,7 @@ async function playAudit(auditConfig: AuditConfig) {
               {
                 value: value.numericValue,
                 unit: value.numericUnit,
+                description: value.description,
               },
             ] as const;
           })

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -286,6 +286,7 @@ async function playAudit(auditConfig: AuditConfig) {
   const runs = auditConfig.runs ?? 5;
   const reports = { ...defaultReports, ...auditConfig.reports };
   const gitRootPath = await GitUtils.getGitRoot("");
+  const pkgPath = process.cwd().replace(gitRootPath ?? "", "");
   const filePathsMap = {
     ...(await getNextJsFilePaths().unwrapOr({})),
     ...(typeof auditConfig.filePath === "string"
@@ -323,12 +324,12 @@ async function playAudit(auditConfig: AuditConfig) {
           })
       );
       const audit: Audit = {
-        name: reports.name,
+        name: new Date().toISOString().replace(/:/g, "_"),
         date: Time.now().toLocaleString(),
         commitHash: process.env.GITHUB_SHA,
         githubRef: process.env.GITHUB_REF,
         os: os.platform(),
-        pkgPath: process.cwd().replace(gitRootPath ?? "", ""),
+        pkgPath,
         vital,
         size,
       };

--- a/packages/engine-test-utils/src/audit.ts
+++ b/packages/engine-test-utils/src/audit.ts
@@ -341,9 +341,7 @@ async function playAudit(auditConfig: AuditConfig) {
         vital,
         size,
       };
-      return audit;
-    })
-    .andThen((audit) => {
+
       if (process.env.AIRTABLE_API_KEY) {
         const headers = {
           Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`,
@@ -384,11 +382,8 @@ async function playAudit(auditConfig: AuditConfig) {
           return audit;
         });
       }
-      return okAsync(audit);
-    })
-    .map((audit) => {
       log(JSON.stringify(audit, null, 2));
-      return audit;
+      return okAsync(audit);
     });
 
   if (result.isErr()) {

--- a/packages/engine-test-utils/src/index.ts
+++ b/packages/engine-test-utils/src/index.ts
@@ -17,6 +17,7 @@ export {
   TestSeedUtils,
 } from "./utils";
 export * from "./presets";
+export * from "./audit";
 export {
   ENGINE_HOOKS,
   ENGINE_HOOKS_MULTI,

--- a/packages/nextjs-template/.gitignore
+++ b/packages/nextjs-template/.gitignore
@@ -49,6 +49,7 @@ custom/*
 !custom/NoOp.tsx
 builds
 test-results/
+playwright-report/
 
 # migrated from packages/dendron-cli/src/utils/build.ts
 public/robots.txt

--- a/packages/nextjs-template/audit/audit.spec.ts
+++ b/packages/nextjs-template/audit/audit.spec.ts
@@ -16,7 +16,7 @@ test.describe("GIVEN AUDIT, WHEN shared chrome instance, ", () => {
       url,
       port: 9222,
       options: {},
-      reports: { formats: { json: true }, directory: ".dendron.lighthouse" },
+      reports: { directory: ".dendron-audit" },
       formFactor: "desktop",
     });
     await context.close();

--- a/packages/nextjs-template/audit/audit.spec.ts
+++ b/packages/nextjs-template/audit/audit.spec.ts
@@ -16,7 +16,7 @@ test.describe("GIVEN AUDIT, WHEN shared chrome instance, ", () => {
       url,
       port: 9222,
       options: {},
-      reports: { directory: ".dendron-audit" },
+      reports: { directory: ".dendron.audit" },
       formFactor: "desktop",
     });
     await context.close();

--- a/packages/nextjs-template/audit/audit.spec.ts
+++ b/packages/nextjs-template/audit/audit.spec.ts
@@ -1,0 +1,24 @@
+import os from "os";
+import path from "path";
+import { chromium } from "playwright";
+import { playAudit } from "@dendronhq/engine-test-utils";
+import test from "../e2e/next-fixture";
+
+test.setTimeout(0);
+test.describe("GIVEN AUDIT, WHEN shared chrome instance, ", () => {
+  test("THEN run audit on desktop", async ({ url }) => {
+    const userDataDir = path.join(os.tmpdir(), "pw", String(Math.random()));
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      args: ["--remote-debugging-port=9222"],
+    });
+
+    await playAudit({
+      url,
+      port: 9222,
+      options: {},
+      reports: { formats: { json: true }, directory: ".dendron.lighthouse" },
+      formFactor: "desktop",
+    });
+    await context.close();
+  });
+});

--- a/packages/nextjs-template/playwright.config.ts
+++ b/packages/nextjs-template/playwright.config.ts
@@ -27,6 +27,10 @@ const config: PlaywrightTestConfig = {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
     },
+    {
+      name: "audit",
+      testDir: "./audit",
+    },
   ],
 };
 export default config;

--- a/packages/nextjs-template/playwright.config.ts
+++ b/packages/nextjs-template/playwright.config.ts
@@ -27,10 +27,10 @@ const config: PlaywrightTestConfig = {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
     },
-    // {
-    //   name: "audit",
-    //   testDir: "./audit",
-    // },
+    {
+      name: "audit",
+      testDir: "./audit",
+    },
   ],
 };
 export default config;

--- a/packages/nextjs-template/playwright.config.ts
+++ b/packages/nextjs-template/playwright.config.ts
@@ -27,10 +27,10 @@ const config: PlaywrightTestConfig = {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
     },
-    {
-      name: "audit",
-      testDir: "./audit",
-    },
+    // {
+    //   name: "audit",
+    //   testDir: "./audit",
+    // },
   ],
 };
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,6 +3592,17 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
+"@sentry/core@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz#156aaa56dd7fad8c89c145be6ad7a4f7209f9785"
+  integrity sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/minimal" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
 "@sentry/core@7.11.1":
   version "7.11.1"
   resolved "https://registry.npmjs.org/@sentry/core/-/core-7.11.1.tgz#d68e796f3b6428aefd6086a1db00118df7a9a9e4"
@@ -3600,6 +3611,15 @@
     "@sentry/hub" "7.11.1"
     "@sentry/types" "7.11.1"
     "@sentry/utils" "7.11.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
+  integrity sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
 "@sentry/hub@7.11.1":
@@ -3621,6 +3641,15 @@
     localforage "^1.8.1"
     tslib "^1.9.3"
 
+"@sentry/minimal@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
+  integrity sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
 "@sentry/node@7.11.1":
   version "7.11.1"
   resolved "https://registry.npmjs.org/@sentry/node/-/node-7.11.1.tgz#97fd26de26e8203a3c34e26b38f3c2a5ba46828b"
@@ -3635,10 +3664,37 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/node@^6.17.4":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz#32963b36b48daebbd559e6f13b1deb2415448592"
+  integrity sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==
+  dependencies:
+    "@sentry/core" "6.19.7"
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
+  integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
+
 "@sentry/types@7.11.1":
   version "7.11.1"
   resolved "https://registry.npmjs.org/@sentry/types/-/types-7.11.1.tgz#06e2827f6ba37159c33644208a0453b86d25e232"
   integrity sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ==
+
+"@sentry/utils@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz#6edd739f8185fd71afe49cbe351c1bbf5e7b7c79"
+  integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
+  dependencies:
+    "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
 
 "@sentry/utils@7.11.1":
   version "7.11.1"
@@ -4742,6 +4798,13 @@
   integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/yauzl@^2.9.1":
+  version "2.10.0"
+  resolved "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
+  dependencies:
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.39.0":
   version "5.39.0"
@@ -6401,7 +6464,7 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.3.5:
+axe-core@4.4.1, axe-core@^4.3.5:
   version "4.4.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
@@ -7742,6 +7805,16 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chrome-launcher@^0.15.0:
+  version "0.15.1"
+  resolved "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz#0a0208037063641e2b3613b7e42b0fcb3fa2d399"
+  integrity sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==
+  dependencies:
+    "@types/node" "*"
+    escape-string-regexp "^4.0.0"
+    is-wsl "^2.2.0"
+    lighthouse-logger "^1.0.0"
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -8735,6 +8808,13 @@ cross-env@^7.0.2, cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-path-sort@1.0.0, cross-path-sort@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/cross-path-sort/-/cross-path-sort-1.0.0.tgz#9c07df9fe5ebdc49d980d99ffcf845f7717865b8"
@@ -8805,6 +8885,11 @@ crypto-randomuuid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/crypto-randomuuid/-/crypto-randomuuid-1.0.0.tgz#acf583e5e085e867ae23e107ff70279024f9e9e7"
   integrity sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==
+
+csp_evaluator@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz#12b7bb0c6ae9053d30c86e8ddc52a1e920e6c0f7"
+  integrity sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw==
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -9046,15 +9131,22 @@ csso@^4.0.0, csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
+cssom@0.3.x, cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
 cssom@^0.4.1, cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
-cssom@~0.3.6:
-  version "0.3.8"
-  resolved "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
-  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+cssstyle@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz#3aceb2759eaf514ac1a21628d723d6043a819495"
+  integrity sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==
+  dependencies:
+    cssom "0.3.x"
 
 cssstyle@^2.0.0, cssstyle@^2.3.0:
   version "2.3.0"
@@ -9768,19 +9860,19 @@ debug@4, debug@4.3.3, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, de
   dependencies:
     ms "2.1.2"
 
+debug@4.3.4, debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.2, debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -10225,6 +10317,11 @@ detective@^5.2.0:
     acorn-node "^1.8.2"
     defined "^1.0.0"
     minimist "^1.2.6"
+
+devtools-protocol@0.0.981744:
+  version "0.0.981744"
+  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
+  integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -10700,7 +10797,7 @@ enhanced-resolve@^5.8.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@^2.3.5:
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -11728,6 +11825,17 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-zip@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -13788,6 +13896,11 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-link-header@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz#a22b41a0c9b1e2d8fac1bf1b697c6bd532d5f5e4"
+  integrity sha512-qsh/wKe1Mk1vtYEFr+LpQBFWTO1gxZQBdii2D0Umj+IUQ23r5sT088Rhpq4XzpSyIpaX7vwjB8Rrtx8u9JTg+Q==
+
 http-parser-js@>=0.5.1:
   version "0.5.5"
   resolved "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.5.tgz#d7c30d5d3c90d865b4a2e870181f9d6f22ac7ac5"
@@ -13873,6 +13986,14 @@ https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@5.0.1, https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^2.2.3:
   version "2.2.4"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
@@ -13880,14 +14001,6 @@ https-proxy-agent@^2.2.3:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
-
-https-proxy-agent@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -14001,6 +14114,11 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
+
+image-ssim@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz#83b42c7a2e6e4b85505477fe6917f5dbc56420e5"
+  integrity sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -14235,6 +14353,18 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+intl-messageformat-parser@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz#0eb14c5618333be4c95c409457b66c8c33ddcc01"
+  integrity sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==
+
+intl-messageformat@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-4.4.0.tgz#aa196a4d04b573f4090bc417f982d81de4f74fad"
+  integrity sha512-z+Bj2rS3LZSYU4+sNitdHrwnBhr0wO80ZJSW8EzKDBowwUe3Q/UsvgCGjrwa+HPzoGCLEb9HAjfJgo4j2Sac8w==
+  dependencies:
+    intl-messageformat-parser "^1.8.1"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -15843,10 +15973,20 @@ joycon@^2.2.5:
   resolved "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
   integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
 
+jpeg-js@^0.4.1, jpeg-js@^0.4.3:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
+
 js-base64@^2.4.3:
   version "2.6.4"
   resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+
+js-library-detector@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.5.0.tgz#96de02e9926a185c2d7a9a6967286d2ba20b5f79"
+  integrity sha512-Kq7VckJ5kb26kHMAu1sDO8t2qr7M5Uw6Gf7fVGtu1YceoHdqTcobwnB5kStcktusPuPmiCE8PbCaiLzhiBsSAw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -16517,6 +16657,52 @@ liftoff@^3.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
+lighthouse-logger@^1.0.0, lighthouse-logger@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.3.0.tgz#ba6303e739307c4eee18f08249524e7dafd510db"
+  integrity sha512-BbqAKApLb9ywUli+0a+PcV04SyJ/N1q/8qgCNe6U97KbPCS1BTksEuHFLYdvc8DltuhfxIUBqDZsC0bBGtl3lA==
+  dependencies:
+    debug "^2.6.9"
+    marky "^1.2.2"
+
+lighthouse-stack-packs@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.8.2.tgz#55111bebe50ed516de3fad0a474795a2556ac36e"
+  integrity sha512-vlCUxxQAB8Nu6LQHqPpDRiMi06Du593/my/6JbMttQeEfJ7pf4OS8obSTh5xSOS80U/O7fq59Q8rQGAUxQatUQ==
+
+lighthouse@^9.6.8:
+  version "9.6.8"
+  resolved "https://registry.npmjs.org/lighthouse/-/lighthouse-9.6.8.tgz#7ec52f37070b557f8dc57cf4f0c68536fdf5205b"
+  integrity sha512-5aRSvnqazci8D2oE7GJM6C7IStvUuMVV+74cGyBuS4n4NCixsDd6+uJdX834XiInSfo+OuVbAJCX4Xu6d2+N9Q==
+  dependencies:
+    "@sentry/node" "^6.17.4"
+    axe-core "4.4.1"
+    chrome-launcher "^0.15.0"
+    configstore "^5.0.1"
+    csp_evaluator "1.1.1"
+    cssstyle "1.2.1"
+    enquirer "^2.3.6"
+    http-link-header "^0.8.0"
+    intl-messageformat "^4.4.0"
+    jpeg-js "^0.4.3"
+    js-library-detector "^6.5.0"
+    lighthouse-logger "^1.3.0"
+    lighthouse-stack-packs "1.8.2"
+    lodash "^4.17.21"
+    lookup-closest-locale "6.2.0"
+    metaviewport-parser "0.2.0"
+    open "^8.4.0"
+    parse-cache-control "1.0.1"
+    ps-list "^8.0.0"
+    puppeteer-core "^13.7.0"
+    robots-parser "^3.0.0"
+    semver "^5.3.0"
+    speedline-core "^1.4.3"
+    third-party-web "^0.17.1"
+    ws "^7.0.0"
+    yargs "^17.3.1"
+    yargs-parser "^21.0.0"
+
 lilconfig@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
@@ -16928,6 +17114,11 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==
 
+lookup-closest-locale@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz#57f665e604fd26f77142d48152015402b607bcf3"
+  integrity sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -17227,6 +17418,11 @@ marked@^4.0.19:
   version "4.1.0"
   resolved "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz#3fc6e7485f21c1ca5d6ec4a39de820e146954796"
   integrity sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==
+
+marky@^1.2.2:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz#55796b688cbd72390d2d399eaaf1832c9413e3c0"
+  integrity sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==
 
 matchdep@^2.0.0:
   version "2.0.0"
@@ -17572,6 +17768,11 @@ mermaid@^9.1.2:
     khroma "^2.0.0"
     moment-mini "^2.24.0"
     stylis "^4.0.10"
+
+metaviewport-parser@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz#535c3ce1ccf6223a5025fddc6a1c36505f7e7db1"
+  integrity sha512-qL5NtY18LGs7lvZCkj3ep2H4Pes9rIiSLZRUyfDdvVw7pWFA0eLwmqaIxApD74RGvUrNEtk9e5Wt1rT+VlCvGw==
 
 methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
@@ -19022,7 +19223,7 @@ open-graph-scraper@4.7.1:
     iconv-lite "^0.6.2"
     validator "^13.5.2"
 
-open@*:
+open@*, open@^8.4.0:
   version "8.4.0"
   resolved "https://registry.npmjs.org/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
   integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
@@ -19361,6 +19562,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-cache-control@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  integrity sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -19749,19 +19955,19 @@ pirates@^4.0.1, pirates@^4.0.4:
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
 
+pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pkg-dir@^5.0.0:
   version "5.0.0"
@@ -20719,7 +20925,7 @@ process@0.11.10, process@^0.11.10, process@~0.11.0:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
-progress@^2.0.0, progress@^2.0.3:
+progress@2.0.3, progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -20828,7 +21034,7 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.1.0:
+proxy-from-env@1.1.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -20837,6 +21043,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+ps-list@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/ps-list/-/ps-list-8.1.0.tgz#aded36339500cd929f1425ece9bf58ac6d3a213e"
+  integrity sha512-NoGBqJe7Ou3kfQxEvDzDyKGAyEgwIuD3YrfXinjcCmBRv0hTld0Xb71hrXvtsNPj7HSFATfemvzB8PPJtq6Yag==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -20911,6 +21122,24 @@ pupa@^2.1.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
+
+puppeteer-core@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.7.0.tgz#3344bee3994163f49120a55ddcd144a40575ba5b"
+  integrity sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==
+  dependencies:
+    cross-fetch "3.1.5"
+    debug "4.3.4"
+    devtools-protocol "0.0.981744"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.1"
+    pkg-dir "4.2.0"
+    progress "2.0.3"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.1.1"
+    unbzip2-stream "1.4.3"
+    ws "8.5.0"
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
@@ -22790,7 +23019,7 @@ rimraf@2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -22811,6 +23040,11 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+robots-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.0.tgz#66af89306302ecd004455f2f24298310d0966631"
+  integrity sha512-6xkze3WRdneibICBAzMKcXyTKQw5shA3GbwoEJy7RSvxpZNGF0GMuYKE1T0VMP4fwx/fQs0n0mtriOqRtk5L1w==
 
 robust-predicates@^3.0.0:
   version "3.0.1"
@@ -23682,6 +23916,15 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+speedline-core@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz#4d6e7276e2063c2d36a375cb25a523ac73475319"
+  integrity sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==
+  dependencies:
+    "@types/node" "*"
+    image-ssim "^0.2.0"
+    jpeg-js "^0.4.1"
+
 split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
@@ -24417,7 +24660,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-fs@^2.0.0:
+tar-fs@2.1.1, tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
@@ -24611,6 +24854,11 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+third-party-web@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.npmjs.org/third-party-web/-/third-party-web-0.17.1.tgz#22e03f1ff519a6380bae4594b704b9bb28e15158"
+  integrity sha512-X9Mha8cVeBwakunlZXkXL6xRzw8VCcDGWqT59EzeTYAJIi8ien3CuufnEGEx4ZUFahumNQdoOwf4H2T9Ca6lBg==
 
 throat@^5.0.0:
   version "5.0.0"
@@ -25316,7 +25564,7 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-unbzip2-stream@^1.0.9:
+unbzip2-stream@1.4.3, unbzip2-stream@^1.0.9:
   version "1.4.3"
   resolved "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
   integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
@@ -26968,6 +27216,11 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+
 ws@^6.2.1:
   version "6.2.2"
   resolved "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
@@ -27239,7 +27492,7 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yauzl@^2.3.1, yauzl@^2.4.2:
+yauzl@^2.10.0, yauzl@^2.3.1, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3761,6 +3761,37 @@
   resolved "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@sitespeed.io/tracium@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz#b497a4a8d5837db1fd9e3053c99b78f6c0e1f53b"
+  integrity sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==
+  dependencies:
+    debug "^4.1.1"
+
+"@size-limit/file@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/@size-limit/file/-/file-8.1.0.tgz#c1624b3c891e4c5f08285b359e85253e1c96bc66"
+  integrity sha512-Ur+NgJSRHBnbQBrD8X2doxXYdBcVJsMxe2KfWrUmnZ6wYz09YKhQ1iYLqNztjf2yf/JEp00zp1vyhmimUQfUHQ==
+  dependencies:
+    semver "7.3.7"
+
+"@size-limit/time@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/@size-limit/time/-/time-8.1.0.tgz#3703363dd8b042da1bd99182ccfb95932bd737e3"
+  integrity sha512-rOfIqpq8RSjKUnByJcWr2qw8XBTo3DAL16lmzjILvzQBkKi1kgDHU4QVa9K/BehYqH+Lx3rA3pVFMrQ5aJsOkg==
+  dependencies:
+    estimo "^2.3.6"
+    react "^17.0.2"
+
+"@size-limit/webpack@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/@size-limit/webpack/-/webpack-8.1.0.tgz#91e98914a7c019cdf863fe6182af8b897fa1990f"
+  integrity sha512-TLego57hQbR0dmYZzIa9KZecebGMJoxZaqJTx9v3NDllxt6kJTljVXWghEvsGLpdKQfZTqraZ6nRm38+lG3sNw==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.3.4"
+    webpack "^5.74.0"
+
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.2"
   resolved "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz#e6786b6af5799f82f7ab3a82e53f6182d2b91a58"
@@ -7305,6 +7336,11 @@ byte-size@^5.0.1:
   resolved "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz#4b651039a5ecd96767e71a3d7ed380e48bed4191"
   integrity sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==
 
+bytes-iec@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz#94cd36bf95c2c22a82002c247df8772d1d591083"
+  integrity sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -7745,7 +7781,7 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.2:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -7829,6 +7865,11 @@ ci-info@^3.2.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz#58331f6f472a25fe3a50a351ae3052936c2c7f32"
   integrity sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==
+
+ci-job-number@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/ci-job-number/-/ci-job-number-1.2.2.tgz#f4e5918fcaeeda95b604f214be7d7d4a961fe0c0"
+  integrity sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -8194,6 +8235,11 @@ commander@^8.0.0, commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@^9.1.0:
+  version "9.4.1"
+  resolved "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 comment-json@4.2.0:
   version "4.2.0"
@@ -11449,6 +11495,17 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
+estimo@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.npmjs.org/estimo/-/estimo-2.3.6.tgz#af0ea229d82a642e89570616d4349b267642fd00"
+  integrity sha512-aPd3VTQAL1TyDyhFfn6fqBTJ9WvbRZVN4Z29Buk6+P6xsI0DuF5Mh3dGv6kYCUxWnZkB4Jt3aYglUxOtuwtxoA==
+  dependencies:
+    "@sitespeed.io/tracium" "^0.3.3"
+    commander "^9.1.0"
+    find-chrome-bin "0.1.0"
+    nanoid "^3.3.2"
+    puppeteer-core "^13.5.1"
+
 estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
@@ -12125,6 +12182,11 @@ find-cache-dir@^3.3.1:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-chrome-bin@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/find-chrome-bin/-/find-chrome-bin-0.1.0.tgz#9fa3e6f86c275762c6d8be9da9af71e6fef05373"
+  integrity sha512-XoFZwaEn1R3pE6zNG8kH64l2e093hgB9+78eEKPmJK0o1EXEou+25cEWdtu2qq4DBQPDSe90VJAWVI2Sz9pX6Q==
 
 find-index@^0.1.1:
   version "0.1.1"
@@ -16708,6 +16770,11 @@ lilconfig@2.0.4:
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
   integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
 
+lilconfig@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
+  integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
+
 limiter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
@@ -18366,7 +18433,7 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-nanoid@^3.1.22, nanoid@^3.3.4:
+nanoid@^3.1.22, nanoid@^3.3.2, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
@@ -18392,6 +18459,13 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+nanospinner@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz#d17ff621cb1784b0a206b400da88a0ef6db39b97"
+  integrity sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==
+  dependencies:
+    picocolors "^1.0.0"
 
 napi-build-utils@^1.0.1:
   version "1.0.2"
@@ -21123,7 +21197,7 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
-puppeteer-core@^13.7.0:
+puppeteer-core@^13.5.1, puppeteer-core@^13.7.0:
   version "13.7.0"
   resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.7.0.tgz#3344bee3994163f49120a55ddcd144a40575ba5b"
   integrity sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==
@@ -23364,6 +23438,13 @@ semver@7.3.5, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver
   dependencies:
     lru-cache "^6.0.0"
 
+semver@7.3.7:
+  version "7.3.7"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -23613,6 +23694,20 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+size-limit@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/size-limit/-/size-limit-8.1.0.tgz#75e8368ffd22e1d23ec611fcba2597f913955ed2"
+  integrity sha512-bUL+Uyyt/G+a1XzKlI2WKHVDepmXtqMDhF65pdtjccheiQTNjExWW4nFefgbRL2QgNTzRfK6ayFKjO3o4ER4gg==
+  dependencies:
+    bytes-iec "^3.1.1"
+    chokidar "^3.5.3"
+    ci-job-number "^1.2.2"
+    globby "^11.1.0"
+    lilconfig "^2.0.6"
+    mkdirp "^1.0.4"
+    nanospinner "^1.1.0"
+    picocolors "^1.0.0"
 
 slash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The aim of this PR is to add a web performance harness that measures the metrics [web vital](https://web.dev/vitals/) (a group of metrics defined by the web-vital project), [bundle size](https://github.com/ai/size-limit) and [time](https://github.com/mbalabash/estimo). 

Reports in airtable: https://airtable.com/appCWyZZPrLlVUblF/tblLRZhYUKGmScOai/viwPWgniLl5LM6gRC?blocks=bipFIuRw2Al2FLkw8 (open "Extensions" panel on the right to view through the [json editor](https://support.airtable.com/docs/json-editor-extension))

In the current state this runs as part of the test-playwright ci job therefore on every PR.

As a next step we could add a comparison,  which prints a warning (PR comment) when a threshold or budget gets exceeded.



