### PR TITLE
Pull release 0.119 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "0.118.0"
+  "version": "0.119.0"
 }

--- a/packages/api-server/CHANGELOG.md
+++ b/packages/api-server/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/api-server",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -54,10 +54,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
-    "@dendronhq/unified": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
+    "@dendronhq/unified": "^0.119.0",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "cors": "^2.8.5",

--- a/packages/common-all/CHANGELOG.md
+++ b/packages/common-all/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/common-all/package.json
+++ b/packages/common-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-all",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "common-all",
   "license": "GPLv3",
   "repository": {

--- a/packages/common-all/src/VaultUtilsV2.ts
+++ b/packages/common-all/src/VaultUtilsV2.ts
@@ -22,7 +22,7 @@ export class VaultUtilsV2 {
     if (vault.seed) {
       return ["seeds", vault.seed, vault.fsPath];
     }
-    return vault.fsPath;
+    return [vault.fsPath];
   }
 
   // TODO: Add Tests

--- a/packages/common-assets/CHANGELOG.md
+++ b/packages/common-assets/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/common-assets/package.json
+++ b/packages/common-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-assets",
   "private": true,
-  "version": "0.118.0",
+  "version": "0.119.0",
   "main": "index.js",
   "license": "GPLv3",
   "scripts": {

--- a/packages/common-frontend/CHANGELOG.md
+++ b/packages/common-frontend/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/common-frontend/package.json
+++ b/packages/common-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-frontend",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "common-frontend",
   "license": "GPLv3",
   "repository": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^4.0.2",
-    "@dendronhq/common-all": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
     "@reduxjs/toolkit": "^1.5.1",
     "lodash": "^4.17.20",
     "querystring": "^0.2.1",

--- a/packages/common-server/CHANGELOG.md
+++ b/packages/common-server/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/common-server",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "common-server",
   "license": "GPLv3",
   "repository": {
@@ -35,7 +35,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "ajv": "^8.6.0",

--- a/packages/common-test-utils/CHANGELOG.md
+++ b/packages/common-test-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/common-test-utils/package.json
+++ b/packages/common-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/common-test-utils",
   "private": true,
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/pods-core": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/pods-core": "^0.119.0",
     "@types/sinon": "^9.0.9",
     "fs-extra": "^9.0.1",
     "jest": "^28.1.0",

--- a/packages/dendron-cli/CHANGELOG.md
+++ b/packages/dendron-cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-cli",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "dendron-cli",
   "license": "GPLv3",
   "repository": {
@@ -41,12 +41,12 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.118.0",
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/dendron-viz": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
-    "@dendronhq/pods-core": "^0.118.0",
+    "@dendronhq/api-server": "^0.119.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/dendron-viz": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
+    "@dendronhq/pods-core": "^0.119.0",
     "@jcoreio/async-throttle": "^1.3.2",
     "@types/prompts": "^2.0.14",
     "clipboardy": "2.3.0",

--- a/packages/dendron-plugin-views/CHANGELOG.md
+++ b/packages/dendron-plugin-views/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/dendron-plugin-views/package.json
+++ b/packages/dendron-plugin-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-plugin-views",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "private": true,
   "workspaces": {
     "nohoist": [
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-frontend": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-frontend": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/packages/dendron-viz/CHANGELOG.md
+++ b/packages/dendron-viz/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/dendron-viz/package.json
+++ b/packages/dendron-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/dendron-viz",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "dendron-viz",
   "license": "GPLv3",
   "repository": {
@@ -32,8 +32,8 @@
     "watch": "yarn copyNonTSFiles && yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
     "d3": "^7.6.1",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.4",

--- a/packages/engine-server/CHANGELOG.md
+++ b/packages/engine-server/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/engine-server",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "dendron-engine",
   "license": "GPLv3",
   "repository": {
@@ -35,9 +35,9 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/unified": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/unified": "^0.119.0",
     "@jcoreio/async-throttle": "^1.4.3",
     "@mapbox/rehype-prism": "^0.5.0",
     "axios": "^0.21.1",

--- a/packages/engine-test-utils/CHANGELOG.md
+++ b/packages/engine-test-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/engine-test-utils/package.json
+++ b/packages/engine-test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dendronhq/engine-test-utils",
   "private": true,
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "",
   "license": "GPLv3",
   "repository": {
@@ -47,15 +47,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.118.0",
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-frontend": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/common-test-utils": "^0.118.0",
-    "@dendronhq/dendron-cli": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
-    "@dendronhq/pods-core": "^0.118.0",
-    "@dendronhq/unified": "^0.118.0",
+    "@dendronhq/api-server": "^0.119.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-frontend": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/common-test-utils": "^0.119.0",
+    "@dendronhq/dendron-cli": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
+    "@dendronhq/pods-core": "^0.119.0",
+    "@dendronhq/unified": "^0.119.0",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/sinon": "^9.0.9",
     "cross-env": "^7.0.3",

--- a/packages/nextjs-template/CHANGELOG.md
+++ b/packages/nextjs-template/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/nextjs-template/package-lock.json
+++ b/packages/nextjs-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/nextjs-template/package.json
+++ b/packages/nextjs-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/nextjs-template",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "license": "Apache-2.0",
   "private": true,
   "repository": {
@@ -24,8 +24,8 @@
     "test:skipbuild": "SKIP_BUILD=1 yarn test"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-frontend": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-frontend": "^0.119.0",
     "@giscus/react": "^2.2.0",
     "antd": "^4.15.5",
     "fs-extra": "^10.0.0",

--- a/packages/plugin-core/CHANGELOG.md
+++ b/packages/plugin-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -4,7 +4,7 @@
   "displayName": "dendron",
   "description": "Dendron is a hierarchical note taking tool that grows as you do.",
   "publisher": "dendron",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "sponsor": {
     "url": "https://accounts.dendron.so/account/subscribe"
   },
@@ -1512,8 +1512,8 @@
     "perf-test": "node ./out/src/test/runPerfTest.js"
   },
   "devDependencies": {
-    "@dendronhq/common-test-utils": "^0.118.0",
-    "@dendronhq/engine-test-utils": "^0.118.0",
+    "@dendronhq/common-test-utils": "^0.119.0",
+    "@dendronhq/engine-test-utils": "^0.119.0",
     "@sentry/webpack-plugin": "^1.17.1",
     "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0.1",
@@ -1556,11 +1556,11 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@dendronhq/api-server": "^0.118.0",
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
-    "@dendronhq/pods-core": "^0.118.0",
+    "@dendronhq/api-server": "^0.119.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
+    "@dendronhq/pods-core": "^0.119.0",
     "@sentry/integrations": "7.11.1",
     "@sentry/node": "7.11.1",
     "@types/vscode": "1.62.0",

--- a/packages/pods-core/CHANGELOG.md
+++ b/packages/pods-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/pods-core/package.json
+++ b/packages/pods-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/pods-core",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "pods-core",
   "license": "GPLv3",
   "repository": {
@@ -52,10 +52,10 @@
   },
   "dependencies": {
     "@dendronhq/airtable": "^0.11.1",
-    "@dendronhq/common-all": "^0.118.0",
-    "@dendronhq/common-server": "^0.118.0",
-    "@dendronhq/engine-server": "^0.118.0",
-    "@dendronhq/unified": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
+    "@dendronhq/common-server": "^0.119.0",
+    "@dendronhq/engine-server": "^0.119.0",
+    "@dendronhq/unified": "^0.119.0",
     "@instantish/martian": "1.0.3",
     "@notionhq/client": "^0.1.9",
     "@octokit/graphql": "^4.6.4",

--- a/packages/unified/CHANGELOG.md
+++ b/packages/unified/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.119.0 (2022-12-06)
+
+
+### Bug Fixes
+
+* preview not rendering ([208c9eb](https://github.com/dendronhq/dendron/commit/208c9eb74da28a180535603bd9ff54feb932e2ed))
+
+
+
+
+
 # 0.118.0 (2022-11-22)
 
 

--- a/packages/unified/package.json
+++ b/packages/unified/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dendronhq/unified",
-  "version": "0.118.0",
+  "version": "0.119.0",
   "description": "Unified parser utilities for Dendron",
   "license": "GPLv3",
   "repository": {
@@ -31,7 +31,7 @@
     "watch": "yarn compile --watch"
   },
   "dependencies": {
-    "@dendronhq/common-all": "^0.118.0",
+    "@dendronhq/common-all": "^0.119.0",
     "@dendronhq/remark-mermaid": "^0.4.0",
     "hast-util-parse-selector": "^2.2.4",
     "hast-util-select": "^4.0.0",


### PR DESCRIPTION
cherry-picked changes from release/0.119.0. 
The existing release/0.119.0 branch reverts #3754. 