### PR TITLE
chore(internal): bump node version to 16 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 14.x
           - 16.x
         suite:
           - cli

--- a/.github/workflows/create-release-image-patch.yml
+++ b/.github/workflows/create-release-image-patch.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Yarn Setup
         run: yarn setup

--- a/.github/workflows/create-release-image.yml
+++ b/.github/workflows/create-release-image.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Yarn Setup
         run: yarn setup

--- a/.github/workflows/hackathon-create-test-image.yml
+++ b/.github/workflows/hackathon-create-test-image.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Yarn Setup
         run: yarn setup

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Yarn Setup
         run: yarn setup

--- a/.github/workflows/publish-extension-dendron-minor.yml
+++ b/.github/workflows/publish-extension-dendron-minor.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Set Environment Variables
         run: |

--- a/.github/workflows/publish-extension-dendron-patch.yml
+++ b/.github/workflows/publish-extension-dendron-patch.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: Set Environment Variables
         run: |


### PR DESCRIPTION
# chore(internal): bump node version to 16 in ci

This PR:
- bumps node version used in github actions to be at least 16.
- for matrices, we can later add 18 and beyond. for now leaving it to only run on 16.

# Pull Request Checklist
