### PR TITLE
chore(internal): note schema parity when sqlite backend is enabled

### DIFF
--- a/packages/common-all/src/index.ts
+++ b/packages/common-all/src/index.ts
@@ -39,6 +39,7 @@ export * from "./parse";
 export * from "./BacklinkUtils";
 export * from "./DLinkUtils";
 export * from "./service";
+export * from "./ResultUtils";
 export * as YamlUtils from "./yaml";
 export * as GitUtils from "./git";
 

--- a/packages/engine-server/src/DendronEngineV3Factory.ts
+++ b/packages/engine-server/src/DendronEngineV3Factory.ts
@@ -55,7 +55,7 @@ export class DendronEngineV3Factory {
       ConfigUtils.getVaults(config),
       fileStore,
       dbFilePath,
-      logger
+      LOGGER
     );
 
     if (dbResult.isErr()) {
@@ -64,6 +64,7 @@ export class DendronEngineV3Factory {
     }
 
     const sqliteMetadataStore = new SqliteMetadataStore(dbResult.value, vaults);
+    await sqliteMetadataStore.initSchema(fileStore, wsRoot, LOGGER);
 
     return new DendronEngineV3({
       wsRoot,

--- a/packages/engine-server/src/DendronEngineV3Factory.ts
+++ b/packages/engine-server/src/DendronEngineV3Factory.ts
@@ -75,6 +75,9 @@ export class DendronEngineV3Factory {
       schemaMetadataStore,
       URI.parse(wsRoot)
     );
+
+    // this step is here because we are still relying one fuse engine on some parts.
+    // this can be removed once we completely remove fuse.
     const bulkWriteSchemaOpts = Object.values(schemas).map((schema) => {
       return { key: schema.root.id, schema };
     });

--- a/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
+++ b/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
@@ -756,9 +756,9 @@ function processReplacedStubs(
       WITH T(oldId, newId) AS
       (VALUES ${values})
       UPDATE Hierarchy
-      SET parent = T.newId
+      SET parentId = T.newId
       FROM T
-      WHERE T.oldId = Hierarchy.parent`;
+      WHERE T.oldId = Hierarchy.parentId`;
 
     return SqliteQueryUtils.run(db, sql2, logger).andThen(() => {
       const values = replacedStubs.map((d) => `('${d.stubId}')`).join(",");

--- a/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
+++ b/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
@@ -7,13 +7,10 @@ import {
   DVault,
   genHash,
   genUUID,
-  NoteDictsUtils,
   NoteProps,
   NotePropsMeta,
   NoteUtils,
   Position,
-  SchemaModuleDict,
-  SchemaUtils,
   string2Note,
   Time,
 } from "@dendronhq/common-all";
@@ -66,7 +63,7 @@ export async function parseAllNoteFilesForSqlite(
   vault: DVault,
   db: Database,
   root: string,
-  schemas: SchemaModuleDict,
+  // schemas: SchemaModuleDict,
   enableLinkCandidates: boolean = false,
   logger?: DLogger
 ): Promise<Result<null, any>> {
@@ -217,12 +214,13 @@ export async function parseAllNoteFilesForSqlite(
   });
 
   // Schemas - only needs to be processed for added notes.
-  const dicts = NoteDictsUtils.createNoteDicts(addedNotes);
-  const domains = addedNotes.filter((note) => !note.fname.includes("."));
-
-  domains.map((domain) => {
-    SchemaUtils.matchDomain(domain, dicts.notesById, schemas);
-  });
+  // const dicts = NoteDictsUtils.createNoteDicts(addedNotes);
+  // const domains = addedNotes.filter(
+  //   (note) => !note.fname.includes(".") && note.fname !== "root"
+  // );
+  // domains.map((domain) => {
+  //   SchemaUtils.matchDomain(domain, dicts.notesById, schemas);
+  // });
 
   const allNotesToProcess = addedNotes.concat(updatedNotes);
 

--- a/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
+++ b/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
@@ -40,7 +40,6 @@ import { SqliteError } from "../sqlite/SqliteError";
 import { SqliteQueryUtils } from "../sqlite/SqliteQueryUtils";
 import { LinksTableUtils, LinkType } from "../sqlite/tables/LinksTableUtils";
 import { NotePropsTableUtils } from "../sqlite/tables/NotePropsTableUtils";
-import { SchemaNotesTableUtils } from "../sqlite/tables/SchemaNotesTableUtils";
 
 /**
  * Given the files in a particular vault, process all of them to update the
@@ -534,13 +533,15 @@ async function processNoteProps(note: NotePropsMeta, db: Database) {
     new VaultNotesTableRow(vaultIdResp.value, note.id)
   );
 
-  if (note.schema) {
-    await SchemaNotesTableUtils.insert(db, {
-      noteId: note.id,
-      moduleId: note.schema.moduleId,
-      schemaId: note.schema.schemaId,
-    });
-  }
+  // at this point we don't have schema yet.
+  // TODO: enable this once we move schema init logic
+  // if (note.schema) {
+  //   await SchemaNotesTableUtils.insert(db, {
+  //     noteId: note.id,
+  //     moduleId: note.schema.moduleId,
+  //     schemaId: note.schema.schemaId,
+  //   });
+  // }
 }
 
 function processParentLinks(

--- a/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
+++ b/packages/engine-server/src/drivers/file/parseAllNoteFilesForSqlite.ts
@@ -54,7 +54,6 @@ import { SchemaNotesTableUtils } from "../sqlite/tables/SchemaNotesTableUtils";
  * vaults, call this function multiple times, once for each vault.
  * @param db
  * @param root
- * @param schemas
  * @param enableLinkCandidates
  * @returns
  */
@@ -63,7 +62,6 @@ export async function parseAllNoteFilesForSqlite(
   vault: DVault,
   db: Database,
   root: string,
-  // schemas: SchemaModuleDict,
   enableLinkCandidates: boolean = false,
   logger?: DLogger
 ): Promise<Result<null, any>> {

--- a/packages/engine-server/src/drivers/sqlite/SqliteDbFactory.ts
+++ b/packages/engine-server/src/drivers/sqlite/SqliteDbFactory.ts
@@ -4,20 +4,14 @@ import {
   DLogger,
   DVault,
   errAsync,
-  ERROR_SEVERITY,
-  ERROR_STATUS,
   IDendronError,
   IFileStore,
   isNotNull,
   isNotUndefined,
   okAsync,
-  RespWithOptError,
-  Result,
   ResultAsync,
   ResultUtils,
   SchemaModuleDict,
-  SchemaModuleProps,
-  VaultUtils,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
 import _ from "lodash";

--- a/packages/engine-server/src/drivers/sqlite/SqliteDbFactory.ts
+++ b/packages/engine-server/src/drivers/sqlite/SqliteDbFactory.ts
@@ -1,13 +1,29 @@
 import {
+  DendronCompositeError,
+  DendronError,
   DLogger,
   DVault,
+  errAsync,
+  ERROR_SEVERITY,
+  ERROR_STATUS,
+  IDendronError,
   IFileStore,
+  isNotNull,
+  isNotUndefined,
+  okAsync,
+  RespWithOptError,
+  Result,
   ResultAsync,
+  ResultUtils,
+  SchemaModuleDict,
+  SchemaModuleProps,
+  VaultUtils,
 } from "@dendronhq/common-all";
 import { vault2Path } from "@dendronhq/common-server";
+import _ from "lodash";
 import { Database } from "sqlite3";
 import { URI } from "vscode-uri";
-import { parseAllNoteFilesForSqlite } from "../file";
+import { parseAllNoteFilesForSqlite, SchemaParser } from "../file";
 import { SqliteQueryUtils } from "./SqliteQueryUtils";
 import { HierarchyTableUtils, VaultsTableUtils } from "./tables";
 import { LinksTableUtils } from "./tables/LinksTableUtils";
@@ -29,13 +45,13 @@ export class SqliteDbFactory {
    * @param dbFilePath - path of the db file. Use :memory: to use an in-memory database
    * @returns
    */
-  public static createInitializedDB(
+  public static async createInitializedDB(
     wsRoot: string,
     vaults: DVault[],
     fileStore: IFileStore,
     dbFilePath: string,
-    logger?: DLogger
-  ): ResultAsync<Database, Error> {
+    logger: DLogger
+  ): Promise<Result<Database, Error>> {
     return SqliteDbFactory.createEmptyDB(dbFilePath).andThen((db) => {
       const results = ResultAsync.combine(
         // Initialize Each Vault
@@ -51,20 +67,18 @@ export class SqliteDbFactory {
               return e;
             }
           ).map((maybeFiles) => {
-            // And parse them
             return parseAllNoteFilesForSqlite(
               maybeFiles.data!,
               vault,
               db,
               vaultPath,
-              {}, // TODO: Add in schemaModuleDict
+              // schemaDict,
               false,
               logger
             );
           });
         })
       );
-
       return results.map(() => {
         return db;
       });
@@ -114,5 +128,122 @@ export class SqliteDbFactory {
           return db;
         });
     });
+  }
+
+  static initSchema(
+    vaults: DVault[],
+    wsRoot: string,
+    fileStore: IFileStore,
+    logger: DLogger
+  ): ResultAsync<SchemaModuleDict, IDendronError> {
+    const schemaParser = new SchemaParser({
+      wsRoot,
+      logger,
+    });
+    const schemaDict: SchemaModuleDict = {};
+    let errors: DendronError[] = [];
+    ResultAsync.combineWithAllErrors(
+      vaults.map((vault) => {
+        const vaultPath = vault2Path({ vault, wsRoot });
+        return ResultUtils.PromiseRespV3ToResultAsync(
+          fileStore.readDir({
+            root: URI.file(vaultPath),
+            include: ["*.schema.yml"],
+          })
+        ).andThen<Awaited<ReturnType<SchemaParser["parse"]>>, never>(
+          (schemaFiles) => {
+            const out = ResultAsync.fromSafePromise(
+              schemaParser.parse(schemaFiles, vault)
+            );
+            return out;
+          }
+        );
+      })
+    ).map((res) => {
+      const schemaResponses = res as Awaited<
+        ReturnType<SchemaParser["parse"]>
+      >[];
+      errors = schemaResponses
+        .flatMap((response) => response.errors)
+        .filter(isNotNull);
+      const schemas = schemaResponses
+        .flatMap((response) => response.schemas)
+        .filter(isNotUndefined);
+
+      schemas.forEach((schema) => {
+        schemaDict[schema.root.id] = schema;
+      });
+    });
+
+    if (errors.length > 0) {
+      return errAsync(new DendronCompositeError(errors));
+    } else {
+      return okAsync(schemaDict);
+    }
+  }
+
+  static async readAllSchema(
+    vaults: DVault[],
+    wsRoot: string,
+    fileStore: IFileStore,
+    logger: DLogger
+  ): Promise<RespWithOptError<SchemaModuleProps[]>> {
+    const ctx = "DEngine:initSchema";
+    logger.info({ ctx, msg: "enter" });
+    let errorList: IDendronError[] = [];
+
+    const schemaResponses: RespWithOptError<SchemaModuleProps[]>[] =
+      await Promise.all(
+        vaults.map(async (vault) => {
+          const vpath = vault2Path({ vault, wsRoot });
+          // Get list of files from filesystem
+          const maybeFiles = await fileStore.readDir({
+            root: URI.file(vpath),
+            include: ["*.schema.yml"],
+          });
+          if (maybeFiles.error || maybeFiles.data.length === 0) {
+            // Keep initializing other vaults
+            return {
+              error: new DendronCompositeError([
+                new DendronError({
+                  message: `Unable to get schemas for vault ${VaultUtils.getName(
+                    vault
+                  )}`,
+                  status: ERROR_STATUS.NO_SCHEMA_FOUND,
+                  severity: ERROR_SEVERITY.MINOR,
+                  payload: maybeFiles.error,
+                }),
+              ]),
+              data: [],
+            };
+          }
+          const schemaFiles = maybeFiles.data.map((entry) => entry.toString());
+          logger.info({ ctx, schemaFiles });
+          const { schemas, errors } = await new SchemaParser({
+            wsRoot,
+            logger,
+          }).parse(schemaFiles, vault);
+
+          if (errors) {
+            errorList = errorList.concat(errors);
+          }
+          return {
+            data: schemas,
+            error: _.isNull(errors)
+              ? undefined
+              : new DendronCompositeError(errors),
+          };
+        })
+      );
+    const errors = schemaResponses
+      .flatMap((response) => response.error)
+      .filter(isNotUndefined);
+
+    return {
+      error: errors.length > 0 ? new DendronCompositeError(errors) : undefined,
+      data: schemaResponses
+        .flatMap((response) => response.data)
+        .filter(isNotUndefined),
+    };
   }
 }

--- a/packages/engine-server/src/drivers/sqlite/SqliteMetadataStore.ts
+++ b/packages/engine-server/src/drivers/sqlite/SqliteMetadataStore.ts
@@ -43,8 +43,7 @@ export class SqliteMetadataStore implements IDataStore<string, NotePropsMeta> {
    * Goes through all domains and recursively apply schemas.
    */
   async initSchema(fileStore: IFileStore, wsRoot: string, logger: DLogger) {
-    // TODO: move this out of SqliteDbFactory
-    // (or move this whole thing to parseAllNoteFilesForSqlite)
+    // this whole thing to parseAllNoteFilesForSqlite / SqliteDbFactory
     const schemaResult = await SqliteDbFactory.initSchema(
       this._vaults,
       wsRoot,
@@ -125,6 +124,7 @@ export class SqliteMetadataStore implements IDataStore<string, NotePropsMeta> {
         }
       })
     );
+    return schemas;
   }
 
   dispose() {
@@ -228,7 +228,7 @@ export class SqliteMetadataStore implements IDataStore<string, NotePropsMeta> {
         data: {},
         type: "note",
         vault,
-        schema,
+        schema: _.isEmpty(schema) ? undefined : schema,
       };
 
       return okAsync(data);

--- a/packages/engine-server/src/drivers/sqlite/tables/HierarchyTableUtils.ts
+++ b/packages/engine-server/src/drivers/sqlite/tables/HierarchyTableUtils.ts
@@ -161,10 +161,6 @@ export class HierarchyTableUtils {
       `    h.childId,`,
       `    1,`, // root note depth. starting from 1
       `    32,`, // arbitrarily set maximum hierarchy depth. we can extend this support the worst case by setting it to (SELECT COUNT(*) FROM "Hierarchy")
-      `    (`,
-      `      SELECT COUNT(*)`,
-      `      FROM "Hierarchy"`,
-      `    )`,
       `  FROM "Hierarchy" h`,
       `  WHERE h.parentId = "${nodeId}"`,
       // UNION ALL assuming we don't have dupes in the hierarchy table.

--- a/packages/engine-server/src/drivers/sqlite/tables/HierarchyTableUtils.ts
+++ b/packages/engine-server/src/drivers/sqlite/tables/HierarchyTableUtils.ts
@@ -160,7 +160,7 @@ export class HierarchyTableUtils {
       `    h.parentId,`,
       `    h.childId,`,
       `    1,`, // root note depth. starting from 1
-      `    32,`, // arbitrarily set maximum hierarchy depth. we can extend this support the worst case by setting it to (SELECT COUNT(*) FROM "Hierarchy")
+      `    32`, // arbitrarily set maximum hierarchy depth. we can extend this support the worst case by setting it to (SELECT COUNT(*) FROM "Hierarchy")
       `  FROM "Hierarchy" h`,
       `  WHERE h.parentId = "${nodeId}"`,
       // UNION ALL assuming we don't have dupes in the hierarchy table.

--- a/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
+++ b/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
@@ -55,9 +55,9 @@ export class SchemaNotesTableUtils {
     const sql = [
       `SELECT *`,
       `FROM SchemaNotes`,
-      `WHERE SchemaNotes.noteId = ${key}`,
+      `WHERE SchemaNotes.noteId = "${key}"`,
     ].join("\n");
 
-    return SqliteQueryUtils.all(db, sql);
+    return SqliteQueryUtils.get(db, sql);
   }
 }

--- a/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
+++ b/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
@@ -51,6 +51,11 @@ export class SchemaNotesTableUtils {
     });
   }
 
+  static truncate(db: Database): ResultAsync<null, SqliteError> {
+    const sql = `DELETE FROM SchemaNotes`;
+    return SqliteQueryUtils.run(db, sql);
+  }
+
   static getByNoteId(db: Database, key: string) {
     const sql = [
       `SELECT *`,

--- a/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
+++ b/packages/engine-server/src/drivers/sqlite/tables/SchemaNotesTableUtils.ts
@@ -50,4 +50,14 @@ export class SchemaNotesTableUtils {
       return e as SqliteError;
     });
   }
+
+  static getByNoteId(db: Database, key: string) {
+    const sql = [
+      `SELECT *`,
+      `FROM SchemaNotes`,
+      `WHERE SchemaNotes.noteId = ${key}`,
+    ].join("\n");
+
+    return SqliteQueryUtils.all(db, sql);
+  }
 }

--- a/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
@@ -34,6 +34,11 @@ async function createNoteStoreUsingSqliteMetadataStore(
   }
 
   const metadataStore = new SqliteMetadataStore(dbResult.value, vaults);
+  await metadataStore.initSchema(
+    fileStore,
+    wsRoot,
+    (engine as DendronEngineClient).logger
+  );
 
   return new NoteStore(fileStore, metadataStore, URI.file(wsRoot));
 }

--- a/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
@@ -11,7 +11,7 @@ import {
   SqliteDbFactory,
   SqliteMetadataStore,
 } from "@dendronhq/engine-server";
-import { runAllNoteStoreTests } from "../../../noteStore.common";
+import { runAllNoteStoreTestsForSqlite } from "../../../noteStore.common";
 
 async function createNoteStoreUsingSqliteMetadataStore(
   wsRoot: string,
@@ -44,5 +44,5 @@ async function createNoteStoreUsingSqliteMetadataStore(
 }
 
 describe("GIVEN a NoteStore containing a SQLiteMetadataStore internally", () => {
-  runAllNoteStoreTests(createNoteStoreUsingSqliteMetadataStore);
+  runAllNoteStoreTestsForSqlite(createNoteStoreUsingSqliteMetadataStore);
 });

--- a/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/common-all/store/sqliteMetadataStore.spec.ts
@@ -1,5 +1,12 @@
-import { DVault, INoteStore, NoteStore, URI } from "@dendronhq/common-all";
 import {
+  DEngineClient,
+  DVault,
+  INoteStore,
+  NoteStore,
+  URI,
+} from "@dendronhq/common-all";
+import {
+  DendronEngineClient,
   NodeJSFileStore,
   SqliteDbFactory,
   SqliteMetadataStore,
@@ -8,7 +15,8 @@ import { runAllNoteStoreTests } from "../../../noteStore.common";
 
 async function createNoteStoreUsingSqliteMetadataStore(
   wsRoot: string,
-  vaults: DVault[]
+  vaults: DVault[],
+  engine: DEngineClient
 ): Promise<INoteStore<string>> {
   const fileStore = new NodeJSFileStore();
 
@@ -17,7 +25,8 @@ async function createNoteStoreUsingSqliteMetadataStore(
     vaults,
     fileStore,
     // "/Users/jyeung/code/dendron/dendron/dendron.test4.db"
-    ":memory:" // This special DB name tells sqlite to create the db in-memory
+    ":memory:", // This special DB name tells sqlite to create the db in-memory,
+    (engine as DendronEngineClient).logger
   );
 
   if (dbResult.isErr()) {

--- a/packages/engine-test-utils/src/__tests__/engine-server/sqlite/parseAllNoteFilesForSqlite.fts.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/sqlite/parseAllNoteFilesForSqlite.fts.spec.ts
@@ -80,7 +80,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   // Query Tests:
   test("WHEN sqlite init is performed with a single note THEN it can be queried by fname", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     const result = await NotePropsFtsTableUtils.query(db, "a");
     expect(result.isOk()).toBeTruthy();
@@ -103,8 +103,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "a.ch2.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     const result = await NotePropsFtsTableUtils.query(db, "a");
@@ -124,15 +123,9 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN a note is added THEN the added note can be queried by fname", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     const result = await NotePropsFtsTableUtils.query(db, "b");
     expect(result.isOk()).toBeTruthy();
@@ -151,16 +144,10 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN a note is removed THEN it no longer can be queried by fname", async () => {
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     // Remove B:
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     const result = await NotePropsFtsTableUtils.query(db, "b");
     expect(result.isOk()).toBeTruthy();
@@ -186,7 +173,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN a note is updated to have a different fname THEN only the updated fname is queryable", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     // Now 'change' the note with ID 'a' to have fname 'b'
     const note = NoteUtils.create({
@@ -198,7 +185,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
     });
     await note2File({ note, vault: testVault, wsRoot: testDir });
 
-    await parseAllNoteFilesForSqlite(["b.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["b.md"], testVault, db, testDir);
 
     const resultB = await NotePropsFtsTableUtils.query(db, "b");
     expect(resultB.isOk()).toBeTruthy();

--- a/packages/engine-test-utils/src/__tests__/engine-server/sqlite/parseAllNoteFilesForSqlite.spec.ts
+++ b/packages/engine-test-utils/src/__tests__/engine-server/sqlite/parseAllNoteFilesForSqlite.spec.ts
@@ -200,7 +200,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   // Vault Setup Tests:
   test("WHEN sqlite init is performed with a single vault THEN vault is present in the Vaults table", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     expect(
       await SqliteTestUtils.getRowCountForTable(db, SqliteTableNames.Vaults)
@@ -208,13 +208,12 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN sqlite init is performed over multiple vaults THEN all vaults are present in the Vaults table", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
     await parseAllNoteFilesForSqlite(
       ["vault-two-note.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
 
     const result = await VaultsTableUtils.getIdByFsPath(db, ".");
@@ -235,8 +234,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       [],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(response.isOk()).toBeTruthy();
@@ -247,7 +245,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN sqlite init is performed on a simple note THEN note is present in the NoteProps and VaultNotes tables", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a", testVault);
 
@@ -258,8 +256,8 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   test("WHEN sqlite init is done multiple times THEN subsequent inits don't affect DB state", async () => {
     // Run twice:
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a", testVault);
 
@@ -272,16 +270,10 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   test("WHEN a new note is added to file system THEN the new note is added to NoteProps and VaultNotes tables", async () => {
     // Set the initial DB state:
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     // Now a second note is added 'offline', and the DB gets initialized again:
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a", testVault);
     await validateNotePropInDB(db, "b", testVault);
@@ -296,15 +288,14 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   test("WHEN many new notes are added to file system THEN all the new notes are added to NoteProps and VaultNotes tables", async () => {
     // Set the initial DB state:
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     // Now multiple notes are added 'offline', and the DB gets initialized again:
     await parseAllNoteFilesForSqlite(
       ["a.md", "b.md", "c.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -326,8 +317,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "wikilink-a.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -379,8 +369,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["wikilink-to-self.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "wikilink-to-self", testVault);
@@ -414,8 +403,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "noteref-a.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     await validateNotePropInDB(db, "a", testVault);
     await validateNotePropInDB(db, "noteref-a", testVault);
@@ -449,7 +437,6 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       testVault,
       db,
       testDir,
-      {},
       true // enableLinkCandidates
     );
 
@@ -484,8 +471,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "unresolved-wikilink.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -518,21 +504,14 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   test("WHEN a note with an unresolved wikilink is added AND the wikilink is later resolved THEN the entry in the links table has source and sinks properly populated", async () => {
     // Set the initial DB state. Wikilink-a is unresolved.
-    await parseAllNoteFilesForSqlite(
-      ["wikilink-a.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["wikilink-a.md"], testVault, db, testDir);
 
     // Now it gets resolved since a got added.
     await parseAllNoteFilesForSqlite(
       ["a.md", "wikilink-a.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -585,8 +564,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResult.isOk()).toBeTruthy();
@@ -618,8 +596,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -659,8 +636,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["root.md", "a.md", "b.md", "c.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "root", testVault);
@@ -707,8 +683,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResult.isOk()).toBeTruthy();
@@ -763,8 +738,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResult.isOk()).toBeTruthy();
@@ -837,8 +811,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResult.isOk()).toBeTruthy();
@@ -848,8 +821,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResultTwo.isOk()).toBeTruthy();
@@ -892,8 +864,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.ch1.gch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResult.isOk()).toBeTruthy();
@@ -903,8 +874,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       [],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(parseResultTwo.isOk()).toBeTruthy();
@@ -920,7 +890,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
 
   // Note Update Tests:
   test("WHEN a note is modified THEN the new note state is reflected in the NoteProps table", async () => {
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     // Now modify the note:
     await NoteTestUtilsV4.createNote({
@@ -931,7 +901,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
     });
 
     // Initialize again:
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     // The updated state should be in the DB:
     const result = await validateNotePropInDB(db, "a", testVault);
@@ -952,8 +922,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "b.md", "wikilink-b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Now modify the note to change the wikilink from 'b' to 'a':
@@ -969,8 +938,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "b.md", "wikilink-b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -1013,8 +981,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "b.md", "wikilink-b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Now modify the note to remove the wikilink:
@@ -1030,8 +997,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "b.md", "wikilink-b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     await validateNotePropInDB(db, "a", testVault);
@@ -1054,13 +1020,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN many new notes are modified THEN the all the new note states are reflected in the DB", async () => {
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     // Now modify the notes:
     await NoteTestUtilsV4.createNote({
@@ -1077,13 +1037,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
     });
 
     // Initialize again:
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     // The updated state should be in the DB:
     const result = await validateNotePropInDB(db, "a", testVault);
@@ -1096,16 +1050,10 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   // Deletion Tests
   test("WHEN a note has been deleted THEN all references to that note are deleted from the DB", async () => {
     // Set the initial DB state:
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     // 'Delete' Note B
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a", testVault);
 
@@ -1124,12 +1072,11 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Now 'delete' the child note a.ch1.md
-    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a", testVault);
 
@@ -1155,12 +1102,11 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Now 'delete' the parent note a.md
-    await parseAllNoteFilesForSqlite(["a.ch1.md"], testVault, db, testDir, {});
+    await parseAllNoteFilesForSqlite(["a.ch1.md"], testVault, db, testDir);
 
     await validateNotePropInDB(db, "a.ch1", testVault);
 
@@ -1181,20 +1127,13 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   });
 
   test("WHEN all notes have been deleted THEN initialization still succeeds and the database is empty apart from the Vaults Table", async () => {
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     const response = await parseAllNoteFilesForSqlite(
       [],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     expect(response.isOk()).toBeTruthy();
@@ -1219,13 +1158,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
   // Tests for more complicated scenarios:
   test("WHEN a combo of adds, updates, and deletes have happened THEN the DB state is updated correctly", async () => {
     // Set the initial DB state:
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "b.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "b.md"], testVault, db, testDir);
 
     // Now modify note A:
     await NoteTestUtilsV4.createNote({
@@ -1236,13 +1169,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
     });
 
     // 'Delete' Note B, Add Note C, modify Note A:
-    await parseAllNoteFilesForSqlite(
-      ["a.md", "c.md"],
-      testVault,
-      db,
-      testDir,
-      {}
-    );
+    await parseAllNoteFilesForSqlite(["a.md", "c.md"], testVault, db, testDir);
 
     // Validate 'A' is modified
     const result = await validateNotePropInDB(db, "a", testVault);
@@ -1277,8 +1204,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "wikilink-a.md", "root.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Now change A's ID:
@@ -1297,8 +1223,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "wikilink-a.md", "root.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
 
     // Validate 'A' is modified
@@ -1375,8 +1300,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md", "a.ch1.md", "wikilink-a.md", "root.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     expect(parseResult.isOk()).toBeTruthy();
 
@@ -1384,8 +1308,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
     expect(parseResult2.isOk()).toBeTruthy();
 
@@ -1492,8 +1415,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["cross-vault-link.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
     expect(parseResultVault2.isOk()).toBeTruthy();
 
@@ -1501,8 +1423,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     expect(parseResult.isOk()).toBeTruthy();
 
@@ -1553,8 +1474,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["b.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     expect(parseResult.isOk()).toBeTruthy();
 
@@ -1563,8 +1483,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["cross-vault-link.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
     expect(parseResultVault2.isOk()).toBeTruthy();
 
@@ -1618,8 +1537,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["cross-vault-link-with-vault-qualifier.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
     expect(parseResultVault2.isOk()).toBeTruthy();
 
@@ -1628,8 +1546,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     expect(parseResultVault1.isOk()).toBeTruthy();
 
@@ -1638,8 +1555,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md"],
       testVaultThree,
       db,
-      path.join(testDir, testVaultThree.fsPath),
-      {}
+      path.join(testDir, testVaultThree.fsPath)
     );
     expect(parseResultVault3.isOk()).toBeTruthy();
 
@@ -1705,8 +1621,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["cross-vault-link-ambiguous.md", "a.md"],
       testVaultTwo,
       db,
-      path.join(testDir, testVaultTwo.fsPath),
-      {}
+      path.join(testDir, testVaultTwo.fsPath)
     );
 
     expect(parseResultVault2.isOk()).toBeTruthy();
@@ -1715,8 +1630,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md"],
       testVault,
       db,
-      testDir,
-      {}
+      testDir
     );
     expect(parseResult.isOk()).toBeTruthy();
 
@@ -1724,8 +1638,7 @@ describe("GIVEN a sqlite store about to be initialized", () => {
       ["a.md"],
       testVaultThree,
       db,
-      path.join(testDir, testVaultThree.fsPath),
-      {}
+      path.join(testDir, testVaultThree.fsPath)
     );
 
     expect(parseResultVault3.isOk()).toBeTruthy();

--- a/packages/engine-test-utils/src/noteStore.common.ts
+++ b/packages/engine-test-utils/src/noteStore.common.ts
@@ -37,6 +37,16 @@ export function runAllNoteStoreTests(
   bulkWriteMetadataTest(noteStoreFactory);
   deleteRootNoteTest(noteStoreFactory);
   getNoteWithAbsolutePathVault(noteStoreFactory);
+}
+
+export function runAllNoteStoreTestsForSqlite(
+  noteStoreFactory: (
+    wsRoot: string,
+    vaults: DVault[],
+    engine: DEngineClient
+  ) => Promise<INoteStore<string>>
+) {
+  runAllNoteStoreTests(noteStoreFactory);
   getNoteWithSchemaTest(noteStoreFactory);
 }
 

--- a/packages/engine-test-utils/src/noteStore.common.ts
+++ b/packages/engine-test-utils/src/noteStore.common.ts
@@ -1,4 +1,5 @@
 import {
+  DEngineClient,
   DVault,
   ERROR_STATUS,
   INoteStore,
@@ -20,7 +21,8 @@ import os from "os";
 export function runAllNoteStoreTests(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   findAndFindMetadataTest(noteStoreFactory);
@@ -40,13 +42,14 @@ export function runAllNoteStoreTests(
 function findAndFindMetadataTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN workspace contains notes, THEN find and findMetadata should return correct notes", async () => {
     await runEngineTestV5(
       async ({ vaults, wsRoot, engine }) => {
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
 
         const engineNotes = await engine.findNotesMeta({ excludeStub: false });
         await Promise.all(
@@ -135,13 +138,14 @@ function findAndFindMetadataTest(
 function queryMetadataTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN workspace contains notes, THEN queryMetadata should return correct notes", async () => {
     await runEngineTestV5(
       async ({ wsRoot, vaults, engine }) => {
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
 
         const engineNotes = await engine.findNotesMeta({ excludeStub: false });
         await Promise.all(
@@ -196,14 +200,15 @@ function queryMetadataTest(
 function retrieveSameNoteTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing a note, THEN get, getMetadata, and queryMetadata should retrieve same note", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
 
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
@@ -260,15 +265,16 @@ function retrieveSameNoteTest(
 function stubNoteTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing a stub note, THEN get and getMetadata should retrieve same note", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "",
@@ -325,15 +331,16 @@ function stubNoteTest(
 function getDeletedNoteTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing and deleting a note, THEN get should return CONTENT_NOT_FOUND", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "note body",
@@ -384,15 +391,16 @@ function getDeletedNoteTest(
 function updateNoteTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing a note, THEN subsequent writes should update note", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "note body",
@@ -438,15 +446,16 @@ function updateNoteTest(
 function writeSameFnameTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing a note with the same fname, THEN content hash should change", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "note body",
@@ -488,15 +497,16 @@ function writeSameFnameTest(
 function writeMismatchKeyTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing a note with a mismatched key, THEN error should be returned", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "note body",
@@ -518,15 +528,16 @@ function writeMismatchKeyTest(
 function retrieveMetadataOnlyTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN writing and getting metadata, THEN only metadata should be retrieved", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar",
           body: "note body",
@@ -583,15 +594,16 @@ function retrieveMetadataOnlyTest(
 function bulkWriteMetadataTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN bulk writing metadata, THEN all metadata should be retrievable", async () => {
     await runEngineTestV5(
-      async ({ vaults, wsRoot }) => {
+      async ({ vaults, wsRoot, engine }) => {
         const vault = vaults[0];
 
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const newNote = await NoteTestUtilsV4.createNote({
           fname: "foobar123",
           body: "note body",
@@ -642,13 +654,14 @@ function bulkWriteMetadataTest(
 function deleteRootNoteTest(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   test("WHEN deleting a root note, THEN error should return and be CANT_DELETE_ROOT", async () => {
     await runEngineTestV5(
       async ({ wsRoot, vaults, engine }) => {
-        const noteStore = await noteStoreFactory(wsRoot, vaults);
+        const noteStore = await noteStoreFactory(wsRoot, vaults, engine);
         const engineNotes = await engine.findNotesMeta({ excludeStub: false });
         await Promise.all(
           engineNotes.map(async (noteMeta) => {
@@ -674,7 +687,8 @@ function deleteRootNoteTest(
 function getNoteWithAbsolutePathVault(
   noteStoreFactory: (
     wsRoot: string,
-    vaults: DVault[]
+    vaults: DVault[],
+    engine: DEngineClient
   ) => Promise<INoteStore<string>>
 ) {
   const wsRoot = tmpDir().name;
@@ -702,7 +716,8 @@ function getNoteWithAbsolutePathVault(
         async ({ wsRoot, engine }) => {
           const noteStore = await noteStoreFactory(
             wsRoot,
-            vaultsWithAbsoluteFsPath
+            vaultsWithAbsoluteFsPath,
+            engine
           );
           const engineNotes = await engine.findNotesMeta({
             excludeStub: false,


### PR DESCRIPTION
# chore(internal): note schema parity when sqlite backend is enabled

This PR:
- properly parse and apply note schemas during engine init when `useSqlite` is enabled.
- supersedes #3822

Notes: 
- now `SchemaNotes` table is properly populated after initialization.
- currently schema initialization happens after all delta initialization steps are done. this may change once we move on to a more proper `Schemas` table in the future.
- there are a few points we can optimize (e.g. remove expensive `.get` calls used to create `NoteDicts`), but currently the init step is implemented to use the existing `SchemaUtils.matchDomain` as much as possible with minimal change to the existing way we do it. this could be done by adding sqlite specific utilities to create `NoteDicts` in one query for example. this is also left for future iteration.

# Pull Request Checklist

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [x] check whether code be simplified
  - [x] check if similar function already exist in the codebase. if so, can it be re-used?
  - [x] check if this change adversely impact performance
- Operations
  - [x] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [x] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)

## Instrumentation

### Basics
- [~] if you are adding analytics related changes, make sure the [Telemetry](https://wiki.dendron.so/notes/84df871b-9442-42fd-b4c3-0024e35b5f3c.html) docs are updated

### Extended
- [~] can we track the performance of this change to know if it is _successful_?
  - eg: [see usage for export pod](https://github.com/dendronhq/dendron/pull/2190#pullrequestreview-855715612)

## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [x] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [x] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)

### Extended
- [~] If you are adding a new language feature (graphically visible in VS Code/preview/publishing), an example is included in the [test workspace](dev.ref.test-workspace)
- CSS
  - [~] display is correct for following dimensions
    - [~] sm: screen ≥ 576px, eg. iphonex, (375x812)
    - [~] lg: screen ≥ 992px
    - [~] xxl: screen ≥ 1600px eg. mac (1600x900)
  - [~] display is correct for following browsers (across the various dimensions)
    - [~] safari
    - [~] firefox
    - [~] chrome

## Docs
- [~] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [~] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [~]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)