### PR TITLE
Adding ./setup.sh to automate development setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ There are a variety of ways to connect with Dendron devs, contributors, and othe
 
 Dendron wouldn't be what it is today without help from the wonderful gardeners 👨‍🌾👩‍🌾
 
-If you would like to contribute (docs, code, finance, or advocacy), you can find instructions to do so [here](https://wiki.dendron.so/notes/125c990b-6fe7-4ada-a65f-44cbde8b33f0.html).
+If you would like to contribute (docs, code, finance, or advocacy), you can find instructions to do so [here](https://wiki.dendron.so/notes/125c990b-6fe7-4ada-a65f-44cbde8b33f0.html). For setup of local development environment run `./setup.sh` which automates the setup.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+# Description: Setup the environment for Dendron development.
+#
+# For further documentation refer to [Dendron Plugin Quickstart]:
+# https://docs.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa/
+main() {
+  export DENDRON_MONOREPO="${PWD:?}"
+
+  "${DENDRON_MONOREPO:?}"/shell/setup.sh
+}
+
+main "${@}" || exit 1

--- a/shell/_setup_nvm_source_me.sh
+++ b/shell/_setup_nvm_source_me.sh
@@ -1,0 +1,17 @@
+main() {
+  if [[ ! -f "$HOME/.nvm/nvm.sh" ]]
+  then
+  	echo "File $HOME/.nvm/nvm.sh does NOT exists. Setup NVM refer to https://github.com/nvm-sh/nvm"
+  	exit 1
+  fi
+
+  # Source nvm script - adjust the path if it's different on your machine
+  #
+  # -s check if file exists and has a size greater than zero
+  [ -s "$HOME/.nvm/nvm.sh" ] && {
+    source "$HOME/.nvm/nvm.sh"
+    echo "Sourced $HOME/.nvm/nvm.sh"
+  }
+}
+
+main "${@}" || exit 1

--- a/shell/_util.sh
+++ b/shell/_util.sh
@@ -1,0 +1,47 @@
+# --------------------------------------------------------------------------------
+# ANSI escape code for green color
+export COLOR_GREEN="\033[0;32m"
+# ANSI escape code to reset color back to default
+export COLOR_RESET="\033[0m" # No Color
+# ANSI escape code for red color
+export COLOR_RED="\033[0;31m"
+
+echo_green(){
+  echo -e "${COLOR_GREEN:?}${*}${COLOR_RESET:?}"
+}
+
+# Check if the file exists and source it.
+source_robust(){
+  local file="${1:?}"
+
+  if [ ! -f "${file:?}" ]; then
+    echo -e "${COLOR_RED:?}File not found: ${file:?}${COLOR_RESET:?}"
+    exit 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "${file:?}"
+}
+
+# Announces command (prints out the command that is going to be executed).
+# Executes the command.
+# If the command fails, prints out error and exits.
+#
+# Note this function will use 'source' with a temporary file, to allow
+# the functions that are executed to modify environment variables.
+eae(){
+  local execution_file=/tmp/execution_file_dendron_setup.sh
+  echo "${@:?}" > "${execution_file:?}"
+
+  echo ""
+  echo -e "Executing: ${COLOR_GREEN}$(cat "${execution_file:?}")${COLOR_RESET:?}"
+
+  # We use source_robust instead of 'eval' to be able to modify environment variables
+  # from the commands that we are running with eae.
+  #
+  # shellcheck disable=SC1090
+  if ! source "${execution_file:?}"; then
+    echo -e "${COLOR_RED:?}Error executing: $(cat "${execution_file:?}")${COLOR_RESET:?}"
+    exit 1
+  fi
+}

--- a/shell/_verify_env_variables.sh
+++ b/shell/_verify_env_variables.sh
@@ -1,0 +1,9 @@
+main() {
+  # -z: returns true when value is empty.
+  if [[ -z "${DENDRON_MONOREPO}" ]]; then
+    echo "DENDRON_MONOREPO environment variable is not set."
+    exit 1
+  fi
+}
+
+main "${@}" || exit 1

--- a/shell/_verify_node_version.sh
+++ b/shell/_verify_node_version.sh
@@ -1,0 +1,19 @@
+main() {
+  MIN_VERSION="14.0.0"
+
+  # Get the current Node.js version
+  CURRENT_VERSION=$(node -v | sed 's/v//') # Removes the 'v' prefix from version
+
+  # Function to compare versions
+  version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+  # Check if the current version is greater than or equal to the minimum version
+  if version_gt "$CURRENT_VERSION" "$MIN_VERSION"; then
+      echo "Current Node.js version is $CURRENT_VERSION. Proceeding..."
+  else
+      echo "Error: Node.js version must be $MIN_VERSION or greater. Current version is $CURRENT_VERSION."
+      exit 1
+  fi
+}
+
+main "${@}" || exit 1

--- a/shell/_verify_npm.sh
+++ b/shell/_verify_npm.sh
@@ -1,0 +1,10 @@
+main() {
+  if command -v npm > /dev/null 2>&1; then
+      echo "Verified npm is installed."
+  else
+      echo "npm is not installed. Please install Node.js and npm."
+      exit 1
+  fi
+}
+
+main "${@}" || exit 1

--- a/shell/_verify_nvm_source_me.sh
+++ b/shell/_verify_nvm_source_me.sh
@@ -1,0 +1,10 @@
+main() {
+  if type nvm > /dev/null 2>&1; then
+      echo "nvm is installed."
+  else
+      echo "nvm is not installed. Please install nvm. (https://github.com/nvm-sh/nvm)"
+      exit 1
+  fi
+}
+
+main "${@}" || exit 1

--- a/shell/_verify_yarn.sh
+++ b/shell/_verify_yarn.sh
@@ -1,0 +1,10 @@
+main() {
+  if command -v yarn > /dev/null 2>&1; then
+      echo "Verified Yarn is installed."
+  else
+      echo "Yarn is not installed. Please install Yarn."
+      exit 1
+  fi
+}
+
+main "${@}" || exit 1

--- a/shell/setup.sh
+++ b/shell/setup.sh
@@ -1,0 +1,74 @@
+# Description: Setup the environment for Dendron development.
+#
+# Pre-requisites:
+# - DENDRON_MONOREPO environment variable must be set.
+#   It should point to dendron's monorepo
+#   (directory where you cloned https://github.com/dendronhq/dendron.git into)
+#
+# This script is based off of https://docs.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa/
+
+# -z: returns true when value is empty.
+if [[ -z "${DENDRON_MONOREPO}" ]]; then
+  echo "DENDRON_MONOREPO environment variable is not set. Please set it to dendron's monorepo directory."
+  exit 1
+fi
+
+if [[ -f "${DENDRON_MONOREPO:?}"/shell/_util.sh ]]
+then
+	source "${DENDRON_MONOREPO:?}"/shell/_util.sh
+else
+  echo "File not found: ${DENDRON_MONOREPO:?}/shell/_util.sh"
+  exit 1
+fi
+
+_setup_node_version(){
+  # NVM is often not propagated to subshells. This is a workaround to
+  # allow usage of NVM within the script.
+  source_robust "${DENDRON_MONOREPO:?}"/shell/_setup_nvm_source_me.sh
+
+  # We need to source verification of NVM due to subshell issue mentioned above.
+  source_robust "${DENDRON_MONOREPO:?}"/shell/_verify_nvm_source_me.sh
+
+  # There is an issue with node 17+ and `yarn setup` that causes an error.
+  # Node 16 is the latest version that works with `yarn setup` with
+  # current dendron setup.
+  #
+  # Another option to try is to use later node version with:
+  # export NODE_OPTIONS=--openssl-legacy-provider
+  #
+  # However, it seems more robust to pick a node version that is known to work.
+  # Hence, we are setting node version to 16.
+  eae nvm install 16
+  eae nvm use 16
+}
+
+main_impl(){
+  eae _setup_node_version
+
+  eae npm install -g yarn
+  eae npm install -g lerna
+
+  eae cd "${DENDRON_MONOREPO:?}"
+
+  echo "install workspace dependencies..."
+  eae yarn
+
+  echo "install package dependencies..."
+  eae yarn setup
+}
+
+main() {
+  echo_green "Starting ${0}..."
+
+  eae "${DENDRON_MONOREPO:?}"/shell/_verify_env_variables.sh
+  eae "${DENDRON_MONOREPO:?}"/shell/_verify_node_version.sh
+  eae "${DENDRON_MONOREPO:?}"/shell/_verify_npm.sh
+  eae "${DENDRON_MONOREPO:?}"/shell/_verify_yarn.sh
+
+  main_impl
+
+  echo "--------------------------------------------------------------------------------"
+  echo_green "Finished ${0} successfully. For further documentation refer to https://docs.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa/ . Particularly look for the part that talks about 'dendron-main.code-workspace' (And use File->Open Workspace from file... to open 'dendron/dendron-main.code-workspace'). Also look for './watch.sh' which wraps the watch command."
+}
+
+main "${@}" || exit 1

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,6 @@
+# Related documentation here https://docs.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa/
+main() {
+  ./bootstrap/scripts/watch.sh
+}
+
+main "${@}" || exit 1


### PR DESCRIPTION
Adding `./setup.sh` which automates the setup described in https://docs.dendron.so/notes/64f0e2d5-2c83-43df-9144-40f2c68935aa/

Tested in `bash` and `zsh`.

To use it, run `./setup.sh` in the root of Dendron mono repo.
