### PR TITLE
enhance(create): show error when applying template but no template found

### DIFF
--- a/packages/plugin-core/src/components/lookup/QuickPickTemplateSelector.ts
+++ b/packages/plugin-core/src/components/lookup/QuickPickTemplateSelector.ts
@@ -53,8 +53,14 @@ export class QuickPickTemplateSelector {
           const data = event.data;
           if (data.cancel) {
             resolve(undefined);
+          } else if (
+            // equivalent to no template found
+            data.selectedItems.length === 1 &&
+            data.selectedItems[0]?.children.length === 0
+          ) {
+            resolve(undefined);
           } else {
-            const templateNote = event.data.selectedItems[0] as NoteProps;
+            const templateNote = data.selectedItems[0] as NoteProps;
             resolve(templateNote);
           }
           NoteLookupProviderUtils.cleanup({


### PR DESCRIPTION
## First Time Specifics

- [ ] if its your first pull request to Dendron, watch out for the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) bot that will ask you to agree to Dendron's CLA
- [ ] if its your first pull request and you're on our Discord, add your discord handle so that we can award you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) role when the PR is merged
  - tlylt
## Commit

- [ ] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)
- [ ] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/QN46JTSWpEkDkr94TJ85w)
- [ ] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.
  - NOTE: make sure to read [Addressing open issues](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)
  - related to #998

## Code

I decided to change the condition in `QuickPickTemplateSelector.ts` to capture the case where the template is not found and return undefined from there. It is also possible to make that change downstream in `ApplyTemplateCommand.ts` (line 61) with something like:

```ts
    if (_.isUndefined(templateNote) || templateNote?.children.length === 0) {
      throw new DendronError({ message: `Template not found` });
    }
```

Similar to the existing logic when template is undefined, template not found will now trigger an error message. 
Let me know if there's any issue with the current approach.


- [ ] code should follow [Code Conventions](https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e)
- [ ] sticking to existing conventions instead of creating new ones 


## Tests

I adjusted some code in the integration tests for apply template to add a case for template not found. Not sure if it's the best way to do it so please let me know if it needs to be updated.

Manual test:
![image](https://user-images.githubusercontent.com/41845017/210734863-07120a80-7ec8-4b4d-b690-60d90ec370de.png)


- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing [snapshot](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
  - [ ] [Update the Snapshot](https://docs.dendron.so/notes/u7utw5w8gyacuh3ok9ehi8j)

## Docs

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR (NOTE: submit the PR against the `dev` branch of the dendron-site repo)


- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/ce9b9b29-d85b-492b-b76d-5e0c5dc52b03) or [Packages](https://wiki.dendron.so/notes/ok9ifke0zsfxnnh7xog79z5)