### PR TITLE
feat: add lookup buttons in web

### DIFF
--- a/packages/common-all/src/types/typesv2.ts
+++ b/packages/common-all/src/types/typesv2.ts
@@ -107,7 +107,10 @@ export type NoteQuickInput = NoteProps & {
  * A reduced version of NoteQuickInput that only keeps the props necessary for
  * lookup quick pick items
  */
-export type NoteQuickInputV2 = Pick<NoteProps, "fname" | "vault" | "schema"> & {
+export type NoteQuickInputV2 = Pick<
+  NoteProps,
+  "fname" | "vault" | "schema" | "stub"
+> & {
   label: string;
   detail?: string;
   alwaysShow?: boolean;

--- a/packages/plugin-core/src/components/lookup/types.ts
+++ b/packages/plugin-core/src/components/lookup/types.ts
@@ -5,7 +5,7 @@ import {
   DVault,
   NoteQuickInput,
 } from "@dendronhq/common-all";
-import { QuickPick, TextEditor, Uri } from "vscode";
+import { QuickPick, QuickPickItem, TextEditor, Uri } from "vscode";
 import { DendronBtn } from "./ButtonTypes";
 
 export type FilterQuickPickFunction = (
@@ -117,6 +117,10 @@ export type DendronQuickPickerV2 = DendronQuickPickItemV2 & {
    * TODO: should be required
    */
   showNote?: (uri: Uri) => Promise<TextEditor>;
+};
+
+export type DendronWebQuickPick<T extends QuickPickItem> = QuickPick<T> & {
+  buttons: DendronBtn[];
 };
 
 export enum VaultSelectionMode {

--- a/packages/plugin-core/src/web/commands/CreateJournalNoteCmd.ts
+++ b/packages/plugin-core/src/web/commands/CreateJournalNoteCmd.ts
@@ -1,4 +1,4 @@
-import { container, inject, injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 import { LookupControllerCreateOpts } from "./lookup/LookupController";
 import { type ILookupProvider } from "./lookup/ILookupProvider";
 import { DENDRON_COMMANDS } from "../../constants";
@@ -12,18 +12,18 @@ export class CreateJournalNoteCmd {
   static key = DENDRON_COMMANDS.CREATE_JOURNAL.key;
   constructor(
     @inject("NoteProvider") private noteProvider: ILookupProvider,
-    @inject("ITelemetryClient") private analytics: ITelemetryClient
+    @inject("ITelemetryClient") private analytics: ITelemetryClient,
+    private lookupCmd: NoteLookupCmd
   ) {}
 
   async run() {
     this.analytics.track(CreateJournalNoteCmd.key);
-    const lookupCmd = container.resolve(NoteLookupCmd);
     const createJournalOpts: LookupControllerCreateOpts = {
       provider: this.noteProvider,
       noteType: LookupNoteTypeEnum.journal,
       buttons: [JournalBtn.create({ pressed: true, canToggle: false })],
       title: "Create Journal Note",
     };
-    await lookupCmd.run(createJournalOpts);
+    await this.lookupCmd.run(createJournalOpts);
   }
 }

--- a/packages/plugin-core/src/web/commands/CreateJournalNoteCmd.ts
+++ b/packages/plugin-core/src/web/commands/CreateJournalNoteCmd.ts
@@ -1,0 +1,29 @@
+import { container, inject, injectable } from "tsyringe";
+import { LookupControllerCreateOpts } from "./lookup/LookupController";
+import { type ILookupProvider } from "./lookup/ILookupProvider";
+import { DENDRON_COMMANDS } from "../../constants";
+import { JournalBtn } from "../../components/lookup/buttons";
+import { LookupNoteTypeEnum } from "@dendronhq/common-all";
+import { type ITelemetryClient } from "../../telemetry/common/ITelemetryClient";
+import { NoteLookupCmd } from "./NoteLookupCmd";
+
+@injectable()
+export class CreateJournalNoteCmd {
+  static key = DENDRON_COMMANDS.CREATE_JOURNAL.key;
+  constructor(
+    @inject("NoteProvider") private noteProvider: ILookupProvider,
+    @inject("ITelemetryClient") private analytics: ITelemetryClient
+  ) {}
+
+  async run() {
+    this.analytics.track(CreateJournalNoteCmd.key);
+    const lookupCmd = container.resolve(NoteLookupCmd);
+    const createJournalOpts: LookupControllerCreateOpts = {
+      provider: this.noteProvider,
+      noteType: LookupNoteTypeEnum.journal,
+      buttons: [JournalBtn.create({ pressed: true, canToggle: false })],
+      title: "Create Journal Note",
+    };
+    await lookupCmd.run(createJournalOpts);
+  }
+}

--- a/packages/plugin-core/src/web/commands/MoveNoteCmd.ts
+++ b/packages/plugin-core/src/web/commands/MoveNoteCmd.ts
@@ -85,6 +85,12 @@ export class MoveNoteCmd {
       vaults: this.vaults,
       fname: data.items[0].fname,
     });
+    if (vaultSuggestions.length === 0) {
+      window.showErrorMessage(
+        `No available vaults for moving note. Each vault already has a note with filename ${data.items[0].fname}`
+      );
+      return { changed: [] };
+    }
     const newVault = await vaultPicker.promptVault(vaultSuggestions);
     if (!newVault) {
       window.showErrorMessage("Move note cancelled. No vault selected");

--- a/packages/plugin-core/src/web/commands/MoveNoteCmd.ts
+++ b/packages/plugin-core/src/web/commands/MoveNoteCmd.ts
@@ -1,0 +1,357 @@
+import {
+  DVault,
+  NoteChangeEntry,
+  ReducedDEngine,
+  RenameNoteOpts,
+  URI,
+  VaultUtils,
+} from "@dendronhq/common-all";
+//import { vault2Path } from "@dendronhq/common-server";
+import _ from "lodash";
+import _md from "markdown-it";
+import path from "path";
+import {
+  commands,
+  ProgressLocation,
+  TextEditor,
+  Uri,
+  ViewColumn,
+  window,
+  workspace,
+} from "vscode";
+//import { FileItem } from "../external/fileutils/FileItem";
+import { inject, injectable } from "tsyringe";
+import { MultiSelectBtn } from "../../components/lookup/buttons";
+import { DENDRON_COMMANDS } from "../../constants";
+import { type ILookupProvider } from "./lookup/ILookupProvider";
+import {
+  LookupController,
+  LookupControllerCreateOpts,
+} from "./lookup/LookupController";
+import { VaultQuickPick } from "./lookup/VaultQuickPick";
+
+const md = _md();
+
+export type CommandOpts = {
+  moves: RenameNoteOpts[];
+  /**
+   * Show notification message
+   */
+  silent?: boolean;
+  /**
+   * Close and open current file
+   */
+  closeAndOpenFile?: boolean;
+  /**
+   * Pause all watchers
+   */
+  noPauseWatcher?: boolean;
+  nonInteractive?: boolean;
+  initialValue?: string;
+  vaultName?: string;
+  /**
+   * If set to true, don't allow toggling vaults
+   * Used in RenameNoteCommand
+   */
+  useSameVault?: boolean;
+  /** Defaults to true. */
+  allowMultiselect?: boolean;
+  /** set a custom title for the quick input. Used for rename note */
+  title?: string;
+};
+
+export type CommandOutput = {
+  changed: NoteChangeEntry[];
+};
+
+function isMultiMove(moves: RenameNoteOpts[]) {
+  return moves.length > 1;
+}
+
+function isMoveNecessary(move: RenameNoteOpts) {
+  return (
+    move.oldLoc.vaultName !== move.newLoc.vaultName ||
+    move.oldLoc.fname.toLowerCase() !== move.newLoc.fname.toLowerCase()
+  );
+}
+
+@injectable()
+export class MoveNoteCmd {
+  static key = DENDRON_COMMANDS.MOVE_NOTE.key;
+
+  constructor(
+    @inject("vaults") private vaults: DVault[],
+    @inject("NoteProvider") private provider: ILookupProvider,
+    @inject("ReducedDEngine")
+    private engine: ReducedDEngine,
+    private controller: LookupController,
+    @inject("wsRoot") private wsRoot: URI
+  ) {}
+
+  // async gatherInputs(opts?: CommandOpts): Promise<CommandInput | undefined> {
+
+  //   //provider.registerOnAcceptHook(ProviderAcceptHooks.oldNewLocationHook);
+
+  //   // return new Promise((resolve) => {
+  //   //   let disposable: Disposable;
+
+  //     // NoteLookupProviderUtils.subscribe({
+  //     //   id: "move",
+  //     //   controller: lc,
+  //     //   logger: this.L,
+  //     //   onDone: async (event: HistoryEvent) => {
+  //     //     const data =
+  //     //       event.data as NoteLookupProviderSuccessResp<OldNewLocation>;
+  //     //     if (data.cancel) {
+  //     //       resolve(undefined);
+  //     //       return;
+  //     //     }
+  //     //     const opts: CommandOpts = {
+  //     //       moves: this.getDesiredMoves(data),
+  //     //     };
+  //     //     resolve(opts);
+
+  //     //     disposable?.dispose();
+  //     //     VSCodeUtils.setContext(DendronContext.NOTE_LOOK_UP_ACTIVE, false);
+  //     //   },
+  //     //   onError: (event: HistoryEvent) => {
+  //     //     const error = event.data.error as DendronError;
+  //     //     window.showErrorMessage(error.message);
+  //     //     resolve(undefined);
+  //     //     disposable?.dispose();
+  //     //     VSCodeUtils.setContext(DendronContext.NOTE_LOOK_UP_ACTIVE, false);
+  //     //   },
+  //     // });
+
+  //   });
+  // }
+
+  // private getDesiredMoves(
+  //   data: NoteLookupProviderSuccessResp<OldNewLocation>
+  // ): RenameNoteOpts[] {
+  //   if (data.selectedItems.length === 1) {
+  //     // If there is only a single element that we are working on then we can allow
+  //     // for the file name to be renamed as part of the move, hence we need to
+  //     // use onAcceptHookResp since it contains the destination file name.
+  //     return data.onAcceptHookResp;
+  //   } else if (data.selectedItems.length > 1) {
+  //     // If there are multiple elements selected then we are aren't doing multi rename
+  //     // in multi note move and therefore we will use selected items to get
+  //     // all the files that the user has selected.
+
+  //     const newVaultName = data.onAcceptHookResp[0].newLoc.vaultName;
+
+  //     return data.selectedItems.map((item) => {
+  //       const renameOpt: RenameNoteOpts = {
+  //         oldLoc: {
+  //           fname: item.fname,
+  //           vaultName: VaultUtils.getName(item.vault),
+  //         },
+  //         newLoc: {
+  //           fname: item.fname,
+  //           vaultName: newVaultName,
+  //         },
+  //       };
+  //       return renameOpt;
+  //     });
+  //   } else {
+  //     throw new DendronError({
+  //       message: `MoveNoteCommand: No items are selected. ${UNKNOWN_ERROR_MSG}`,
+  //     });
+  //   }
+  // }
+
+  async run(_opts?: CommandOpts) {
+    if (_.isUndefined(window.activeTextEditor)) {
+      return "No document open";
+    }
+    const lookupCreateOpts: LookupControllerCreateOpts = {
+      provider: this.provider,
+      nodeType: "note",
+      // rename note opt
+      disableVaultSelection: _opts?.useSameVault,
+      // If vault selection is enabled we alwaysPrompt selection mode,
+      // hence disable toggling.
+      vaultSelectCanToggle: false,
+      // allow users to select multiple notes to move
+      buttons: [MultiSelectBtn.create({ pressed: false })],
+      title: "Move note",
+      initialValue: _opts?.initialValue,
+      allowCreateNew: false,
+    };
+    const data = await this.controller.showLookup(lookupCreateOpts);
+
+    const vaultPicker = new VaultQuickPick(this.engine);
+    if (!data?.items) return "no items selected";
+    const vaultSuggestions = await vaultPicker.getVaultRecommendations({
+      vault: data.items[0].vault,
+      vaults: this.vaults,
+      fname: data.items[0].fname,
+    });
+    const newLocation = await vaultPicker.promptVault(vaultSuggestions);
+    if (!newLocation) return "no vault selected";
+    const moves: RenameNoteOpts[] = [
+      {
+        oldLoc: {
+          fname: data.items[0].fname,
+          vaultName: VaultUtils.getName(data.items[0].vault),
+        },
+        newLoc: {
+          fname: data.items[0].fname,
+          vaultName: VaultUtils.getName(newLocation),
+        },
+      },
+    ];
+
+    const opts = _.defaults(_opts, {
+      closeAndOpenFile: true,
+      allowMultiselect: true,
+    });
+
+    // if (isMultiMove(opts.moves)) {
+    //   await this.showMultiMovePreview(opts.moves);
+    //   const result = await QuickPickUtils.showProceedCancel();
+
+    //   if (result !== ProceedCancel.PROCEED) {
+    //     window.showInformationMessage("cancelled");
+    //     return { changed: [] };
+    //   }
+    // }
+
+    const changed = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Refactoring...",
+        cancellable: false,
+      },
+      async () => {
+        const allChanges = await this.moveNotes(this.engine, moves);
+        return allChanges;
+      }
+    );
+
+    if (opts.closeAndOpenFile) {
+      // During bulk move we will only open a single file that was moved to avoid
+      // cluttering user tabs with all moved files.
+      await closeCurrentFileOpenMovedFile(
+        this.wsRoot.fsPath,
+        moves[0],
+        this.vaults
+      );
+    }
+    return { changed };
+  }
+
+  /** Performs the actual move of the notes. */
+  private async moveNotes(
+    engine: ReducedDEngine,
+    moves: RenameNoteOpts[]
+  ): Promise<NoteChangeEntry[]> {
+    const necessaryMoves = moves.filter((move) => isMoveNecessary(move));
+
+    const allChanges: NoteChangeEntry[] = [];
+
+    for (const move of necessaryMoves) {
+      // We need to wait for a rename to finish before triggering another rename
+      // eslint-disable-next-line no-await-in-loop
+      const changes = await engine.renameNote(move);
+
+      allChanges.push(...(changes.data as NoteChangeEntry[]));
+    }
+
+    return allChanges;
+  }
+
+  private async showMultiMovePreview(moves: RenameNoteOpts[]) {
+    // All the moves when doing bulk-move will have the same destination vault.
+    const destVault = moves[0].newLoc.vaultName;
+
+    const contentLines = [
+      "# Move notes preview",
+      "",
+      `## The following files will be moved to vault: ${destVault}`,
+    ];
+
+    const necessaryMoves = moves.filter((m) => isMoveNecessary(m));
+    const movesBySourceVaultName = _.groupBy(
+      necessaryMoves,
+      "oldLoc.vaultName"
+    );
+
+    function formatRowFileName(move: RenameNoteOpts) {
+      return `| ${path.basename(move.oldLoc.fname)} |`;
+    }
+
+    _.forEach(
+      movesBySourceVaultName,
+      (moves: RenameNoteOpts[], sourceVault: string) => {
+        contentLines.push(`| From vault: ${sourceVault} to ${destVault} |`);
+        contentLines.push(`|------------------------|`);
+        moves.forEach((move) => {
+          contentLines.push(formatRowFileName(move));
+        });
+        contentLines.push("---");
+      }
+    );
+
+    // When we are doing multi select move we don't support renaming file name
+    // functionality hence the files that do not require a move must have
+    // been attempted to be moved into the vault that they are already are.
+    const sameVaultMoves = moves.filter((m) => !isMoveNecessary(m));
+    if (sameVaultMoves.length) {
+      contentLines.push(`|The following are already in vault: ${destVault}|`);
+      contentLines.push(`|-----------------------------------------------|`);
+      sameVaultMoves.forEach((m) => {
+        contentLines.push(formatRowFileName(m));
+      });
+    }
+
+    const panel = window.createWebviewPanel(
+      "noteMovePreview", // Identifies the type of the webview. Used internally
+      "Move Notes Preview", // Title of the panel displayed to the user
+      ViewColumn.One, // Editor column to show the new webview panel in.
+      {} // Webview options. More on these later.
+    );
+    panel.webview.html = md.render(contentLines.join("\n"));
+  }
+}
+
+async function closeCurrentFileOpenMovedFile(
+  wsRoot: string,
+  moveOpts: RenameNoteOpts,
+  vaults: DVault[]
+) {
+  const vault = VaultUtils.getVaultByName({
+    vaults,
+    vname: moveOpts.newLoc.vaultName!,
+  })!;
+
+  const vpath = vault.fsPath;
+  const newUri = Uri.file(
+    path.join(wsRoot, "notes", vpath, moveOpts.newLoc.fname + ".md")
+  );
+  commands.executeCommand("workbench.action.closeActiveEditor");
+  await openFileInEditor(newUri);
+}
+
+async function openFileInEditor(
+  file: Uri,
+  opts?: Partial<{
+    column: ViewColumn;
+  }>
+): Promise<TextEditor | undefined> {
+  const textDocument = await workspace.openTextDocument(file);
+
+  if (!textDocument) {
+    throw new Error("Could not open file!");
+  }
+
+  const col = opts?.column || ViewColumn.Active;
+
+  const editor = await window.showTextDocument(textDocument, col);
+  if (!editor) {
+    throw new Error("Could not show document!");
+  }
+
+  return editor;
+}

--- a/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
+++ b/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
@@ -10,12 +10,12 @@ import { URI, Utils } from "vscode-uri";
 import { DENDRON_COMMANDS } from "../../constants";
 import { type ITelemetryClient } from "../../telemetry/common/ITelemetryClient";
 import { type ILookupProvider } from "./lookup/ILookupProvider";
-import { LookupQuickpickFactory } from "./lookup/LookupQuickpickFactory";
+import { LookupController } from "./lookup/LookupController";
 
 @injectable()
 export class NoteLookupCmd {
   constructor(
-    private factory: LookupQuickpickFactory,
+    private factory: LookupController,
     @inject("wsRoot") private wsRoot: URI,
     @inject("ReducedDEngine")
     private engine: ReducedDEngine,

--- a/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
+++ b/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
@@ -3,6 +3,9 @@ import {
   NoteUtils,
   VaultUtils,
   VSCodeEvents,
+  ConfigUtils,
+  DendronConfig,
+  getJournalTitle,
 } from "@dendronhq/common-all";
 import { inject, injectable } from "tsyringe";
 import * as vscode from "vscode";
@@ -23,7 +26,8 @@ export class NoteLookupCmd {
     @inject("ReducedDEngine")
     private engine: ReducedDEngine,
     @inject("NoteProvider") private noteProvider: ILookupProvider,
-    @inject("ITelemetryClient") private _analytics: ITelemetryClient
+    @inject("ITelemetryClient") private _analytics: ITelemetryClient,
+    @inject("DendronConfig") private config: DendronConfig
   ) {}
 
   public async run(_opts?: LookupControllerCreateOpts) {
@@ -43,9 +47,17 @@ export class NoteLookupCmd {
       result.items.map(async (value) => {
         if (value.label === "Create New") {
           isNew = true;
+          let title;
+          if (this.factory.isJournalButtonPressed()) {
+            const journalDateFormat = ConfigUtils.getJournal(
+              this.config
+            ).dateFormat;
+            title = getJournalTitle(value.fname, journalDateFormat);
+          }
           const newNote = NoteUtils.create({
             fname: value.fname,
             vault: value.vault,
+            title,
           });
 
           // TODO: Add Schema and Template functionality

--- a/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
+++ b/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
@@ -10,6 +10,7 @@ import {
 import { inject, injectable } from "tsyringe";
 import * as vscode from "vscode";
 import { URI, Utils } from "vscode-uri";
+import { VaultSelectionMode } from "../../components/lookup/types";
 import { DENDRON_COMMANDS } from "../../constants";
 import { type ITelemetryClient } from "../../telemetry/common/ITelemetryClient";
 import { type ILookupProvider } from "./lookup/ILookupProvider";
@@ -35,6 +36,17 @@ export class NoteLookupCmd {
     const opts = _opts || {
       provider: this.noteProvider,
     };
+    const lookupConfig = ConfigUtils.getCommands(this.config).lookup;
+    const noteLookupConfig = lookupConfig.note;
+    if (opts?.vaultSelectionMode) {
+      opts.vaultButtonPressed =
+        opts.vaultSelectionMode === VaultSelectionMode.alwaysPrompt;
+    } else {
+      const vaultSelectionMode = noteLookupConfig.vaultSelectionModeOnCreate;
+      opts.vaultButtonPressed = vaultSelectionMode === "alwaysPrompt";
+    }
+    opts.disableVaultSelection = !noteLookupConfig.confirmVaultOnCreate;
+
     const result = await this.factory.showLookup(opts);
 
     if (!result) {

--- a/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
+++ b/packages/plugin-core/src/web/commands/NoteLookupCmd.ts
@@ -10,7 +10,10 @@ import { URI, Utils } from "vscode-uri";
 import { DENDRON_COMMANDS } from "../../constants";
 import { type ITelemetryClient } from "../../telemetry/common/ITelemetryClient";
 import { type ILookupProvider } from "./lookup/ILookupProvider";
-import { LookupController } from "./lookup/LookupController";
+import {
+  LookupController,
+  LookupControllerCreateOpts,
+} from "./lookup/LookupController";
 
 @injectable()
 export class NoteLookupCmd {
@@ -23,12 +26,12 @@ export class NoteLookupCmd {
     @inject("ITelemetryClient") private _analytics: ITelemetryClient
   ) {}
 
-  public async run() {
+  public async run(_opts?: LookupControllerCreateOpts) {
     this._analytics.track(DENDRON_COMMANDS.LOOKUP_NOTE.key);
-
-    const result = await this.factory.showLookup({
+    const opts = _opts || {
       provider: this.noteProvider,
-    });
+    };
+    const result = await this.factory.showLookup(opts);
 
     if (!result) {
       return;

--- a/packages/plugin-core/src/web/commands/lookup/LookupController.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupController.ts
@@ -91,6 +91,7 @@ export class LookupController {
       buttons: opts.buttons,
       provider: opts.provider,
       initialValue,
+      noteType: opts.noteType,
     });
     this._disposables.push(new LookupQuickPickView(qp, this.viewModel));
 
@@ -217,13 +218,14 @@ export class LookupController {
         },
       })
       .then((initialItems) => {
-        if (initialItems) {
+        if (initialItems && !qp.items.length) {
           qp.items = initialItems;
-          initialized = true;
         }
+        initialized = true;
       });
 
     qp.onDidChangeValue(async (newInput) => {
+      if (!initialized && !opts.noteType) return;
       const items = await opts.provider!.provideItems({
         pickerValue: newInput,
         showDirectChildrenOnly: false,

--- a/packages/plugin-core/src/web/commands/lookup/LookupController.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupController.ts
@@ -112,69 +112,7 @@ export class LookupController {
       new LookupQuickPickView(qp, this.viewModel, this.lookupUtils)
     );
 
-    const journalBtn = this.lookupUtils.getButtonFromArray(
-      LookupNoteTypeEnum.journal,
-      qp.buttons
-    );
-    if (journalBtn) {
-      this._disposables.push(
-        this.viewModel.nameModifierMode.bind(async (newValue, prevValue) => {
-          switch (prevValue) {
-            case LookupNoteTypeEnum.journal:
-              if (journalBtn)
-                this.lookupUtils.onJournalButtonToggled(
-                  false,
-                  qp,
-                  initialValue
-                );
-              break;
-            default:
-              break;
-          }
-
-          switch (newValue) {
-            case LookupNoteTypeEnum.journal:
-              if (journalBtn) this.lookupUtils.onJournalButtonToggled(true, qp);
-              break;
-            case LookupNoteTypeEnum.none:
-              break;
-            default:
-          }
-        })
-      );
-    }
-
-    const directChildBtn = this.lookupUtils.getButton(
-      "directChildOnly",
-      qp.buttons
-    );
-    if (directChildBtn) {
-      this._disposables.push(
-        this.viewModel.isApplyDirectChildFilter.bind(async (newValue) => {
-          const items = await opts.provider.provideItems({
-            pickerValue: qp.value,
-            showDirectChildrenOnly: newValue,
-            workspaceState: {
-              vaults: this.vaults,
-              schemas: {},
-            },
-          });
-          qp.items = items;
-        })
-      );
-    }
-
-    const vaultSelectionBtn = this.lookupUtils.getButton(
-      "selectVault",
-      qp.buttons
-    );
-    if (vaultSelectionBtn) {
-      this._disposables.push(
-        this.viewModel.vaultSelectionMode.bind(async (newValue) => {
-          this.viewModel.vaultSelectionMode.value = newValue;
-        })
-      );
-    }
+    this.setupViewModelCallbacks(qp, initialValue, opts);
 
     this.initializeViewStateFromButtons(qp.buttons);
 
@@ -469,5 +407,87 @@ export class LookupController {
     if (_.isUndefined(bubbleUpCreateNew)) bubbleUpCreateNew = true;
 
     return noSpecialQueryChars && noExactMatches && bubbleUpCreateNew;
+  }
+
+  private setupViewModelCallbacks(
+    qp: DendronWebQuickPick<NoteQuickInputV2>,
+    initialValue: string | undefined,
+    opts: LookupControllerCreateOpts
+  ) {
+    const journalBtn = this.lookupUtils.getButtonFromArray(
+      LookupNoteTypeEnum.journal,
+      qp.buttons
+    );
+    if (journalBtn) {
+      this._disposables.push(
+        this.viewModel.nameModifierMode.bind(async (newValue, prevValue) => {
+          switch (prevValue) {
+            case LookupNoteTypeEnum.journal:
+              if (journalBtn)
+                this.lookupUtils.onJournalButtonToggled(
+                  false,
+                  qp,
+                  initialValue
+                );
+              break;
+            default:
+              break;
+          }
+
+          switch (newValue) {
+            case LookupNoteTypeEnum.journal:
+              if (journalBtn) this.lookupUtils.onJournalButtonToggled(true, qp);
+              break;
+            case LookupNoteTypeEnum.none:
+              break;
+            default:
+          }
+        })
+      );
+    }
+
+    const directChildBtn = this.lookupUtils.getButton(
+      "directChildOnly",
+      qp.buttons
+    );
+    if (directChildBtn) {
+      this._disposables.push(
+        this.viewModel.isApplyDirectChildFilter.bind(async (newValue) => {
+          const items = await opts.provider.provideItems({
+            pickerValue: qp.value,
+            showDirectChildrenOnly: newValue,
+            workspaceState: {
+              vaults: this.vaults,
+              schemas: {},
+            },
+          });
+          qp.items = items;
+        })
+      );
+    }
+
+    const vaultSelectionBtn = this.lookupUtils.getButton(
+      "selectVault",
+      qp.buttons
+    );
+    if (vaultSelectionBtn) {
+      this._disposables.push(
+        this.viewModel.vaultSelectionMode.bind(async (newValue) => {
+          this.viewModel.vaultSelectionMode.value = newValue;
+        })
+      );
+    }
+
+    const multiSelectBtn = this.lookupUtils.getButton(
+      "multiSelect",
+      qp.buttons
+    );
+    if (multiSelectBtn) {
+      this._disposables.push(
+        this.viewModel.isMultiSelectEnabled.bind(async (newValue) => {
+          qp.canSelectMany = newValue;
+        })
+      );
+    }
   }
 }

--- a/packages/plugin-core/src/web/commands/lookup/LookupController.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupController.ts
@@ -191,6 +191,10 @@ export class LookupController {
     return lookupPromise;
   }
 
+  public isJournalButtonPressed(): boolean {
+    return this.viewModel.nameModifierMode.value === LookupNoteTypeEnum.journal;
+  }
+
   createQuickPick(
     opts: LookupControllerCreateOpts
   ): DendronWebQuickPick<NoteQuickInputV2> {

--- a/packages/plugin-core/src/web/commands/lookup/LookupController.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupController.ts
@@ -53,7 +53,6 @@ export type LookupControllerCreateOpts = QuickPickOptions & {
    *  Defaults to true. */
   vaultSelectCanToggle?: boolean;
   vaultSelectionMode?: VaultSelectionMode;
-  nodeType?: "note" | "schema";
   //default true
   allowCreateNew?: boolean;
 };
@@ -98,16 +97,11 @@ export class LookupController {
     if (!initialValue) {
       initialValue = this.getInitialValueBasedOnActiveNote();
     }
-    const qp = this.createQuickPick({
-      title: opts.title || "Lookup Note",
-      buttons: opts.buttons,
-      provider: opts.provider,
+    opts = _.defaults(opts, {
       initialValue,
-      noteType: opts.noteType,
-      vaultButtonPressed: opts.vaultButtonPressed,
-      disableVaultSelection: opts.disableVaultSelection,
-      allowCreateNew: opts.allowCreateNew,
+      title: "Lookup Note",
     });
+    const qp = this.createQuickPick(opts);
     this._disposables.push(
       new LookupQuickPickView(qp, this.viewModel, this.lookupUtils)
     );

--- a/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
@@ -1,0 +1,328 @@
+import {
+  assertUnreachable,
+  LookupNoteTypeEnum,
+  LookupSelectionTypeEnum,
+  NoteQuickInputV2,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+import {
+  DendronWebQuickPick,
+  VaultSelectionMode,
+} from "../../../components/lookup/types";
+import { Disposable, QuickInputButton } from "vscode";
+import { ILookupViewModel } from "../../../components/lookup/LookupViewModel";
+import {
+  ButtonType,
+  DendronBtn,
+  IDendronQuickInputButton,
+} from "../../../components/lookup/ButtonTypes";
+
+/**
+ * A 'view' that represents the UI state of the Lookup Quick Pick. This
+ * essentially controls the button state of the quick pick and reacts upon user
+ * mouse clicks to the buttons.
+ */
+export class LookupQuickPickView implements Disposable {
+  private _quickPick: DendronWebQuickPick<NoteQuickInputV2>;
+  private _viewState: ILookupViewModel;
+  private _disposables: Disposable[];
+
+  constructor(
+    quickPick: DendronWebQuickPick<NoteQuickInputV2>,
+    viewModel: ILookupViewModel
+  ) {
+    this._quickPick = quickPick;
+    this._viewState = viewModel;
+    this._disposables = [];
+
+    this.setupViewModel();
+
+    this._disposables.push(
+      this._quickPick.onDidTriggerButton(this.onTriggerButton)
+    );
+  }
+
+  dispose() {
+    this._disposables.forEach((callback) => callback.dispose());
+  }
+
+  private setupViewModel(): void {
+    const ToLinkBtn = this.getButton("selection2link");
+    const ExtractBtn = this.getButton("selectionExtract");
+    const ToItemsBtn = this.getButton("selection2Items");
+
+    this._disposables.push(
+      this._viewState.selectionState.bind(async (newValue) => {
+        switch (newValue) {
+          case LookupSelectionTypeEnum.selection2Items: {
+            if (ToLinkBtn) ToLinkBtn.pressed = false;
+            if (ExtractBtn) ExtractBtn.pressed = false;
+            if (ToItemsBtn) ToItemsBtn.pressed = true;
+            break;
+          }
+
+          case LookupSelectionTypeEnum.selection2link: {
+            if (ToLinkBtn) ToLinkBtn.pressed = true;
+            if (ExtractBtn) ExtractBtn.pressed = false;
+            if (ToItemsBtn) ToItemsBtn.pressed = false;
+            break;
+          }
+          case LookupSelectionTypeEnum.selectionExtract: {
+            if (ToLinkBtn) ToLinkBtn.pressed = false;
+            if (ExtractBtn) ExtractBtn.pressed = true;
+            if (ToItemsBtn) ToItemsBtn.pressed = false;
+            break;
+          }
+          case LookupSelectionTypeEnum.none: {
+            if (ToLinkBtn) ToLinkBtn.pressed = false;
+            if (ExtractBtn) ExtractBtn.pressed = false;
+            if (ToItemsBtn) ToItemsBtn.pressed = false;
+            break;
+          }
+          default:
+            assertUnreachable(newValue);
+        }
+
+        const buttons: DendronBtn[] = [];
+
+        if (ToLinkBtn) buttons.push(ToLinkBtn);
+        if (ExtractBtn) buttons.push(ExtractBtn);
+        if (ToItemsBtn) buttons.push(ToItemsBtn);
+
+        this.updateButtonsOnQuickPick(...buttons);
+      })
+    );
+
+    const vaultSelectionBtn = this.getButton("selectVault");
+    if (vaultSelectionBtn !== undefined) {
+      this._disposables.push(
+        this._viewState.vaultSelectionMode.bind(async (newValue) => {
+          vaultSelectionBtn.pressed =
+            newValue === VaultSelectionMode.alwaysPrompt;
+          this.updateButtonsOnQuickPick(vaultSelectionBtn);
+        })
+      );
+    }
+
+    const multiSelectBtn = this.getButton("multiSelect");
+    if (multiSelectBtn) {
+      this._disposables.push(
+        this._viewState.isMultiSelectEnabled.bind(async (newValue) => {
+          multiSelectBtn.pressed = newValue;
+          this.updateButtonsOnQuickPick(multiSelectBtn);
+        })
+      );
+    }
+
+    const copyLinkBtn = this.getButton("copyNoteLink");
+    if (copyLinkBtn) {
+      this._disposables.push(
+        this._viewState.isCopyNoteLinkEnabled.bind(async (enabled) => {
+          copyLinkBtn.pressed = enabled;
+          this.updateButtonsOnQuickPick(copyLinkBtn);
+        })
+      );
+    }
+
+    const directChildBtn = this.getButton("directChildOnly");
+    if (directChildBtn) {
+      this._disposables.push(
+        this._viewState.isApplyDirectChildFilter.bind(async (newValue) => {
+          directChildBtn.pressed = newValue;
+          this.updateButtonsOnQuickPick(directChildBtn);
+        })
+      );
+    }
+
+    const journalBtn = this.getButton(LookupNoteTypeEnum.journal);
+    const scratchBtn = this.getButton(LookupNoteTypeEnum.scratch);
+    const taskBtn = this.getButton(LookupNoteTypeEnum.task);
+
+    this._disposables.push(
+      this._viewState.nameModifierMode.bind(async (newValue) => {
+        switch (newValue) {
+          case LookupNoteTypeEnum.journal:
+            if (journalBtn) journalBtn.pressed = true;
+            if (scratchBtn) scratchBtn.pressed = false;
+            if (taskBtn) taskBtn.pressed = false;
+            break;
+
+          case LookupNoteTypeEnum.scratch:
+            if (journalBtn) journalBtn.pressed = false;
+            if (scratchBtn) scratchBtn.pressed = true;
+            if (taskBtn) taskBtn.pressed = false;
+            break;
+
+          case LookupNoteTypeEnum.task:
+            if (journalBtn) journalBtn.pressed = false;
+            if (scratchBtn) scratchBtn.pressed = false;
+            if (taskBtn) taskBtn.pressed = true;
+            break;
+
+          case LookupNoteTypeEnum.none:
+            if (journalBtn) journalBtn.pressed = false;
+            if (scratchBtn) scratchBtn.pressed = false;
+            if (taskBtn) taskBtn.pressed = false;
+            break;
+
+          default:
+            assertUnreachable(newValue);
+        }
+
+        const validButtons: DendronBtn[] = [];
+
+        if (journalBtn) validButtons.push(journalBtn);
+        if (scratchBtn) validButtons.push(scratchBtn);
+        if (taskBtn) validButtons.push(taskBtn);
+
+        this.updateButtonsOnQuickPick(...validButtons);
+      })
+    );
+
+    const horizontalBtn = this.getButton("horizontal");
+    if (horizontalBtn) {
+      this._disposables.push(
+        this._viewState.isSplitHorizontally.bind(async (splitHorizontally) => {
+          horizontalBtn.pressed = splitHorizontally;
+
+          this.updateButtonsOnQuickPick(horizontalBtn);
+        })
+      );
+    }
+  }
+
+  private getButtonFromArray(type: ButtonType, buttons: readonly DendronBtn[]) {
+    //@ts-ignore
+    return _.find(buttons, (value) => value.type === type);
+  }
+
+  private getButton(type: ButtonType): DendronBtn | undefined {
+    if (this._quickPick) {
+      return this.getButtonFromArray(type, this._quickPick.buttons);
+    }
+    return;
+  }
+
+  private updateButtonsOnQuickPick(...btns: DendronBtn[]): void {
+    const newButtons = this._quickPick!.buttons.map((b: DendronBtn) => {
+      //@ts-ignore
+      const toUpdate = _.find(btns, (value) => value.type === b.type);
+
+      if (toUpdate) {
+        return toUpdate;
+      } else {
+        return b.clone();
+      }
+    });
+    this._quickPick!.buttons = newButtons;
+  }
+
+  private onTriggerButton = (btn: QuickInputButton) => {
+    const btnType = (btn as IDendronQuickInputButton).type;
+
+    switch (btnType) {
+      case LookupSelectionTypeEnum.selection2Items:
+        if (
+          this.getButton(LookupSelectionTypeEnum.selection2Items)?.canToggle
+        ) {
+          this._viewState.selectionState.value =
+            this._viewState.selectionState.value ===
+            LookupSelectionTypeEnum.selection2Items
+              ? LookupSelectionTypeEnum.none
+              : LookupSelectionTypeEnum.selection2Items;
+        }
+        break;
+
+      case LookupSelectionTypeEnum.selection2link:
+        if (this.getButton(LookupSelectionTypeEnum.selection2link)?.canToggle) {
+          this._viewState.selectionState.value =
+            this._viewState.selectionState.value ===
+            LookupSelectionTypeEnum.selection2link
+              ? LookupSelectionTypeEnum.none
+              : LookupSelectionTypeEnum.selection2link;
+        }
+        break;
+
+      case LookupSelectionTypeEnum.selectionExtract:
+        if (
+          this.getButton(LookupSelectionTypeEnum.selectionExtract)?.canToggle
+        ) {
+          this._viewState.selectionState.value =
+            this._viewState.selectionState.value ===
+            LookupSelectionTypeEnum.selectionExtract
+              ? LookupSelectionTypeEnum.none
+              : LookupSelectionTypeEnum.selectionExtract;
+        }
+        break;
+      case "selectVault": {
+        if (this.getButton("selectVault")?.canToggle) {
+          this._viewState.vaultSelectionMode.value =
+            this._viewState.vaultSelectionMode.value ===
+            VaultSelectionMode.alwaysPrompt
+              ? VaultSelectionMode.smart
+              : VaultSelectionMode.alwaysPrompt;
+        }
+        break;
+      }
+      case "multiSelect": {
+        if (this.getButton("multiSelect")?.canToggle) {
+          this._viewState.isMultiSelectEnabled.value =
+            !this._viewState.isMultiSelectEnabled.value;
+        }
+        break;
+      }
+      case "copyNoteLink": {
+        if (this.getButton("copyNoteLink")?.canToggle) {
+          this._viewState.isCopyNoteLinkEnabled.value =
+            !this._viewState.isCopyNoteLinkEnabled.value;
+        }
+        break;
+      }
+      case "directChildOnly": {
+        if (this.getButton("directChildOnly")?.canToggle) {
+          this._viewState.isApplyDirectChildFilter.value =
+            !this._viewState.isApplyDirectChildFilter.value;
+        }
+        break;
+      }
+      case LookupNoteTypeEnum.journal: {
+        if (this.getButton(LookupNoteTypeEnum.journal)?.canToggle) {
+          this._viewState.nameModifierMode.value =
+            this._viewState.nameModifierMode.value ===
+            LookupNoteTypeEnum.journal
+              ? LookupNoteTypeEnum.none
+              : LookupNoteTypeEnum.journal;
+        }
+        break;
+      }
+      case LookupNoteTypeEnum.scratch: {
+        if (this.getButton(LookupNoteTypeEnum.scratch)?.canToggle) {
+          this._viewState.nameModifierMode.value =
+            this._viewState.nameModifierMode.value ===
+            LookupNoteTypeEnum.scratch
+              ? LookupNoteTypeEnum.none
+              : LookupNoteTypeEnum.scratch;
+        }
+        break;
+      }
+      case LookupNoteTypeEnum.task: {
+        if (this.getButton(LookupNoteTypeEnum.task)?.canToggle) {
+          this._viewState.nameModifierMode.value =
+            this._viewState.nameModifierMode.value === LookupNoteTypeEnum.task
+              ? LookupNoteTypeEnum.none
+              : LookupNoteTypeEnum.task;
+        }
+        break;
+      }
+      case "horizontal": {
+        if (this.getButton("horizontal")?.canToggle) {
+          this._viewState.isSplitHorizontally.value =
+            !this._viewState.isSplitHorizontally.value;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+}

--- a/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
@@ -12,10 +12,10 @@ import {
 import { Disposable, QuickInputButton } from "vscode";
 import { ILookupViewModel } from "../../../components/lookup/LookupViewModel";
 import {
-  ButtonType,
   DendronBtn,
   IDendronQuickInputButton,
 } from "../../../components/lookup/ButtonTypes";
+import { NoteLookupUtilsWeb } from "../../utils/NoteLookupUtilsWeb";
 
 /**
  * A 'view' that represents the UI state of the Lookup Quick Pick. This
@@ -29,7 +29,8 @@ export class LookupQuickPickView implements Disposable {
 
   constructor(
     quickPick: DendronWebQuickPick<NoteQuickInputV2>,
-    viewModel: ILookupViewModel
+    viewModel: ILookupViewModel,
+    private lookupUtils: NoteLookupUtilsWeb
   ) {
     this._quickPick = quickPick;
     this._viewState = viewModel;
@@ -47,9 +48,18 @@ export class LookupQuickPickView implements Disposable {
   }
 
   private setupViewModel(): void {
-    const ToLinkBtn = this.getButton("selection2link");
-    const ExtractBtn = this.getButton("selectionExtract");
-    const ToItemsBtn = this.getButton("selection2Items");
+    const ToLinkBtn = this.lookupUtils.getButton(
+      "selection2link",
+      this._quickPick.buttons
+    );
+    const ExtractBtn = this.lookupUtils.getButton(
+      "selectionExtract",
+      this._quickPick.buttons
+    );
+    const ToItemsBtn = this.lookupUtils.getButton(
+      "selection2Items",
+      this._quickPick.buttons
+    );
 
     this._disposables.push(
       this._viewState.selectionState.bind(async (newValue) => {
@@ -93,7 +103,10 @@ export class LookupQuickPickView implements Disposable {
       })
     );
 
-    const vaultSelectionBtn = this.getButton("selectVault");
+    const vaultSelectionBtn = this.lookupUtils.getButton(
+      "selectVault",
+      this._quickPick.buttons
+    );
     if (vaultSelectionBtn !== undefined) {
       this._disposables.push(
         this._viewState.vaultSelectionMode.bind(async (newValue) => {
@@ -104,7 +117,10 @@ export class LookupQuickPickView implements Disposable {
       );
     }
 
-    const multiSelectBtn = this.getButton("multiSelect");
+    const multiSelectBtn = this.lookupUtils.getButton(
+      "multiSelect",
+      this._quickPick.buttons
+    );
     if (multiSelectBtn) {
       this._disposables.push(
         this._viewState.isMultiSelectEnabled.bind(async (newValue) => {
@@ -114,7 +130,10 @@ export class LookupQuickPickView implements Disposable {
       );
     }
 
-    const copyLinkBtn = this.getButton("copyNoteLink");
+    const copyLinkBtn = this.lookupUtils.getButton(
+      "copyNoteLink",
+      this._quickPick.buttons
+    );
     if (copyLinkBtn) {
       this._disposables.push(
         this._viewState.isCopyNoteLinkEnabled.bind(async (enabled) => {
@@ -124,7 +143,10 @@ export class LookupQuickPickView implements Disposable {
       );
     }
 
-    const directChildBtn = this.getButton("directChildOnly");
+    const directChildBtn = this.lookupUtils.getButton(
+      "directChildOnly",
+      this._quickPick.buttons
+    );
     if (directChildBtn) {
       this._disposables.push(
         this._viewState.isApplyDirectChildFilter.bind(async (newValue) => {
@@ -134,9 +156,18 @@ export class LookupQuickPickView implements Disposable {
       );
     }
 
-    const journalBtn = this.getButton(LookupNoteTypeEnum.journal);
-    const scratchBtn = this.getButton(LookupNoteTypeEnum.scratch);
-    const taskBtn = this.getButton(LookupNoteTypeEnum.task);
+    const journalBtn = this.lookupUtils.getButton(
+      LookupNoteTypeEnum.journal,
+      this._quickPick.buttons
+    );
+    const scratchBtn = this.lookupUtils.getButton(
+      LookupNoteTypeEnum.scratch,
+      this._quickPick.buttons
+    );
+    const taskBtn = this.lookupUtils.getButton(
+      LookupNoteTypeEnum.task,
+      this._quickPick.buttons
+    );
 
     this._disposables.push(
       this._viewState.nameModifierMode.bind(async (newValue) => {
@@ -179,7 +210,10 @@ export class LookupQuickPickView implements Disposable {
       })
     );
 
-    const horizontalBtn = this.getButton("horizontal");
+    const horizontalBtn = this.lookupUtils.getButton(
+      "horizontal",
+      this._quickPick.buttons
+    );
     if (horizontalBtn) {
       this._disposables.push(
         this._viewState.isSplitHorizontally.bind(async (splitHorizontally) => {
@@ -189,17 +223,6 @@ export class LookupQuickPickView implements Disposable {
         })
       );
     }
-  }
-
-  private getButtonFromArray(type: ButtonType, buttons: readonly DendronBtn[]) {
-    return _.find(buttons, (value) => value.type === type);
-  }
-
-  private getButton(type: ButtonType): DendronBtn | undefined {
-    if (this._quickPick) {
-      return this.getButtonFromArray(type, this._quickPick.buttons);
-    }
-    return;
   }
 
   private updateButtonsOnQuickPick(...btns: DendronBtn[]): void {
@@ -222,7 +245,10 @@ export class LookupQuickPickView implements Disposable {
     switch (btnType) {
       case LookupSelectionTypeEnum.selection2Items:
         if (
-          this.getButton(LookupSelectionTypeEnum.selection2Items)?.canToggle
+          this.lookupUtils.getButton(
+            LookupSelectionTypeEnum.selection2Items,
+            this._quickPick.buttons
+          )?.canToggle
         ) {
           this._viewState.selectionState.value =
             this._viewState.selectionState.value ===
@@ -233,7 +259,12 @@ export class LookupQuickPickView implements Disposable {
         break;
 
       case LookupSelectionTypeEnum.selection2link:
-        if (this.getButton(LookupSelectionTypeEnum.selection2link)?.canToggle) {
+        if (
+          this.lookupUtils.getButton(
+            LookupSelectionTypeEnum.selection2link,
+            this._quickPick.buttons
+          )?.canToggle
+        ) {
           this._viewState.selectionState.value =
             this._viewState.selectionState.value ===
             LookupSelectionTypeEnum.selection2link
@@ -244,7 +275,10 @@ export class LookupQuickPickView implements Disposable {
 
       case LookupSelectionTypeEnum.selectionExtract:
         if (
-          this.getButton(LookupSelectionTypeEnum.selectionExtract)?.canToggle
+          this.lookupUtils.getButton(
+            LookupSelectionTypeEnum.selectionExtract,
+            this._quickPick.buttons
+          )?.canToggle
         ) {
           this._viewState.selectionState.value =
             this._viewState.selectionState.value ===
@@ -254,7 +288,10 @@ export class LookupQuickPickView implements Disposable {
         }
         break;
       case "selectVault": {
-        if (this.getButton("selectVault")?.canToggle) {
+        if (
+          this.lookupUtils.getButton("selectVault", this._quickPick.buttons)
+            ?.canToggle
+        ) {
           this._viewState.vaultSelectionMode.value =
             this._viewState.vaultSelectionMode.value ===
             VaultSelectionMode.alwaysPrompt
@@ -264,28 +301,42 @@ export class LookupQuickPickView implements Disposable {
         break;
       }
       case "multiSelect": {
-        if (this.getButton("multiSelect")?.canToggle) {
+        if (
+          this.lookupUtils.getButton("multiSelect", this._quickPick.buttons)
+            ?.canToggle
+        ) {
           this._viewState.isMultiSelectEnabled.value =
             !this._viewState.isMultiSelectEnabled.value;
         }
         break;
       }
       case "copyNoteLink": {
-        if (this.getButton("copyNoteLink")?.canToggle) {
+        if (
+          this.lookupUtils.getButton("copyNoteLink", this._quickPick.buttons)
+            ?.canToggle
+        ) {
           this._viewState.isCopyNoteLinkEnabled.value =
             !this._viewState.isCopyNoteLinkEnabled.value;
         }
         break;
       }
       case "directChildOnly": {
-        if (this.getButton("directChildOnly")?.canToggle) {
+        if (
+          this.lookupUtils.getButton("directChildOnly", this._quickPick.buttons)
+            ?.canToggle
+        ) {
           this._viewState.isApplyDirectChildFilter.value =
             !this._viewState.isApplyDirectChildFilter.value;
         }
         break;
       }
       case LookupNoteTypeEnum.journal: {
-        if (this.getButton(LookupNoteTypeEnum.journal)?.canToggle) {
+        if (
+          this.lookupUtils.getButton(
+            LookupNoteTypeEnum.journal,
+            this._quickPick.buttons
+          )?.canToggle
+        ) {
           this._viewState.nameModifierMode.value =
             this._viewState.nameModifierMode.value ===
             LookupNoteTypeEnum.journal
@@ -295,7 +346,12 @@ export class LookupQuickPickView implements Disposable {
         break;
       }
       case LookupNoteTypeEnum.scratch: {
-        if (this.getButton(LookupNoteTypeEnum.scratch)?.canToggle) {
+        if (
+          this.lookupUtils.getButton(
+            LookupNoteTypeEnum.scratch,
+            this._quickPick.buttons
+          )?.canToggle
+        ) {
           this._viewState.nameModifierMode.value =
             this._viewState.nameModifierMode.value ===
             LookupNoteTypeEnum.scratch
@@ -305,7 +361,12 @@ export class LookupQuickPickView implements Disposable {
         break;
       }
       case LookupNoteTypeEnum.task: {
-        if (this.getButton(LookupNoteTypeEnum.task)?.canToggle) {
+        if (
+          this.lookupUtils.getButton(
+            LookupNoteTypeEnum.task,
+            this._quickPick.buttons
+          )?.canToggle
+        ) {
           this._viewState.nameModifierMode.value =
             this._viewState.nameModifierMode.value === LookupNoteTypeEnum.task
               ? LookupNoteTypeEnum.none
@@ -314,7 +375,10 @@ export class LookupQuickPickView implements Disposable {
         break;
       }
       case "horizontal": {
-        if (this.getButton("horizontal")?.canToggle) {
+        if (
+          this.lookupUtils.getButton("horizontal", this._quickPick.buttons)
+            ?.canToggle
+        ) {
           this._viewState.isSplitHorizontally.value =
             !this._viewState.isSplitHorizontally.value;
         }

--- a/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
+++ b/packages/plugin-core/src/web/commands/lookup/LookupQuickPickView.ts
@@ -192,7 +192,6 @@ export class LookupQuickPickView implements Disposable {
   }
 
   private getButtonFromArray(type: ButtonType, buttons: readonly DendronBtn[]) {
-    //@ts-ignore
     return _.find(buttons, (value) => value.type === type);
   }
 

--- a/packages/plugin-core/src/web/commands/lookup/QuickPickUtils.ts
+++ b/packages/plugin-core/src/web/commands/lookup/QuickPickUtils.ts
@@ -1,0 +1,55 @@
+import { DNodeUtils, DVault, NoteProps, URI } from "@dendronhq/common-all";
+import { inject, injectable } from "tsyringe";
+import { window } from "vscode";
+
+export enum ProceedCancel {
+  PROCEED = "proceed",
+  CANCEL = "cancel",
+}
+
+@injectable()
+export class QuickPickUtils {
+  constructor(
+    @inject("vaults") private vaults: DVault[],
+    @inject("wsRoot") private wsRoot: URI
+  ) {}
+  /** Shows quick pick with proceed/cancel view which
+   *  will be blocking until user picks an answer. */
+  static async showProceedCancel(): Promise<ProceedCancel> {
+    const proceedString = "proceed";
+
+    const userChoice = await window.showQuickPick([proceedString, "cancel"], {
+      placeHolder: proceedString,
+      ignoreFocusOut: true,
+    });
+
+    if (userChoice === proceedString) {
+      return ProceedCancel.PROCEED;
+    } else {
+      return ProceedCancel.CANCEL;
+    }
+  }
+
+  /**
+   *  Show a quick pick with the given notes as choices. Returns the chosen note
+   *  or undefined if user cancelled the note selection.
+   *  */
+  async showChooseNote(notes: NoteProps[]): Promise<NoteProps | undefined> {
+    const inputItems = await Promise.all(
+      notes.map(async (ent) => {
+        return DNodeUtils.enhancePropForQuickInputV3({
+          wsRoot: this.wsRoot.fsPath,
+          props: ent,
+          vaults: this.vaults,
+        });
+      })
+    );
+
+    const chosen = await window.showQuickPick(inputItems);
+    if (chosen === undefined) {
+      return undefined;
+    } else {
+      return chosen;
+    }
+  }
+}

--- a/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
+++ b/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
@@ -172,7 +172,8 @@ export class VaultQuickPick {
       allVaults = _.filter(allVaults, (v) => {
         return !_.isEqual(v, vault);
       });
-
+      // TODO: this isn't right. Sometimes vaultSuggestion already has
+      // the value that we are trying to push. This leads to duplicate entries
       allVaults.forEach((wsVault) => {
         vaultSuggestions.push({
           vault: wsVault,

--- a/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
+++ b/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
@@ -67,7 +67,6 @@ export class VaultQuickPick {
     vaults: DVault[];
     fname: string;
   }): Promise<VaultPickerItem[]> {
-    // TODO: Filter out any vaults where a note with that fname already exists.
     let vaultSuggestions: VaultPickerItem[] = [];
 
     // Only 1 vault, no other options to choose from:
@@ -172,14 +171,22 @@ export class VaultQuickPick {
       allVaults = _.filter(allVaults, (v) => {
         return !_.isEqual(v, vault);
       });
-      // TODO: this isn't right. Sometimes vaultSuggestion already has
-      // the value that we are trying to push. This leads to duplicate entries
       allVaults.forEach((wsVault) => {
         vaultSuggestions.push({
           vault: wsVault,
           label: VaultUtils.getName(wsVault),
         });
       });
+    }
+    // Filter out any vaults where a note with that fname already exists.
+    const vaultsWithMatchingFile = new Set(
+      (await this._engine.findNotesMeta({ fname })).map((n) => n.vault.fsPath)
+    );
+    if (vaultsWithMatchingFile.size > 0) {
+      // Available vaults are vaults that do not have the desired file name.
+      vaultSuggestions = vaultSuggestions.filter(
+        (v) => !vaultsWithMatchingFile.has(v.vault.fsPath)
+      );
     }
 
     return vaultSuggestions;

--- a/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
+++ b/packages/plugin-core/src/web/commands/lookup/VaultQuickPick.ts
@@ -58,7 +58,7 @@ export class VaultQuickPick {
    * @param
    * @returns
    */
-  private async getVaultRecommendations({
+  async getVaultRecommendations({
     vault,
     vaults,
     fname,
@@ -185,7 +185,7 @@ export class VaultQuickPick {
     return vaultSuggestions;
   }
 
-  private async promptVault(
+  async promptVault(
     pickerItems: VaultPickerItem[]
   ): Promise<DVault | undefined> {
     const items = pickerItems.map((ent) => ({

--- a/packages/plugin-core/src/web/extension.ts
+++ b/packages/plugin-core/src/web/extension.ts
@@ -11,6 +11,7 @@ import { CopyNoteURLCmd } from "./commands/CopyNoteURLCmd";
 import { NoteLookupCmd } from "./commands/NoteLookupCmd";
 import { TogglePreviewCmd } from "./commands/TogglePreviewCmd";
 import { setupWebExtContainer } from "./injection-providers/setupWebExtContainer";
+import { CreateJournalNoteCmd } from "./commands/CreateJournalNoteCmd";
 
 /**
  * This is the entry point for the web extension variant of Dendron
@@ -109,6 +110,16 @@ async function setupCommands(context: vscode.ExtensionContext) {
         DENDRON_COMMANDS.TREEVIEW_GOTO_NOTE.key,
         async (_args: any) => {
           await container.resolve(NoteLookupCmd).run();
+        }
+      )
+    );
+  }
+  if (!existingCommands.includes(CreateJournalNoteCmd.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        CreateJournalNoteCmd.key,
+        async (_args: any) => {
+          await container.resolve(CreateJournalNoteCmd).run();
         }
       )
     );

--- a/packages/plugin-core/src/web/extension.ts
+++ b/packages/plugin-core/src/web/extension.ts
@@ -12,6 +12,7 @@ import { NoteLookupCmd } from "./commands/NoteLookupCmd";
 import { TogglePreviewCmd } from "./commands/TogglePreviewCmd";
 import { setupWebExtContainer } from "./injection-providers/setupWebExtContainer";
 import { CreateJournalNoteCmd } from "./commands/CreateJournalNoteCmd";
+import { MoveNoteCmd } from "./commands/MoveNoteCmd";
 
 /**
  * This is the entry point for the web extension variant of Dendron
@@ -122,6 +123,13 @@ async function setupCommands(context: vscode.ExtensionContext) {
           await container.resolve(CreateJournalNoteCmd).run();
         }
       )
+    );
+  }
+  if (!existingCommands.includes(MoveNoteCmd.key)) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(MoveNoteCmd.key, async (_args: any) => {
+        await container.resolve(MoveNoteCmd).run();
+      })
     );
   }
 }

--- a/packages/plugin-core/src/web/test/helpers/setupTestEngineContainer.ts
+++ b/packages/plugin-core/src/web/test/helpers/setupTestEngineContainer.ts
@@ -193,7 +193,7 @@ export async function createNote(opts: CreateNoteOptsV4) {
   return note;
 }
 
-function getConfig(): DendronConfig {
+export function getConfig(): DendronConfig {
   const pubConfig: DendronPublishingConfig = {
     copyAssets: false,
     siteHierarchies: [],

--- a/packages/plugin-core/src/web/test/helpers/setupTestEngineContainer.ts
+++ b/packages/plugin-core/src/web/test/helpers/setupTestEngineContainer.ts
@@ -157,7 +157,7 @@ type CreateNoteOptsV4 = {
   stub?: boolean;
 };
 
-async function createNote(opts: CreateNoteOptsV4) {
+export async function createNote(opts: CreateNoteOptsV4) {
   const {
     fname,
     vault,

--- a/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
@@ -14,7 +14,7 @@ import {
   QuickPickUtils,
 } from "../../../commands/lookup/QuickPickUtils";
 import { createNote } from "../../helpers/setupTestEngineContainer";
-import { WorkspaceHelpers } from "../../helpers/WorkspaceHelpers";
+import * as vscode from "vscode";
 
 function getVaults(): DVault[] {
   const vaults: DVault[] = [{ fsPath: "vault1" }, { fsPath: "vault2" }];
@@ -26,7 +26,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN move note from vault1 to vault2 THEN move successfully", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
+    const wsRoot = vscode.Uri.file("tmp");
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -68,7 +68,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN multiple notes are moved from vault1 to vault2 THEN the desired moves has correct data", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
+    const wsRoot = vscode.Uri.file("tmp");
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -120,7 +120,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN all vaults already have a note selected to move THEN show error message to user", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
+    const wsRoot = vscode.Uri.file("tmp");
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -137,13 +137,13 @@ suite("WHEN Move note command is run", () => {
       fname: "foo.one",
       vault: vaults[0],
       wsRoot,
-      noWrite: false,
+      noWrite: true,
     });
     const note2 = await createNote({
       fname: "foo.one",
       vault: vaults[1],
       wsRoot,
-      noWrite: false,
+      noWrite: true,
     });
     mockEngine.queryNotes.resolves([]);
     mockEngine.findNotesMeta.resolves([note1, note2]);
@@ -167,7 +167,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN no items selected to move THEN result should be an empty array", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
+    const wsRoot = vscode.Uri.file("tmp");
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);

--- a/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
@@ -2,7 +2,6 @@ import { DVault, NoteQuickInput, ReducedDEngine } from "@dendronhq/common-all";
 import { stubInterface } from "ts-sinon";
 import { ILookupProvider } from "../../../commands/lookup/ILookupProvider";
 import { MoveNoteCmd } from "../../../commands/MoveNoteCmd";
-import * as vscode from "vscode";
 import {
   LookupAcceptPayload,
   LookupController,
@@ -15,6 +14,7 @@ import {
   QuickPickUtils,
 } from "../../../commands/lookup/QuickPickUtils";
 import { createNote } from "../../helpers/setupTestEngineContainer";
+import { WorkspaceHelpers } from "../../helpers/WorkspaceHelpers";
 
 function getVaults(): DVault[] {
   const vaults: DVault[] = [{ fsPath: "vault1" }, { fsPath: "vault2" }];
@@ -26,7 +26,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN move note from vault1 to vault2 THEN move successfully", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -68,7 +68,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN multiple notes are moved from vault1 to vault2 THEN the desired moves has correct data", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -120,7 +120,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN all vaults already have a note selected to move THEN show error message to user", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
@@ -137,11 +137,13 @@ suite("WHEN Move note command is run", () => {
       fname: "foo.one",
       vault: vaults[0],
       wsRoot,
+      noWrite: false,
     });
     const note2 = await createNote({
       fname: "foo.one",
       vault: vaults[1],
       wsRoot,
+      noWrite: false,
     });
     mockEngine.queryNotes.resolves([]);
     mockEngine.findNotesMeta.resolves([note1, note2]);
@@ -165,7 +167,7 @@ suite("WHEN Move note command is run", () => {
   test("WHEN no items selected to move THEN result should be an empty array", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();
     const mockEngine = stubInterface<ReducedDEngine>();
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);

--- a/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
@@ -1,0 +1,191 @@
+import { DVault, NoteQuickInput, ReducedDEngine } from "@dendronhq/common-all";
+import { stubInterface } from "ts-sinon";
+import { ILookupProvider } from "../../../commands/lookup/ILookupProvider";
+import { MoveNoteCmd } from "../../../commands/MoveNoteCmd";
+import * as vscode from "vscode";
+import {
+  LookupAcceptPayload,
+  LookupController,
+} from "../../../commands/lookup/LookupController";
+import sinon from "sinon";
+import { window } from "vscode";
+import assert from "assert";
+import {
+  ProceedCancel,
+  QuickPickUtils,
+} from "../../../commands/lookup/QuickPickUtils";
+import { createNote } from "../../helpers/setupTestEngineContainer";
+
+function getVaults(): DVault[] {
+  const vaults: DVault[] = [{ fsPath: "vault1" }, { fsPath: "vault2" }];
+
+  return vaults;
+}
+
+suite("WHEN Move note command is run", () => {
+  test("WHEN move note from vault1 to vault2 THEN move successfully", async () => {
+    const mockNoteProvider = stubInterface<ILookupProvider>();
+    const mockEngine = stubInterface<ReducedDEngine>();
+    const wsRoot = vscode.Uri.file("tmp");
+    const factory = {
+      showLookup: () => {
+        return Promise.resolve(0);
+      },
+    } as unknown as LookupController;
+    const vaults = getVaults();
+    const lookupReturn: LookupAcceptPayload = {
+      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInput],
+    };
+
+    const showLookupFake = sinon.fake.resolves(lookupReturn);
+    sinon.replace(factory, "showLookup", showLookupFake);
+    mockEngine.renameNote.resolves({ data: [] });
+    mockEngine.queryNotes.resolves([]);
+    mockEngine.findNotesMeta.resolves([]);
+    sinon.stub(window, "showQuickPick").resolves({ vault: vaults[1] } as any);
+
+    const moveNoteCmd = new MoveNoteCmd(
+      vaults,
+      mockNoteProvider,
+      mockEngine,
+      factory,
+      wsRoot
+    );
+    const movesSpy = sinon.spy(moveNoteCmd, "getDesiredMoves");
+
+    await moveNoteCmd.run({ closeAndOpenFile: false });
+    assert(movesSpy.alwaysCalledWith(lookupReturn, vaults[1]));
+    assert(
+      movesSpy.alwaysReturned([
+        {
+          oldLoc: { fname: "foo.one", vaultName: "vault1" },
+          newLoc: { fname: "foo.one", vaultName: "vault2" },
+        },
+      ])
+    );
+    sinon.restore();
+  });
+  test("WHEN multiple notes are moved from vault1 to vault2 THEN the desired moves has correct data", async () => {
+    const mockNoteProvider = stubInterface<ILookupProvider>();
+    const mockEngine = stubInterface<ReducedDEngine>();
+    const wsRoot = vscode.Uri.file("tmp");
+    const factory = {
+      showLookup: () => {
+        return Promise.resolve(0);
+      },
+    } as unknown as LookupController;
+    const vaults = getVaults();
+    const lookupReturn: LookupAcceptPayload = {
+      items: [
+        { fname: "foo.one", vault: vaults[0] } as NoteQuickInput,
+        { fname: "foo.two", vault: vaults[0] } as NoteQuickInput,
+      ],
+    };
+
+    const showLookupFake = sinon.fake.resolves(lookupReturn);
+    sinon.replace(factory, "showLookup", showLookupFake);
+    mockEngine.renameNote.resolves({ data: [] });
+    mockEngine.queryNotes.resolves([]);
+    mockEngine.findNotesMeta.resolves([]);
+    sinon.stub(window, "showQuickPick").resolves({ vault: vaults[1] } as any);
+
+    const moveNoteCmd = new MoveNoteCmd(
+      vaults,
+      mockNoteProvider,
+      mockEngine,
+      factory,
+      wsRoot
+    );
+    const movesSpy = sinon.spy(moveNoteCmd, "getDesiredMoves");
+    sinon
+      .stub(QuickPickUtils, "showProceedCancel")
+      .resolves(ProceedCancel.CANCEL);
+    const result = await moveNoteCmd.run({ closeAndOpenFile: false });
+    assert(movesSpy.alwaysCalledWith(lookupReturn, vaults[1]));
+    assert(
+      movesSpy.alwaysReturned([
+        {
+          oldLoc: { fname: "foo.one", vaultName: "vault1" },
+          newLoc: { fname: "foo.one", vaultName: "vault2" },
+        },
+        {
+          oldLoc: { fname: "foo.two", vaultName: "vault1" },
+          newLoc: { fname: "foo.two", vaultName: "vault2" },
+        },
+      ])
+    );
+    assert(result.changed.length === 0);
+    sinon.restore();
+  });
+  test("WHEN all vaults already have a note selected to move THEN show error message to user", async () => {
+    const mockNoteProvider = stubInterface<ILookupProvider>();
+    const mockEngine = stubInterface<ReducedDEngine>();
+    const wsRoot = vscode.Uri.file("tmp");
+    const factory = {
+      showLookup: () => {
+        return Promise.resolve(0);
+      },
+    } as unknown as LookupController;
+    const vaults = getVaults();
+    const lookupReturn: LookupAcceptPayload = {
+      items: [{ fname: "foo.one", vault: vaults[0] } as NoteQuickInput],
+    };
+
+    const showLookupFake = sinon.fake.resolves(lookupReturn);
+    sinon.replace(factory, "showLookup", showLookupFake);
+    const note1 = await createNote({
+      fname: "foo.one",
+      vault: vaults[0],
+      wsRoot,
+    });
+    const note2 = await createNote({
+      fname: "foo.one",
+      vault: vaults[1],
+      wsRoot,
+    });
+    mockEngine.queryNotes.resolves([]);
+    mockEngine.findNotesMeta.resolves([note1, note2]);
+    const windowSpy = sinon.spy(window, "showErrorMessage");
+    const moveNoteCmd = new MoveNoteCmd(
+      vaults,
+      mockNoteProvider,
+      mockEngine,
+      factory,
+      wsRoot
+    );
+
+    const result = await moveNoteCmd.run({ closeAndOpenFile: false });
+    const errorMsg = windowSpy.getCall(0).args[0];
+    assert(
+      errorMsg ===
+        "No available vaults for moving note. Each vault already has a note with filename foo.one"
+    );
+    assert(result.changed.length === 0);
+
+    sinon.restore();
+  });
+  test("WHEN no items selected to move THEN result should be an empty array", async () => {
+    const mockNoteProvider = stubInterface<ILookupProvider>();
+    const mockEngine = stubInterface<ReducedDEngine>();
+    const wsRoot = vscode.Uri.file("tmp");
+    const factory = {
+      showLookup: () => {
+        return Promise.resolve(0);
+      },
+    } as unknown as LookupController;
+    const vaults = getVaults();
+    const lookupReturn = {};
+
+    const showLookupFake = sinon.fake.resolves(lookupReturn);
+    sinon.replace(factory, "showLookup", showLookupFake);
+    const moveNoteCmd = new MoveNoteCmd(
+      vaults,
+      mockNoteProvider,
+      mockEngine,
+      factory,
+      wsRoot
+    );
+    const result = await moveNoteCmd.run({ closeAndOpenFile: false });
+    assert(result.changed.length === 0);
+  });
+});

--- a/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/MoveNoteCmd.test.ts
@@ -161,8 +161,6 @@ suite("WHEN Move note command is run", () => {
         "No available vaults for moving note. Each vault already has a note with filename foo.one"
     );
     assert(result.changed.length === 0);
-
-    sinon.restore();
   });
   test("WHEN no items selected to move THEN result should be an empty array", async () => {
     const mockNoteProvider = stubInterface<ILookupProvider>();

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -11,8 +11,8 @@ import { DummyTelemetryClient } from "../../../../telemetry/common/DummyTelemetr
 import { ILookupProvider } from "../../../commands/lookup/ILookupProvider";
 import {
   LookupAcceptPayload,
-  LookupQuickpickFactory,
-} from "../../../commands/lookup/LookupQuickpickFactory";
+  LookupController,
+} from "../../../commands/lookup/LookupController";
 import { NoteLookupCmd } from "../../../commands/NoteLookupCmd";
 
 require("mocha/mocha");
@@ -27,7 +27,7 @@ suite("GIVEN a NoteLookupCmd", () => {
       showLookup: () => {
         return Promise.resolve(0);
       },
-    } as unknown as LookupQuickpickFactory;
+    } as unknown as LookupController;
 
     const showLookupFake = sinon.fake.resolves(undefined);
     sinon.replace(factory, "showLookup", showLookupFake);
@@ -63,7 +63,7 @@ suite("GIVEN a NoteLookupCmd", () => {
       showLookup: () => {
         return Promise.resolve(0);
       },
-    } as unknown as LookupQuickpickFactory;
+    } as unknown as LookupController;
 
     const vault: DVault = {
       selfContained: true,
@@ -111,7 +111,7 @@ suite("GIVEN a NoteLookupCmd", () => {
       showLookup: () => {
         return Promise.resolve(0);
       },
-    } as unknown as LookupQuickpickFactory;
+    } as unknown as LookupController;
 
     const vault: DVault = {
       selfContained: true,

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -14,6 +14,8 @@ import {
   LookupController,
 } from "../../../commands/lookup/LookupController";
 import { NoteLookupCmd } from "../../../commands/NoteLookupCmd";
+import { getWorkspaceConfig } from "../../../injection-providers/getWorkspaceConfig";
+import { WorkspaceHelpers } from "../../helpers/WorkspaceHelpers";
 
 require("mocha/mocha");
 
@@ -21,6 +23,8 @@ suite("GIVEN a NoteLookupCmd", () => {
   test("WHEN the user selects nothing THEN nothing is written to the engine", async () => {
     const wsRoot = vscode.Uri.file("tmp");
 
+    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
+    const config = await getWorkspaceConfig(wsRoot);
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {
@@ -42,7 +46,8 @@ suite("GIVEN a NoteLookupCmd", () => {
       wsRoot,
       mockEngine,
       mockNoteProvider,
-      new DummyTelemetryClient()
+      new DummyTelemetryClient(),
+      config
     );
 
     await cmd.run();
@@ -56,7 +61,8 @@ suite("GIVEN a NoteLookupCmd", () => {
 
   test("WHEN the user selects a note THEN that note is opened", async () => {
     const wsRoot = vscode.Uri.file("tmp");
-
+    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
+    const config = await getWorkspaceConfig(wsRoot);
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {
@@ -89,7 +95,8 @@ suite("GIVEN a NoteLookupCmd", () => {
       wsRoot,
       mockEngine,
       mockNoteProvider,
-      new DummyTelemetryClient()
+      new DummyTelemetryClient(),
+      config
     );
 
     await cmd.run();
@@ -104,13 +111,15 @@ suite("GIVEN a NoteLookupCmd", () => {
 
   test("WHEN Create New is selected THEN a new note is written", async () => {
     const wsRoot = vscode.Uri.file("tmp");
-
+    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
+    const config = await getWorkspaceConfig(wsRoot);
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {
       showLookup: () => {
         return Promise.resolve(0);
       },
+      isJournalButtonPressed: () => false,
     } as unknown as LookupController;
 
     const vault: DVault = {
@@ -123,7 +132,6 @@ suite("GIVEN a NoteLookupCmd", () => {
 
     const showLookupFake = sinon.fake.resolves(lookupReturn);
     sinon.replace(factory, "showLookup", showLookupFake);
-
     const openTextDocumentFake = sinon.fake.resolves(undefined);
     sinon.replace(vscode.workspace, "openTextDocument", openTextDocumentFake);
 
@@ -139,7 +147,8 @@ suite("GIVEN a NoteLookupCmd", () => {
       wsRoot,
       mockEngine,
       mockNoteProvider,
-      new DummyTelemetryClient()
+      new DummyTelemetryClient(),
+      config
     );
 
     await cmd.run();

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -14,17 +14,15 @@ import {
   LookupController,
 } from "../../../commands/lookup/LookupController";
 import { NoteLookupCmd } from "../../../commands/NoteLookupCmd";
-import { getWorkspaceConfig } from "../../../injection-providers/getWorkspaceConfig";
-import { WorkspaceHelpers } from "../../helpers/WorkspaceHelpers";
+import { getConfig } from "../../helpers/setupTestEngineContainer";
 
 require("mocha/mocha");
 
 suite("GIVEN a NoteLookupCmd", () => {
   test("WHEN the user selects nothing THEN nothing is written to the engine", async () => {
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
+    const wsRoot = vscode.Uri.file("tmp");
 
-    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
-    const config = await getWorkspaceConfig(wsRoot);
+    const config = getConfig();
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {
@@ -60,9 +58,8 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN the user selects a note THEN that note is opened", async () => {
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
-    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
-    const config = await getWorkspaceConfig(wsRoot);
+    const wsRoot = vscode.Uri.file("tmp");
+    const config = getConfig();
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {
@@ -110,9 +107,8 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN Create New is selected THEN a new note is written", async () => {
-    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
-    await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
-    const config = await getWorkspaceConfig(wsRoot);
+    const wsRoot = vscode.Uri.file("tmp");
+    const config = getConfig();
     const mockNoteProvider = stubInterface<ILookupProvider>();
 
     const factory = {

--- a/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
+++ b/packages/plugin-core/src/web/test/suite/commands/NoteLookupCmd.test.ts
@@ -21,7 +21,7 @@ require("mocha/mocha");
 
 suite("GIVEN a NoteLookupCmd", () => {
   test("WHEN the user selects nothing THEN nothing is written to the engine", async () => {
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
 
     await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
     const config = await getWorkspaceConfig(wsRoot);
@@ -60,7 +60,7 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN the user selects a note THEN that note is opened", async () => {
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
     const config = await getWorkspaceConfig(wsRoot);
     const mockNoteProvider = stubInterface<ILookupProvider>();
@@ -110,7 +110,7 @@ suite("GIVEN a NoteLookupCmd", () => {
   });
 
   test("WHEN Create New is selected THEN a new note is written", async () => {
-    const wsRoot = vscode.Uri.file("tmp");
+    const wsRoot = await WorkspaceHelpers.getWSRootForTest();
     await WorkspaceHelpers.createTestYAMLConfigFile(wsRoot, {});
     const config = await getWorkspaceConfig(wsRoot);
     const mockNoteProvider = stubInterface<ILookupProvider>();

--- a/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
+++ b/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
@@ -17,7 +17,7 @@ import { Utils } from "vscode-uri";
 import { _noteAddBehaviorEnum } from "../../constants";
 import * as vscode from "vscode";
 import { DendronWebQuickPick } from "../../components/lookup/types";
-import { DendronBtn } from "../../components/lookup/ButtonTypes";
+import { ButtonType, DendronBtn } from "../../components/lookup/ButtonTypes";
 
 type CreateFnameOverrides = {
   domain?: string;
@@ -176,7 +176,10 @@ export class NoteLookupUtilsWeb {
     return editor.document.getText(selection);
   }
 
-  getButtonFromArray(type: LookupNoteTypeEnum, buttons: DendronBtn[]) {
+  getButtonFromArray(type: ButtonType, buttons: DendronBtn[]) {
     return _.find(buttons, (value) => value.type === type);
+  }
+  getButton(type: ButtonType, buttons: DendronBtn[]): DendronBtn | undefined {
+    return this.getButtonFromArray(type, buttons);
   }
 }

--- a/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
+++ b/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
@@ -17,6 +17,7 @@ import { Utils } from "vscode-uri";
 import { _noteAddBehaviorEnum } from "../../constants";
 import * as vscode from "vscode";
 import { DendronWebQuickPick } from "../../components/lookup/types";
+import { DendronBtn } from "../../components/lookup/ButtonTypes";
 
 type CreateFnameOverrides = {
   domain?: string;
@@ -173,5 +174,9 @@ export class NoteLookupUtilsWeb {
     }
     const selection = editor.selection;
     return editor.document.getText(selection);
+  }
+
+  getButtonFromArray(type: LookupNoteTypeEnum, buttons: DendronBtn[]) {
+    return _.find(buttons, (value) => value.type === type);
   }
 }

--- a/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
+++ b/packages/plugin-core/src/web/utils/NoteLookupUtilsWeb.ts
@@ -1,0 +1,177 @@
+import {
+  assertUnreachable,
+  ConfigUtils,
+  DendronConfig,
+  DNodeUtils,
+  getSlugger,
+  LookupNoteTypeEnum,
+  NoteAddBehavior,
+  NoteAddBehaviorEnum,
+  NoteQuickInputV2,
+  NoteUtils,
+  Time,
+} from "@dendronhq/common-all";
+import _ from "lodash";
+import { inject, injectable } from "tsyringe";
+import { Utils } from "vscode-uri";
+import { _noteAddBehaviorEnum } from "../../constants";
+import * as vscode from "vscode";
+import { DendronWebQuickPick } from "../../components/lookup/types";
+
+type CreateFnameOverrides = {
+  domain?: string;
+};
+
+type CreateFnameOpts = {
+  overrides?: CreateFnameOverrides;
+};
+
+@injectable()
+export class NoteLookupUtilsWeb {
+  constructor(@inject("DendronConfig") private config: DendronConfig) {}
+  genNoteName(
+    type:
+      | LookupNoteTypeEnum.journal
+      | LookupNoteTypeEnum.scratch
+      | LookupNoteTypeEnum.task,
+    opts?: CreateFnameOpts
+  ): {
+    noteName: string;
+    prefix: string;
+  } {
+    let dateFormat: string;
+    let addBehavior: NoteAddBehavior;
+    let name: string;
+
+    switch (type) {
+      case LookupNoteTypeEnum.scratch: {
+        const scratchConfig = ConfigUtils.getScratch(this.config);
+        dateFormat = scratchConfig.dateFormat;
+        addBehavior = scratchConfig.addBehavior;
+        name = scratchConfig.name;
+        break;
+      }
+      case LookupNoteTypeEnum.journal: {
+        const journalConfig = ConfigUtils.getJournal(this.config);
+        dateFormat = journalConfig.dateFormat;
+        addBehavior = journalConfig.addBehavior;
+        name = journalConfig.name;
+        break;
+      }
+      case LookupNoteTypeEnum.task: {
+        const taskConfig = ConfigUtils.getTask(this.config);
+        dateFormat = taskConfig.dateFormat;
+        addBehavior = taskConfig.addBehavior;
+        name = taskConfig.name;
+        break;
+      }
+      default:
+        assertUnreachable(type);
+    }
+
+    if (!_.includes(_noteAddBehaviorEnum, addBehavior)) {
+      const actual = addBehavior;
+      const choices = Object.keys(NoteAddBehaviorEnum).join(", ");
+      throw Error(`${actual} must be one of: ${choices}`);
+    }
+
+    const editorPath = vscode.window.activeTextEditor?.document.uri;
+    const currentNoteFname =
+      opts?.overrides?.domain ||
+      (editorPath ? Utils.basename(editorPath).slice(0, -3) : undefined);
+    if (!currentNoteFname) {
+      throw Error("Must be run from within a note");
+    }
+
+    const prefix = this.genNotePrefix(currentNoteFname, addBehavior);
+
+    const noteDate = Time.now().toFormat(dateFormat);
+    const noteName = [prefix, name, noteDate]
+      .filter((ent) => !_.isEmpty(ent))
+      .join(".");
+    return { noteName, prefix };
+  }
+
+  private genNotePrefix(fname: string, addBehavior: NoteAddBehavior) {
+    let out: string;
+    switch (addBehavior) {
+      case "childOfDomain": {
+        out = DNodeUtils.domainName(fname);
+        break;
+      }
+      case "childOfDomainNamespace": {
+        out = NoteUtils.getPathUpTo(fname, 2);
+        break;
+      }
+      case "childOfCurrent": {
+        out = fname;
+        break;
+      }
+      case "asOwnDomain": {
+        out = "";
+        break;
+      }
+      default: {
+        throw Error(`unknown add Behavior: ${addBehavior}`);
+      }
+    }
+    return out;
+  }
+
+  onJournalButtonToggled(
+    enabled: boolean,
+    qp: DendronWebQuickPick<NoteQuickInputV2>,
+    initialValue: string = ""
+  ) {
+    if (enabled) {
+      let data: { [key: string]: string };
+      try {
+        data = this.genNoteName(LookupNoteTypeEnum.journal);
+      } catch (error) {
+        data = { noteName: "", prefix: "" };
+      }
+      const noteModifierValue = _.difference(
+        data.noteName.split("."),
+        data.prefix.split(".")
+      ).join(".");
+      const text = this.getSelectedText();
+      const slugger = getSlugger();
+      const selectionModifierValue = text ? slugger.slug(text) : undefined;
+
+      qp.value = this.generatePickerValue({
+        prefix: data.prefix,
+        noteModifierValue,
+        selectionModifierValue,
+      });
+    } else {
+      qp.value = this.generatePickerValue({
+        prefix: initialValue,
+        noteModifierValue: undefined,
+        selectionModifierValue: undefined,
+      });
+    }
+  }
+
+  generatePickerValue({
+    prefix,
+    noteModifierValue,
+    selectionModifierValue,
+  }: {
+    prefix: string;
+    noteModifierValue?: string;
+    selectionModifierValue?: string;
+  }): string {
+    return [prefix, noteModifierValue, selectionModifierValue]
+      .filter((ent) => !_.isEmpty(ent))
+      .join(".");
+  }
+
+  getSelectedText() {
+    const editor = vscode.window.activeTextEditor;
+    if (_.isUndefined(editor)) {
+      return undefined;
+    }
+    const selection = editor.selection;
+    return editor.document.getText(selection);
+  }
+}

--- a/packages/plugin-core/src/web/utils/WSUtils.ts
+++ b/packages/plugin-core/src/web/utils/WSUtils.ts
@@ -6,7 +6,7 @@ import {
   type ReducedDEngine,
 } from "@dendronhq/common-all";
 import { inject, injectable } from "tsyringe";
-import vscode from "vscode";
+import vscode, { window } from "vscode";
 import { URI, Utils } from "vscode-uri";
 
 @injectable()
@@ -73,5 +73,13 @@ export class WSUtilsWeb {
       VaultUtils.getRelPath(vault),
       fname + ".md"
     );
+  }
+
+  public getVaultForOpenEditor(): DVault {
+    const activeDocument = window.activeTextEditor?.document;
+    if (!activeDocument) {
+      return this.vaults[0];
+    }
+    return this.getVaultFromDocument(activeDocument);
   }
 }

--- a/packages/plugin-core/src/web/utils/WSUtils.ts
+++ b/packages/plugin-core/src/web/utils/WSUtils.ts
@@ -9,6 +9,8 @@ import { inject, injectable } from "tsyringe";
 import vscode, { window } from "vscode";
 import { URI, Utils } from "vscode-uri";
 
+export const UNKNOWN_ERROR_MSG = `You found a bug! We didn't think this could happen but you proved us wrong. Please file the bug here -->  https://github.com/dendronhq/dendron/issues/new?assignees=&labels=&template=bug_report.md&title= We will put our best bug exterminators on this right away!`;
+
 @injectable()
 export class WSUtilsWeb {
   constructor(


### PR DESCRIPTION
This Pr aims to add Move Note command in web along with the following buttons to lookup
- vault confirm on create button
- direct child only
- journal note

# Dendron Extended PR Checklist

- NOTE: the links don't work. you'll need to go into the wiki and use lookup to find the note until we fix some issues in the markdown export

## Code

### Basics

- [x] code should follow [Code Conventions](dev.process.code)
- [x] circular dependency check: make sure your code is not introducing new circular dependencies in plugin-core.  See [Avoiding Circular Dependencies](dev.process.code.best-practices).
- [x] sticking to existing conventions instead of creating new ones
  - eg: [if configuration for utilities are already in one module or package, add future utilities there as well](https://github.com/dendronhq/dendron/pull/1960#discussion_r786228021)

### Extended
- General
  - [ ] check whether code be simplified
  - [ ] check if similar function already exist in the codebase. if so, can it be re-used?
  - [ ] check if this change adversely impact performance
- Operations
  - [ ] when shipping this change, will it just work or will it introduce additional operational overhead due to complicated interface or known bugs?
- Architecture
  - [ ] check if code is introducing changes on a foundational class or interface. if so, call for design review if needed
    - eg: [making changes to DNode](https://github.com/dendronhq/dendron/pull/2158#pullrequestreview-854689586)


## Instrumentation

### Basics
## Tests

### Basics

- [x] [Write Tests](dev.process.qa.test) 
- [ ] [Confirm existing tests pass](dev.process.qa.test)
- [x] [Confirm manual testing](dev.process.qa.test) 
- [x] Common cases tested
- [x] 1-2 Edge cases tested
- [ ] If your tests changes an existing snapshot, snapshots have been [updated](dev.process.qa.test)


## Docs
- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR
- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](dev) or [Packages](pkg)

## Close the Loop

### Extended
- [ ]  is this a developer BREAKING change? if another person cloning from this branch will need to adjust their dependencies or mental model of the architecture, then it is. if this is the case, make sure this is communicated according to [Close Loop](dev.process.close-loop)
  - eg: [breaking dev change due to new dependency](https://github.com/dendronhq/dendron/pull/2188#pullrequestreview-855696330)