### PR TITLE
chore: separate general build job for nightly

### DIFF
--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -11,7 +11,90 @@ on:
     - cron: "0 7 * * 1-6"
 
 jobs:
-  build:
+  general-build:
+    if: github.repository_owner == 'dendronhq'
+    timeout-minutes: 60
+    environment: plugin-production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Gather environment data
+        run: |
+          node --version
+          npm --version
+          yarn --version
+
+      - name: Configure Git user
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Yarn Setup
+        run: yarn setup
+
+      - name: Update schema file
+        run: yarn gen:data
+
+      - name: Set Up Yarn Local Registry
+        run: yarn config set registry http://localhost:4873
+
+      - name: Set Up NPM Local Registry
+        run: npm set registry http://localhost:4873/
+
+      - name: Set Environment Variables
+        run: |
+          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`-nightly" >> $GITHUB_ENV
+          echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
+          echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
+          echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Build the VSIX
+        run: |
+          yarn build:patch:local:ci:nightly:noparam
+
+      - name: Check for VSIX
+        run: |
+          vsixCount=`ls ./packages/plugin-core/*.vsix | wc -l | awk '{print $1}'`
+          if [ $vsixCount = 1 ]; then
+            vsix=$(ls ./packages/plugin-core/*.vsix | tail -1)
+            echo "found a single .vsix file named $vsix" 
+            echo "VSIX_FILE_NAME=$(basename $vsix)" >> $GITHUB_ENV
+            echo "VSIX_RELATIVE_PATH=$vsix" >> $GITHUB_ENV
+            else
+            echo "error: expected 1 .vsix file, found $vsixCount"
+            exit 1
+          fi
+
+      - name: Upload VSIX Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vsix
+          path: ${{ env.VSIX_RELATIVE_PATH }}
+          if-no-files-found: error
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
+        working-directory: ./packages/plugin-core
+        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }}
+
+      - name: Publish to Open VSX Marketplace
+        env:
+          OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
+        working-directory: ./packages/plugin-core
+        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}
+
+  platform-specific:
     # Don't run this job outside of the Dendronhq organization https://github.com/prisma/prisma/issues/3539#issuecomment-690260573
     if: github.repository_owner == 'dendronhq'
     timeout-minutes: 60
@@ -33,8 +116,6 @@ jobs:
             arch: x64
           - platform: darwin
             arch: arm64
-          - platform: general
-            arch: general
 
     runs-on: ubuntu-latest
 
@@ -65,10 +146,8 @@ jobs:
         run: |
           if [ ${{ matrix.platform }} == linux ]; then
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
-          elif [ ${{ matrix.platform }} != general ]; then
+            else
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
-          else 
-            echo "Skipping SQLite binary install for general build."
           fi
         working-directory: ./packages/plugin-core
 
@@ -92,11 +171,7 @@ jobs:
 
       - name: Build the VSIX
         run: |
-          if [ ${{ matrix.platform }} == general ]; then
-            yarn build:patch:local:ci:nightly:noparam
-          else 
-            yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
-          fi
+          yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
 
       - name: Check for VSIX
         run: |


### PR DESCRIPTION
 Context: there's still one issue with the nightly flow, which is that the publishing of the general version of the ext fails cuz the platform-specific ones are published already.  There's an issue just opened on vsce about this: https://github.com/microsoft/vscode-vsce/issues/785