### PR TITLE
chore(internal): add platform specific matrix to publish extension workflow

### DIFF
--- a/.github/workflows/create-release-image.yml
+++ b/.github/workflows/create-release-image.yml
@@ -15,6 +15,22 @@ jobs:
     environment: plugin-development
     strategy:
       fail-fast: true
+      matrix:
+        include:
+          - platform: win32
+            arch: x64
+          - platform: win32
+            arch: ia32
+          - platform: linux
+            arch: x64
+          - platform: linux
+            arch: arm64
+          - platform: darwin
+            arch: x64
+          - platform: darwin
+            arch: arm64
+          - platform: general
+            arch: general
 
     timeout-minutes: 30
 
@@ -43,6 +59,17 @@ jobs:
       - name: Yarn Setup
         run: yarn setup
 
+      - name: Download SQLite Binary
+        run: |
+          if [ ${{ matrix.platform }} == linux ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
+          elif [ ${{ matrix.platform }} != general ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          else 
+            echo "Skipping SQLite binary install for general build."
+          fi
+        working-directory: ./packages/plugin-core
+
       - name: Set Up Yarn Local Registry
         run: yarn config set registry http://localhost:4873
 
@@ -56,10 +83,15 @@ jobs:
           echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}" >> $GITHUB_ENV
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Build the VSIX
         run: |
-          yarn build:minor:local:ci
+          if [ ${{ matrix.platform }} == general ]; then
+            yarn build:minor:local:ci:noparam
+          else 
+            yarn build:minor:local:ci ${{ env.PUBLISHING_TARGET }}
+          fi
 
       - name: Check for VSIX
         run: |

--- a/.github/workflows/publish-extension-dendron-minor.yml
+++ b/.github/workflows/publish-extension-dendron-minor.yml
@@ -95,7 +95,7 @@ jobs:
           if [ ${{ matrix.platform }} == general ]; then
             yarn build:minor:remote:ci:noparam
           else 
-            yarn build:minor:remote:ci ${{ env.PUBLISHING_TARGET }}
+            yarn build:minor:local:ci ${{ env.PUBLISHING_TARGET }}
           fi
 
       - name: Upload VSIX Artifact

--- a/.github/workflows/publish-extension-dendron-minor.yml
+++ b/.github/workflows/publish-extension-dendron-minor.yml
@@ -11,6 +11,22 @@ jobs:
     environment: plugin-production
     strategy:
       fail-fast: true
+      matrix:
+        include:
+          - platform: win32
+            arch: x64
+          - platform: win32
+            arch: ia32
+          - platform: linux
+            arch: x64
+          - platform: linux
+            arch: arm64
+          - platform: darwin
+            arch: x64
+          - platform: darwin
+            arch: arm64
+          - platform: general
+            arch: general
 
     timeout-minutes: 30
 
@@ -44,6 +60,7 @@ jobs:
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
           echo "NPM_TOKEN=${{ secrets.NPM_AUTH_TOKEN }}" >> $GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Configure NPM
         run: |
@@ -51,6 +68,17 @@ jobs:
 
       - name: Yarn Setup
         run: yarn setup
+
+      - name: Download SQLite Binary
+        run: |
+          if [ ${{ matrix.platform }} == linux ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
+          elif [ ${{ matrix.platform }} != general ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          else 
+            echo "Skipping SQLite binary install for general build."
+          fi
+        working-directory: ./packages/plugin-core
 
       - name: Update schema file
         run: yarn gen:data
@@ -64,7 +92,11 @@ jobs:
         run: |
           echo "VSIX_FILE_NAME=dendron-${{ env.DENDRON_RELEASE_VERSION }}.vsix" >> $GITHUB_ENV
           echo "VSIX_RELATIVE_PATH=./packages/plugin-core/dendron-${{ env.DENDRON_RELEASE_VERSION }}.vsix" >> $GITHUB_ENV
-          yarn build:minor:remote:ci
+          if [ ${{ matrix.platform }} == general ]; then
+            yarn build:minor:remote:ci:noparam
+          else 
+            yarn build:minor:remote:ci ${{ env.PUBLISHING_TARGET }}
+          fi
 
       - name: Upload VSIX Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -95,7 +95,7 @@ jobs:
           if [ ${{ matrix.platform }} == general ]; then
             yarn build:patch:remote:ci:noparam
           else 
-            yarn build:patch:remote:ci ${{ env.PUBLISHING_TARGET }}
+            yarn build:patch:local:ci ${{ env.PUBLISHING_TARGET }}
           fi
 
       - name: Upload VSIX Artifact

--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -11,6 +11,22 @@ jobs:
     environment: plugin-production
     strategy:
       fail-fast: true
+      matrix:
+        include:
+          - platform: win32
+            arch: x64
+          - platform: win32
+            arch: ia32
+          - platform: linux
+            arch: x64
+          - platform: linux
+            arch: arm64
+          - platform: darwin
+            arch: x64
+          - platform: darwin
+            arch: arm64
+          - platform: general
+            arch: general
 
     timeout-minutes: 30
 
@@ -44,6 +60,7 @@ jobs:
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> $GITHUB_ENV
           echo "NODE_OPTIONS=--max_old_space_size=4096" >> $GITHUB_ENV
           echo "NPM_TOKEN=${{ secrets.NPM_AUTH_TOKEN }}" >> $GITHUB_ENV
+          echo "PUBLISHING_TARGET=${{ matrix.platform }}-${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Configure NPM
         run: |
@@ -51,6 +68,17 @@ jobs:
 
       - name: Yarn Setup
         run: yarn setup
+
+      - name: Download SQLite Binary
+        run: |
+          if [ ${{ matrix.platform }} == linux ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }}
+          elif [ ${{ matrix.platform }} != general ]; then
+            yarn download-sqlite-binary --target_arch=${{ matrix.arch }} --target_platform=${{ matrix.platform }} --target_libc=unknown
+          else 
+            echo "Skipping SQLite binary install for general build."
+          fi
+        working-directory: ./packages/plugin-core
 
       - name: Update schema file
         run: yarn gen:data
@@ -64,7 +92,11 @@ jobs:
         run: |
           echo "VSIX_FILE_NAME=dendron-${{ env.DENDRON_RELEASE_VERSION }}.vsix" >> $GITHUB_ENV
           echo "VSIX_RELATIVE_PATH=./packages/plugin-core/dendron-${{ env.DENDRON_RELEASE_VERSION }}.vsix" >> $GITHUB_ENV
-          yarn build:patch:remote:ci
+          if [ ${{ matrix.platform }} == general ]; then
+            yarn build:patch:remote:ci:noparam
+          else 
+            yarn build:patch:remote:ci ${{ env.PUBLISHING_TARGET }}
+          fi
 
       - name: Upload VSIX Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-extension-nightly.yml
+++ b/.github/workflows/publish-extension-nightly.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
 
       - name: Yarn Setup
         run: yarn setup

--- a/bootstrap/scripts/buildPatch.sh
+++ b/bootstrap/scripts/buildPatch.sh
@@ -27,6 +27,11 @@ if [ $SCRIPT_BUILD_ENV = "ci" ]; then
   DENDRON_CLI=./packages/dendron-cli/lib/bin/dendron-cli.js
 fi
 
+TARGET="--extensionTarget $1"
+if [ "$PARAMS" = "none" ]; then
+  TARGET=''
+fi
+
 EXT_TYPE=dendron
 if [ $SCRIPT_EXT_TYPE = "nightly" ]; then
   EXT_TYPE=nightly
@@ -36,10 +41,10 @@ if [ $SCRIPT_EXT_TYPE = "enterprise" ]; then
 fi
 
 if [ -z $FAST ]; then
-	LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --extensionType $EXT_TYPE
+	LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --extensionType $EXT_TYPE $TARGET
 else
 	echo "running fast mode..."
-	SKIP_SENTRY=1 LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --fast --extensionType $EXT_TYPE
+	SKIP_SENTRY=1 LOG_LEVEL=info $DENDRON_CLI dev build --upgradeType $UPGRADE_TYPE --publishEndpoint $PUBLISH_ENDPOINT --fast --extensionType $EXT_TYPE $TARGET
 fi
 
 if [ $PUBLISH_ENDPOINT = "local" ]; then

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "build:minor:local:ci": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote:ci": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote BUILD_ENV=ci ./bootstrap/scripts/buildPatch.sh",
+    "build:minor:remote:ci:noparam": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote BUILD_ENV=ci PARAMS=none ./bootstrap/scripts/buildPatch.sh",
     "gen:data": "yarn dendron dev generate_json_schema_from_config",
     "dendron": "node packages/dendron-cli/lib/bin/dendron-cli.js",
     "cleanup": "./bootstrap/scripts/cleanup.sh",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "build:patch:remote:ci:noparam": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote BUILD_ENV=ci PARAMS=none ./bootstrap/scripts/buildPatch.sh",
     "build:minor:local": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local ./bootstrap/scripts/buildPatch.sh",
     "build:minor:local:ci": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
+    "build:minor:local:ci:noparam": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local BUILD_ENV=ci PARAMS=none USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote:ci": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote BUILD_ENV=ci ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote:ci:noparam": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote BUILD_ENV=ci PARAMS=none ./bootstrap/scripts/buildPatch.sh",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "build:patch:local:ci:enterprise": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 EXT_TYPE=enterprise ./bootstrap/scripts/buildPatch.sh",
     "build:patch:remote": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote ./bootstrap/scripts/buildPatch.sh",
     "build:patch:remote:ci": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote BUILD_ENV=ci ./bootstrap/scripts/buildPatch.sh",
+    "build:patch:remote:ci:noparam": "cross-env UPGRADE_TYPE=patch PUBLISH_ENDPOINT=remote BUILD_ENV=ci PARAMS=none ./bootstrap/scripts/buildPatch.sh",
     "build:minor:local": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local ./bootstrap/scripts/buildPatch.sh",
     "build:minor:local:ci": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=local BUILD_ENV=ci USE_IN_MEMORY_REGISTRY=1 ./bootstrap/scripts/buildPatch.sh",
     "build:minor:remote": "cross-env UPGRADE_TYPE=minor PUBLISH_ENDPOINT=remote ./bootstrap/scripts/buildPatch.sh",


### PR DESCRIPTION
This PR aims to update both `publishing-minor` and `publishing-patch` workflow to include platform-specific matrix for downloading sqlite binaries 