### PR TITLE
chore: rename sqlite db file for .gitignore 

### DIFF
--- a/packages/common-all/src/constants/index.ts
+++ b/packages/common-all/src/constants/index.ts
@@ -32,7 +32,7 @@ export const CONSTANTS = {
   DENDRON_DELIMETER: "dendron://",
   DENDRON_USER_FILE: ".dendron.user",
   DENDRON_CACHE_FILE: ".dendron.cache.json",
-  DENDRON_DB_FILE: "dendron.metadata.db",
+  DENDRON_DB_FILE: ".dendron.metadata.db",
   DENDRON_ID: ".dendron.uuid",
   DENDRON_NO_TELEMETRY: ".dendron.no-telemetry",
   DENDRON_TELEMETRY: ".dendron.telemetry",


### PR DESCRIPTION
## chore: rename sqlite db file for .gitignore 

This change adds a '.' prefix to the sqlite db file, to make it covered by the existing .gitignore pattern of `.dendron.*` - this is to prevent users from accidentally checking in their sqlite db file into git. 