### PR TITLE
Correct small typo in tutorial

### DIFF
--- a/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
+++ b/packages/plugin-core/assets/dendron-ws/tutorial/treatments/quickstart-v1/tutorial.md
@@ -86,7 +86,7 @@ Depending on your needs, here are some common next steps:
 
 - I want to **start writing**: [Create a daily journal note](command:dendron.createDailyJournalNote) ([docs](https://wiki.dendron.so/notes/ogIUqY5VDCJP28G3cAJhd))
 
-- I want to **use templates**: Use the [Appy Template](https://wiki.dendron.so/notes/ftohqknticu6bw4cfmzskq6) command to apply [templates](https://wiki.dendron.so/notes/861cbdf8-102e-4633-9933-1f3d74df53d2) to existing notes
+- I want to **use templates**: Use the [Apply Template](https://wiki.dendron.so/notes/ftohqknticu6bw4cfmzskq6) command to apply [templates](https://wiki.dendron.so/notes/861cbdf8-102e-4633-9933-1f3d74df53d2) to existing notes
 
 - I want to do a **longer tutorial**: Check out our [5min tutorial to explore more of Dendron's functionality](https://wiki.dendron.so/notes/678c77d9-ef2c-4537-97b5-64556d6337f1/)
 


### PR DESCRIPTION
While going through the Dendron tutorial I found this typo in the Markdown file. Wanted to contribute to correct the information for future users.


# Pull Request Checklist

If you are a community contributor, copy and paste the PR template from [Dendron Community PR Checklist](https://gist.github.com/kevinslin/5d1a6663638259e7dbd33b01975cc00f) and add it to the body of the pull request. 

If you are a team member, copy and paste the template from [Dendron Extended PR Checklist](https://gist.github.com/kevinslin/dfc7a101f21c58478216aa0d70256bc2).

To copy the template, click on the `Raw` button on the gist to copy the plaintext version of the template to this PR.