### PR TITLE
Updating `image-labler` GitHub Action

### DIFF
--- a/.github/workflows/issue-labler.yml
+++ b/.github/workflows/issue-labler.yml
@@ -7,9 +7,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v2.2
+      - uses: github/issue-labeler@v3.2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: ${{ github.token }}
           configuration-path: .github/config/issue-labler/labler.yml
           not-before: "2020-02-21T00:00:00Z"
           enable-versioned-regex: 1


### PR DESCRIPTION
The task that runs when a new issue is opened, [`issue-labler`](https://github.com/marketplace/actions/regex-issue-labeler), is powered by an Action that's three years out of date & relies on Node v12. GitHub Actions no longer supports Node v12, forces the Action to run on v16.

The actual error that is causing the task to fail though is attempting an HTTP `DELETE` on `https://api.github.com/repos/dendronhq/dendron/issues/3950/labels/scope.schema` where #3950 was the issue I created and it never had the `scope.schema` tag, nor should it have had.

All this code does is upgrade the version of `issue-labler` & changes how the GitHub token is accessed to match the documentation. My hopes are that the new plugin will handle deleting a non-existent tag more gracefully. *(That & not want to run on Node v12.)*

I can't really test this without deploying it. In fact it has to be in `master` for the `isue-labler` to run, so I should set this up onm a separate repo & see if it works…

# Pull Request Checklist

## First Time Specifics

- [X] if its your first pull request to Dendron, watch out for the [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) bot that will ask you to agree to Dendron's CLA
- [X] if its your first pull request and you're on our Discord, add your discord handle so that we can award you the [horticulturalist](https://wiki.dendron.so/notes/7c00d606-7b75-4d28-b563-d75f33f8e0d7.html#horticulturalist) role when the PR is merged

I'm @dysbulic.

## Commit

- [X] make sure your branch names adhere to our [branch style](https://docs.dendron.so/notes/adc39825-77a6-46cf-9c49-2642fcb4248e)
- [ ] make sure the commit message follows Dendron's [commit style](https://docs.dendron.so/notes/QN46JTSWpEkDkr94TJ85w)
- [X] if this pull request is addressing an existing issue, make sure to link this PR to the issue that it is resolving.

## Code

- [X] code should follow [Code Conventions](https://docs.dendron.so/notes/773e0b5a-510f-4c21-acf4-2d1ab3ed741e)
- [X] sticking to existing conventions instead of creating new ones 

## Tests

- [ ] [Write Tests](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [X] [Confirm existing tests pass](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
- [ ] [Confirm manual testing](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro) 
- [ ] Common cases tested
- [ ] 1-2 Edge cases tested
- [ ] If your tests changes an existing [snapshot](https://docs.dendron.so/notes/99q7A73uGmCwu2KvSHZro)
  - [ ] [Update the Snapshot](https://docs.dendron.so/notes/u7utw5w8gyacuh3ok9ehi8j)

## Docs

- [ ] if your change reflects documentation changes, also submit a PR to [dendron-site](https://github.com/dendronhq/dendron-site) and mention the doc PR link in your current PR (NOTE: submit the PR against the `dev` branch of the dendron-site repo)

- [ ] does this change introduce a new or better way of doing things that others need to be aware of? if so, an async should be created and a process added in [Development](https://wiki.dendron.so/notes/ce9b9b29-d85b-492b-b76d-5e0c5dc52b03) or [Packages](https://wiki.dendron.so/notes/ok9ifke0zsfxnnh7xog79z5)