### PR TITLE
chore: add general build in nightly matrix

### DIFF
--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -11,96 +11,11 @@ on:
     - cron: "0 7 * * 1-6"
 
 jobs:
-  general-build:
-    if: github.repository_owner == 'dendronhq'
-    timeout-minutes: 60
-    environment: plugin-production
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Gather environment data
-        run: |
-          node --version
-          npm --version
-          yarn --version
-
-      - name: Configure Git user
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-
-      - name: Checkout source
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      - name: Yarn Setup
-        run: yarn setup
-
-      - name: Update schema file
-        run: yarn gen:data
-
-      - name: Set Up Yarn Local Registry
-        run: yarn config set registry http://localhost:4873
-
-      - name: Set Up NPM Local Registry
-        run: npm set registry http://localhost:4873/
-
-      - name: Set Environment Variables
-        run: |
-          echo "DENDRON_RELEASE_VERSION=`(cat ./packages/plugin-core/package.json | jq .version -r; npx vsce show dendron.nightly --json | jq .versions[0].version -r) | sort -rn | head -n 1 | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}'`-nightly" >> $GITHUB_ENV
-          echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}" >> $GITHUB_ENV
-          echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
-          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
-          echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
-          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
-
-      - name: Build the VSIX
-        run: |
-          yarn build:patch:local:ci:nightly:noparam
-
-      - name: Check for VSIX
-        run: |
-          vsixCount=`ls ./packages/plugin-core/*.vsix | wc -l | awk '{print $1}'`
-          if [ $vsixCount = 1 ]; then
-            vsix=$(ls ./packages/plugin-core/*.vsix | tail -1)
-            echo "found a single .vsix file named $vsix" 
-            echo "VSIX_FILE_NAME=$(basename $vsix)" >> $GITHUB_ENV
-            echo "VSIX_RELATIVE_PATH=$vsix" >> $GITHUB_ENV
-            else
-            echo "error: expected 1 .vsix file, found $vsixCount"
-            exit 1
-          fi
-
-      - name: Upload VSIX Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: vsix
-          path: ${{ env.VSIX_RELATIVE_PATH }}
-          if-no-files-found: error
-
-      - name: Publish to VS Code Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCODE_PUBLISH_PWD }}
-        working-directory: ./packages/plugin-core
-        run: yarn deploy:vscode:vsix ${{ env.VSIX_FILE_NAME }}
-
-      - name: Publish to Open VSX Marketplace
-        env:
-          OVSX_PAT: ${{ secrets.VSCODIUM_PUBLISH_PWD }}
-        working-directory: ./packages/plugin-core
-        run: yarn deploy:ovsx:vsix ${{ env.VSIX_FILE_NAME }}
-
-  platform-specific:
+  build:
     # Don't run this job outside of the Dendronhq organization https://github.com/prisma/prisma/issues/3539#issuecomment-690260573
     if: github.repository_owner == 'dendronhq'
     timeout-minutes: 60
     environment: plugin-production
-    # need to order the jobs at the moment due to a bug in VSCode. Refer to https://github.com/microsoft/vscode-vsce/issues/785 for more details.
-    needs: general-build
 
     strategy:
       fail-fast: false
@@ -118,6 +33,8 @@ jobs:
             arch: x64
           - platform: darwin
             arch: arm64
+          - platform: general
+            arch: general
 
     runs-on: ubuntu-latest
 
@@ -148,8 +65,10 @@ jobs:
         run: |
           if [ ${{ matrix.platform }} == linux ]; then
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
-            else
+          elif [ ${{ matrix.platform }} != general ]; then
             yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          else 
+            echo "Skipping SQLite binary install for general build."
           fi
         working-directory: ./packages/plugin-core
 
@@ -173,7 +92,11 @@ jobs:
 
       - name: Build the VSIX
         run: |
-          yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
+          if [ ${{ matrix.platform }} == general ]; then
+            yarn build:patch:local:ci:nightly:noparam
+          else 
+            yarn build:patch:local:ci:nightly ${{ env.PUBLISHING_TARGET }}
+          fi
 
       - name: Check for VSIX
         run: |

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typedoc-plugin-markdown": "^3.13.6",
     "verdaccio": "^5.1.3",
     "verdaccio-auth-memory": "^10.0.1",
-    "vsce": "^2.10.0"
+    "vsce": "^2.15.0"
   },
   "scripts": {
     "setup": "yarn && yarn bootstrap:bootstrap && yarn bootstrap:build && yarn setup:cli",
@@ -101,7 +101,7 @@
     "ci:test:cli": "yarn test:cli",
     "ci:test:plugin": "npx lerna run test --scope @dendronhq/plugin-core --stream",
     "ci:test:plugin-web": "npx lerna run compile-web --scope @dendronhq/plugin-core && npx lerna run test-in-browser --scope @dendronhq/plugin-core",
-    "ci:test:plugin-perf":"npx lerna run perf-test --scope @dendronhq/plugin-core",
+    "ci:test:plugin-perf": "npx lerna run perf-test --scope @dendronhq/plugin-core",
     "ci:test:template": "yarn --cwd packages/nextjs-template run test",
     "ci:test:template:docker": "docker run -it --rm --ipc=host -v \"$(pwd):/test\" -u \"$(id -u ${USER}):$(id -g ${USER})\" mcr.microsoft.com/playwright:v1.26.0-focal /bin/bash -c 'cd /test; npx playwright install; yarn ci:test:template $([ \"$0\" = \"/bin/bash\" ] || ([ \"$#\" = 0 ] && echo \"$0\" || echo \"$0 $@\"))'",
     "template:build": "yarn --cwd packages/nextjs-template run build",

--- a/packages/dendron-cli/package.json
+++ b/packages/dendron-cli/package.json
@@ -72,7 +72,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "vsce": "^2.10.0"
+    "vsce": "2.15.0"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -1549,7 +1549,7 @@
     "ts-node": "^8.10.2",
     "ts-sinon": "^2.0.2",
     "tsyringe": "^4.7.0",
-    "vsce": "^2.10.0",
+    "vsce": "2.15.0",
     "webpack": "^5.56.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26093,7 +26093,33 @@ vm-browserify@^1.0.0, vm-browserify@^1.0.1:
   resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vsce@^2.10.0, vsce@^2.6.3:
+vsce@2.15.0, vsce@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.npmjs.org/vsce/-/vsce-2.15.0.tgz#4a992e78532092a34a755143c6b6c2cabcb7d729"
+  integrity sha512-P8E9LAZvBCQnoGoizw65JfGvyMqNGlHdlUXD1VAuxtvYAaHBKLBdKPnpy60XKVDAkQCfmMu53g+gq9FM+ydepw==
+  dependencies:
+    azure-devops-node-api "^11.0.1"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.9"
+    commander "^6.1.0"
+    glob "^7.0.6"
+    hosted-git-info "^4.0.2"
+    keytar "^7.7.0"
+    leven "^3.1.0"
+    markdown-it "^12.3.2"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "^0.2.1"
+    typed-rest-client "^1.8.4"
+    url-join "^4.0.1"
+    xml2js "^0.4.23"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
+vsce@^2.6.3:
   version "2.10.0"
   resolved "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz#19a9f070ec319e26d4f23567f32826f48fc694aa"
   integrity sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==


### PR DESCRIPTION
The existing issue with a general build in vsce got resolved in the latest release, hence reverted the separate general and platform-specific jobs